### PR TITLE
feat(rust): expose HTTP response metadata on paginated results

### DIFF
--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -1,7 +1,7 @@
 {{BASE64_IMPORT}}use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
+    header::{HeaderMap, HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
 use serde::de::DeserializeOwned;
@@ -12,6 +12,18 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
+
+/// A parsed HTTP response that includes the deserialized body along with
+/// the HTTP status code and response headers.
+#[derive(Debug)]
+pub struct RawResponse<T> {
+    /// The deserialized response body.
+    pub body: T,
+    /// The HTTP status code of the response.
+    pub status_code: u16,
+    /// The HTTP response headers.
+    pub headers: HeaderMap,
+}
 
 /// A streaming byte stream for downloading files efficiently
 pub struct ByteStream {
@@ -152,6 +164,48 @@ impl HttpClient {
     /// Returns a reference to the client configuration.
     pub fn config(&self) -> &ClientConfig {
         &self.config
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the HTTP metadata from the response,
+    /// which is useful for paginated endpoints where callers need access to status codes
+    /// and headers alongside the deserialized body.
+    pub async fn execute_request_raw<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<RawResponse<T>, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        self.parse_response_raw(response).await
     }
 
     /// Execute a request with the given method, path, and options
@@ -430,6 +484,29 @@ impl HttpClient {
         }
 
         serde_json::from_str(&text).map_err(ApiError::Serialization)
+    }
+
+    async fn parse_response_raw<T>(&self, response: Response) -> Result<RawResponse<T>, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let status_code = response.status().as_u16();
+        let headers = response.headers().clone();
+        let text = response.text().await.map_err(ApiError::Network)?;
+
+        if text.is_empty() {
+            return Err(ApiError::Http {
+                status: status_code,
+                message: String::new(),
+            });
+        }
+
+        let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;
+        Ok(RawResponse {
+            body,
+            status_code,
+            headers,
+        })
     }
 
 {{BASE64_METHOD}}

--- a/generators/rust/base/src/asIs/pagination.rs
+++ b/generators/rust/base/src/asIs/pagination.rs
@@ -5,16 +5,23 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP metadata from the response.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body as a JSON value.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response.
+    pub status_code: u16,
+    /// The HTTP response headers.
+    pub headers: HeaderMap,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +41,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: u16,
+    last_headers: HeaderMap,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,12 +63,30 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: 0,
+            last_headers: HeaderMap::new(),
         })
     }
 
     /// Check if there are more pages available
     pub fn has_next_page(&self) -> bool {
         !self.current_page.is_empty() || self.has_next_page
+    }
+
+    /// The full parsed response from the most recent page load.
+    pub fn response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recent page load.
+    pub fn status_code(&self) -> u16 {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recent page load.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.last_headers
     }
 
     /// Load the next page explicitly
@@ -72,6 +100,9 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
     }
@@ -96,6 +127,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +164,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +202,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: u16,
+    last_headers: HeaderMap,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,12 +225,30 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: 0,
+            last_headers: HeaderMap::new(),
         })
     }
 
     /// Check if there are more pages available
     pub fn has_next_page(&self) -> bool {
         !self.current_page.is_empty() || self.has_next_page
+    }
+
+    /// The full parsed response from the most recent page load.
+    pub fn response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recent page load.
+    pub fn status_code(&self) -> u16 {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recent page load.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.last_headers
     }
 
     /// Load the next page explicitly
@@ -203,6 +261,9 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
     }
@@ -246,6 +307,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -302,6 +366,9 @@ mod tests {
                 items: vec![],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: 200,
+                headers: HeaderMap::new(),
             })
         }, None).unwrap();
         assert!(paginator.has_next_page());
@@ -315,6 +382,9 @@ mod tests {
                 items: vec!["a".to_string(), "b".to_string()],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: 200,
+                headers: HeaderMap::new(),
             })
         }, None).unwrap();
 
@@ -331,6 +401,9 @@ mod tests {
                 items: vec!["a".to_string()],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: 200,
+                headers: HeaderMap::new(),
             })
         }, None).unwrap();
 
@@ -354,6 +427,9 @@ mod tests {
                         items: vec![1, 2],
                         next_cursor: Some("page2".to_string()),
                         has_next_page: true,
+                        response: None,
+                        status_code: 200,
+                        headers: HeaderMap::new(),
                     })
                 }
                 1 => {
@@ -362,6 +438,9 @@ mod tests {
                         items: vec![3, 4],
                         next_cursor: None,
                         has_next_page: false,
+                        response: None,
+                        status_code: 200,
+                        headers: HeaderMap::new(),
                     })
                 }
                 _ => panic!("Unexpected call"),
@@ -390,11 +469,17 @@ mod tests {
                     items: vec![1, 2],
                     next_cursor: Some("next".to_string()),
                     has_next_page: true,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
                 }),
                 1 => Ok(PaginationResult {
                     items: vec![3],
                     next_cursor: None,
                     has_next_page: false,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
                 }),
                 _ => panic!("Unexpected call"),
             }
@@ -417,11 +502,17 @@ mod tests {
                     items: vec![10, 20],
                     next_cursor: Some("p2".to_string()),
                     has_next_page: true,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
                 }),
                 1 => Ok(PaginationResult {
                     items: vec![30],
                     next_cursor: None,
                     has_next_page: false,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
                 }),
                 _ => panic!("Unexpected call"),
             }
@@ -463,6 +554,9 @@ mod tests {
                 items: vec!["item".to_string()],
                 next_cursor: None,
                 has_next_page: false,
+                response: None,
+                status_code: 200,
+                headers: HeaderMap::new(),
             })
         }, Some("start_here".to_string())).unwrap();
 
@@ -480,6 +574,9 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: None,
+            status_code: 200,
+            headers: HeaderMap::new(),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));

--- a/generators/rust/sdk/changes/unreleased/expose-pagination-metadata.yml
+++ b/generators/rust/sdk/changes/unreleased/expose-pagination-metadata.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Expose HTTP response metadata (status code, headers, and full parsed response body) on paginated results.
+    The `PaginationResult` struct now includes `status_code`, `headers`, and `response` fields, and both
+    `AsyncPaginator` and `SyncPaginator` expose accessor methods for this metadata from the most recent page load.
+    A new `RawResponse<T>` struct and `execute_request_raw` method on `HttpClient` support this functionality.
+  type: feat

--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -341,6 +341,7 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
             lines.push("mod websocket;");
         }
         lines.push("mod utils;");
+        lines.push("pub mod pagination;");
         if (hasDateTime) {
             lines.push("pub mod flexible_datetime;");
         }
@@ -354,7 +355,7 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
             lines.push("pub mod number_serializers;");
         }
         lines.push("");
-        lines.push("pub use http_client::{ByteStream, HttpClient, OAuthConfig};");
+        lines.push("pub use http_client::{ByteStream, HttpClient, OAuthConfig, RawResponse};");
         lines.push("pub use oauth_token_provider::OAuthTokenProvider;");
         lines.push("pub use request_options::RequestOptions;");
         lines.push("pub use query_parameter_builder::{QueryBuilder, QueryBuilderError, parse_structured_query};");
@@ -367,6 +368,7 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
             lines.push("pub use websocket::{DisconnectInfo, WebSocketClient, WebSocketMessage, WebSocketOptions, WebSocketState};");
         }
         lines.push("pub use utils::join_url;");
+        lines.push("pub use pagination::{AsyncPaginator, SyncPaginator, PaginationResult};");
         lines.push("");
 
         return new RustFile({

--- a/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
@@ -1,7 +1,7 @@
 {{BASE64_IMPORT}}use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
+    header::{HeaderMap, HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
 use serde::de::DeserializeOwned;
@@ -12,6 +12,18 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
+
+/// A parsed HTTP response that includes the deserialized body along with
+/// the HTTP status code and response headers.
+#[derive(Debug)]
+pub struct RawResponse<T> {
+    /// The deserialized response body.
+    pub body: T,
+    /// The HTTP status code of the response.
+    pub status_code: u16,
+    /// The HTTP response headers.
+    pub headers: HeaderMap,
+}
 
 /// A streaming byte stream for downloading files efficiently
 pub struct ByteStream {
@@ -152,6 +164,48 @@ impl HttpClient {
     /// Returns a reference to the client configuration.
     pub fn config(&self) -> &ClientConfig {
         &self.config
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the HTTP metadata from the response,
+    /// which is useful for paginated endpoints where callers need access to status codes
+    /// and headers alongside the deserialized body.
+    pub async fn execute_request_raw<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<RawResponse<T>, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        self.parse_response_raw(response).await
     }
 
     /// Execute a request with the given method, path, and options
@@ -430,6 +484,29 @@ impl HttpClient {
         }
 
         serde_json::from_str(&text).map_err(ApiError::Serialization)
+    }
+
+    async fn parse_response_raw<T>(&self, response: Response) -> Result<RawResponse<T>, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let status_code = response.status().as_u16();
+        let headers = response.headers().clone();
+        let text = response.text().await.map_err(ApiError::Network)?;
+
+        if text.is_empty() {
+            return Err(ApiError::Http {
+                status: status_code,
+                message: String::new(),
+            });
+        }
+
+        let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;
+        Ok(RawResponse {
+            body,
+            status_code,
+            headers,
+        })
     }
 
 {{BASE64_METHOD}}

--- a/generators/rust/sdk/src/generators/SubClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/SubClientGenerator.ts
@@ -1971,13 +1971,14 @@ export class SubClientGenerator {
                     ${this.generateCapturedVariableCloningForAsyncMove(params)}
                     
                     Box::pin(async move {
-                        let response: serde_json::Value = client.execute_request(
+                        let raw_response = client.execute_request_raw::<serde_json::Value>(
                             Method::${httpMethod},
                             ${this.buildPathExpressionForAsyncMove(pathExpression, params)},
                             ${this.buildRequestBodyForAsyncMove(requestBody, params)},
                             Some(query_params),
                             options_for_request,
                         ).await?;
+                        let response = raw_response.body;
                         
                         // Extract pagination info from response
                         ${this.generatePaginationExtraction(endpoint, false)}
@@ -1986,6 +1987,9 @@ export class SubClientGenerator {
                             items,
                             next_cursor,
                             has_next_page,
+                            response: Some(response),
+                            status_code: raw_response.status_code,
+                            headers: raw_response.headers,
                         })
                     })
                 },
@@ -2032,13 +2036,14 @@ export class SubClientGenerator {
                     ${this.generateCapturedVariableCloningForAsyncMove(params)}
                     
                     Box::pin(async move {
-                        let response: serde_json::Value = client.execute_request(
+                        let raw_response = client.execute_request_raw::<serde_json::Value>(
                             Method::${httpMethod},
                             ${this.buildPathExpressionForAsyncMove(pathExpression, params)},
                             ${this.buildRequestBodyForAsyncMove(requestBody, params)},
                             Some(query_params),
                             options_for_request,
                         ).await?;
+                        let response = raw_response.body;
                         
                         // Extract pagination info from response
                         ${this.generatePaginationExtraction(endpoint, true)}
@@ -2047,6 +2052,9 @@ export class SubClientGenerator {
                             items,
                             next_cursor,
                             has_next_page,
+                            response: Some(response),
+                            status_code: raw_response.status_code,
+                            headers: raw_response.headers,
                         })
                     })
                 },
@@ -2086,13 +2094,14 @@ export class SubClientGenerator {
                     ${this.generateCapturedVariableCloningForAsyncMove(params)}
                     
                     Box::pin(async move {
-                        let response: serde_json::Value = client.execute_request(
+                        let raw_response = client.execute_request_raw::<serde_json::Value>(
                             Method::${httpMethod},
                             ${this.buildPathExpressionForAsyncMove(pathExpression, params)},
                             ${this.buildRequestBodyForAsyncMove(requestBody, params)},
                             query_params,
                             options_for_request,
                         ).await?;
+                        let response = raw_response.body;
                         
                         // Custom extraction logic would go here
                         ${this.generatePaginationExtraction(endpoint)}
@@ -2101,6 +2110,9 @@ export class SubClientGenerator {
                             items,
                             next_cursor,
                             has_next_page,
+                            response: Some(response),
+                            status_code: raw_response.status_code,
+                            headers: raw_response.headers,
                         })
                     })
                 },

--- a/seed/rust-sdk/pagination/.fern/metadata.json
+++ b/seed/rust-sdk/pagination/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/pagination/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination/src/core/http_client.rs
@@ -1,7 +1,7 @@
 use crate::{join_url, ApiError, ClientConfig, OAuthTokenProvider, RequestOptions};
 use futures::{Stream, StreamExt};
 use reqwest::{
-    header::{HeaderName, HeaderValue},
+    header::{HeaderMap, HeaderName, HeaderValue},
     Client, Method, Request, Response,
 };
 use serde::de::DeserializeOwned;
@@ -12,6 +12,18 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
+
+/// A parsed HTTP response that includes the deserialized body along with
+/// the HTTP status code and response headers.
+#[derive(Debug)]
+pub struct RawResponse<T> {
+    /// The deserialized response body.
+    pub body: T,
+    /// The HTTP status code of the response.
+    pub status_code: u16,
+    /// The HTTP response headers.
+    pub headers: HeaderMap,
+}
 
 /// A streaming byte stream for downloading files efficiently
 pub struct ByteStream {
@@ -152,6 +164,48 @@ impl HttpClient {
     /// Returns a reference to the client configuration.
     pub fn config(&self) -> &ClientConfig {
         &self.config
+    }
+
+    /// Execute a request and return the parsed body along with HTTP status code and headers.
+    ///
+    /// Unlike `execute_request`, this method preserves the HTTP metadata from the response,
+    /// which is useful for paginated endpoints where callers need access to status codes
+    /// and headers alongside the deserialized body.
+    pub async fn execute_request_raw<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<RawResponse<T>, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(&self.config.base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+        self.parse_response_raw(response).await
     }
 
     /// Execute a request with the given method, path, and options
@@ -431,6 +485,29 @@ impl HttpClient {
         }
 
         serde_json::from_str(&text).map_err(ApiError::Serialization)
+    }
+
+    async fn parse_response_raw<T>(&self, response: Response) -> Result<RawResponse<T>, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let status_code = response.status().as_u16();
+        let headers = response.headers().clone();
+        let text = response.text().await.map_err(ApiError::Network)?;
+
+        if text.is_empty() {
+            return Err(ApiError::Http {
+                status: status_code,
+                message: String::new(),
+            });
+        }
+
+        let body: T = serde_json::from_str(&text).map_err(ApiError::Serialization)?;
+        Ok(RawResponse {
+            body,
+            status_code,
+            headers,
+        })
     }
 
     /// Execute a request and return a streaming response (for large file downloads)

--- a/seed/rust-sdk/pagination/src/core/mod.rs
+++ b/seed/rust-sdk/pagination/src/core/mod.rs
@@ -3,12 +3,14 @@
 mod http_client;
 pub mod number_serializers;
 mod oauth_token_provider;
+pub mod pagination;
 mod query_parameter_builder;
 mod request_options;
 mod utils;
 
-pub use http_client::{ByteStream, HttpClient, OAuthConfig};
+pub use http_client::{ByteStream, HttpClient, OAuthConfig, RawResponse};
 pub use oauth_token_provider::OAuthTokenProvider;
+pub use pagination::{AsyncPaginator, PaginationResult, SyncPaginator};
 pub use query_parameter_builder::{parse_structured_query, QueryBuilder, QueryBuilderError};
 pub use request_options::RequestOptions;
 pub use utils::join_url;

--- a/seed/rust-sdk/pagination/src/core/pagination.rs
+++ b/seed/rust-sdk/pagination/src/core/pagination.rs
@@ -5,16 +5,23 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use reqwest::header::HeaderMap;
 use serde_json::Value;
 
 use crate::{ApiError, HttpClient};
 
-/// Result of a pagination request
+/// Result of a pagination request, including HTTP metadata from the response.
 #[derive(Debug)]
 pub struct PaginationResult<T> {
     pub items: Vec<T>,
     pub next_cursor: Option<String>,
     pub has_next_page: bool,
+    /// The full parsed response body as a JSON value.
+    pub response: Option<Value>,
+    /// The HTTP status code of the response.
+    pub status_code: u16,
+    /// The HTTP response headers.
+    pub headers: HeaderMap,
 }
 
 /// Async paginator that implements Stream for iterating over paginated results
@@ -34,6 +41,9 @@ pub struct AsyncPaginator<T> {
     has_next_page: bool,
     loading_next:
         Option<Pin<Box<dyn Future<Output = Result<PaginationResult<T>, ApiError>> + Send>>>,
+    last_response: Option<Value>,
+    last_status_code: u16,
+    last_headers: HeaderMap,
 }
 
 impl<T> AsyncPaginator<T> {
@@ -53,12 +63,30 @@ impl<T> AsyncPaginator<T> {
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially, will be updated after first request
             loading_next: None,
+            last_response: None,
+            last_status_code: 0,
+            last_headers: HeaderMap::new(),
         })
     }
 
     /// Check if there are more pages available
     pub fn has_next_page(&self) -> bool {
         !self.current_page.is_empty() || self.has_next_page
+    }
+
+    /// The full parsed response from the most recent page load.
+    pub fn response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recent page load.
+    pub fn status_code(&self) -> u16 {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recent page load.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.last_headers
     }
 
     /// Load the next page explicitly
@@ -72,6 +100,9 @@ impl<T> AsyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
     }
@@ -96,6 +127,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     // Try to get the next item from the newly loaded page
@@ -130,6 +164,9 @@ where
                     self.current_page.extend(result.items);
                     self.current_cursor = result.next_cursor;
                     self.has_next_page = result.has_next_page;
+                    self.last_response = result.response;
+                    self.last_status_code = result.status_code;
+                    self.last_headers = result.headers;
                     self.loading_next = None;
 
                     if let Some(item) = self.current_page.pop_front() {
@@ -165,6 +202,9 @@ pub struct SyncPaginator<T> {
     current_page: VecDeque<T>,
     current_cursor: Option<String>,
     has_next_page: bool,
+    last_response: Option<Value>,
+    last_status_code: u16,
+    last_headers: HeaderMap,
 }
 
 impl<T> SyncPaginator<T> {
@@ -185,12 +225,30 @@ impl<T> SyncPaginator<T> {
             current_page: VecDeque::new(),
             current_cursor: initial_cursor,
             has_next_page: true, // Assume true initially
+            last_response: None,
+            last_status_code: 0,
+            last_headers: HeaderMap::new(),
         })
     }
 
     /// Check if there are more pages available
     pub fn has_next_page(&self) -> bool {
         !self.current_page.is_empty() || self.has_next_page
+    }
+
+    /// The full parsed response from the most recent page load.
+    pub fn response(&self) -> Option<&Value> {
+        self.last_response.as_ref()
+    }
+
+    /// The HTTP status code from the most recent page load.
+    pub fn status_code(&self) -> u16 {
+        self.last_status_code
+    }
+
+    /// The HTTP response headers from the most recent page load.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.last_headers
     }
 
     /// Load the next page explicitly
@@ -203,6 +261,9 @@ impl<T> SyncPaginator<T> {
 
         self.current_cursor = result.next_cursor;
         self.has_next_page = result.has_next_page;
+        self.last_response = result.response;
+        self.last_status_code = result.status_code;
+        self.last_headers = result.headers;
 
         Ok(result.items)
     }
@@ -246,6 +307,9 @@ impl<T> Iterator for SyncPaginator<T> {
                 self.current_page.extend(result.items);
                 self.current_cursor = result.next_cursor;
                 self.has_next_page = result.has_next_page;
+                self.last_response = result.response;
+                self.last_status_code = result.status_code;
+                self.last_headers = result.headers;
 
                 // Return the first item from the newly loaded page
                 self.current_page.pop_front().map(Ok)
@@ -287,7 +351,9 @@ mod tests {
     use crate::ClientConfig;
 
     fn make_http_client() -> Arc<HttpClient> {
-        Arc::new(HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"))
+        Arc::new(
+            HttpClient::new(ClientConfig::default()).expect("Failed to create test HttpClient"),
+        )
     }
 
     // ===========================
@@ -297,26 +363,42 @@ mod tests {
     #[test]
     fn test_sync_paginator_has_next_page_initially() {
         let client = make_http_client();
-        let paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec![],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec![],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
+                })
+            },
+            None,
+        )
+        .unwrap();
         assert!(paginator.has_next_page());
     }
 
     #[test]
     fn test_sync_paginator_single_page() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string(), "b".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string(), "b".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["a".to_string(), "b".to_string()]);
@@ -326,13 +408,21 @@ mod tests {
     #[test]
     fn test_sync_paginator_exhausted_returns_empty() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, _cursor| {
-            Ok(PaginationResult {
-                items: vec!["a".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, _cursor| {
+                Ok(PaginationResult {
+                    items: vec!["a".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
+                })
+            },
+            None,
+        )
+        .unwrap();
 
         let _ = paginator.next_page().unwrap();
         let empty = paginator.next_page().unwrap();
@@ -345,28 +435,39 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => {
-                    assert!(cursor.is_none());
-                    Ok(PaginationResult {
-                        items: vec![1, 2],
-                        next_cursor: Some("page2".to_string()),
-                        has_next_page: true,
-                    })
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => {
+                        assert!(cursor.is_none());
+                        Ok(PaginationResult {
+                            items: vec![1, 2],
+                            next_cursor: Some("page2".to_string()),
+                            has_next_page: true,
+                            response: None,
+                            status_code: 200,
+                            headers: HeaderMap::new(),
+                        })
+                    }
+                    1 => {
+                        assert_eq!(cursor, Some("page2".to_string()));
+                        Ok(PaginationResult {
+                            items: vec![3, 4],
+                            next_cursor: None,
+                            has_next_page: false,
+                            response: None,
+                            status_code: 200,
+                            headers: HeaderMap::new(),
+                        })
+                    }
+                    _ => panic!("Unexpected call"),
                 }
-                1 => {
-                    assert_eq!(cursor, Some("page2".to_string()));
-                    Ok(PaginationResult {
-                        items: vec![3, 4],
-                        next_cursor: None,
-                        has_next_page: false,
-                    })
-                }
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+            },
+            None,
+        )
+        .unwrap();
 
         let page1 = paginator.next_page().unwrap();
         assert_eq!(page1, vec![1, 2]);
@@ -383,22 +484,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let mut paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![1, 2],
-                    next_cursor: Some("next".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![3],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![1, 2],
+                        next_cursor: Some("next".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: 200,
+                        headers: HeaderMap::new(),
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![3],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: 200,
+                        headers: HeaderMap::new(),
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let all = paginator.collect_all().unwrap();
         assert_eq!(all, vec![1, 2, 3]);
@@ -410,22 +522,33 @@ mod tests {
         let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let count = call_count.clone();
 
-        let paginator = SyncPaginator::new(client, move |_client, _cursor| {
-            let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            match call {
-                0 => Ok(PaginationResult {
-                    items: vec![10, 20],
-                    next_cursor: Some("p2".to_string()),
-                    has_next_page: true,
-                }),
-                1 => Ok(PaginationResult {
-                    items: vec![30],
-                    next_cursor: None,
-                    has_next_page: false,
-                }),
-                _ => panic!("Unexpected call"),
-            }
-        }, None).unwrap();
+        let paginator = SyncPaginator::new(
+            client,
+            move |_client, _cursor| {
+                let call = count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                match call {
+                    0 => Ok(PaginationResult {
+                        items: vec![10, 20],
+                        next_cursor: Some("p2".to_string()),
+                        has_next_page: true,
+                        response: None,
+                        status_code: 200,
+                        headers: HeaderMap::new(),
+                    }),
+                    1 => Ok(PaginationResult {
+                        items: vec![30],
+                        next_cursor: None,
+                        has_next_page: false,
+                        response: None,
+                        status_code: 200,
+                        headers: HeaderMap::new(),
+                    }),
+                    _ => panic!("Unexpected call"),
+                }
+            },
+            None,
+        )
+        .unwrap();
 
         let items: Vec<i32> = paginator.map(|r| r.unwrap()).collect();
         assert_eq!(items, vec![10, 20, 30]);
@@ -434,9 +557,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let result = paginator.next_page();
         assert!(result.is_err());
@@ -445,9 +571,12 @@ mod tests {
     #[test]
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
-        }, None).unwrap();
+        let mut paginator = SyncPaginator::<String>::new(
+            client,
+            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            None,
+        )
+        .unwrap();
 
         let item = paginator.next();
         assert!(item.is_some());
@@ -457,14 +586,22 @@ mod tests {
     #[test]
     fn test_sync_paginator_with_initial_cursor() {
         let client = make_http_client();
-        let mut paginator = SyncPaginator::new(client, |_client, cursor| {
-            assert_eq!(cursor, Some("start_here".to_string()));
-            Ok(PaginationResult {
-                items: vec!["item".to_string()],
-                next_cursor: None,
-                has_next_page: false,
-            })
-        }, Some("start_here".to_string())).unwrap();
+        let mut paginator = SyncPaginator::new(
+            client,
+            |_client, cursor| {
+                assert_eq!(cursor, Some("start_here".to_string()));
+                Ok(PaginationResult {
+                    items: vec!["item".to_string()],
+                    next_cursor: None,
+                    has_next_page: false,
+                    response: None,
+                    status_code: 200,
+                    headers: HeaderMap::new(),
+                })
+            },
+            Some("start_here".to_string()),
+        )
+        .unwrap();
 
         let page = paginator.next_page().unwrap();
         assert_eq!(page, vec!["item".to_string()]);
@@ -480,6 +617,9 @@ mod tests {
             items: vec![1, 2, 3],
             next_cursor: Some("abc".to_string()),
             has_next_page: true,
+            response: None,
+            status_code: 200,
+            headers: HeaderMap::new(),
         };
         assert_eq!(result.items.len(), 3);
         assert_eq!(result.next_cursor, Some("abc".to_string()));


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-9800

Expose HTTP response metadata (status code, headers, and full parsed response body) on paginated API responses in the Rust SDK generator. This follows the patterns established in the [C# PR #14762](https://github.com/fern-api/fern/pull/14762) and [Go PR #10629](https://github.com/fern-api/fern/pull/10629).

## Changes Made
- Added `RawResponse<T>` struct to `http_client.rs` with `body`, `status_code`, and `headers` fields
- Added `execute_request_raw<T>()` method to `HttpClient` that returns `RawResponse<T>` instead of just `T`
- Extended `PaginationResult<T>` with `response: Option<Value>`, `status_code: u16`, and `headers: HeaderMap` fields
- Updated `AsyncPaginator` and `SyncPaginator` to store and expose HTTP metadata via `response()`, `status_code()`, and `headers()` accessor methods
- Updated `SubClientGenerator.ts` pagination logic to use `execute_request_raw` and populate new fields
- Exported `RawResponse` and pagination types from `core/mod.rs`
- Updated snapshot test for `HttpClient`
- Regenerated seed `pagination` fixture

## Testing
- [x] `pnpm seed test --generator rust-sdk --fixture pagination --skip-scripts` — passed
- [x] `pnpm turbo run test --filter @fern-api/rust-sdk` — passed (snapshot updated)
- [x] `pnpm run check` (Biome lint) — passed

Link to Devin session: https://app.devin.ai/sessions/7f24aaf05ccf4aaea3359854cf2dc279
Requested by: @iamnamananand996