### PR TITLE
feat(rust): expose metadata on paginated responses

### DIFF
--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -1,8 +1,8 @@
 {{BASE64_IMPORT}}use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 {{SERDE_ERROR_IMPORT}}
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
 {{MULTIPART_METHOD}}{{BYTES_METHOD}}    async fn apply_auth_headers(

--- a/generators/rust/base/src/asIs/pagination.rs
+++ b/generators/rust/base/src/asIs/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -302,6 +416,9 @@ mod tests {
                 items: vec![],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
             })
         }, None).unwrap();
         assert!(paginator.has_next_page());
@@ -315,6 +432,9 @@ mod tests {
                 items: vec!["a".to_string(), "b".to_string()],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
             })
         }, None).unwrap();
 
@@ -331,6 +451,9 @@ mod tests {
                 items: vec!["a".to_string()],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
             })
         }, None).unwrap();
 
@@ -354,6 +477,9 @@ mod tests {
                         items: vec![1, 2],
                         next_cursor: Some("page2".to_string()),
                         has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
                     })
                 }
                 1 => {
@@ -362,6 +488,9 @@ mod tests {
                         items: vec![3, 4],
                         next_cursor: None,
                         has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
                     })
                 }
                 _ => panic!("Unexpected call"),
@@ -390,11 +519,17 @@ mod tests {
                     items: vec![1, 2],
                     next_cursor: Some("next".to_string()),
                     has_next_page: true,
+                    response: None,
+                    status_code: None,
+                    headers: None,
                 }),
                 1 => Ok(PaginationResult {
                     items: vec![3],
                     next_cursor: None,
                     has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
                 }),
                 _ => panic!("Unexpected call"),
             }
@@ -417,11 +552,17 @@ mod tests {
                     items: vec![10, 20],
                     next_cursor: Some("p2".to_string()),
                     has_next_page: true,
+                    response: None,
+                    status_code: None,
+                    headers: None,
                 }),
                 1 => Ok(PaginationResult {
                     items: vec![30],
                     next_cursor: None,
                     has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
                 }),
                 _ => panic!("Unexpected call"),
             }
@@ -463,6 +604,9 @@ mod tests {
                 items: vec!["item".to_string()],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
             })
         }, Some("start_here".to_string())).unwrap();
 
@@ -480,10 +624,71 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
+            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            match call {
+                0 => Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: Some("next".to_string()),
+                    has_next_page: true,
+                    response: Some(serde_json::json!({"data": ["a"]})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                }),
+                _ => Ok(PaginationResult {
+                    items: vec!["b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["b"]})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                }),
+            }
+        }, None).unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
+            Ok(PaginationResult {
+                items: vec!["x".to_string()],
+                next_cursor: None,
+                has_next_page: false,
+                response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                status_code: Some(StatusCode::OK),
+                headers: Some(HeaderMap::new()),
+            })
+        }, None).unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/generators/rust/sdk/changes/unreleased/expose-pagination-metadata.yml
+++ b/generators/rust/sdk/changes/unreleased/expose-pagination-metadata.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Expose HTTP status code, headers, and full response on paginated results
+    for feature parity with Go and C# SDKs. Paginated endpoints now generate
+    an additional `_paginated` method returning an `AsyncPaginator` that
+    provides access to response metadata via `last_response()`,
+    `last_status_code()`, and `last_headers()` accessors.
+  type: feat

--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -341,6 +341,7 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
             lines.push("mod websocket;");
         }
         lines.push("mod utils;");
+        lines.push("pub mod pagination;");
         if (hasDateTime) {
             lines.push("pub mod flexible_datetime;");
         }
@@ -358,6 +359,7 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
         lines.push("pub use oauth_token_provider::OAuthTokenProvider;");
         lines.push("pub use request_options::RequestOptions;");
         lines.push("pub use query_parameter_builder::{QueryBuilder, QueryBuilderError, parse_structured_query};");
+        lines.push("pub use pagination::{AsyncPaginator, SyncPaginator, PaginationResult};")
         if (hasStreaming) {
             lines.push('#[cfg(feature = "sse")]');
             lines.push("pub use sse_stream::SseStream;");

--- a/generators/rust/sdk/src/generators/SubClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/SubClientGenerator.ts
@@ -228,6 +228,11 @@ export class SubClientGenerator {
             crateItems.push("RequestOptions");
         }
 
+        // Add pagination types if we have paginated endpoints
+        if (this.hasPaginatedEndpoints()) {
+            crateItems.push("AsyncPaginator", "PaginationResult");
+        }
+
         // Add ByteStream if we have binary endpoints (file downloads)
         if (hasBinaryEndpoints) {
             crateItems.push("ByteStream");
@@ -852,6 +857,7 @@ export class SubClientGenerator {
 
         for (const endpoint of endpoints) {
             methods.push(this.generateHttpMethod(endpoint));
+            methods.push(...this.generatePaginatedMethods(endpoint));
         }
 
         return methods;
@@ -1901,7 +1907,7 @@ export class SubClientGenerator {
         const paginationLogic = this.generatePaginationLogic(endpoint, httpMethod, pathExpression, requestBody);
 
         return {
-            name: baseName,
+            name: `${baseName}_paginated`,
             parameters,
             returnType: returnType.toString(),
             isAsync: true,
@@ -1971,7 +1977,7 @@ export class SubClientGenerator {
                     ${this.generateCapturedVariableCloningForAsyncMove(params)}
                     
                     Box::pin(async move {
-                        let response: serde_json::Value = client.execute_request(
+                        let (response, _status_code, _headers): (serde_json::Value, reqwest::StatusCode, reqwest::header::HeaderMap) = client.execute_request_returning_response(
                             Method::${httpMethod},
                             ${this.buildPathExpressionForAsyncMove(pathExpression, params)},
                             ${this.buildRequestBodyForAsyncMove(requestBody, params)},
@@ -1986,6 +1992,9 @@ export class SubClientGenerator {
                             items,
                             next_cursor,
                             has_next_page,
+                            response: Some(response),
+                            status_code: Some(_status_code),
+                            headers: Some(_headers),
                         })
                     })
                 },
@@ -2032,7 +2041,7 @@ export class SubClientGenerator {
                     ${this.generateCapturedVariableCloningForAsyncMove(params)}
                     
                     Box::pin(async move {
-                        let response: serde_json::Value = client.execute_request(
+                        let (response, _status_code, _headers): (serde_json::Value, reqwest::StatusCode, reqwest::header::HeaderMap) = client.execute_request_returning_response(
                             Method::${httpMethod},
                             ${this.buildPathExpressionForAsyncMove(pathExpression, params)},
                             ${this.buildRequestBodyForAsyncMove(requestBody, params)},
@@ -2047,6 +2056,9 @@ export class SubClientGenerator {
                             items,
                             next_cursor,
                             has_next_page,
+                            response: Some(response),
+                            status_code: Some(_status_code),
+                            headers: Some(_headers),
                         })
                     })
                 },
@@ -2086,7 +2098,7 @@ export class SubClientGenerator {
                     ${this.generateCapturedVariableCloningForAsyncMove(params)}
                     
                     Box::pin(async move {
-                        let response: serde_json::Value = client.execute_request(
+                        let (response, _status_code, _headers): (serde_json::Value, reqwest::StatusCode, reqwest::header::HeaderMap) = client.execute_request_returning_response(
                             Method::${httpMethod},
                             ${this.buildPathExpressionForAsyncMove(pathExpression, params)},
                             ${this.buildRequestBodyForAsyncMove(requestBody, params)},
@@ -2101,6 +2113,9 @@ export class SubClientGenerator {
                             items,
                             next_cursor,
                             has_next_page,
+                            response: Some(response),
+                            status_code: Some(_status_code),
+                            headers: Some(_headers),
                         })
                     })
                 },

--- a/seed/rust-sdk/accept-header/.fern/metadata.json
+++ b/seed/rust-sdk/accept-header/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/accept-header/src/core/http_client.rs
+++ b/seed/rust-sdk/accept-header/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/accept-header/src/core/mod.rs
+++ b/seed/rust-sdk/accept-header/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/accept-header/src/core/pagination.rs
+++ b/seed/rust-sdk/accept-header/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/alias-extends/.fern/metadata.json
+++ b/seed/rust-sdk/alias-extends/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/alias-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/alias-extends/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/alias-extends/src/core/mod.rs
+++ b/seed/rust-sdk/alias-extends/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/alias-extends/src/core/pagination.rs
+++ b/seed/rust-sdk/alias-extends/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/alias/.fern/metadata.json
+++ b/seed/rust-sdk/alias/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/alias/src/core/http_client.rs
+++ b/seed/rust-sdk/alias/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/alias/src/core/mod.rs
+++ b/seed/rust-sdk/alias/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/alias/src/core/pagination.rs
+++ b/seed/rust-sdk/alias/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/allof-inline/.fern/metadata.json
+++ b/seed/rust-sdk/allof-inline/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/allof-inline/src/core/http_client.rs
+++ b/seed/rust-sdk/allof-inline/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/allof-inline/src/core/mod.rs
+++ b/seed/rust-sdk/allof-inline/src/core/mod.rs
@@ -3,12 +3,14 @@
 pub mod flexible_datetime;
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/allof-inline/src/core/pagination.rs
+++ b/seed/rust-sdk/allof-inline/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/allof/.fern/metadata.json
+++ b/seed/rust-sdk/allof/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/allof/src/core/http_client.rs
+++ b/seed/rust-sdk/allof/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/allof/src/core/mod.rs
+++ b/seed/rust-sdk/allof/src/core/mod.rs
@@ -3,12 +3,14 @@
 pub mod flexible_datetime;
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/allof/src/core/pagination.rs
+++ b/seed/rust-sdk/allof/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/any-auth/.fern/metadata.json
+++ b/seed/rust-sdk/any-auth/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/any-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/any-auth/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/any-auth/src/core/mod.rs
+++ b/seed/rust-sdk/any-auth/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/any-auth/src/core/pagination.rs
+++ b/seed/rust-sdk/any-auth/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/api-wide-base-path/.fern/metadata.json
+++ b/seed/rust-sdk/api-wide-base-path/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/api-wide-base-path/src/core/mod.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/api-wide-base-path/src/core/pagination.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/audiences/.fern/metadata.json
+++ b/seed/rust-sdk/audiences/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/audiences/src/core/http_client.rs
+++ b/seed/rust-sdk/audiences/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/audiences/src/core/mod.rs
+++ b/seed/rust-sdk/audiences/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/audiences/src/core/pagination.rs
+++ b/seed/rust-sdk/audiences/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/basic-auth-environment-variables/.fern/metadata.json
+++ b/seed/rust-sdk/basic-auth-environment-variables/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/mod.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/pagination.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/basic-auth-pw-omitted/.fern/metadata.json
+++ b/seed/rust-sdk/basic-auth-pw-omitted/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/basic-auth-pw-omitted/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-pw-omitted/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/basic-auth-pw-omitted/src/core/mod.rs
+++ b/seed/rust-sdk/basic-auth-pw-omitted/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/basic-auth-pw-omitted/src/core/pagination.rs
+++ b/seed/rust-sdk/basic-auth-pw-omitted/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/basic-auth/.fern/metadata.json
+++ b/seed/rust-sdk/basic-auth/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/basic-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/basic-auth/src/core/mod.rs
+++ b/seed/rust-sdk/basic-auth/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/basic-auth/src/core/pagination.rs
+++ b/seed/rust-sdk/basic-auth/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/bearer-token-environment-variable/.fern/metadata.json
+++ b/seed/rust-sdk/bearer-token-environment-variable/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/mod.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/pagination.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/bytes-download/.fern/metadata.json
+++ b/seed/rust-sdk/bytes-download/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/bytes-download/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-download/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/bytes-download/src/core/mod.rs
+++ b/seed/rust-sdk/bytes-download/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/bytes-download/src/core/pagination.rs
+++ b/seed/rust-sdk/bytes-download/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/bytes-upload/.fern/metadata.json
+++ b/seed/rust-sdk/bytes-upload/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/bytes-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     /// Execute a request with a raw bytes body (application/octet-stream).

--- a/seed/rust-sdk/bytes-upload/src/core/mod.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/bytes-upload/src/core/pagination.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/circular-references-advanced/.fern/metadata.json
+++ b/seed/rust-sdk/circular-references-advanced/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/circular-references-advanced/src/core/mod.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/circular-references-advanced/src/core/pagination.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/circular-references-extends/.fern/metadata.json
+++ b/seed/rust-sdk/circular-references-extends/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/circular-references-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-extends/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/circular-references-extends/src/core/mod.rs
+++ b/seed/rust-sdk/circular-references-extends/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/circular-references-extends/src/core/pagination.rs
+++ b/seed/rust-sdk/circular-references-extends/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/circular-references/.fern/metadata.json
+++ b/seed/rust-sdk/circular-references/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/circular-references/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/circular-references/src/core/mod.rs
+++ b/seed/rust-sdk/circular-references/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/circular-references/src/core/pagination.rs
+++ b/seed/rust-sdk/circular-references/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/client-side-params/.fern/metadata.json
+++ b/seed/rust-sdk/client-side-params/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/client-side-params/src/core/http_client.rs
+++ b/seed/rust-sdk/client-side-params/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/client-side-params/src/core/mod.rs
+++ b/seed/rust-sdk/client-side-params/src/core/mod.rs
@@ -3,12 +3,14 @@
 pub mod flexible_datetime;
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/client-side-params/src/core/pagination.rs
+++ b/seed/rust-sdk/client-side-params/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/content-type/.fern/metadata.json
+++ b/seed/rust-sdk/content-type/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/content-type/src/core/http_client.rs
+++ b/seed/rust-sdk/content-type/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/content-type/src/core/mod.rs
+++ b/seed/rust-sdk/content-type/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/content-type/src/core/pagination.rs
+++ b/seed/rust-sdk/content-type/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/cross-package-type-names/.fern/metadata.json
+++ b/seed/rust-sdk/cross-package-type-names/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/cross-package-type-names/src/core/mod.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/cross-package-type-names/src/core/pagination.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/dollar-string-examples/.fern/metadata.json
+++ b/seed/rust-sdk/dollar-string-examples/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/dollar-string-examples/src/core/mod.rs
+++ b/seed/rust-sdk/dollar-string-examples/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/dollar-string-examples/src/core/pagination.rs
+++ b/seed/rust-sdk/dollar-string-examples/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/empty-clients/.fern/metadata.json
+++ b/seed/rust-sdk/empty-clients/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/empty-clients/src/core/http_client.rs
+++ b/seed/rust-sdk/empty-clients/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/empty-clients/src/core/mod.rs
+++ b/seed/rust-sdk/empty-clients/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/empty-clients/src/core/pagination.rs
+++ b/seed/rust-sdk/empty-clients/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/endpoint-security-auth/.fern/metadata.json
+++ b/seed/rust-sdk/endpoint-security-auth/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/endpoint-security-auth/src/core/mod.rs
+++ b/seed/rust-sdk/endpoint-security-auth/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/endpoint-security-auth/src/core/pagination.rs
+++ b/seed/rust-sdk/endpoint-security-auth/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/enum/.fern/metadata.json
+++ b/seed/rust-sdk/enum/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/enum/src/core/http_client.rs
+++ b/seed/rust-sdk/enum/src/core/http_client.rs
@@ -2,8 +2,8 @@ use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions
 use base64::Engine;
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 use serde::de::Error as SerdeError;
@@ -240,6 +240,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     /// Execute a multipart/form-data request with the given method, path, and options

--- a/seed/rust-sdk/enum/src/core/mod.rs
+++ b/seed/rust-sdk/enum/src/core/mod.rs
@@ -3,12 +3,14 @@
 pub mod base64_bytes;
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/enum/src/core/pagination.rs
+++ b/seed/rust-sdk/enum/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/error-property/.fern/metadata.json
+++ b/seed/rust-sdk/error-property/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/error-property/src/core/http_client.rs
+++ b/seed/rust-sdk/error-property/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/error-property/src/core/mod.rs
+++ b/seed/rust-sdk/error-property/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/error-property/src/core/pagination.rs
+++ b/seed/rust-sdk/error-property/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/errors/.fern/metadata.json
+++ b/seed/rust-sdk/errors/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/errors/src/core/http_client.rs
+++ b/seed/rust-sdk/errors/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/errors/src/core/mod.rs
+++ b/seed/rust-sdk/errors/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/errors/src/core/pagination.rs
+++ b/seed/rust-sdk/errors/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/examples/no-custom-config/.fern/metadata.json
+++ b/seed/rust-sdk/examples/no-custom-config/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
@@ -2,8 +2,8 @@ use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions
 use base64::Engine;
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 use serde::de::Error as SerdeError;
@@ -240,6 +240,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/examples/no-custom-config/src/core/mod.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/core/mod.rs
@@ -5,12 +5,14 @@ pub mod flexible_datetime;
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/examples/no-custom-config/src/core/pagination.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/examples/readme-config/.fern/metadata.json
+++ b/seed/rust-sdk/examples/readme-config/.fern/metadata.json
@@ -17,8 +17,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
@@ -2,8 +2,8 @@ use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions
 use base64::Engine;
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 use serde::de::Error as SerdeError;
@@ -240,6 +240,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/examples/readme-config/src/core/mod.rs
+++ b/seed/rust-sdk/examples/readme-config/src/core/mod.rs
@@ -5,12 +5,14 @@ pub mod flexible_datetime;
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/examples/readme-config/src/core/pagination.rs
+++ b/seed/rust-sdk/examples/readme-config/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/exhaustive/.fern/metadata.json
+++ b/seed/rust-sdk/exhaustive/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/exhaustive/src/api/resources/endpoints/pagination/endpoints_pagination.rs
+++ b/seed/rust-sdk/exhaustive/src/api/resources/endpoints/pagination/endpoints_pagination.rs
@@ -1,5 +1,8 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{
+    ApiError, AsyncPaginator, ClientConfig, HttpClient, PaginationResult, QueryBuilder,
+    RequestOptions,
+};
 use reqwest::Method;
 
 pub struct PaginationClient {
@@ -41,5 +44,73 @@ impl PaginationClient {
                 options,
             )
             .await
+    }
+
+    pub async fn list_items_paginated(
+        &self,
+        request: &ListItemsQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = QueryBuilder::new()
+            .int("limit", request.limit.clone())
+            .build();
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("cursor".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/pagination",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("items")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("next")
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
     }
 }

--- a/seed/rust-sdk/exhaustive/src/core/http_client.rs
+++ b/seed/rust-sdk/exhaustive/src/core/http_client.rs
@@ -2,8 +2,8 @@ use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions
 use base64::Engine;
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 use serde::de::Error as SerdeError;
@@ -240,6 +240,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     /// Execute a request with a raw bytes body (application/octet-stream).

--- a/seed/rust-sdk/exhaustive/src/core/mod.rs
+++ b/seed/rust-sdk/exhaustive/src/core/mod.rs
@@ -6,12 +6,14 @@ pub mod flexible_datetime;
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/exhaustive/src/core/pagination.rs
+++ b/seed/rust-sdk/exhaustive/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/extends/.fern/metadata.json
+++ b/seed/rust-sdk/extends/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/extends/src/core/http_client.rs
+++ b/seed/rust-sdk/extends/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/extends/src/core/mod.rs
+++ b/seed/rust-sdk/extends/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/extends/src/core/pagination.rs
+++ b/seed/rust-sdk/extends/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/extra-properties/.fern/metadata.json
+++ b/seed/rust-sdk/extra-properties/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/extra-properties/src/core/http_client.rs
+++ b/seed/rust-sdk/extra-properties/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/extra-properties/src/core/mod.rs
+++ b/seed/rust-sdk/extra-properties/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/extra-properties/src/core/pagination.rs
+++ b/seed/rust-sdk/extra-properties/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/file-download/.fern/metadata.json
+++ b/seed/rust-sdk/file-download/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/file-download/src/core/http_client.rs
+++ b/seed/rust-sdk/file-download/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/file-download/src/core/mod.rs
+++ b/seed/rust-sdk/file-download/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/file-download/src/core/pagination.rs
+++ b/seed/rust-sdk/file-download/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/file-upload-openapi/.fern/metadata.json
+++ b/seed/rust-sdk/file-upload-openapi/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
@@ -2,8 +2,8 @@ use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions
 use base64::Engine;
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 use serde::de::Error as SerdeError;
@@ -240,6 +240,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     /// Execute a multipart/form-data request with the given method, path, and options

--- a/seed/rust-sdk/file-upload-openapi/src/core/mod.rs
+++ b/seed/rust-sdk/file-upload-openapi/src/core/mod.rs
@@ -3,12 +3,14 @@
 pub mod base64_bytes;
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/file-upload-openapi/src/core/pagination.rs
+++ b/seed/rust-sdk/file-upload-openapi/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/file-upload/.fern/metadata.json
+++ b/seed/rust-sdk/file-upload/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/file-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload/src/core/http_client.rs
@@ -2,8 +2,8 @@ use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions
 use base64::Engine;
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 use serde::de::Error as SerdeError;
@@ -240,6 +240,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     /// Execute a multipart/form-data request with the given method, path, and options

--- a/seed/rust-sdk/file-upload/src/core/mod.rs
+++ b/seed/rust-sdk/file-upload/src/core/mod.rs
@@ -3,12 +3,14 @@
 pub mod base64_bytes;
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/file-upload/src/core/pagination.rs
+++ b/seed/rust-sdk/file-upload/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/folders/.fern/metadata.json
+++ b/seed/rust-sdk/folders/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/folders/src/core/http_client.rs
+++ b/seed/rust-sdk/folders/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/folders/src/core/mod.rs
+++ b/seed/rust-sdk/folders/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/folders/src/core/pagination.rs
+++ b/seed/rust-sdk/folders/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/header-auth-environment-variable/.fern/metadata.json
+++ b/seed/rust-sdk/header-auth-environment-variable/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/header-auth-environment-variable/src/core/mod.rs
+++ b/seed/rust-sdk/header-auth-environment-variable/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/header-auth-environment-variable/src/core/pagination.rs
+++ b/seed/rust-sdk/header-auth-environment-variable/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/header-auth/.fern/metadata.json
+++ b/seed/rust-sdk/header-auth/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/header-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/header-auth/src/core/mod.rs
+++ b/seed/rust-sdk/header-auth/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/header-auth/src/core/pagination.rs
+++ b/seed/rust-sdk/header-auth/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/http-head/.fern/metadata.json
+++ b/seed/rust-sdk/http-head/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/http-head/src/core/http_client.rs
+++ b/seed/rust-sdk/http-head/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/http-head/src/core/mod.rs
+++ b/seed/rust-sdk/http-head/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/http-head/src/core/pagination.rs
+++ b/seed/rust-sdk/http-head/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/idempotency-headers/.fern/metadata.json
+++ b/seed/rust-sdk/idempotency-headers/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/idempotency-headers/src/core/mod.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/idempotency-headers/src/core/pagination.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/imdb/imdb-custom-config/.fern/metadata.json
+++ b/seed/rust-sdk/imdb/imdb-custom-config/.fern/metadata.json
@@ -14,8 +14,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/imdb/imdb-custom-config/src/core/mod.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-config/src/core/mod.rs
@@ -3,12 +3,14 @@
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/imdb/imdb-custom-config/src/core/pagination.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-config/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/imdb/imdb-custom-features/.fern/metadata.json
+++ b/seed/rust-sdk/imdb/imdb-custom-features/.fern/metadata.json
@@ -19,8 +19,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/imdb/imdb-custom-features/src/core/mod.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-features/src/core/mod.rs
@@ -3,12 +3,14 @@
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/imdb/imdb-custom-features/src/core/pagination.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-features/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/imdb/imdb/.fern/metadata.json
+++ b/seed/rust-sdk/imdb/imdb/.fern/metadata.json
@@ -8,8 +8,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/imdb/imdb/src/core/mod.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/mod.rs
@@ -3,12 +3,14 @@
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/imdb/imdb/src/core/pagination.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/inferred-auth-explicit/.fern/metadata.json
+++ b/seed/rust-sdk/inferred-auth-explicit/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/mod.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/pagination.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
+++ b/seed/rust-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/mod.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/pagination.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/mod.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/pagination.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/inferred-auth-implicit-reference/.fern/metadata.json
+++ b/seed/rust-sdk/inferred-auth-implicit-reference/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/inferred-auth-implicit-reference/src/core/mod.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-reference/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/inferred-auth-implicit-reference/src/core/pagination.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-reference/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/inferred-auth-implicit/.fern/metadata.json
+++ b/seed/rust-sdk/inferred-auth-implicit/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/mod.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/pagination.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/license/basic/.fern/metadata.json
+++ b/seed/rust-sdk/license/basic/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/license/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/license/basic/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/license/basic/src/core/mod.rs
+++ b/seed/rust-sdk/license/basic/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/license/basic/src/core/pagination.rs
+++ b/seed/rust-sdk/license/basic/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/license/both-license-options/.fern/metadata.json
+++ b/seed/rust-sdk/license/both-license-options/.fern/metadata.json
@@ -8,8 +8,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
+++ b/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/license/both-license-options/src/core/mod.rs
+++ b/seed/rust-sdk/license/both-license-options/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/license/both-license-options/src/core/pagination.rs
+++ b/seed/rust-sdk/license/both-license-options/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/license/custom-license-file/.fern/metadata.json
+++ b/seed/rust-sdk/license/custom-license-file/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/license/custom-license-file/src/core/mod.rs
+++ b/seed/rust-sdk/license/custom-license-file/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/license/custom-license-file/src/core/pagination.rs
+++ b/seed/rust-sdk/license/custom-license-file/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/license/empty-license-file/.fern/metadata.json
+++ b/seed/rust-sdk/license/empty-license-file/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/license/empty-license-file/src/core/mod.rs
+++ b/seed/rust-sdk/license/empty-license-file/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/license/empty-license-file/src/core/pagination.rs
+++ b/seed/rust-sdk/license/empty-license-file/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/literal/.fern/metadata.json
+++ b/seed/rust-sdk/literal/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/literal/src/core/http_client.rs
+++ b/seed/rust-sdk/literal/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/literal/src/core/mod.rs
+++ b/seed/rust-sdk/literal/src/core/mod.rs
@@ -3,12 +3,14 @@
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/literal/src/core/pagination.rs
+++ b/seed/rust-sdk/literal/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/literals-unions/.fern/metadata.json
+++ b/seed/rust-sdk/literals-unions/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/literals-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/literals-unions/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/literals-unions/src/core/mod.rs
+++ b/seed/rust-sdk/literals-unions/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/literals-unions/src/core/pagination.rs
+++ b/seed/rust-sdk/literals-unions/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/mixed-case/.fern/metadata.json
+++ b/seed/rust-sdk/mixed-case/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/mixed-case/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-case/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/mixed-case/src/core/mod.rs
+++ b/seed/rust-sdk/mixed-case/src/core/mod.rs
@@ -3,12 +3,14 @@
 pub mod flexible_datetime;
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/mixed-case/src/core/pagination.rs
+++ b/seed/rust-sdk/mixed-case/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/mixed-file-directory/.fern/metadata.json
+++ b/seed/rust-sdk/mixed-file-directory/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/mixed-file-directory/src/core/mod.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/mixed-file-directory/src/core/pagination.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/multi-line-docs/.fern/metadata.json
+++ b/seed/rust-sdk/multi-line-docs/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/multi-line-docs/src/core/mod.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/multi-line-docs/src/core/pagination.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/multi-url-environment-no-default/.fern/metadata.json
+++ b/seed/rust-sdk/multi-url-environment-no-default/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/mod.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/pagination.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/multi-url-environment-reference/.fern/metadata.json
+++ b/seed/rust-sdk/multi-url-environment-reference/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/multi-url-environment-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-reference/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/multi-url-environment-reference/src/core/mod.rs
+++ b/seed/rust-sdk/multi-url-environment-reference/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/multi-url-environment-reference/src/core/pagination.rs
+++ b/seed/rust-sdk/multi-url-environment-reference/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/multi-url-environment/.fern/metadata.json
+++ b/seed/rust-sdk/multi-url-environment/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/multi-url-environment/src/core/mod.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/multi-url-environment/src/core/pagination.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/multiple-request-bodies/.fern/metadata.json
+++ b/seed/rust-sdk/multiple-request-bodies/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     /// Execute a request with a raw bytes body (application/octet-stream).

--- a/seed/rust-sdk/multiple-request-bodies/src/core/mod.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/multiple-request-bodies/src/core/pagination.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/no-content-response/.fern/metadata.json
+++ b/seed/rust-sdk/no-content-response/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/no-content-response/src/core/http_client.rs
+++ b/seed/rust-sdk/no-content-response/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/no-content-response/src/core/mod.rs
+++ b/seed/rust-sdk/no-content-response/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/no-content-response/src/core/pagination.rs
+++ b/seed/rust-sdk/no-content-response/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/no-environment/.fern/metadata.json
+++ b/seed/rust-sdk/no-environment/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/no-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/no-environment/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/no-environment/src/core/mod.rs
+++ b/seed/rust-sdk/no-environment/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/no-environment/src/core/pagination.rs
+++ b/seed/rust-sdk/no-environment/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/no-retries/.fern/metadata.json
+++ b/seed/rust-sdk/no-retries/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/no-retries/src/core/http_client.rs
+++ b/seed/rust-sdk/no-retries/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/no-retries/src/core/mod.rs
+++ b/seed/rust-sdk/no-retries/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/no-retries/src/core/pagination.rs
+++ b/seed/rust-sdk/no-retries/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/null-type/.fern/metadata.json
+++ b/seed/rust-sdk/null-type/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/null-type/src/core/http_client.rs
+++ b/seed/rust-sdk/null-type/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/null-type/src/core/mod.rs
+++ b/seed/rust-sdk/null-type/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/null-type/src/core/pagination.rs
+++ b/seed/rust-sdk/null-type/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/nullable-allof-extends/.fern/metadata.json
+++ b/seed/rust-sdk/nullable-allof-extends/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/nullable-allof-extends/src/core/mod.rs
+++ b/seed/rust-sdk/nullable-allof-extends/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/nullable-allof-extends/src/core/pagination.rs
+++ b/seed/rust-sdk/nullable-allof-extends/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/nullable-optional/.fern/metadata.json
+++ b/seed/rust-sdk/nullable-optional/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/nullable-optional/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/nullable-optional/src/core/mod.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/mod.rs
@@ -3,12 +3,14 @@
 pub mod flexible_datetime;
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/nullable-optional/src/core/pagination.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/nullable-request-body/.fern/metadata.json
+++ b/seed/rust-sdk/nullable-request-body/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/nullable-request-body/src/core/mod.rs
+++ b/seed/rust-sdk/nullable-request-body/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/nullable-request-body/src/core/pagination.rs
+++ b/seed/rust-sdk/nullable-request-body/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/nullable/.fern/metadata.json
+++ b/seed/rust-sdk/nullable/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/nullable/src/core/mod.rs
+++ b/seed/rust-sdk/nullable/src/core/mod.rs
@@ -4,12 +4,14 @@ pub mod flexible_datetime;
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/nullable/src/core/pagination.rs
+++ b/seed/rust-sdk/nullable/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/oauth-client-credentials-custom/.fern/metadata.json
+++ b/seed/rust-sdk/oauth-client-credentials-custom/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/pagination.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/oauth-client-credentials-default/.fern/metadata.json
+++ b/seed/rust-sdk/oauth-client-credentials-default/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/pagination.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/pagination.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/oauth-client-credentials-mandatory-auth/.fern/metadata.json
+++ b/seed/rust-sdk/oauth-client-credentials-mandatory-auth/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/pagination.rs
+++ b/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/pagination.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/oauth-client-credentials-openapi/.fern/metadata.json
+++ b/seed/rust-sdk/oauth-client-credentials-openapi/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/oauth-client-credentials-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-openapi/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/oauth-client-credentials-openapi/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-openapi/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/oauth-client-credentials-openapi/src/core/pagination.rs
+++ b/seed/rust-sdk/oauth-client-credentials-openapi/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/oauth-client-credentials-reference/.fern/metadata.json
+++ b/seed/rust-sdk/oauth-client-credentials-reference/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/oauth-client-credentials-reference/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-reference/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/oauth-client-credentials-reference/src/core/pagination.rs
+++ b/seed/rust-sdk/oauth-client-credentials-reference/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/pagination.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/oauth-client-credentials/.fern/metadata.json
+++ b/seed/rust-sdk/oauth-client-credentials/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/oauth-client-credentials/src/core/mod.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/oauth-client-credentials/src/core/pagination.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/object/.fern/metadata.json
+++ b/seed/rust-sdk/object/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/object/src/core/http_client.rs
+++ b/seed/rust-sdk/object/src/core/http_client.rs
@@ -2,8 +2,8 @@ use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions
 use base64::Engine;
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 use serde::de::Error as SerdeError;
@@ -240,6 +240,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/object/src/core/mod.rs
+++ b/seed/rust-sdk/object/src/core/mod.rs
@@ -6,12 +6,14 @@ pub mod flexible_datetime;
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/object/src/core/pagination.rs
+++ b/seed/rust-sdk/object/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/objects-with-imports/.fern/metadata.json
+++ b/seed/rust-sdk/objects-with-imports/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/objects-with-imports/src/core/mod.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/objects-with-imports/src/core/pagination.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/optional/.fern/metadata.json
+++ b/seed/rust-sdk/optional/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/optional/src/core/http_client.rs
+++ b/seed/rust-sdk/optional/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/optional/src/core/mod.rs
+++ b/seed/rust-sdk/optional/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/optional/src/core/pagination.rs
+++ b/seed/rust-sdk/optional/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/package-yml/.fern/metadata.json
+++ b/seed/rust-sdk/package-yml/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/package-yml/src/core/http_client.rs
+++ b/seed/rust-sdk/package-yml/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/package-yml/src/core/mod.rs
+++ b/seed/rust-sdk/package-yml/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/package-yml/src/core/pagination.rs
+++ b/seed/rust-sdk/package-yml/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/pagination-custom/.fern/metadata.json
+++ b/seed/rust-sdk/pagination-custom/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/pagination-custom/src/api/resources/users/users.rs
+++ b/seed/rust-sdk/pagination-custom/src/api/resources/users/users.rs
@@ -1,5 +1,8 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{
+    ApiError, AsyncPaginator, ClientConfig, HttpClient, PaginationResult, QueryBuilder,
+    RequestOptions,
+};
 use reqwest::Method;
 
 pub struct UsersClient {
@@ -30,5 +33,70 @@ impl UsersClient {
                 options,
             )
             .await
+    }
+
+    pub async fn list_with_custom_pager_paginated(
+        &self,
+        request: &ListWithCustomPagerQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = QueryBuilder::new()
+            .int("limit", request.limit.clone())
+            .string("starting_after", request.starting_after.clone())
+            .build();
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let query_params = base_query_params.clone();
+                let options_for_request = options_clone.clone();
+                // Custom pagination logic would go here
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/users",
+                            None,
+                            query_params,
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Custom extraction logic would go here
+                    // Generic extraction for custom pagination - tries common field names
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .or_else(|| response.get("results"))
+                        .or_else(|| response.get("items"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = None;
+                    let has_next_page = false; // Custom pagination requires manual implementation
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None,
+        )
     }
 }

--- a/seed/rust-sdk/pagination-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/pagination-custom/src/core/mod.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/pagination-custom/src/core/pagination.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/pagination-uri-path/.fern/metadata.json
+++ b/seed/rust-sdk/pagination-uri-path/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/pagination-uri-path/src/api/resources/users/users.rs
+++ b/seed/rust-sdk/pagination-uri-path/src/api/resources/users/users.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, AsyncPaginator, ClientConfig, HttpClient, PaginationResult, RequestOptions};
 use reqwest::Method;
 
 pub struct UsersClient {
@@ -22,6 +22,65 @@ impl UsersClient {
             .await
     }
 
+    pub async fn list_with_uri_pagination_paginated(
+        &self,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let query_params = base_query_params.clone();
+                let options_for_request = options_clone.clone();
+                // Custom pagination logic would go here
+
+                // Clone captured variables to move into the async block
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/users/uri",
+                            None,
+                            query_params,
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Custom extraction logic would go here
+                    // Generic extraction for custom pagination - tries common field names
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .or_else(|| response.get("results"))
+                        .or_else(|| response.get("items"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = None;
+                    let has_next_page = false; // Custom pagination requires manual implementation
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None,
+        )
+    }
+
     pub async fn list_with_path_pagination(
         &self,
         options: Option<RequestOptions>,
@@ -29,5 +88,64 @@ impl UsersClient {
         self.http_client
             .execute_request(Method::GET, "/users/path", None, None, options)
             .await
+    }
+
+    pub async fn list_with_path_pagination_paginated(
+        &self,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let query_params = base_query_params.clone();
+                let options_for_request = options_clone.clone();
+                // Custom pagination logic would go here
+
+                // Clone captured variables to move into the async block
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/users/path",
+                            None,
+                            query_params,
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Custom extraction logic would go here
+                    // Generic extraction for custom pagination - tries common field names
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .or_else(|| response.get("results"))
+                        .or_else(|| response.get("items"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = None;
+                    let has_next_page = false; // Custom pagination requires manual implementation
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None,
+        )
     }
 }

--- a/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/pagination-uri-path/src/core/mod.rs
+++ b/seed/rust-sdk/pagination-uri-path/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/pagination-uri-path/src/core/pagination.rs
+++ b/seed/rust-sdk/pagination-uri-path/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/pagination/.fern/metadata.json
+++ b/seed/rust-sdk/pagination/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/pagination/src/api/resources/complex/complex.rs
+++ b/seed/rust-sdk/pagination/src/api/resources/complex/complex.rs
@@ -1,5 +1,5 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, RequestOptions};
+use crate::{ApiError, AsyncPaginator, ClientConfig, HttpClient, PaginationResult, RequestOptions};
 use reqwest::Method;
 
 pub struct ComplexClient {
@@ -28,5 +28,76 @@ impl ComplexClient {
                 options,
             )
             .await
+    }
+
+    pub async fn search_paginated(
+        &self,
+        index: &str,
+        request: &SearchRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let index_clone = index.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("starting_after".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let index_for_async = index_clone.clone();
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::POST,
+                            &format!("{}/conversations/search", index),
+                            Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("conversations")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("pages")
+                        .and_then(|v| v.get("next"))
+                        .and_then(|v| v.get("starting_after"))
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
     }
 }

--- a/seed/rust-sdk/pagination/src/api/resources/inline_users/inline_users/inline_users_inline_users.rs
+++ b/seed/rust-sdk/pagination/src/api/resources/inline_users/inline_users/inline_users_inline_users.rs
@@ -1,5 +1,8 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{
+    ApiError, AsyncPaginator, ClientConfig, HttpClient, PaginationResult, QueryBuilder,
+    RequestOptions,
+};
 use reqwest::Method;
 
 pub struct InlineUsersClient2 {
@@ -34,6 +37,79 @@ impl InlineUsersClient2 {
             .await
     }
 
+    pub async fn list_with_cursor_pagination_paginated(
+        &self,
+        request: &InlineUsersInlineUsersListWithCursorPaginationQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = QueryBuilder::new()
+            .int("page", request.page.clone())
+            .int("per_page", request.per_page.clone())
+            .serialize("order", request.order.clone())
+            .build();
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("starting_after".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/inline-users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.get("users"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("page")
+                        .and_then(|v| v.get("next"))
+                        .and_then(|v| v.get("starting_after"))
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
+    }
+
     pub async fn list_with_mixed_type_cursor_pagination(
         &self,
         request: &InlineUsersInlineUsersListWithMixedTypeCursorPaginationQueryRequest,
@@ -52,6 +128,73 @@ impl InlineUsersClient2 {
             .await
     }
 
+    pub async fn list_with_mixed_type_cursor_pagination_paginated(
+        &self,
+        request: &InlineUsersInlineUsersListWithMixedTypeCursorPaginationQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("cursor".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::POST,
+                            "/inline-users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.get("users"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("next")
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
+    }
+
     pub async fn list_with_body_cursor_pagination(
         &self,
         request: &ListUsersBodyCursorPaginationRequest,
@@ -66,6 +209,75 @@ impl InlineUsersClient2 {
                 options,
             )
             .await
+    }
+
+    pub async fn list_with_body_cursor_pagination_paginated(
+        &self,
+        request: &ListUsersBodyCursorPaginationRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("cursor".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::POST,
+                            "/inline-users",
+                            Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.get("users"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("page")
+                        .and_then(|v| v.get("next"))
+                        .and_then(|v| v.get("starting_after"))
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
     }
 
     pub async fn list_with_offset_pagination(
@@ -89,6 +301,87 @@ impl InlineUsersClient2 {
             .await
     }
 
+    pub async fn list_with_offset_pagination_paginated(
+        &self,
+        request: &InlineUsersInlineUsersListWithOffsetPaginationQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = QueryBuilder::new()
+            .int("per_page", request.per_page.clone())
+            .serialize("order", request.order.clone())
+            .string("starting_after", request.starting_after.clone())
+            .build();
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, page_token| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+
+                // Use page_token as offset/page number (start from 0 if None)
+                let current_page = page_token.unwrap_or_else(|| "0".to_string());
+                query_params.push(("page".to_string(), current_page.clone()));
+
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/inline-users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction for offset pagination
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.get("users"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let has_next_page = !items.is_empty();
+                    // Calculate next page number for offset pagination
+                    let next_cursor: Option<String> = if has_next_page {
+                        let current_page_num: u64 = current_page.parse().unwrap_or(0);
+                        let step_size = if let Some(step) = response.get("per_page") {
+                            step.as_u64().unwrap_or(1)
+                        } else {
+                            1 // Default step size
+                        };
+                        Some((current_page_num + step_size).to_string())
+                    } else {
+                        None
+                    };
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with page 0
+        )
+    }
+
     pub async fn list_with_double_offset_pagination(
         &self,
         request: &InlineUsersInlineUsersListWithDoubleOffsetPaginationQueryRequest,
@@ -110,6 +403,87 @@ impl InlineUsersClient2 {
             .await
     }
 
+    pub async fn list_with_double_offset_pagination_paginated(
+        &self,
+        request: &InlineUsersInlineUsersListWithDoubleOffsetPaginationQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = QueryBuilder::new()
+            .float("per_page", request.per_page.clone())
+            .serialize("order", request.order.clone())
+            .string("starting_after", request.starting_after.clone())
+            .build();
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, page_token| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+
+                // Use page_token as offset/page number (start from 0 if None)
+                let current_page = page_token.unwrap_or_else(|| "0".to_string());
+                query_params.push(("page".to_string(), current_page.clone()));
+
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/inline-users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction for offset pagination
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.get("users"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let has_next_page = !items.is_empty();
+                    // Calculate next page number for offset pagination
+                    let next_cursor: Option<String> = if has_next_page {
+                        let current_page_num: u64 = current_page.parse().unwrap_or(0);
+                        let step_size = if let Some(step) = response.get("per_page") {
+                            step.as_u64().unwrap_or(1)
+                        } else {
+                            1 // Default step size
+                        };
+                        Some((current_page_num + step_size).to_string())
+                    } else {
+                        None
+                    };
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with page 0
+        )
+    }
+
     pub async fn list_with_body_offset_pagination(
         &self,
         request: &ListUsersBodyOffsetPaginationRequest,
@@ -124,6 +498,83 @@ impl InlineUsersClient2 {
                 options,
             )
             .await
+    }
+
+    pub async fn list_with_body_offset_pagination_paginated(
+        &self,
+        request: &ListUsersBodyOffsetPaginationRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, page_token| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+
+                // Use page_token as offset/page number (start from 0 if None)
+                let current_page = page_token.unwrap_or_else(|| "0".to_string());
+                query_params.push(("page".to_string(), current_page.clone()));
+
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::POST,
+                            "/inline-users",
+                            Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction for offset pagination
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.get("users"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let has_next_page = !items.is_empty();
+                    // Calculate next page number for offset pagination
+                    let next_cursor: Option<String> = if has_next_page {
+                        let current_page_num: u64 = current_page.parse().unwrap_or(0);
+                        let step_size = if let Some(step) = response.get("per_page") {
+                            step.as_u64().unwrap_or(1)
+                        } else {
+                            1 // Default step size
+                        };
+                        Some((current_page_num + step_size).to_string())
+                    } else {
+                        None
+                    };
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with page 0
+        )
     }
 
     pub async fn list_with_offset_step_pagination(
@@ -146,6 +597,85 @@ impl InlineUsersClient2 {
             .await
     }
 
+    pub async fn list_with_offset_step_pagination_paginated(
+        &self,
+        request: &InlineUsersInlineUsersListWithOffsetStepPaginationQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = QueryBuilder::new()
+            .serialize("order", request.order.clone())
+            .build();
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, page_token| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+
+                // Use page_token as offset/page number (start from 0 if None)
+                let current_page = page_token.unwrap_or_else(|| "0".to_string());
+                query_params.push(("page".to_string(), current_page.clone()));
+
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/inline-users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction for offset pagination
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.get("users"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let has_next_page = !items.is_empty();
+                    // Calculate next page number for offset pagination
+                    let next_cursor: Option<String> = if has_next_page {
+                        let current_page_num: u64 = current_page.parse().unwrap_or(0);
+                        let step_size = if let Some(step) = response.get("limit") {
+                            step.as_u64().unwrap_or(1)
+                        } else {
+                            1 // Default step size
+                        };
+                        Some((current_page_num + step_size).to_string())
+                    } else {
+                        None
+                    };
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with page 0
+        )
+    }
+
     pub async fn list_with_offset_pagination_has_next_page(
         &self,
         request: &InlineUsersInlineUsersListWithOffsetPaginationHasNextPageQueryRequest,
@@ -166,6 +696,88 @@ impl InlineUsersClient2 {
             .await
     }
 
+    pub async fn list_with_offset_pagination_has_next_page_paginated(
+        &self,
+        request: &InlineUsersInlineUsersListWithOffsetPaginationHasNextPageQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = QueryBuilder::new()
+            .serialize("order", request.order.clone())
+            .build();
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, page_token| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+
+                // Use page_token as offset/page number (start from 0 if None)
+                let current_page = page_token.unwrap_or_else(|| "0".to_string());
+                query_params.push(("page".to_string(), current_page.clone()));
+
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/inline-users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction for offset pagination
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.get("users"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let has_next_page = response
+                        .get("hasNextPage")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(!items.is_empty());
+                    // Calculate next page number for offset pagination
+                    let next_cursor: Option<String> = if has_next_page {
+                        let current_page_num: u64 = current_page.parse().unwrap_or(0);
+                        let step_size = if let Some(step) = response.get("limit") {
+                            step.as_u64().unwrap_or(1)
+                        } else {
+                            1 // Default step size
+                        };
+                        Some((current_page_num + step_size).to_string())
+                    } else {
+                        None
+                    };
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with page 0
+        )
+    }
+
     pub async fn list_with_extended_results(
         &self,
         request: &InlineUsersInlineUsersListWithExtendedResultsQueryRequest,
@@ -182,6 +794,73 @@ impl InlineUsersClient2 {
                 options,
             )
             .await
+    }
+
+    pub async fn list_with_extended_results_paginated(
+        &self,
+        request: &InlineUsersInlineUsersListWithExtendedResultsQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("cursor".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/inline-users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.get("users"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("next")
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
     }
 
     pub async fn list_with_extended_results_and_optional_data(
@@ -202,6 +881,73 @@ impl InlineUsersClient2 {
             .await
     }
 
+    pub async fn list_with_extended_results_and_optional_data_paginated(
+        &self,
+        request: &InlineUsersInlineUsersListWithExtendedResultsAndOptionalDataQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("cursor".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/inline-users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.get("users"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("next")
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
+    }
+
     pub async fn list_usernames(
         &self,
         request: &InlineUsersInlineUsersListUsernamesQueryRequest,
@@ -220,6 +966,74 @@ impl InlineUsersClient2 {
             .await
     }
 
+    pub async fn list_usernames_paginated(
+        &self,
+        request: &InlineUsersInlineUsersListUsernamesQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("starting_after".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/inline-users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("cursor")
+                        .and_then(|v| v.get("data"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("cursor")
+                        .and_then(|v| v.get("after"))
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
+    }
+
     pub async fn list_with_global_config(
         &self,
         request: &InlineUsersInlineUsersListWithGlobalConfigQueryRequest,
@@ -236,5 +1050,81 @@ impl InlineUsersClient2 {
                 options,
             )
             .await
+    }
+
+    pub async fn list_with_global_config_paginated(
+        &self,
+        request: &InlineUsersInlineUsersListWithGlobalConfigQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, page_token| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+
+                // Use page_token as offset/page number (start from 0 if None)
+                let current_page = page_token.unwrap_or_else(|| "0".to_string());
+                query_params.push(("offset".to_string(), current_page.clone()));
+
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/inline-users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction for offset pagination
+                    let items: Vec<serde_json::Value> = response
+                        .get("results")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let has_next_page = !items.is_empty();
+                    // Calculate next page number for offset pagination
+                    let next_cursor: Option<String> = if has_next_page {
+                        let current_page_num: u64 = current_page.parse().unwrap_or(0);
+                        let step_size = if let Some(step) = response.get("per_page") {
+                            step.as_u64().unwrap_or(1)
+                        } else {
+                            1 // Default step size
+                        };
+                        Some((current_page_num + step_size).to_string())
+                    } else {
+                        None
+                    };
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with page 0
+        )
     }
 }

--- a/seed/rust-sdk/pagination/src/api/resources/users/users.rs
+++ b/seed/rust-sdk/pagination/src/api/resources/users/users.rs
@@ -1,5 +1,8 @@
 use crate::api::*;
-use crate::{ApiError, ClientConfig, HttpClient, QueryBuilder, RequestOptions};
+use crate::{
+    ApiError, AsyncPaginator, ClientConfig, HttpClient, PaginationResult, QueryBuilder,
+    RequestOptions,
+};
 use reqwest::Method;
 
 pub struct UsersClient {
@@ -34,6 +37,78 @@ impl UsersClient {
             .await
     }
 
+    pub async fn list_with_cursor_pagination_paginated(
+        &self,
+        request: &UsersListWithCursorPaginationQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = QueryBuilder::new()
+            .int("page", request.page.clone())
+            .int("per_page", request.per_page.clone())
+            .serialize("order", request.order.clone())
+            .build();
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("starting_after".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("page")
+                        .and_then(|v| v.get("next"))
+                        .and_then(|v| v.get("starting_after"))
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
+    }
+
     pub async fn list_with_mixed_type_cursor_pagination(
         &self,
         request: &UsersListWithMixedTypeCursorPaginationQueryRequest,
@@ -52,6 +127,72 @@ impl UsersClient {
             .await
     }
 
+    pub async fn list_with_mixed_type_cursor_pagination_paginated(
+        &self,
+        request: &UsersListWithMixedTypeCursorPaginationQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("cursor".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::POST,
+                            "/users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("next")
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
+    }
+
     pub async fn list_with_body_cursor_pagination(
         &self,
         request: &ListUsersBodyCursorPaginationRequest,
@@ -66,6 +207,74 @@ impl UsersClient {
                 options,
             )
             .await
+    }
+
+    pub async fn list_with_body_cursor_pagination_paginated(
+        &self,
+        request: &ListUsersBodyCursorPaginationRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("cursor".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::POST,
+                            "/users",
+                            Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("page")
+                        .and_then(|v| v.get("next"))
+                        .and_then(|v| v.get("starting_after"))
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
     }
 
     /// Pagination endpoint with a top-level cursor field in the request body.
@@ -95,6 +304,72 @@ impl UsersClient {
             .await
     }
 
+    pub async fn list_with_top_level_body_cursor_pagination_paginated(
+        &self,
+        request: &ListUsersTopLevelBodyCursorPaginationRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("cursor".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::POST,
+                            "/users/top-level-cursor",
+                            Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("next_cursor")
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
+    }
+
     pub async fn list_with_offset_pagination(
         &self,
         request: &UsersListWithOffsetPaginationQueryRequest,
@@ -114,6 +389,86 @@ impl UsersClient {
                 options,
             )
             .await
+    }
+
+    pub async fn list_with_offset_pagination_paginated(
+        &self,
+        request: &UsersListWithOffsetPaginationQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = QueryBuilder::new()
+            .int("per_page", request.per_page.clone())
+            .serialize("order", request.order.clone())
+            .string("starting_after", request.starting_after.clone())
+            .build();
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, page_token| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+
+                // Use page_token as offset/page number (start from 0 if None)
+                let current_page = page_token.unwrap_or_else(|| "0".to_string());
+                query_params.push(("page".to_string(), current_page.clone()));
+
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction for offset pagination
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let has_next_page = !items.is_empty();
+                    // Calculate next page number for offset pagination
+                    let next_cursor: Option<String> = if has_next_page {
+                        let current_page_num: u64 = current_page.parse().unwrap_or(0);
+                        let step_size = if let Some(step) = response.get("per_page") {
+                            step.as_u64().unwrap_or(1)
+                        } else {
+                            1 // Default step size
+                        };
+                        Some((current_page_num + step_size).to_string())
+                    } else {
+                        None
+                    };
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with page 0
+        )
     }
 
     pub async fn list_with_double_offset_pagination(
@@ -137,6 +492,86 @@ impl UsersClient {
             .await
     }
 
+    pub async fn list_with_double_offset_pagination_paginated(
+        &self,
+        request: &UsersListWithDoubleOffsetPaginationQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = QueryBuilder::new()
+            .float("per_page", request.per_page.clone())
+            .serialize("order", request.order.clone())
+            .string("starting_after", request.starting_after.clone())
+            .build();
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, page_token| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+
+                // Use page_token as offset/page number (start from 0 if None)
+                let current_page = page_token.unwrap_or_else(|| "0".to_string());
+                query_params.push(("page".to_string(), current_page.clone()));
+
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction for offset pagination
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let has_next_page = !items.is_empty();
+                    // Calculate next page number for offset pagination
+                    let next_cursor: Option<String> = if has_next_page {
+                        let current_page_num: u64 = current_page.parse().unwrap_or(0);
+                        let step_size = if let Some(step) = response.get("per_page") {
+                            step.as_u64().unwrap_or(1)
+                        } else {
+                            1 // Default step size
+                        };
+                        Some((current_page_num + step_size).to_string())
+                    } else {
+                        None
+                    };
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with page 0
+        )
+    }
+
     pub async fn list_with_body_offset_pagination(
         &self,
         request: &ListUsersBodyOffsetPaginationRequest,
@@ -151,6 +586,82 @@ impl UsersClient {
                 options,
             )
             .await
+    }
+
+    pub async fn list_with_body_offset_pagination_paginated(
+        &self,
+        request: &ListUsersBodyOffsetPaginationRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, page_token| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+
+                // Use page_token as offset/page number (start from 0 if None)
+                let current_page = page_token.unwrap_or_else(|| "0".to_string());
+                query_params.push(("page".to_string(), current_page.clone()));
+
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::POST,
+                            "/users",
+                            Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction for offset pagination
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let has_next_page = !items.is_empty();
+                    // Calculate next page number for offset pagination
+                    let next_cursor: Option<String> = if has_next_page {
+                        let current_page_num: u64 = current_page.parse().unwrap_or(0);
+                        let step_size = if let Some(step) = response.get("per_page") {
+                            step.as_u64().unwrap_or(1)
+                        } else {
+                            1 // Default step size
+                        };
+                        Some((current_page_num + step_size).to_string())
+                    } else {
+                        None
+                    };
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with page 0
+        )
     }
 
     pub async fn list_with_offset_step_pagination(
@@ -173,6 +684,84 @@ impl UsersClient {
             .await
     }
 
+    pub async fn list_with_offset_step_pagination_paginated(
+        &self,
+        request: &UsersListWithOffsetStepPaginationQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = QueryBuilder::new()
+            .serialize("order", request.order.clone())
+            .build();
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, page_token| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+
+                // Use page_token as offset/page number (start from 0 if None)
+                let current_page = page_token.unwrap_or_else(|| "0".to_string());
+                query_params.push(("page".to_string(), current_page.clone()));
+
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction for offset pagination
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let has_next_page = !items.is_empty();
+                    // Calculate next page number for offset pagination
+                    let next_cursor: Option<String> = if has_next_page {
+                        let current_page_num: u64 = current_page.parse().unwrap_or(0);
+                        let step_size = if let Some(step) = response.get("limit") {
+                            step.as_u64().unwrap_or(1)
+                        } else {
+                            1 // Default step size
+                        };
+                        Some((current_page_num + step_size).to_string())
+                    } else {
+                        None
+                    };
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with page 0
+        )
+    }
+
     pub async fn list_with_offset_pagination_has_next_page(
         &self,
         request: &UsersListWithOffsetPaginationHasNextPageQueryRequest,
@@ -193,6 +782,87 @@ impl UsersClient {
             .await
     }
 
+    pub async fn list_with_offset_pagination_has_next_page_paginated(
+        &self,
+        request: &UsersListWithOffsetPaginationHasNextPageQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = QueryBuilder::new()
+            .serialize("order", request.order.clone())
+            .build();
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, page_token| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+
+                // Use page_token as offset/page number (start from 0 if None)
+                let current_page = page_token.unwrap_or_else(|| "0".to_string());
+                query_params.push(("page".to_string(), current_page.clone()));
+
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction for offset pagination
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let has_next_page = response
+                        .get("hasNextPage")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(!items.is_empty());
+                    // Calculate next page number for offset pagination
+                    let next_cursor: Option<String> = if has_next_page {
+                        let current_page_num: u64 = current_page.parse().unwrap_or(0);
+                        let step_size = if let Some(step) = response.get("limit") {
+                            step.as_u64().unwrap_or(1)
+                        } else {
+                            1 // Default step size
+                        };
+                        Some((current_page_num + step_size).to_string())
+                    } else {
+                        None
+                    };
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with page 0
+        )
+    }
+
     pub async fn list_with_extended_results(
         &self,
         request: &UsersListWithExtendedResultsQueryRequest,
@@ -209,6 +879,73 @@ impl UsersClient {
                 options,
             )
             .await
+    }
+
+    pub async fn list_with_extended_results_paginated(
+        &self,
+        request: &UsersListWithExtendedResultsQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("cursor".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.get("users"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("next")
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
     }
 
     pub async fn list_with_extended_results_and_optional_data(
@@ -229,6 +966,73 @@ impl UsersClient {
             .await
     }
 
+    pub async fn list_with_extended_results_and_optional_data_paginated(
+        &self,
+        request: &UsersListWithExtendedResultsAndOptionalDataQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("cursor".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.get("users"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("next")
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
+    }
+
     pub async fn list_usernames(
         &self,
         request: &UsersListUsernamesQueryRequest,
@@ -245,6 +1049,74 @@ impl UsersClient {
                 options,
             )
             .await
+    }
+
+    pub async fn list_usernames_paginated(
+        &self,
+        request: &UsersListUsernamesQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("starting_after".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("cursor")
+                        .and_then(|v| v.get("data"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("cursor")
+                        .and_then(|v| v.get("after"))
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
     }
 
     pub async fn list_usernames_with_optional_response(
@@ -265,6 +1137,74 @@ impl UsersClient {
             .await
     }
 
+    pub async fn list_usernames_with_optional_response_paginated(
+        &self,
+        request: &ListUsernamesWithOptionalResponseQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("starting_after".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("cursor")
+                        .and_then(|v| v.get("data"))
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("cursor")
+                        .and_then(|v| v.get("after"))
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
+    }
+
     pub async fn list_with_global_config(
         &self,
         request: &UsersListWithGlobalConfigQueryRequest,
@@ -281,6 +1221,82 @@ impl UsersClient {
                 options,
             )
             .await
+    }
+
+    pub async fn list_with_global_config_paginated(
+        &self,
+        request: &UsersListWithGlobalConfigQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, page_token| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+
+                // Use page_token as offset/page number (start from 0 if None)
+                let current_page = page_token.unwrap_or_else(|| "0".to_string());
+                query_params.push(("offset".to_string(), current_page.clone()));
+
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/users",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction for offset pagination
+                    let items: Vec<serde_json::Value> = response
+                        .get("results")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let has_next_page = !items.is_empty();
+                    // Calculate next page number for offset pagination
+                    let next_cursor: Option<String> = if has_next_page {
+                        let current_page_num: u64 = current_page.parse().unwrap_or(0);
+                        let step_size = if let Some(step) = response.get("per_page") {
+                            step.as_u64().unwrap_or(1)
+                        } else {
+                            1 // Default step size
+                        };
+                        Some((current_page_num + step_size).to_string())
+                    } else {
+                        None
+                    };
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with page 0
+        )
     }
 
     pub async fn list_with_optional_data(
@@ -301,6 +1317,82 @@ impl UsersClient {
             .await
     }
 
+    pub async fn list_with_optional_data_paginated(
+        &self,
+        request: &ListWithOptionalDataQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = None;
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, page_token| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+
+                // Use page_token as offset/page number (start from 0 if None)
+                let current_page = page_token.unwrap_or_else(|| "0".to_string());
+                query_params.push(("page".to_string(), current_page.clone()));
+
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/users/optional-data",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction for offset pagination
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let has_next_page = !items.is_empty();
+                    // Calculate next page number for offset pagination
+                    let next_cursor: Option<String> = if has_next_page {
+                        let current_page_num: u64 = current_page.parse().unwrap_or(0);
+                        let step_size = if let Some(step) = response.get("per_page") {
+                            step.as_u64().unwrap_or(1)
+                        } else {
+                            1 // Default step size
+                        };
+                        Some((current_page_num + step_size).to_string())
+                    } else {
+                        None
+                    };
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with page 0
+        )
+    }
+
     pub async fn list_with_aliased_data(
         &self,
         request: &ListWithAliasedDataQueryRequest,
@@ -319,5 +1411,76 @@ impl UsersClient {
                 options,
             )
             .await
+    }
+
+    pub async fn list_with_aliased_data_paginated(
+        &self,
+        request: &ListWithAliasedDataQueryRequest,
+        options: Option<RequestOptions>,
+    ) -> Result<AsyncPaginator<serde_json::Value>, ApiError> {
+        let http_client = std::sync::Arc::new(self.http_client.clone());
+        let base_query_params = QueryBuilder::new()
+            .int("page", request.page.clone())
+            .int("per_page", request.per_page.clone())
+            .build();
+        let options_clone = options.clone();
+        let request_clone = request.clone();
+
+        AsyncPaginator::new(
+            http_client,
+            move |client, cursor_value| {
+                let mut query_params: Vec<(String, String)> =
+                    base_query_params.clone().unwrap_or_default();
+                if let Some(cursor) = cursor_value {
+                    // Add cursor parameter based on pagination configuration
+                    query_params.push(("starting_after".to_string(), cursor));
+                }
+                let options_for_request = options_clone.clone();
+
+                // Clone captured variables to move into the async block
+                let request_for_async = request_clone.clone();
+
+                Box::pin(async move {
+                    let (response, _status_code, _headers): (
+                        serde_json::Value,
+                        reqwest::StatusCode,
+                        reqwest::header::HeaderMap,
+                    ) = client
+                        .execute_request_returning_response(
+                            Method::GET,
+                            "/users/aliased-data",
+                            None,
+                            Some(query_params),
+                            options_for_request,
+                        )
+                        .await?;
+
+                    // Extract pagination info from response
+                    // Generic field extraction using pagination configuration
+                    let items: Vec<serde_json::Value> = response
+                        .get("data")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| arr.clone())
+                        .unwrap_or_default();
+
+                    let next_cursor: Option<String> = response
+                        .get("page")
+                        .and_then(|v| v.get("next"))
+                        .and_then(|v| v.get("starting_after"))
+                        .and_then(|v| v.as_str().map(|s| s.to_string()));
+                    let has_next_page = next_cursor.is_some();
+
+                    Ok(PaginationResult {
+                        items,
+                        next_cursor,
+                        has_next_page,
+                        response: Some(response),
+                        status_code: Some(_status_code),
+                        headers: Some(_headers),
+                    })
+                })
+            },
+            None, // Start with no cursor
+        )
     }
 }

--- a/seed/rust-sdk/pagination/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/pagination/src/core/mod.rs
+++ b/seed/rust-sdk/pagination/src/core/mod.rs
@@ -3,12 +3,14 @@
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/pagination/src/core/pagination.rs
+++ b/seed/rust-sdk/pagination/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/path-parameters/.fern/metadata.json
+++ b/seed/rust-sdk/path-parameters/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/path-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/path-parameters/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/path-parameters/src/core/mod.rs
+++ b/seed/rust-sdk/path-parameters/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/path-parameters/src/core/pagination.rs
+++ b/seed/rust-sdk/path-parameters/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/plain-text/.fern/metadata.json
+++ b/seed/rust-sdk/plain-text/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/plain-text/src/core/http_client.rs
+++ b/seed/rust-sdk/plain-text/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/plain-text/src/core/mod.rs
+++ b/seed/rust-sdk/plain-text/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/plain-text/src/core/pagination.rs
+++ b/seed/rust-sdk/plain-text/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/property-access/.fern/metadata.json
+++ b/seed/rust-sdk/property-access/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/property-access/src/core/http_client.rs
+++ b/seed/rust-sdk/property-access/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/property-access/src/core/mod.rs
+++ b/seed/rust-sdk/property-access/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/property-access/src/core/pagination.rs
+++ b/seed/rust-sdk/property-access/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/public-object/.fern/metadata.json
+++ b/seed/rust-sdk/public-object/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/public-object/src/core/http_client.rs
+++ b/seed/rust-sdk/public-object/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/public-object/src/core/mod.rs
+++ b/seed/rust-sdk/public-object/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/public-object/src/core/pagination.rs
+++ b/seed/rust-sdk/public-object/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/query-param-name-conflict/.fern/metadata.json
+++ b/seed/rust-sdk/query-param-name-conflict/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/query-param-name-conflict/src/core/http_client.rs
+++ b/seed/rust-sdk/query-param-name-conflict/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/query-param-name-conflict/src/core/mod.rs
+++ b/seed/rust-sdk/query-param-name-conflict/src/core/mod.rs
@@ -3,12 +3,14 @@
 pub mod flexible_datetime;
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/query-param-name-conflict/src/core/pagination.rs
+++ b/seed/rust-sdk/query-param-name-conflict/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/mod.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/mod.rs
@@ -3,12 +3,14 @@
 pub mod flexible_datetime;
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/pagination.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/query-parameters-openapi/.fern/metadata.json
+++ b/seed/rust-sdk/query-parameters-openapi/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/query-parameters-openapi/src/core/mod.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/mod.rs
@@ -3,12 +3,14 @@
 pub mod flexible_datetime;
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/query-parameters-openapi/src/core/pagination.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/query-parameters/.fern/metadata.json
+++ b/seed/rust-sdk/query-parameters/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/query-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters/src/core/http_client.rs
@@ -2,8 +2,8 @@ use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions
 use base64::Engine;
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 use serde::de::Error as SerdeError;
@@ -240,6 +240,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/query-parameters/src/core/mod.rs
+++ b/seed/rust-sdk/query-parameters/src/core/mod.rs
@@ -4,12 +4,14 @@ pub mod base64_bytes;
 pub mod flexible_datetime;
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/query-parameters/src/core/pagination.rs
+++ b/seed/rust-sdk/query-parameters/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/request-parameters/.fern/metadata.json
+++ b/seed/rust-sdk/request-parameters/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/request-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/request-parameters/src/core/http_client.rs
@@ -2,8 +2,8 @@ use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions
 use base64::Engine;
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 use serde::de::Error as SerdeError;
@@ -240,6 +240,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/request-parameters/src/core/mod.rs
+++ b/seed/rust-sdk/request-parameters/src/core/mod.rs
@@ -5,12 +5,14 @@ pub mod bigint_string;
 pub mod flexible_datetime;
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/request-parameters/src/core/pagination.rs
+++ b/seed/rust-sdk/request-parameters/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/required-nullable/.fern/metadata.json
+++ b/seed/rust-sdk/required-nullable/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/required-nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/required-nullable/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/required-nullable/src/core/mod.rs
+++ b/seed/rust-sdk/required-nullable/src/core/mod.rs
@@ -3,12 +3,14 @@
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/required-nullable/src/core/pagination.rs
+++ b/seed/rust-sdk/required-nullable/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/reserved-keywords/.fern/metadata.json
+++ b/seed/rust-sdk/reserved-keywords/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/reserved-keywords/src/core/mod.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/reserved-keywords/src/core/pagination.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/response-property/.fern/metadata.json
+++ b/seed/rust-sdk/response-property/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/response-property/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/response-property/src/core/mod.rs
+++ b/seed/rust-sdk/response-property/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/response-property/src/core/pagination.rs
+++ b/seed/rust-sdk/response-property/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/schemaless-request-body-examples/.fern/metadata.json
+++ b/seed/rust-sdk/schemaless-request-body-examples/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/schemaless-request-body-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/schemaless-request-body-examples/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/schemaless-request-body-examples/src/core/mod.rs
+++ b/seed/rust-sdk/schemaless-request-body-examples/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/schemaless-request-body-examples/src/core/pagination.rs
+++ b/seed/rust-sdk/schemaless-request-body-examples/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/.fern/metadata.json
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/.fern/metadata.json
@@ -9,8 +9,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/mod.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/mod.rs
@@ -2,6 +2,7 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 #[cfg(feature = "sse")]
@@ -10,6 +11,7 @@ mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 #[cfg(feature = "sse")]

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/pagination.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/server-sent-events-openapi/.fern/metadata.json
+++ b/seed/rust-sdk/server-sent-events-openapi/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/server-sent-events-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/server-sent-events-openapi/src/core/mod.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/core/mod.rs
@@ -4,6 +4,7 @@ pub mod flexible_datetime;
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 #[cfg(feature = "sse")]
@@ -12,6 +13,7 @@ mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 #[cfg(feature = "sse")]

--- a/seed/rust-sdk/server-sent-events-openapi/src/core/pagination.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/server-sent-events/with-wire-tests/.fern/metadata.json
+++ b/seed/rust-sdk/server-sent-events/with-wire-tests/.fern/metadata.json
@@ -9,8 +9,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/mod.rs
+++ b/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/mod.rs
@@ -2,6 +2,7 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 #[cfg(feature = "sse")]
@@ -10,6 +11,7 @@ mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 #[cfg(feature = "sse")]

--- a/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/pagination.rs
+++ b/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/server-url-templating/.fern/metadata.json
+++ b/seed/rust-sdk/server-url-templating/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/server-url-templating/src/core/http_client.rs
+++ b/seed/rust-sdk/server-url-templating/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/server-url-templating/src/core/mod.rs
+++ b/seed/rust-sdk/server-url-templating/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/server-url-templating/src/core/pagination.rs
+++ b/seed/rust-sdk/server-url-templating/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/simple-api/basic-custom-config/.fern/metadata.json
+++ b/seed/rust-sdk/simple-api/basic-custom-config/.fern/metadata.json
@@ -10,8 +10,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/simple-api/basic-custom-config/src/core/mod.rs
+++ b/seed/rust-sdk/simple-api/basic-custom-config/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/simple-api/basic-custom-config/src/core/pagination.rs
+++ b/seed/rust-sdk/simple-api/basic-custom-config/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/simple-api/basic/.fern/metadata.json
+++ b/seed/rust-sdk/simple-api/basic/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/simple-api/basic/src/core/mod.rs
+++ b/seed/rust-sdk/simple-api/basic/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/simple-api/basic/src/core/pagination.rs
+++ b/seed/rust-sdk/simple-api/basic/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/simple-fhir/.fern/metadata.json
+++ b/seed/rust-sdk/simple-fhir/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/simple-fhir/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/simple-fhir/src/core/mod.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/simple-fhir/src/core/pagination.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/single-url-environment-default/basic/.fern/metadata.json
+++ b/seed/rust-sdk/single-url-environment-default/basic/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/single-url-environment-default/basic/src/core/mod.rs
+++ b/seed/rust-sdk/single-url-environment-default/basic/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/single-url-environment-default/basic/src/core/pagination.rs
+++ b/seed/rust-sdk/single-url-environment-default/basic/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/.fern/metadata.json
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/.fern/metadata.json
@@ -9,8 +9,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/mod.rs
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/pagination.rs
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/single-url-environment-default/full-custom/.fern/metadata.json
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/.fern/metadata.json
@@ -20,8 +20,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/single-url-environment-default/full-custom/src/core/mod.rs
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/single-url-environment-default/full-custom/src/core/pagination.rs
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/single-url-environment-no-default/.fern/metadata.json
+++ b/seed/rust-sdk/single-url-environment-no-default/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/mod.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/pagination.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/streaming-parameter/.fern/metadata.json
+++ b/seed/rust-sdk/streaming-parameter/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/streaming-parameter/src/core/mod.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/mod.rs
@@ -2,6 +2,7 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 #[cfg(feature = "sse")]
@@ -10,6 +11,7 @@ mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 #[cfg(feature = "sse")]

--- a/seed/rust-sdk/streaming-parameter/src/core/pagination.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/streaming/.fern/metadata.json
+++ b/seed/rust-sdk/streaming/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/streaming/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/streaming/src/core/mod.rs
+++ b/seed/rust-sdk/streaming/src/core/mod.rs
@@ -2,6 +2,7 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 #[cfg(feature = "sse")]
@@ -10,6 +11,7 @@ mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 #[cfg(feature = "sse")]

--- a/seed/rust-sdk/streaming/src/core/pagination.rs
+++ b/seed/rust-sdk/streaming/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/trace/.fern/metadata.json
+++ b/seed/rust-sdk/trace/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/trace/src/core/http_client.rs
+++ b/seed/rust-sdk/trace/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/trace/src/core/mod.rs
+++ b/seed/rust-sdk/trace/src/core/mod.rs
@@ -4,12 +4,14 @@ pub mod flexible_datetime;
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/trace/src/core/pagination.rs
+++ b/seed/rust-sdk/trace/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
+++ b/seed/rust-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/mod.rs
+++ b/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/pagination.rs
+++ b/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/undiscriminated-unions/.fern/metadata.json
+++ b/seed/rust-sdk/undiscriminated-unions/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/undiscriminated-unions/src/core/mod.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/mod.rs
@@ -3,12 +3,14 @@
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/undiscriminated-unions/src/core/pagination.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/unions-with-local-date/.fern/metadata.json
+++ b/seed/rust-sdk/unions-with-local-date/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/unions-with-local-date/src/core/mod.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/core/mod.rs
@@ -4,12 +4,14 @@ pub mod flexible_datetime;
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/unions-with-local-date/src/core/pagination.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/unions/.fern/metadata.json
+++ b/seed/rust-sdk/unions/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/unions/src/core/http_client.rs
+++ b/seed/rust-sdk/unions/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/unions/src/core/mod.rs
+++ b/seed/rust-sdk/unions/src/core/mod.rs
@@ -4,12 +4,14 @@ pub mod flexible_datetime;
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/unions/src/core/pagination.rs
+++ b/seed/rust-sdk/unions/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/unknown/.fern/metadata.json
+++ b/seed/rust-sdk/unknown/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/unknown/src/core/http_client.rs
+++ b/seed/rust-sdk/unknown/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/unknown/src/core/mod.rs
+++ b/seed/rust-sdk/unknown/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/unknown/src/core/pagination.rs
+++ b/seed/rust-sdk/unknown/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/url-form-encoded/.fern/metadata.json
+++ b/seed/rust-sdk/url-form-encoded/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
+++ b/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/url-form-encoded/src/core/mod.rs
+++ b/seed/rust-sdk/url-form-encoded/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/url-form-encoded/src/core/pagination.rs
+++ b/seed/rust-sdk/url-form-encoded/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/validation/.fern/metadata.json
+++ b/seed/rust-sdk/validation/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/validation/src/core/http_client.rs
+++ b/seed/rust-sdk/validation/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/validation/src/core/mod.rs
+++ b/seed/rust-sdk/validation/src/core/mod.rs
@@ -3,12 +3,14 @@
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/validation/src/core/pagination.rs
+++ b/seed/rust-sdk/validation/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/variables/.fern/metadata.json
+++ b/seed/rust-sdk/variables/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/variables/src/core/http_client.rs
+++ b/seed/rust-sdk/variables/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/variables/src/core/mod.rs
+++ b/seed/rust-sdk/variables/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/variables/src/core/pagination.rs
+++ b/seed/rust-sdk/variables/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/version-no-default/.fern/metadata.json
+++ b/seed/rust-sdk/version-no-default/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/version-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/version-no-default/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/version-no-default/src/core/mod.rs
+++ b/seed/rust-sdk/version-no-default/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/version-no-default/src/core/pagination.rs
+++ b/seed/rust-sdk/version-no-default/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/version/.fern/metadata.json
+++ b/seed/rust-sdk/version/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/version/src/core/http_client.rs
+++ b/seed/rust-sdk/version/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/version/src/core/mod.rs
+++ b/seed/rust-sdk/version/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/version/src/core/pagination.rs
+++ b/seed/rust-sdk/version/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/webhook-audience/.fern/metadata.json
+++ b/seed/rust-sdk/webhook-audience/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/webhook-audience/src/core/http_client.rs
+++ b/seed/rust-sdk/webhook-audience/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/webhook-audience/src/core/mod.rs
+++ b/seed/rust-sdk/webhook-audience/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/webhook-audience/src/core/pagination.rs
+++ b/seed/rust-sdk/webhook-audience/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/webhooks/.fern/metadata.json
+++ b/seed/rust-sdk/webhooks/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/webhooks/src/core/http_client.rs
+++ b/seed/rust-sdk/webhooks/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/webhooks/src/core/mod.rs
+++ b/seed/rust-sdk/webhooks/src/core/mod.rs
@@ -3,12 +3,14 @@
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/webhooks/src/core/pagination.rs
+++ b/seed/rust-sdk/webhooks/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/websocket-bearer-auth/.fern/metadata.json
+++ b/seed/rust-sdk/websocket-bearer-auth/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/mod.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/mod.rs
@@ -2,6 +2,7 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
@@ -10,6 +11,7 @@ mod websocket;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/pagination.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/websocket-inferred-auth/.fern/metadata.json
+++ b/seed/rust-sdk/websocket-inferred-auth/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/mod.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/mod.rs
@@ -2,6 +2,7 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
@@ -10,6 +11,7 @@ mod websocket;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/pagination.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/websocket-multi-url/.fern/metadata.json
+++ b/seed/rust-sdk/websocket-multi-url/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/websocket-multi-url/src/core/mod.rs
+++ b/seed/rust-sdk/websocket-multi-url/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/websocket-multi-url/src/core/pagination.rs
+++ b/seed/rust-sdk/websocket-multi-url/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/websocket/.fern/metadata.json
+++ b/seed/rust-sdk/websocket/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/websocket/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/websocket/src/core/mod.rs
+++ b/seed/rust-sdk/websocket/src/core/mod.rs
@@ -7,11 +7,13 @@ mod query_parameter_builder;
 #[cfg(feature = "websocket")]
 mod websocket;
 mod utils;
+pub mod pagination;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
 pub use request_options::RequestOptions;
 pub use query_parameter_builder::{QueryBuilder, QueryBuilderError, parse_structured_query};
+pub use pagination::{AsyncPaginator, SyncPaginator, PaginationResult};
 #[cfg(feature = "websocket")]
 pub use websocket::{DisconnectInfo, WebSocketClient, WebSocketMessage, WebSocketOptions, WebSocketState};
 pub use utils::join_url;

--- a/seed/rust-sdk/websocket/src/core/pagination.rs
+++ b/seed/rust-sdk/websocket/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -302,6 +416,9 @@ mod tests {
                 items: vec![],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
             })
         }, None).unwrap();
         assert!(paginator.has_next_page());
@@ -315,6 +432,9 @@ mod tests {
                 items: vec!["a".to_string(), "b".to_string()],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
             })
         }, None).unwrap();
 
@@ -331,6 +451,9 @@ mod tests {
                 items: vec!["a".to_string()],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
             })
         }, None).unwrap();
 
@@ -354,6 +477,9 @@ mod tests {
                         items: vec![1, 2],
                         next_cursor: Some("page2".to_string()),
                         has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
                     })
                 }
                 1 => {
@@ -362,6 +488,9 @@ mod tests {
                         items: vec![3, 4],
                         next_cursor: None,
                         has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
                     })
                 }
                 _ => panic!("Unexpected call"),
@@ -390,11 +519,17 @@ mod tests {
                     items: vec![1, 2],
                     next_cursor: Some("next".to_string()),
                     has_next_page: true,
+                    response: None,
+                    status_code: None,
+                    headers: None,
                 }),
                 1 => Ok(PaginationResult {
                     items: vec![3],
                     next_cursor: None,
                     has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
                 }),
                 _ => panic!("Unexpected call"),
             }
@@ -417,11 +552,17 @@ mod tests {
                     items: vec![10, 20],
                     next_cursor: Some("p2".to_string()),
                     has_next_page: true,
+                    response: None,
+                    status_code: None,
+                    headers: None,
                 }),
                 1 => Ok(PaginationResult {
                     items: vec![30],
                     next_cursor: None,
                     has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
                 }),
                 _ => panic!("Unexpected call"),
             }
@@ -463,6 +604,9 @@ mod tests {
                 items: vec!["item".to_string()],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
             })
         }, Some("start_here".to_string())).unwrap();
 
@@ -480,10 +624,71 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
+            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            match call {
+                0 => Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: Some("next".to_string()),
+                    has_next_page: true,
+                    response: Some(serde_json::json!({"data": ["a"]})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                }),
+                _ => Ok(PaginationResult {
+                    items: vec!["b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["b"]})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                }),
+            }
+        }, None).unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
+            Ok(PaginationResult {
+                items: vec!["x".to_string()],
+                next_cursor: None,
+                has_next_page: false,
+                response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                status_code: Some(StatusCode::OK),
+                headers: Some(HeaderMap::new()),
+            })
+        }, None).unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================

--- a/seed/rust-sdk/x-fern-default/.fern/metadata.json
+++ b/seed/rust-sdk/x-fern-default/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/x-fern-default/src/core/http_client.rs
+++ b/seed/rust-sdk/x-fern-default/src/core/http_client.rs
@@ -1,8 +1,8 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
-    Client, Method, Request, Response,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Client, Method, Request, Response, StatusCode,
 };
 use serde::de::DeserializeOwned;
 
@@ -238,6 +238,51 @@ impl HttpClient {
 
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the response metadata (status code
+    /// and headers) alongside the deserialized body, which is useful for pagination and
+    /// other cases where callers need access to HTTP-level information.
+    pub async fn execute_request_returning_response<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<(T, StatusCode, HeaderMap), ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        let status_code = response.status();
+        let headers = response.headers().clone();
+        let parsed: T = self.parse_response(response).await?;
+        Ok((parsed, status_code, headers))
     }
 
     async fn apply_auth_headers(

--- a/seed/rust-sdk/x-fern-default/src/core/mod.rs
+++ b/seed/rust-sdk/x-fern-default/src/core/mod.rs
@@ -2,12 +2,14 @@
 
 mod http_client;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
 pub use http_client::{ByteStream, HttpClient, OAuthConfig};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/x-fern-default/src/core/pagination.rs
+++ b/seed/rust-sdk/x-fern-default/src/core/pagination.rs
@@ -5,16 +5,24 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP response metadata.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body for this page.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response that produced this page.
+    pub status_code: Option<StatusCode>,
+    /// The HTTP response headers from the response that produced this page.
+    pub headers: Option<HeaderMap>,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +42,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,6 +64,9 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -72,8 +86,51 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub async fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result =
+            (self.page_loader)(self.http_client.clone(), self.current_cursor.clone()).await?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 }
 
@@ -96,6 +153,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +190,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +228,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: Option<StatusCode>,
+    last_headers: Option<HeaderMap>,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,6 +251,9 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: None,
+            last_headers: None,
         })
     }
 
@@ -203,8 +272,50 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
+    }
+
+    /// Load the next page and return the full pagination result including HTTP metadata.
+    pub fn next_page_with_response(&mut self) -> Result<PaginationResult<T>, ApiError> {
+        if !self.has_next_page {
+            return Ok(PaginationResult {
+                items: Vec::new(),
+                next_cursor: None,
+                has_next_page: false,
+                response: None,
+                status_code: None,
+                headers: None,
+            });
+        }
+
+        let result = (self.page_loader)(self.http_client.clone(), self.current_cursor.clone())?;
+
+        self.current_cursor = result.next_cursor.clone();
+        self.has_next_page = result.has_next_page;
+        self.last_response = result.response.clone();
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers.clone();
+
+        Ok(result)
+    }
+
+    /// The full parsed response body from the most recently loaded page.
+    pub fn last_response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recently loaded page.
+    pub fn last_status_code(&self) -> Option<StatusCode> {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recently loaded page.
+    pub fn last_headers(&self) -> Option<&HeaderMap> {
+        self.last_headers.as_ref()
     }
 
     /// Get all remaining items by loading all pages
@@ -246,6 +357,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +401,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +413,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +458,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +485,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: None,
+                            headers: None,
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +534,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +572,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: None,
+                        headers: None,
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +607,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +621,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +636,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: None,
+                    headers: None,
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,10 +667,81 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: Some(serde_json::json!({"data": [1, 2, 3]})),
+            status_code: Some(StatusCode::OK),
+            headers: Some(HeaderMap::new()),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));
         assert!(result.has_next_page);
+        assert!(result.response.is_some());
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.headers.is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_metadata_tracking() {
+        let client = make_http_client();
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count = call_count.clone();
+
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec!["a".to_string()],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: Some(serde_json::json!({"data": ["a"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                    _ => Ok(PaginationResult {
+                        items: vec!["b".to_string()],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: Some(serde_json::json!({"data": ["b"]})),
+                        status_code: Some(StatusCode::OK),
+                        headers: Some(HeaderMap::new()),
+                    }),
+                }
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(paginator.last_status_code().is_none());
+        let _ = paginator.next_page().unwrap();
+        assert_eq!(paginator.last_status_code(), Some(StatusCode::OK));
+        assert!(paginator.last_response().is_some());
+        assert!(paginator.last_headers().is_some());
+    }
+
+    #[test]
+    fn test_sync_paginator_next_page_with_response() {
+        let client = make_http_client();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["x".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: Some(serde_json::json!({"data": ["x"], "total": 1})),
+                    status_code: Some(StatusCode::OK),
+                    headers: Some(HeaderMap::new()),
+                })
+            },
+            None,
+        )
+        .unwrap();
+
+        let result = paginator.next_page_with_response().unwrap();
+        assert_eq!(result.items, vec!["x".to_string()]);
+        assert_eq!(result.status_code, Some(StatusCode::OK));
+        assert!(result.response.is_some());
     }
 
     // ===========================


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-9800](https://linear.app/buildwithfern/issue/FER-9800/rust-expose-full-response-status-code-and-headers-on-paginated)

Brings Rust SDK pagination to feature parity with Go ([#10629](https://github.com/fern-api/fern/pull/10629)) and C# ([#14762](https://github.com/fern-api/fern/pull/14762)) by exposing the full parsed response, HTTP status code, and response headers on paginated result types.

## Changes Made

### Core pagination types (`pagination.rs`)
- Extended `PaginationResult<T>` with three new optional fields: `response: Option<Value>`, `status_code: Option<StatusCode>`, `headers: Option<HeaderMap>`
- Added metadata tracking fields to `AsyncPaginator<T>` and `SyncPaginator<T>`
- Added `next_page_with_response()` method that returns the full `PaginationResult` including HTTP metadata
- Added accessor methods: `last_response()`, `last_status_code()`, `last_headers()` on both paginator types
- Updated `Stream`/`Iterator` implementations to capture metadata on each page load

### HTTP client (`http_client.rs`)
- Added new `execute_request_returning_response<T>()` method that returns `(T, StatusCode, HeaderMap)` tuple, preserving HTTP metadata alongside the deserialized body

### Generator (`SubClientGenerator.ts`, `SdkGeneratorCli.ts`)
- Paginated endpoints now generate an additional `_paginated` method returning `AsyncPaginator<serde_json::Value>`
- Updated cursor, offset, and custom pagination generators to call `execute_request_returning_response` and populate all metadata fields
- Added `mod pagination` declaration and re-exports to dynamically generated `core/mod.rs`
- Added `AsyncPaginator` and `PaginationResult` to client imports for paginated endpoints

### Seed outputs
- Regenerated all 128 rust-sdk seed fixtures (pagination.rs, http_client.rs, core/mod.rs updated everywhere)
- Pagination fixture now includes `_paginated` methods with full metadata support

- [ ] Updated README.md generator (if applicable) — N/A

## Testing
- [x] All 128/128 rust-sdk seed tests pass
- [x] Pagination, pagination-custom, and pagination-uri-path fixtures all generate successfully
- [x] Code formatted with biome

Link to Devin session: https://app.devin.ai/sessions/36bfd2508d3a4b4786faa80730a0cbc6
Requested by: @iamnamananand996