### PR TITLE
feat(rust,ruby): expose HTTP response metadata on paginated results

### DIFF
--- a/generators/ruby-v2/base/src/asIs/internal/iterators/cursor_page_iterator.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/iterators/cursor_page_iterator.Template.rb
@@ -3,17 +3,33 @@ module <%= gem_namespace %>
     class CursorPageIterator
       include Enumerable
 
+      # The HTTP status code from the most recent page response.
+      # @return [Integer, nil]
+      attr_reader :status_code
+
+      # The HTTP response headers from the most recent page response.
+      # @return [Hash{String => String}, nil]
+      attr_reader :headers
+
+      # The raw HTTP response from the most recent page response.
+      # @return [Net::HTTPResponse, nil]
+      attr_reader :http_response
+
       # Instantiates a CursorPageIterator, an Enumerable class which wraps calls to a cursor-based paginated API and yields pages of items.
       #
       # @param initial_cursor [String] The initial cursor to use when iterating, if any.
       # @param cursor_field [Symbol] The name of the field in API responses to extract the next cursor from.
       # @param block [Proc] A block which is responsible for receiving a cursor to use and returning the given page from the API.
+      #   The block should return a two-element array: [parsed_page, raw_http_response].
       # @return [<%= gem_namespace %>::Internal::CursorPageIterator]
       def initialize(initial_cursor:, cursor_field:, &block)
         @need_initial_load = initial_cursor.nil?
         @cursor = initial_cursor
         @cursor_field = cursor_field
         @get_next_page = block
+        @status_code = nil
+        @headers = nil
+        @http_response = nil
       end
 
       # Iterates over each page returned by the API.
@@ -35,11 +51,19 @@ module <%= gem_namespace %>
 
       # Retrieves the next page from the API.
       #
-      # @return [Boolean]
+      # @return [Object, nil]
       def next_page
         return if !@need_initial_load && @cursor.nil?
         @need_initial_load = false
-        fetched_page = @get_next_page.call(@cursor)
+        result = @get_next_page.call(@cursor)
+        if result.is_a?(Array)
+          fetched_page, raw_response = result
+          @http_response = raw_response
+          @status_code = raw_response&.code&.to_i
+          @headers = raw_response&.each_header&.to_h
+        else
+          fetched_page = result
+        end
         @cursor = fetched_page.send(@cursor_field)
         fetched_page
       end

--- a/generators/ruby-v2/base/src/asIs/internal/iterators/custom_pager.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/iterators/custom_pager.Template.rb
@@ -13,18 +13,31 @@ module <%= gem_namespace %>
       # @return [Object] The current page response
       attr_reader :current
 
+      # The HTTP status code from the most recent page response.
+      # @return [Integer, nil]
+      attr_reader :status_code
+
+      # The HTTP response headers from the most recent page response.
+      # @return [Hash{String => String}, nil]
+      attr_reader :headers
+
+      # The raw HTTP response from the most recent page response.
+      # @return [Net::HTTPResponse, nil]
+      attr_reader :http_response
+
       # Creates a new custom pager with the given initial response.
       #
       # @param initial [Object] The initial page response
       # @param item_field [Symbol, nil] The field name containing items for iteration
       # @param raw_client [Object, nil] The HTTP client for fetching additional pages
+      # @param initial_http_response [Net::HTTPResponse, nil] The raw HTTP response for the initial page
       # @param has_next_proc [Proc, nil] A proc that returns true if there's a next page
       # @param has_prev_proc [Proc, nil] A proc that returns true if there's a previous page
       # @param get_next_proc [Proc, nil] A proc that fetches the next page
       # @param get_prev_proc [Proc, nil] A proc that fetches the previous page
       # @return [<%= gem_namespace %>::Internal::<%= custom_pager_class_name %>]
-      def initialize(initial, item_field: nil, raw_client: nil, has_next_proc: nil, has_prev_proc: nil,
-                     get_next_proc: nil, get_prev_proc: nil)
+      def initialize(initial, item_field: nil, raw_client: nil, initial_http_response: nil, has_next_proc: nil,
+                     has_prev_proc: nil, get_next_proc: nil, get_prev_proc: nil)
         @current = initial
         @item_field = item_field
         @raw_client = raw_client
@@ -32,6 +45,9 @@ module <%= gem_namespace %>
         @has_prev_proc = has_prev_proc
         @get_next_proc = get_next_proc
         @get_prev_proc = get_prev_proc
+        @http_response = initial_http_response
+        @status_code = initial_http_response&.code&.to_i
+        @headers = initial_http_response&.each_header&.to_h
       end
 
       # Returns true if there is a next page available.

--- a/generators/ruby-v2/base/src/asIs/internal/iterators/item_iterator.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/iterators/item_iterator.Template.rb
@@ -3,6 +3,24 @@ module <%= gem_namespace %>
     class ItemIterator
       include Enumerable
 
+      # The HTTP status code from the most recent page response.
+      # @return [Integer, nil]
+      def status_code
+        @page_iterator&.status_code
+      end
+
+      # The HTTP response headers from the most recent page response.
+      # @return [Hash{String => String}, nil]
+      def headers
+        @page_iterator&.headers
+      end
+
+      # The raw HTTP response from the most recent page response.
+      # @return [Net::HTTPResponse, nil]
+      def http_response
+        @page_iterator&.http_response
+      end
+
       # Iterates over each item returned by the API.
       #
       # @param block [Proc] The block which each retrieved item is yielded to.

--- a/generators/ruby-v2/base/src/asIs/internal/iterators/offset_page_iterator.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/iterators/offset_page_iterator.Template.rb
@@ -3,6 +3,18 @@ module <%= gem_namespace %>
     class OffsetPageIterator
       include Enumerable
 
+      # The HTTP status code from the most recent page response.
+      # @return [Integer, nil]
+      attr_reader :status_code
+
+      # The HTTP response headers from the most recent page response.
+      # @return [Hash{String => String}, nil]
+      attr_reader :headers
+
+      # The raw HTTP response from the most recent page response.
+      # @return [Net::HTTPResponse, nil]
+      attr_reader :http_response
+
       # Instantiates an OffsetPageIterator, an Enumerable class which wraps calls to an offset-based paginated API and yields pages of items from it.
       #
       # @param initial_page [Integer] The initial page to use when iterating, if any.
@@ -10,6 +22,7 @@ module <%= gem_namespace %>
       # @param has_next_field [Symbol] The field to pull the boolean of whether a next page exists from, if any.
       # @param step [Boolean] If true, treats the page number as a true offset (i.e. increments the page number by the number of items returned from each call rather than just 1)
       # @param block [Proc] A block which is responsible for receiving a page number to use and returning the given page from the API.
+      #   The block should return a two-element array: [parsed_page, raw_http_response].
       # @return [<%= gem_namespace %>::Internal::OffsetPageIterator]
       def initialize(initial_page:, item_field:, has_next_field:, step:, &block)
         @page_number = initial_page || (step ? 0 : 1)
@@ -22,6 +35,10 @@ module <%= gem_namespace %>
         @next_page = nil
         # ...or the actual next page, preloaded, if it doesn't.
         @has_next_page = nil
+
+        @status_code = nil
+        @headers = nil
+        @http_response = nil
       end
 
       # Iterates over each page returned by the API.
@@ -41,7 +58,7 @@ module <%= gem_namespace %>
         return @has_next_page unless @has_next_page.nil?
         return true if @next_page
 
-        fetched_page = @get_next_page.call(@page_number)
+        fetched_page = fetch_page(@page_number)
         fetched_page_items = fetched_page&.send(@item_field)
         if fetched_page_items.nil? || fetched_page_items.empty?
           @has_next_page = false
@@ -59,7 +76,7 @@ module <%= gem_namespace %>
           this_page = @next_page
           @next_page = nil
         else
-          this_page = @get_next_page.call(@page_number)
+          this_page = fetch_page(@page_number)
         end
 
         if @has_next_field
@@ -77,6 +94,21 @@ module <%= gem_namespace %>
         end
 
         this_page
+      end
+
+      private
+
+      def fetch_page(page_number)
+        result = @get_next_page.call(page_number)
+        if result.is_a?(Array)
+          fetched_page, raw_response = result
+          @http_response = raw_response
+          @status_code = raw_response&.code&.to_i
+          @headers = raw_response&.each_header&.to_h
+          fetched_page
+        else
+          result
+        end
       end
     end
   end

--- a/generators/ruby-v2/sdk/changes/unreleased/expose-pagination-metadata.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/expose-pagination-metadata.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Expose HTTP response metadata (status code, headers, and raw HTTP response) on paginated iterators.
+    `CursorPageIterator`, `OffsetPageIterator`, `CustomPager`, and `ItemIterator` now expose `status_code`,
+    `headers`, and `http_response` methods that return metadata from the most recent page load.
+  type: feat

--- a/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -97,10 +97,12 @@ export class HttpEndpointGenerator {
         });
 
         const isCustomPagination = endpoint.pagination?.type === "custom";
+        const isPaginated = endpoint.pagination != null;
         let requestStatements = this.generateRequestProcedure({
             endpoint,
             sendRequestCodeBlock,
-            storeResponseInVariable: isCustomPagination
+            storeResponseInVariable: isCustomPagination,
+            wrapWithHttpResponse: isPaginated && !isCustomPagination
         });
 
         const enhancedDocstring = this.generateEnhancedDocstring({ endpoint, request });
@@ -132,6 +134,10 @@ export class HttpEndpointGenerator {
                                 ruby.keywordArgument({
                                     name: "raw_client",
                                     value: ruby.codeblock("@client")
+                                }),
+                                ruby.keywordArgument({
+                                    name: "initial_http_response",
+                                    value: ruby.codeblock(HTTP_RESPONSE_VN)
                                 })
                             ]
                         })
@@ -268,11 +274,13 @@ export class HttpEndpointGenerator {
     private generateRequestProcedure({
         endpoint,
         sendRequestCodeBlock,
-        storeResponseInVariable
+        storeResponseInVariable,
+        wrapWithHttpResponse
     }: {
         endpoint: FernIr.HttpEndpoint;
         sendRequestCodeBlock?: ruby.CodeBlock;
         storeResponseInVariable?: boolean;
+        wrapWithHttpResponse?: boolean;
     }): ruby.AstNode[] {
         const statements: ruby.AstNode[] = [];
 
@@ -316,11 +324,20 @@ export class HttpEndpointGenerator {
                             } else {
                                 switch (endpoint.response.body.type) {
                                     case "json":
-                                        this.loadResponseBodyFromJson({
-                                            writer,
-                                            typeReference: endpoint.response.body.value.responseBodyType,
-                                            storeInVariable: storeResponseInVariable
-                                        });
+                                        if (wrapWithHttpResponse) {
+                                            this.loadResponseBodyFromJson({
+                                                writer,
+                                                typeReference: endpoint.response.body.value.responseBodyType,
+                                                storeInVariable: true
+                                            });
+                                            writer.writeLine(`[parsed_response, ${HTTP_RESPONSE_VN}]`);
+                                        } else {
+                                            this.loadResponseBodyFromJson({
+                                                writer,
+                                                typeReference: endpoint.response.body.value.responseBodyType,
+                                                storeInVariable: storeResponseInVariable
+                                            });
+                                        }
                                         break;
                                     default:
                                         break;

--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -1,7 +1,7 @@
 {{BASE64_IMPORT}}use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
+    header::{HeaderMap, HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
 use serde::de::DeserializeOwned;
@@ -12,6 +12,18 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
+
+/// A parsed HTTP response that includes the deserialized body along with
+/// the HTTP status code and response headers.
+#[derive(Debug)]
+pub struct RawResponse<T> {
+    /// The deserialized response body.
+    pub body: T,
+    /// The HTTP status code of the response.
+    pub status_code: u16,
+    /// The HTTP response headers.
+    pub headers: HeaderMap,
+}
 
 /// A streaming byte stream for downloading files efficiently
 pub struct ByteStream {
@@ -152,6 +164,48 @@ impl HttpClient {
     /// Returns a reference to the client configuration.
     pub fn config(&self) -> &ClientConfig {
         &self.config
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the HTTP metadata from the response,
+    /// which is useful for paginated endpoints where callers need access to status codes
+    /// and headers alongside the deserialized body.
+    pub async fn execute_request_raw<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<RawResponse<T>, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        self.parse_response_raw(response).await
     }
 
     /// Execute a request with the given method, path, and options
@@ -430,6 +484,29 @@ impl HttpClient {
         }
 
         serde_json::from_str(&text).map_err(ApiError::Serialization)
+    }
+
+    async fn parse_response_raw<T>(&self, response: Response) -> Result<RawResponse<T>, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let status_code = response.status().as_u16();
+        let headers = response.headers().clone();
+        let text = response.text().await.map_err(ApiError::Network)?;
+
+        if text.is_empty() {
+            return Err(ApiError::Http {
+                status: status_code,
+                message: String::new(),
+            });
+        }
+
+        let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;
+        Ok(RawResponse {
+            body,
+            status_code,
+            headers,
+        })
     }
 
 {{BASE64_METHOD}}

--- a/generators/rust/base/src/asIs/pagination.rs
+++ b/generators/rust/base/src/asIs/pagination.rs
@@ -5,16 +5,23 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP metadata from the response.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body as a JSON value.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response.
+    pub status_code: u16,
+    /// The HTTP response headers.
+    pub headers: HeaderMap,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +41,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: u16,
+    last_headers: HeaderMap,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,12 +63,30 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: 0,
+            last_headers: HeaderMap::new(),
         })
     }
 
     /// Check if there are more pages available
     pub fn has_next_page(&self) -> bool {
         !self.current_page.is_empty() || self.has_next_page
+    }
+
+    /// The full parsed response from the most recent page load.
+    pub fn response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recent page load.
+    pub fn status_code(&self) -> u16 {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recent page load.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.last_headers
     }
 
     /// Load the next page explicitly
@@ -72,6 +100,9 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
     }
@@ -96,6 +127,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +164,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +202,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: u16,
+    last_headers: HeaderMap,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,12 +225,30 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: 0,
+            last_headers: HeaderMap::new(),
         })
     }
 
     /// Check if there are more pages available
     pub fn has_next_page(&self) -> bool {
         !self.current_page.is_empty() || self.has_next_page
+    }
+
+    /// The full parsed response from the most recent page load.
+    pub fn response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recent page load.
+    pub fn status_code(&self) -> u16 {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recent page load.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.last_headers
     }
 
     /// Load the next page explicitly
@@ -203,6 +261,9 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
     }
@@ -246,6 +307,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -302,6 +366,9 @@ mod tests {
                 items: vec![],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: 200,
+                headers: HeaderMap::new(),
             })
         }, None).unwrap();
         assert!(paginator.has_next_page());
@@ -315,6 +382,9 @@ mod tests {
                 items: vec!["a".to_string(), "b".to_string()],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: 200,
+                headers: HeaderMap::new(),
             })
         }, None).unwrap();
 
@@ -331,6 +401,9 @@ mod tests {
                 items: vec!["a".to_string()],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: 200,
+                headers: HeaderMap::new(),
             })
         }, None).unwrap();
 
@@ -354,6 +427,9 @@ mod tests {
                         items: vec![1, 2],
                         next_cursor: Some("page2".to_string()),
                         has_next_page: true,
+                        response: None,
+                        status_code: 200,
+                        headers: HeaderMap::new(),
                     })
                 }
                 1 => {
@@ -362,6 +438,9 @@ mod tests {
                         items: vec![3, 4],
                         next_cursor: None,
                         has_next_page: false,
+                        response: None,
+                        status_code: 200,
+                        headers: HeaderMap::new(),
                     })
                 }
                 _ => panic!("Unexpected call"),
@@ -390,11 +469,17 @@ mod tests {
                     items: vec![1, 2],
                     next_cursor: Some("next".to_string()),
                     has_next_page: true,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
                 }),
                 1 => Ok(PaginationResult {
                     items: vec![3],
                     next_cursor: None,
                     has_next_page: false,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
                 }),
                 _ => panic!("Unexpected call"),
             }
@@ -417,11 +502,17 @@ mod tests {
                     items: vec![10, 20],
                     next_cursor: Some("p2".to_string()),
                     has_next_page: true,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
                 }),
                 1 => Ok(PaginationResult {
                     items: vec![30],
                     next_cursor: None,
                     has_next_page: false,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
                 }),
                 _ => panic!("Unexpected call"),
             }
@@ -463,6 +554,9 @@ mod tests {
                 items: vec!["item".to_string()],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: 200,
+                headers: HeaderMap::new(),
             })
         }, Some("start_here".to_string())).unwrap();
 
@@ -480,6 +574,9 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: None,
+            status_code: 200,
+            headers: HeaderMap::new(),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));

--- a/generators/rust/sdk/changes/unreleased/expose-pagination-metadata.yml
+++ b/generators/rust/sdk/changes/unreleased/expose-pagination-metadata.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Expose HTTP response metadata (status code, headers, and full parsed response body) on paginated results.
+    The `PaginationResult` struct now includes `status_code`, `headers`, and `response` fields, and both
+    `AsyncPaginator` and `SyncPaginator` expose accessor methods for this metadata from the most recent page load.
+    A new `RawResponse<T>` struct and `execute_request_raw` method on `HttpClient` support this functionality.
+  type: feat

--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -341,6 +341,7 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
             lines.push("mod websocket;");
         }
         lines.push("mod utils;");
+        lines.push("pub mod pagination;");
         if (hasDateTime) {
             lines.push("pub mod flexible_datetime;");
         }
@@ -354,7 +355,7 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
             lines.push("pub mod number_serializers;");
         }
         lines.push("");
-        lines.push("pub use http_client::{ByteStream, HttpClient, OAuthConfig};");
+        lines.push("pub use http_client::{ByteStream, HttpClient, OAuthConfig, RawResponse};");
         lines.push("pub use oauth_token_provider::OAuthTokenProvider;");
         lines.push("pub use request_options::RequestOptions;");
         lines.push("pub use query_parameter_builder::{QueryBuilder, QueryBuilderError, parse_structured_query};");
@@ -367,6 +368,7 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
             lines.push("pub use websocket::{DisconnectInfo, WebSocketClient, WebSocketMessage, WebSocketOptions, WebSocketState};");
         }
         lines.push("pub use utils::join_url;");
+        lines.push("pub use pagination::{AsyncPaginator, SyncPaginator, PaginationResult};");
         lines.push("");
 
         return new RustFile({

--- a/generators/rust/sdk/src/generators/SubClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/SubClientGenerator.ts
@@ -1971,13 +1971,14 @@ export class SubClientGenerator {
                     ${this.generateCapturedVariableCloningForAsyncMove(params)}
                     
                     Box::pin(async move {
-                        let response: serde_json::Value = client.execute_request(
+                        let raw_response = client.execute_request_raw::<serde_json::Value>(
                             Method::${httpMethod},
                             ${this.buildPathExpressionForAsyncMove(pathExpression, params)},
                             ${this.buildRequestBodyForAsyncMove(requestBody, params)},
                             Some(query_params),
                             options_for_request,
                         ).await?;
+                        let response = raw_response.body;
                         
                         // Extract pagination info from response
                         ${this.generatePaginationExtraction(endpoint, false)}
@@ -1986,6 +1987,9 @@ export class SubClientGenerator {
                             items,
                             next_cursor,
                             has_next_page,
+                            response: Some(response),
+                            status_code: raw_response.status_code,
+                            headers: raw_response.headers,
                         })
                     })
                 },
@@ -2032,13 +2036,14 @@ export class SubClientGenerator {
                     ${this.generateCapturedVariableCloningForAsyncMove(params)}
                     
                     Box::pin(async move {
-                        let response: serde_json::Value = client.execute_request(
+                        let raw_response = client.execute_request_raw::<serde_json::Value>(
                             Method::${httpMethod},
                             ${this.buildPathExpressionForAsyncMove(pathExpression, params)},
                             ${this.buildRequestBodyForAsyncMove(requestBody, params)},
                             Some(query_params),
                             options_for_request,
                         ).await?;
+                        let response = raw_response.body;
                         
                         // Extract pagination info from response
                         ${this.generatePaginationExtraction(endpoint, true)}
@@ -2047,6 +2052,9 @@ export class SubClientGenerator {
                             items,
                             next_cursor,
                             has_next_page,
+                            response: Some(response),
+                            status_code: raw_response.status_code,
+                            headers: raw_response.headers,
                         })
                     })
                 },
@@ -2086,13 +2094,14 @@ export class SubClientGenerator {
                     ${this.generateCapturedVariableCloningForAsyncMove(params)}
                     
                     Box::pin(async move {
-                        let response: serde_json::Value = client.execute_request(
+                        let raw_response = client.execute_request_raw::<serde_json::Value>(
                             Method::${httpMethod},
                             ${this.buildPathExpressionForAsyncMove(pathExpression, params)},
                             ${this.buildRequestBodyForAsyncMove(requestBody, params)},
                             query_params,
                             options_for_request,
                         ).await?;
+                        let response = raw_response.body;
                         
                         // Custom extraction logic would go here
                         ${this.generatePaginationExtraction(endpoint)}
@@ -2101,6 +2110,9 @@ export class SubClientGenerator {
                             items,
                             next_cursor,
                             has_next_page,
+                            response: Some(response),
+                            status_code: raw_response.status_code,
+                            headers: raw_response.headers,
                         })
                     })
                 },

--- a/seed/ruby-sdk-v2/pagination/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/pagination/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/ruby-sdk-v2/pagination/lib/seed/complex/client.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/complex/client.rb
@@ -42,7 +42,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Complex::Types::PaginatedConversationResponse.load(response.body)
+            parsed_response = Seed::Complex::Types::PaginatedConversationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)

--- a/seed/ruby-sdk-v2/pagination/lib/seed/inline_users/inline_users/client.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/inline_users/inline_users/client.rb
@@ -54,7 +54,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -99,7 +100,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersMixedTypePaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersMixedTypePaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -138,7 +140,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -190,7 +193,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -242,7 +246,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -282,7 +287,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -332,7 +338,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -382,7 +389,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -427,7 +435,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersExtendedResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersExtendedResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -472,7 +481,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersExtendedOptionalListResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersExtendedOptionalListResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -517,7 +527,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::Types::UsernameCursor.load(response.body)
+              parsed_response = Seed::Types::UsernameCursor.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -563,7 +574,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::UsernameContainer.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::UsernameContainer.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)

--- a/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/cursor_page_iterator.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/cursor_page_iterator.rb
@@ -5,17 +5,33 @@ module Seed
     class CursorPageIterator
       include Enumerable
 
+      # The HTTP status code from the most recent page response.
+      # @return [Integer, nil]
+      attr_reader :status_code
+
+      # The HTTP response headers from the most recent page response.
+      # @return [Hash{String => String}, nil]
+      attr_reader :headers
+
+      # The raw HTTP response from the most recent page response.
+      # @return [Net::HTTPResponse, nil]
+      attr_reader :http_response
+
       # Instantiates a CursorPageIterator, an Enumerable class which wraps calls to a cursor-based paginated API and yields pages of items.
       #
       # @param initial_cursor [String] The initial cursor to use when iterating, if any.
       # @param cursor_field [Symbol] The name of the field in API responses to extract the next cursor from.
       # @param block [Proc] A block which is responsible for receiving a cursor to use and returning the given page from the API.
+      #   The block should return a two-element array: [parsed_page, raw_http_response].
       # @return [Seed::Internal::CursorPageIterator]
       def initialize(initial_cursor:, cursor_field:, &block)
         @need_initial_load = initial_cursor.nil?
         @cursor = initial_cursor
         @cursor_field = cursor_field
         @get_next_page = block
+        @status_code = nil
+        @headers = nil
+        @http_response = nil
       end
 
       # Iterates over each page returned by the API.
@@ -37,12 +53,20 @@ module Seed
 
       # Retrieves the next page from the API.
       #
-      # @return [Boolean]
+      # @return [Object, nil]
       def next_page
         return if !@need_initial_load && @cursor.nil?
 
         @need_initial_load = false
-        fetched_page = @get_next_page.call(@cursor)
+        result = @get_next_page.call(@cursor)
+        if result.is_a?(Array)
+          fetched_page, raw_response = result
+          @http_response = raw_response
+          @status_code = raw_response&.code&.to_i
+          @headers = raw_response&.each_header&.to_h
+        else
+          fetched_page = result
+        end
         @cursor = fetched_page.send(@cursor_field)
         fetched_page
       end

--- a/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/item_iterator.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/item_iterator.rb
@@ -5,6 +5,24 @@ module Seed
     class ItemIterator
       include Enumerable
 
+      # The HTTP status code from the most recent page response.
+      # @return [Integer, nil]
+      def status_code
+        @page_iterator&.status_code
+      end
+
+      # The HTTP response headers from the most recent page response.
+      # @return [Hash{String => String}, nil]
+      def headers
+        @page_iterator&.headers
+      end
+
+      # The raw HTTP response from the most recent page response.
+      # @return [Net::HTTPResponse, nil]
+      def http_response
+        @page_iterator&.http_response
+      end
+
       # Iterates over each item returned by the API.
       #
       # @param block [Proc] The block which each retrieved item is yielded to.

--- a/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/offset_page_iterator.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/offset_page_iterator.rb
@@ -5,6 +5,18 @@ module Seed
     class OffsetPageIterator
       include Enumerable
 
+      # The HTTP status code from the most recent page response.
+      # @return [Integer, nil]
+      attr_reader :status_code
+
+      # The HTTP response headers from the most recent page response.
+      # @return [Hash{String => String}, nil]
+      attr_reader :headers
+
+      # The raw HTTP response from the most recent page response.
+      # @return [Net::HTTPResponse, nil]
+      attr_reader :http_response
+
       # Instantiates an OffsetPageIterator, an Enumerable class which wraps calls to an offset-based paginated API and yields pages of items from it.
       #
       # @param initial_page [Integer] The initial page to use when iterating, if any.
@@ -12,6 +24,7 @@ module Seed
       # @param has_next_field [Symbol] The field to pull the boolean of whether a next page exists from, if any.
       # @param step [Boolean] If true, treats the page number as a true offset (i.e. increments the page number by the number of items returned from each call rather than just 1)
       # @param block [Proc] A block which is responsible for receiving a page number to use and returning the given page from the API.
+      #   The block should return a two-element array: [parsed_page, raw_http_response].
       # @return [Seed::Internal::OffsetPageIterator]
       def initialize(initial_page:, item_field:, has_next_field:, step:, &block)
         @page_number = initial_page || (step ? 0 : 1)
@@ -24,6 +37,10 @@ module Seed
         @next_page = nil
         # ...or the actual next page, preloaded, if it doesn't.
         @has_next_page = nil
+
+        @status_code = nil
+        @headers = nil
+        @http_response = nil
       end
 
       # Iterates over each page returned by the API.
@@ -43,7 +60,7 @@ module Seed
         return @has_next_page unless @has_next_page.nil?
         return true if @next_page
 
-        fetched_page = @get_next_page.call(@page_number)
+        fetched_page = fetch_page(@page_number)
         fetched_page_items = fetched_page&.send(@item_field)
         if fetched_page_items.nil? || fetched_page_items.empty?
           @has_next_page = false
@@ -61,7 +78,7 @@ module Seed
           this_page = @next_page
           @next_page = nil
         else
-          this_page = @get_next_page.call(@page_number)
+          this_page = fetch_page(@page_number)
         end
 
         @has_next_page = this_page&.send(@has_next_field) if @has_next_field
@@ -77,6 +94,21 @@ module Seed
         end
 
         this_page
+      end
+
+      private
+
+      def fetch_page(page_number)
+        result = @get_next_page.call(page_number)
+        if result.is_a?(Array)
+          fetched_page, raw_response = result
+          @http_response = raw_response
+          @status_code = raw_response&.code&.to_i
+          @headers = raw_response&.each_header&.to_h
+          fetched_page
+        else
+          result
+        end
       end
     end
   end

--- a/seed/ruby-sdk-v2/pagination/lib/seed/users/client.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/users/client.rb
@@ -53,7 +53,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -98,7 +99,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersMixedTypePaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersMixedTypePaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -137,7 +139,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -180,7 +183,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersTopLevelCursorPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersTopLevelCursorPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -232,7 +236,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -284,7 +289,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -324,7 +330,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -374,7 +381,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -424,7 +432,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -469,7 +478,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersExtendedResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersExtendedResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -514,7 +524,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersExtendedOptionalListResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersExtendedOptionalListResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -559,7 +570,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Types::UsernameCursor.load(response.body)
+            parsed_response = Seed::Types::UsernameCursor.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -603,7 +615,9 @@ module Seed
             raise Seed::Errors::TimeoutError
           end
           code = response.code.to_i
-          unless code.between?(200, 299)
+          if code.between?(200, 299)
+            [parsed_response, response]
+          else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
           end
@@ -648,7 +662,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::UsernameContainer.load(response.body)
+            parsed_response = Seed::Users::Types::UsernameContainer.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -694,7 +709,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersOptionalDataPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersOptionalDataPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -743,7 +759,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersAliasedDataPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersAliasedDataPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)

--- a/seed/rust-sdk/pagination/.fern/metadata.json
+++ b/seed/rust-sdk/pagination/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/pagination/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination/src/core/http_client.rs
@@ -1,7 +1,7 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
+    header::{HeaderMap, HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
 use serde::de::DeserializeOwned;
@@ -12,6 +12,18 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
+
+/// A parsed HTTP response that includes the deserialized body along with
+/// the HTTP status code and response headers.
+#[derive(Debug)]
+pub struct RawResponse<T> {
+    /// The deserialized response body.
+    pub body: T,
+    /// The HTTP status code of the response.
+    pub status_code: u16,
+    /// The HTTP response headers.
+    pub headers: HeaderMap,
+}
 
 /// A streaming byte stream for downloading files efficiently
 pub struct ByteStream {
@@ -152,6 +164,48 @@ impl HttpClient {
     /// Returns a reference to the client configuration.
     pub fn config(&self) -> &ClientConfig {
         &self.config
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the HTTP metadata from the response,
+    /// which is useful for paginated endpoints where callers need access to status codes
+    /// and headers alongside the deserialized body.
+    pub async fn execute_request_raw<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<RawResponse<T>, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        self.parse_response_raw(response).await
     }
 
     /// Execute a request with the given method, path, and options
@@ -431,6 +485,29 @@ impl HttpClient {
         }
 
         serde_json::from_str(&text).map_err(ApiError::Serialization)
+    }
+
+    async fn parse_response_raw<T>(&self, response: Response) -> Result<RawResponse<T>, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let status_code = response.status().as_u16();
+        let headers = response.headers().clone();
+        let text = response.text().await.map_err(ApiError::Network)?;
+
+        if text.is_empty() {
+            return Err(ApiError::Http {
+                status: status_code,
+                message: String::new(),
+            });
+        }
+
+        let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;
+        Ok(RawResponse {
+            body,
+            status_code,
+            headers,
+        })
     }
 
     /// Execute a request and return a streaming response (for large file downloads)

--- a/seed/rust-sdk/pagination/src/core/mod.rs
+++ b/seed/rust-sdk/pagination/src/core/mod.rs
@@ -3,12 +3,14 @@
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
-pub use http_client::{ByteStream, HttpClient, OAuthConfig};
+pub use http_client::{ByteStream, HttpClient, OAuthConfig, RawResponse};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/pagination/src/core/pagination.rs
+++ b/seed/rust-sdk/pagination/src/core/pagination.rs
@@ -5,16 +5,23 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP metadata from the response.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body as a JSON value.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response.
+    pub status_code: u16,
+    /// The HTTP response headers.
+    pub headers: HeaderMap,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +41,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: u16,
+    last_headers: HeaderMap,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,12 +63,30 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: 0,
+            last_headers: HeaderMap::new(),
         })
     }
 
     /// Check if there are more pages available
     pub fn has_next_page(&self) -> bool {
         !self.current_page.is_empty() || self.has_next_page
+    }
+
+    /// The full parsed response from the most recent page load.
+    pub fn response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recent page load.
+    pub fn status_code(&self) -> u16 {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recent page load.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.last_headers
     }
 
     /// Load the next page explicitly
@@ -72,6 +100,9 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
     }
@@ -96,6 +127,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +164,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +202,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: u16,
+    last_headers: HeaderMap,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,12 +225,30 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: 0,
+            last_headers: HeaderMap::new(),
         })
     }
 
     /// Check if there are more pages available
     pub fn has_next_page(&self) -> bool {
         !self.current_page.is_empty() || self.has_next_page
+    }
+
+    /// The full parsed response from the most recent page load.
+    pub fn response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recent page load.
+    pub fn status_code(&self) -> u16 {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recent page load.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.last_headers
     }
 
     /// Load the next page explicitly
@@ -203,6 +261,9 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
     }
@@ -246,6 +307,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +351,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +363,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +408,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +435,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: 200,
+                            headers: HeaderMap::new(),
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: 200,
+                            headers: HeaderMap::new(),
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +484,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: 200,
+                        headers: HeaderMap::new(),
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: 200,
+                        headers: HeaderMap::new(),
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +522,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: 200,
+                        headers: HeaderMap::new(),
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: 200,
+                        headers: HeaderMap::new(),
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +557,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +571,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +586,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,6 +617,9 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: None,
+            status_code: 200,
+            headers: HeaderMap::new(),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-9800, Closes FER-9798

Adds feature parity for exposing HTTP response metadata (status code, headers, and full parsed response) on paginated API responses in the Rust and Ruby-v2 SDK generators. This follows the existing patterns established in the [C# PR #14762](https://github.com/fern-api/fern/pull/14762) and [Go PR #10629](https://github.com/fern-api/fern/pull/10629).

## Changes Made

### Rust (FER-9800)
- Added `RawResponse<T>` struct to `http_client.rs` with `body`, `status_code`, and `headers` fields
- Added `execute_request_raw<T>()` method to `HttpClient` that returns `RawResponse<T>` instead of just `T`
- Extended `PaginationResult<T>` with `response: Option<Value>`, `status_code: u16`, and `headers: HeaderMap` fields
- Updated `AsyncPaginator` and `SyncPaginator` to store and expose HTTP metadata via `response()`, `status_code()`, and `headers()` accessor methods
- Updated `SubClientGenerator.ts` pagination logic to use `execute_request_raw` and populate new fields
- Exported `RawResponse` and pagination types from `core/mod.rs`

### Ruby-v2 (FER-9798)
- Added `status_code`, `headers`, and `http_response` `attr_reader` accessors to `CursorPageIterator` and `OffsetPageIterator`
- Added `status_code`, `headers`, and `http_response` attributes to `CustomPager` (via `initial_http_response` parameter)
- Added delegation methods on `ItemIterator` to expose page-level HTTP metadata
- Updated `HttpEndpointGenerator.ts` to return `[parsed_page, response]` tuples from pagination blocks
- Page iterators handle both plain and tuple return values for backward compatibility

### Both generators
- Regenerated seed `pagination` fixtures
- Added changelog entries

## Testing
- [x] `pnpm seed test --generator rust-sdk --fixture pagination --skip-scripts` — passed
- [x] `pnpm seed test --generator ruby-sdk-v2 --fixture pagination --skip-scripts` — passed
- [x] `pnpm run check` (Biome lint) — passed
- [x] TypeScript compilation for both generators — passed

Link to Devin session: https://app.devin.ai/sessions/7f24aaf05ccf4aaea3359854cf2dc279
Requested by: @iamnamananand996