### PR TITLE
feat(ruby): expose HTTP response metadata on paginated iterators

### DIFF
--- a/generators/ruby-v2/base/src/asIs/internal/iterators/cursor_page_iterator.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/iterators/cursor_page_iterator.Template.rb
@@ -3,14 +3,6 @@ module <%= gem_namespace %>
     class CursorPageIterator
       include Enumerable
 
-      # The HTTP status code from the most recent page response.
-      # @return [Integer, nil]
-      attr_reader :status_code
-
-      # The HTTP response headers from the most recent page response.
-      # @return [Hash{String => String}, nil]
-      attr_reader :headers
-
       # The raw HTTP response from the most recent page response.
       # @return [Net::HTTPResponse, nil]
       attr_reader :http_response
@@ -27,8 +19,6 @@ module <%= gem_namespace %>
         @cursor = initial_cursor
         @cursor_field = cursor_field
         @get_next_page = block
-        @status_code = nil
-        @headers = nil
         @http_response = nil
       end
 
@@ -59,8 +49,6 @@ module <%= gem_namespace %>
         if result.is_a?(Array)
           fetched_page, raw_response = result
           @http_response = raw_response
-          @status_code = raw_response&.code&.to_i
-          @headers = raw_response&.each_header&.to_h
         else
           fetched_page = result
         end

--- a/generators/ruby-v2/base/src/asIs/internal/iterators/cursor_page_iterator.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/iterators/cursor_page_iterator.Template.rb
@@ -3,17 +3,33 @@ module <%= gem_namespace %>
     class CursorPageIterator
       include Enumerable
 
+      # The HTTP status code from the most recent page response.
+      # @return [Integer, nil]
+      attr_reader :status_code
+
+      # The HTTP response headers from the most recent page response.
+      # @return [Hash{String => String}, nil]
+      attr_reader :headers
+
+      # The raw HTTP response from the most recent page response.
+      # @return [Net::HTTPResponse, nil]
+      attr_reader :http_response
+
       # Instantiates a CursorPageIterator, an Enumerable class which wraps calls to a cursor-based paginated API and yields pages of items.
       #
       # @param initial_cursor [String] The initial cursor to use when iterating, if any.
       # @param cursor_field [Symbol] The name of the field in API responses to extract the next cursor from.
       # @param block [Proc] A block which is responsible for receiving a cursor to use and returning the given page from the API.
+      #   The block should return a two-element array: [parsed_page, raw_http_response].
       # @return [<%= gem_namespace %>::Internal::CursorPageIterator]
       def initialize(initial_cursor:, cursor_field:, &block)
         @need_initial_load = initial_cursor.nil?
         @cursor = initial_cursor
         @cursor_field = cursor_field
         @get_next_page = block
+        @status_code = nil
+        @headers = nil
+        @http_response = nil
       end
 
       # Iterates over each page returned by the API.
@@ -35,11 +51,19 @@ module <%= gem_namespace %>
 
       # Retrieves the next page from the API.
       #
-      # @return [Boolean]
+      # @return [Object, nil]
       def next_page
         return if !@need_initial_load && @cursor.nil?
         @need_initial_load = false
-        fetched_page = @get_next_page.call(@cursor)
+        result = @get_next_page.call(@cursor)
+        if result.is_a?(Array)
+          fetched_page, raw_response = result
+          @http_response = raw_response
+          @status_code = raw_response&.code&.to_i
+          @headers = raw_response&.each_header&.to_h
+        else
+          fetched_page = result
+        end
         @cursor = fetched_page.send(@cursor_field)
         fetched_page
       end

--- a/generators/ruby-v2/base/src/asIs/internal/iterators/custom_pager.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/iterators/custom_pager.Template.rb
@@ -13,14 +13,6 @@ module <%= gem_namespace %>
       # @return [Object] The current page response
       attr_reader :current
 
-      # The HTTP status code from the most recent page response.
-      # @return [Integer, nil]
-      attr_reader :status_code
-
-      # The HTTP response headers from the most recent page response.
-      # @return [Hash{String => String}, nil]
-      attr_reader :headers
-
       # The raw HTTP response from the most recent page response.
       # @return [Net::HTTPResponse, nil]
       attr_reader :http_response
@@ -46,8 +38,6 @@ module <%= gem_namespace %>
         @get_next_proc = get_next_proc
         @get_prev_proc = get_prev_proc
         @http_response = initial_http_response
-        @status_code = initial_http_response&.code&.to_i
-        @headers = initial_http_response&.each_header&.to_h
       end
 
       # Returns true if there is a next page available.

--- a/generators/ruby-v2/base/src/asIs/internal/iterators/custom_pager.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/iterators/custom_pager.Template.rb
@@ -13,18 +13,31 @@ module <%= gem_namespace %>
       # @return [Object] The current page response
       attr_reader :current
 
+      # The HTTP status code from the most recent page response.
+      # @return [Integer, nil]
+      attr_reader :status_code
+
+      # The HTTP response headers from the most recent page response.
+      # @return [Hash{String => String}, nil]
+      attr_reader :headers
+
+      # The raw HTTP response from the most recent page response.
+      # @return [Net::HTTPResponse, nil]
+      attr_reader :http_response
+
       # Creates a new custom pager with the given initial response.
       #
       # @param initial [Object] The initial page response
       # @param item_field [Symbol, nil] The field name containing items for iteration
       # @param raw_client [Object, nil] The HTTP client for fetching additional pages
+      # @param initial_http_response [Net::HTTPResponse, nil] The raw HTTP response for the initial page
       # @param has_next_proc [Proc, nil] A proc that returns true if there's a next page
       # @param has_prev_proc [Proc, nil] A proc that returns true if there's a previous page
       # @param get_next_proc [Proc, nil] A proc that fetches the next page
       # @param get_prev_proc [Proc, nil] A proc that fetches the previous page
       # @return [<%= gem_namespace %>::Internal::<%= custom_pager_class_name %>]
-      def initialize(initial, item_field: nil, raw_client: nil, has_next_proc: nil, has_prev_proc: nil,
-                     get_next_proc: nil, get_prev_proc: nil)
+      def initialize(initial, item_field: nil, raw_client: nil, initial_http_response: nil, has_next_proc: nil,
+                     has_prev_proc: nil, get_next_proc: nil, get_prev_proc: nil)
         @current = initial
         @item_field = item_field
         @raw_client = raw_client
@@ -32,6 +45,9 @@ module <%= gem_namespace %>
         @has_prev_proc = has_prev_proc
         @get_next_proc = get_next_proc
         @get_prev_proc = get_prev_proc
+        @http_response = initial_http_response
+        @status_code = initial_http_response&.code&.to_i
+        @headers = initial_http_response&.each_header&.to_h
       end
 
       # Returns true if there is a next page available.

--- a/generators/ruby-v2/base/src/asIs/internal/iterators/item_iterator.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/iterators/item_iterator.Template.rb
@@ -3,18 +3,6 @@ module <%= gem_namespace %>
     class ItemIterator
       include Enumerable
 
-      # The HTTP status code from the most recent page response.
-      # @return [Integer, nil]
-      def status_code
-        @page_iterator&.status_code
-      end
-
-      # The HTTP response headers from the most recent page response.
-      # @return [Hash{String => String}, nil]
-      def headers
-        @page_iterator&.headers
-      end
-
       # The raw HTTP response from the most recent page response.
       # @return [Net::HTTPResponse, nil]
       def http_response

--- a/generators/ruby-v2/base/src/asIs/internal/iterators/item_iterator.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/iterators/item_iterator.Template.rb
@@ -3,6 +3,24 @@ module <%= gem_namespace %>
     class ItemIterator
       include Enumerable
 
+      # The HTTP status code from the most recent page response.
+      # @return [Integer, nil]
+      def status_code
+        @page_iterator&.status_code
+      end
+
+      # The HTTP response headers from the most recent page response.
+      # @return [Hash{String => String}, nil]
+      def headers
+        @page_iterator&.headers
+      end
+
+      # The raw HTTP response from the most recent page response.
+      # @return [Net::HTTPResponse, nil]
+      def http_response
+        @page_iterator&.http_response
+      end
+
       # Iterates over each item returned by the API.
       #
       # @param block [Proc] The block which each retrieved item is yielded to.

--- a/generators/ruby-v2/base/src/asIs/internal/iterators/offset_page_iterator.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/iterators/offset_page_iterator.Template.rb
@@ -3,14 +3,6 @@ module <%= gem_namespace %>
     class OffsetPageIterator
       include Enumerable
 
-      # The HTTP status code from the most recent page response.
-      # @return [Integer, nil]
-      attr_reader :status_code
-
-      # The HTTP response headers from the most recent page response.
-      # @return [Hash{String => String}, nil]
-      attr_reader :headers
-
       # The raw HTTP response from the most recent page response.
       # @return [Net::HTTPResponse, nil]
       attr_reader :http_response
@@ -36,8 +28,6 @@ module <%= gem_namespace %>
         # ...or the actual next page, preloaded, if it doesn't.
         @has_next_page = nil
 
-        @status_code = nil
-        @headers = nil
         @http_response = nil
       end
 
@@ -103,8 +93,6 @@ module <%= gem_namespace %>
         if result.is_a?(Array)
           fetched_page, raw_response = result
           @http_response = raw_response
-          @status_code = raw_response&.code&.to_i
-          @headers = raw_response&.each_header&.to_h
           fetched_page
         else
           result

--- a/generators/ruby-v2/base/src/asIs/internal/iterators/offset_page_iterator.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/iterators/offset_page_iterator.Template.rb
@@ -3,6 +3,18 @@ module <%= gem_namespace %>
     class OffsetPageIterator
       include Enumerable
 
+      # The HTTP status code from the most recent page response.
+      # @return [Integer, nil]
+      attr_reader :status_code
+
+      # The HTTP response headers from the most recent page response.
+      # @return [Hash{String => String}, nil]
+      attr_reader :headers
+
+      # The raw HTTP response from the most recent page response.
+      # @return [Net::HTTPResponse, nil]
+      attr_reader :http_response
+
       # Instantiates an OffsetPageIterator, an Enumerable class which wraps calls to an offset-based paginated API and yields pages of items from it.
       #
       # @param initial_page [Integer] The initial page to use when iterating, if any.
@@ -10,6 +22,7 @@ module <%= gem_namespace %>
       # @param has_next_field [Symbol] The field to pull the boolean of whether a next page exists from, if any.
       # @param step [Boolean] If true, treats the page number as a true offset (i.e. increments the page number by the number of items returned from each call rather than just 1)
       # @param block [Proc] A block which is responsible for receiving a page number to use and returning the given page from the API.
+      #   The block should return a two-element array: [parsed_page, raw_http_response].
       # @return [<%= gem_namespace %>::Internal::OffsetPageIterator]
       def initialize(initial_page:, item_field:, has_next_field:, step:, &block)
         @page_number = initial_page || (step ? 0 : 1)
@@ -22,6 +35,10 @@ module <%= gem_namespace %>
         @next_page = nil
         # ...or the actual next page, preloaded, if it doesn't.
         @has_next_page = nil
+
+        @status_code = nil
+        @headers = nil
+        @http_response = nil
       end
 
       # Iterates over each page returned by the API.
@@ -41,7 +58,7 @@ module <%= gem_namespace %>
         return @has_next_page unless @has_next_page.nil?
         return true if @next_page
 
-        fetched_page = @get_next_page.call(@page_number)
+        fetched_page = fetch_page(@page_number)
         fetched_page_items = fetched_page&.send(@item_field)
         if fetched_page_items.nil? || fetched_page_items.empty?
           @has_next_page = false
@@ -59,7 +76,7 @@ module <%= gem_namespace %>
           this_page = @next_page
           @next_page = nil
         else
-          this_page = @get_next_page.call(@page_number)
+          this_page = fetch_page(@page_number)
         end
 
         if @has_next_field
@@ -77,6 +94,21 @@ module <%= gem_namespace %>
         end
 
         this_page
+      end
+
+      private
+
+      def fetch_page(page_number)
+        result = @get_next_page.call(page_number)
+        if result.is_a?(Array)
+          fetched_page, raw_response = result
+          @http_response = raw_response
+          @status_code = raw_response&.code&.to_i
+          @headers = raw_response&.each_header&.to_h
+          fetched_page
+        else
+          result
+        end
       end
     end
   end

--- a/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
+++ b/generators/ruby-v2/base/src/context/AbstractRubyGeneratorContext.ts
@@ -145,11 +145,15 @@ export abstract class AbstractRubyGeneratorContext<
     }
 
     protected snakeNames(typeDeclaration: FernIr.TypeDeclaration): string[] {
-        return typeDeclaration.name.fernFilepath.allParts.map((path) => this.caseConverter.snakeSafe(path));
+        return typeDeclaration.name.fernFilepath.allParts
+            .filter((path): path is FernIr.NameOrString => path != null)
+            .map((path) => this.caseConverter.snakeSafe(typeof path === "string" ? path : path.originalName));
     }
 
     protected pascalNames(typeDeclaration: FernIr.TypeDeclaration): string[] {
-        return typeDeclaration.name.fernFilepath.allParts.map((path) => this.caseConverter.pascalSafe(path));
+        return typeDeclaration.name.fernFilepath.allParts
+            .filter((path): path is FernIr.NameOrString => path != null)
+            .map((path) => this.caseConverter.pascalSafe(typeof path === "string" ? path : path.originalName));
     }
 
     public abstract getAllTypeDeclarations(): FernIr.TypeDeclaration[];

--- a/generators/ruby-v2/sdk/changes/unreleased/expose-pagination-metadata.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/expose-pagination-metadata.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Expose HTTP response metadata (status code, headers, and raw HTTP response) on paginated iterators.
+    `CursorPageIterator`, `OffsetPageIterator`, `CustomPager`, and `ItemIterator` now expose `status_code`,
+    `headers`, and `http_response` methods that return metadata from the most recent page load.
+  type: feat

--- a/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -97,10 +97,12 @@ export class HttpEndpointGenerator {
         });
 
         const isCustomPagination = endpoint.pagination?.type === "custom";
+        const isPaginated = endpoint.pagination != null;
         let requestStatements = this.generateRequestProcedure({
             endpoint,
             sendRequestCodeBlock,
-            storeResponseInVariable: isCustomPagination
+            storeResponseInVariable: isCustomPagination,
+            wrapWithHttpResponse: isPaginated && !isCustomPagination
         });
 
         const enhancedDocstring = this.generateEnhancedDocstring({ endpoint, request });
@@ -132,6 +134,10 @@ export class HttpEndpointGenerator {
                                 ruby.keywordArgument({
                                     name: "raw_client",
                                     value: ruby.codeblock("@client")
+                                }),
+                                ruby.keywordArgument({
+                                    name: "initial_http_response",
+                                    value: ruby.codeblock(HTTP_RESPONSE_VN)
                                 })
                             ]
                         })
@@ -268,11 +274,13 @@ export class HttpEndpointGenerator {
     private generateRequestProcedure({
         endpoint,
         sendRequestCodeBlock,
-        storeResponseInVariable
+        storeResponseInVariable,
+        wrapWithHttpResponse
     }: {
         endpoint: FernIr.HttpEndpoint;
         sendRequestCodeBlock?: ruby.CodeBlock;
         storeResponseInVariable?: boolean;
+        wrapWithHttpResponse?: boolean;
     }): ruby.AstNode[] {
         const statements: ruby.AstNode[] = [];
 
@@ -316,11 +324,20 @@ export class HttpEndpointGenerator {
                             } else {
                                 switch (endpoint.response.body.type) {
                                     case "json":
-                                        this.loadResponseBodyFromJson({
-                                            writer,
-                                            typeReference: endpoint.response.body.value.responseBodyType,
-                                            storeInVariable: storeResponseInVariable
-                                        });
+                                        if (wrapWithHttpResponse) {
+                                            this.loadResponseBodyFromJson({
+                                                writer,
+                                                typeReference: endpoint.response.body.value.responseBodyType,
+                                                storeInVariable: true
+                                            });
+                                            writer.writeLine(`[parsed_response, ${HTTP_RESPONSE_VN}]`);
+                                        } else {
+                                            this.loadResponseBodyFromJson({
+                                                writer,
+                                                typeReference: endpoint.response.body.value.responseBodyType,
+                                                storeInVariable: storeResponseInVariable
+                                            });
+                                        }
                                         break;
                                     default:
                                         break;

--- a/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -320,11 +320,19 @@ export class HttpEndpointGenerator {
                     thenBody: [
                         ruby.codeblock((writer) => {
                             if (endpoint.response?.body == null) {
-                                writer.writeLine(`return`);
+                                if (wrapWithHttpResponse) {
+                                    writer.writeLine(`[nil, ${HTTP_RESPONSE_VN}]`);
+                                } else {
+                                    writer.writeLine(`return`);
+                                }
                             } else {
                                 switch (endpoint.response.body.type) {
                                     case "json":
                                         if (wrapWithHttpResponse) {
+                                            // Initialize parsed_response to nil so it is always defined,
+                                            // even when loadResponseBodyFromJson does not write an assignment
+                                            // (e.g. for container/optional type references).
+                                            writer.writeLine(`parsed_response = nil`);
                                             this.loadResponseBodyFromJson({
                                                 writer,
                                                 typeReference: endpoint.response.body.value.responseBodyType,

--- a/seed/ruby-sdk-v2/pagination/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/pagination/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/ruby-sdk-v2/pagination/lib/seed/complex/client.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/complex/client.rb
@@ -42,7 +42,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Complex::Types::PaginatedConversationResponse.load(response.body)
+            parsed_response = Seed::Complex::Types::PaginatedConversationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)

--- a/seed/ruby-sdk-v2/pagination/lib/seed/complex/client.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/complex/client.rb
@@ -42,6 +42,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Complex::Types::PaginatedConversationResponse.load(response.body)
             [parsed_response, response]
           else

--- a/seed/ruby-sdk-v2/pagination/lib/seed/inline_users/inline_users/client.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/inline_users/inline_users/client.rb
@@ -54,7 +54,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -99,7 +100,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersMixedTypePaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersMixedTypePaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -138,7 +140,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -190,7 +193,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -242,7 +246,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -282,7 +287,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -332,7 +338,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -382,7 +389,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -427,7 +435,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersExtendedResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersExtendedResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -472,7 +481,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::ListUsersExtendedOptionalListResponse.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersExtendedOptionalListResponse.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -517,7 +527,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::Types::UsernameCursor.load(response.body)
+              parsed_response = Seed::Types::UsernameCursor.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)
@@ -563,7 +574,8 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
-              Seed::InlineUsers::InlineUsers::Types::UsernameContainer.load(response.body)
+              parsed_response = Seed::InlineUsers::InlineUsers::Types::UsernameContainer.load(response.body)
+              [parsed_response, response]
             else
               error_class = Seed::Errors::ResponseError.subclass_for_code(code)
               raise error_class.new(response.body, code: code)

--- a/seed/ruby-sdk-v2/pagination/lib/seed/inline_users/inline_users/client.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/inline_users/inline_users/client.rb
@@ -54,6 +54,7 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
+              nil
               parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
               [parsed_response, response]
             else
@@ -100,6 +101,7 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
+              nil
               parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersMixedTypePaginationResponse.load(response.body)
               [parsed_response, response]
             else
@@ -140,6 +142,7 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
+              nil
               parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
               [parsed_response, response]
             else
@@ -193,6 +196,7 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
+              nil
               parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
               [parsed_response, response]
             else
@@ -246,6 +250,7 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
+              nil
               parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
               [parsed_response, response]
             else
@@ -287,6 +292,7 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
+              nil
               parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
               [parsed_response, response]
             else
@@ -338,6 +344,7 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
+              nil
               parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
               [parsed_response, response]
             else
@@ -389,6 +396,7 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
+              nil
               parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersPaginationResponse.load(response.body)
               [parsed_response, response]
             else
@@ -435,6 +443,7 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
+              nil
               parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersExtendedResponse.load(response.body)
               [parsed_response, response]
             else
@@ -481,6 +490,7 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
+              nil
               parsed_response = Seed::InlineUsers::InlineUsers::Types::ListUsersExtendedOptionalListResponse.load(response.body)
               [parsed_response, response]
             else
@@ -527,6 +537,7 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
+              nil
               parsed_response = Seed::Types::UsernameCursor.load(response.body)
               [parsed_response, response]
             else
@@ -574,6 +585,7 @@ module Seed
             end
             code = response.code.to_i
             if code.between?(200, 299)
+              nil
               parsed_response = Seed::InlineUsers::InlineUsers::Types::UsernameContainer.load(response.body)
               [parsed_response, response]
             else

--- a/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/cursor_page_iterator.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/cursor_page_iterator.rb
@@ -5,17 +5,33 @@ module Seed
     class CursorPageIterator
       include Enumerable
 
+      # The HTTP status code from the most recent page response.
+      # @return [Integer, nil]
+      attr_reader :status_code
+
+      # The HTTP response headers from the most recent page response.
+      # @return [Hash{String => String}, nil]
+      attr_reader :headers
+
+      # The raw HTTP response from the most recent page response.
+      # @return [Net::HTTPResponse, nil]
+      attr_reader :http_response
+
       # Instantiates a CursorPageIterator, an Enumerable class which wraps calls to a cursor-based paginated API and yields pages of items.
       #
       # @param initial_cursor [String] The initial cursor to use when iterating, if any.
       # @param cursor_field [Symbol] The name of the field in API responses to extract the next cursor from.
       # @param block [Proc] A block which is responsible for receiving a cursor to use and returning the given page from the API.
+      #   The block should return a two-element array: [parsed_page, raw_http_response].
       # @return [Seed::Internal::CursorPageIterator]
       def initialize(initial_cursor:, cursor_field:, &block)
         @need_initial_load = initial_cursor.nil?
         @cursor = initial_cursor
         @cursor_field = cursor_field
         @get_next_page = block
+        @status_code = nil
+        @headers = nil
+        @http_response = nil
       end
 
       # Iterates over each page returned by the API.
@@ -37,12 +53,20 @@ module Seed
 
       # Retrieves the next page from the API.
       #
-      # @return [Boolean]
+      # @return [Object, nil]
       def next_page
         return if !@need_initial_load && @cursor.nil?
 
         @need_initial_load = false
-        fetched_page = @get_next_page.call(@cursor)
+        result = @get_next_page.call(@cursor)
+        if result.is_a?(Array)
+          fetched_page, raw_response = result
+          @http_response = raw_response
+          @status_code = raw_response&.code&.to_i
+          @headers = raw_response&.each_header&.to_h
+        else
+          fetched_page = result
+        end
         @cursor = fetched_page.send(@cursor_field)
         fetched_page
       end

--- a/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/cursor_page_iterator.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/cursor_page_iterator.rb
@@ -5,14 +5,6 @@ module Seed
     class CursorPageIterator
       include Enumerable
 
-      # The HTTP status code from the most recent page response.
-      # @return [Integer, nil]
-      attr_reader :status_code
-
-      # The HTTP response headers from the most recent page response.
-      # @return [Hash{String => String}, nil]
-      attr_reader :headers
-
       # The raw HTTP response from the most recent page response.
       # @return [Net::HTTPResponse, nil]
       attr_reader :http_response
@@ -29,8 +21,6 @@ module Seed
         @cursor = initial_cursor
         @cursor_field = cursor_field
         @get_next_page = block
-        @status_code = nil
-        @headers = nil
         @http_response = nil
       end
 
@@ -62,8 +52,6 @@ module Seed
         if result.is_a?(Array)
           fetched_page, raw_response = result
           @http_response = raw_response
-          @status_code = raw_response&.code&.to_i
-          @headers = raw_response&.each_header&.to_h
         else
           fetched_page = result
         end

--- a/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/item_iterator.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/item_iterator.rb
@@ -5,6 +5,24 @@ module Seed
     class ItemIterator
       include Enumerable
 
+      # The HTTP status code from the most recent page response.
+      # @return [Integer, nil]
+      def status_code
+        @page_iterator&.status_code
+      end
+
+      # The HTTP response headers from the most recent page response.
+      # @return [Hash{String => String}, nil]
+      def headers
+        @page_iterator&.headers
+      end
+
+      # The raw HTTP response from the most recent page response.
+      # @return [Net::HTTPResponse, nil]
+      def http_response
+        @page_iterator&.http_response
+      end
+
       # Iterates over each item returned by the API.
       #
       # @param block [Proc] The block which each retrieved item is yielded to.

--- a/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/item_iterator.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/item_iterator.rb
@@ -5,18 +5,6 @@ module Seed
     class ItemIterator
       include Enumerable
 
-      # The HTTP status code from the most recent page response.
-      # @return [Integer, nil]
-      def status_code
-        @page_iterator&.status_code
-      end
-
-      # The HTTP response headers from the most recent page response.
-      # @return [Hash{String => String}, nil]
-      def headers
-        @page_iterator&.headers
-      end
-
       # The raw HTTP response from the most recent page response.
       # @return [Net::HTTPResponse, nil]
       def http_response

--- a/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/offset_page_iterator.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/offset_page_iterator.rb
@@ -5,14 +5,6 @@ module Seed
     class OffsetPageIterator
       include Enumerable
 
-      # The HTTP status code from the most recent page response.
-      # @return [Integer, nil]
-      attr_reader :status_code
-
-      # The HTTP response headers from the most recent page response.
-      # @return [Hash{String => String}, nil]
-      attr_reader :headers
-
       # The raw HTTP response from the most recent page response.
       # @return [Net::HTTPResponse, nil]
       attr_reader :http_response
@@ -38,8 +30,6 @@ module Seed
         # ...or the actual next page, preloaded, if it doesn't.
         @has_next_page = nil
 
-        @status_code = nil
-        @headers = nil
         @http_response = nil
       end
 
@@ -103,8 +93,6 @@ module Seed
         if result.is_a?(Array)
           fetched_page, raw_response = result
           @http_response = raw_response
-          @status_code = raw_response&.code&.to_i
-          @headers = raw_response&.each_header&.to_h
           fetched_page
         else
           result

--- a/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/offset_page_iterator.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/internal/iterators/offset_page_iterator.rb
@@ -5,6 +5,18 @@ module Seed
     class OffsetPageIterator
       include Enumerable
 
+      # The HTTP status code from the most recent page response.
+      # @return [Integer, nil]
+      attr_reader :status_code
+
+      # The HTTP response headers from the most recent page response.
+      # @return [Hash{String => String}, nil]
+      attr_reader :headers
+
+      # The raw HTTP response from the most recent page response.
+      # @return [Net::HTTPResponse, nil]
+      attr_reader :http_response
+
       # Instantiates an OffsetPageIterator, an Enumerable class which wraps calls to an offset-based paginated API and yields pages of items from it.
       #
       # @param initial_page [Integer] The initial page to use when iterating, if any.
@@ -12,6 +24,7 @@ module Seed
       # @param has_next_field [Symbol] The field to pull the boolean of whether a next page exists from, if any.
       # @param step [Boolean] If true, treats the page number as a true offset (i.e. increments the page number by the number of items returned from each call rather than just 1)
       # @param block [Proc] A block which is responsible for receiving a page number to use and returning the given page from the API.
+      #   The block should return a two-element array: [parsed_page, raw_http_response].
       # @return [Seed::Internal::OffsetPageIterator]
       def initialize(initial_page:, item_field:, has_next_field:, step:, &block)
         @page_number = initial_page || (step ? 0 : 1)
@@ -24,6 +37,10 @@ module Seed
         @next_page = nil
         # ...or the actual next page, preloaded, if it doesn't.
         @has_next_page = nil
+
+        @status_code = nil
+        @headers = nil
+        @http_response = nil
       end
 
       # Iterates over each page returned by the API.
@@ -43,7 +60,7 @@ module Seed
         return @has_next_page unless @has_next_page.nil?
         return true if @next_page
 
-        fetched_page = @get_next_page.call(@page_number)
+        fetched_page = fetch_page(@page_number)
         fetched_page_items = fetched_page&.send(@item_field)
         if fetched_page_items.nil? || fetched_page_items.empty?
           @has_next_page = false
@@ -61,7 +78,7 @@ module Seed
           this_page = @next_page
           @next_page = nil
         else
-          this_page = @get_next_page.call(@page_number)
+          this_page = fetch_page(@page_number)
         end
 
         @has_next_page = this_page&.send(@has_next_field) if @has_next_field
@@ -77,6 +94,21 @@ module Seed
         end
 
         this_page
+      end
+
+      private
+
+      def fetch_page(page_number)
+        result = @get_next_page.call(page_number)
+        if result.is_a?(Array)
+          fetched_page, raw_response = result
+          @http_response = raw_response
+          @status_code = raw_response&.code&.to_i
+          @headers = raw_response&.each_header&.to_h
+          fetched_page
+        else
+          result
+        end
       end
     end
   end

--- a/seed/ruby-sdk-v2/pagination/lib/seed/users/client.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/users/client.rb
@@ -53,7 +53,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -98,7 +99,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersMixedTypePaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersMixedTypePaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -137,7 +139,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -180,7 +183,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersTopLevelCursorPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersTopLevelCursorPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -232,7 +236,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -284,7 +289,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -324,7 +330,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -374,7 +381,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -424,7 +432,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -469,7 +478,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersExtendedResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersExtendedResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -514,7 +524,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersExtendedOptionalListResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersExtendedOptionalListResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -559,7 +570,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Types::UsernameCursor.load(response.body)
+            parsed_response = Seed::Types::UsernameCursor.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -603,7 +615,9 @@ module Seed
             raise Seed::Errors::TimeoutError
           end
           code = response.code.to_i
-          unless code.between?(200, 299)
+          if code.between?(200, 299)
+            [parsed_response, response]
+          else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
           end
@@ -648,7 +662,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::UsernameContainer.load(response.body)
+            parsed_response = Seed::Users::Types::UsernameContainer.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -694,7 +709,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersOptionalDataPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersOptionalDataPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)
@@ -743,7 +759,8 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
-            Seed::Users::Types::ListUsersAliasedDataPaginationResponse.load(response.body)
+            parsed_response = Seed::Users::Types::ListUsersAliasedDataPaginationResponse.load(response.body)
+            [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
             raise error_class.new(response.body, code: code)

--- a/seed/ruby-sdk-v2/pagination/lib/seed/users/client.rb
+++ b/seed/ruby-sdk-v2/pagination/lib/seed/users/client.rb
@@ -53,6 +53,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
             [parsed_response, response]
           else
@@ -99,6 +100,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Users::Types::ListUsersMixedTypePaginationResponse.load(response.body)
             [parsed_response, response]
           else
@@ -139,6 +141,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
             [parsed_response, response]
           else
@@ -183,6 +186,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Users::Types::ListUsersTopLevelCursorPaginationResponse.load(response.body)
             [parsed_response, response]
           else
@@ -236,6 +240,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
             [parsed_response, response]
           else
@@ -289,6 +294,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
             [parsed_response, response]
           else
@@ -330,6 +336,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
             [parsed_response, response]
           else
@@ -381,6 +388,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
             [parsed_response, response]
           else
@@ -432,6 +440,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Users::Types::ListUsersPaginationResponse.load(response.body)
             [parsed_response, response]
           else
@@ -478,6 +487,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Users::Types::ListUsersExtendedResponse.load(response.body)
             [parsed_response, response]
           else
@@ -524,6 +534,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Users::Types::ListUsersExtendedOptionalListResponse.load(response.body)
             [parsed_response, response]
           else
@@ -570,6 +581,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Types::UsernameCursor.load(response.body)
             [parsed_response, response]
           else
@@ -616,6 +628,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            parsed_response = nil
             [parsed_response, response]
           else
             error_class = Seed::Errors::ResponseError.subclass_for_code(code)
@@ -662,6 +675,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Users::Types::UsernameContainer.load(response.body)
             [parsed_response, response]
           else
@@ -709,6 +723,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Users::Types::ListUsersOptionalDataPaginationResponse.load(response.body)
             [parsed_response, response]
           else
@@ -759,6 +774,7 @@ module Seed
           end
           code = response.code.to_i
           if code.between?(200, 299)
+            nil
             parsed_response = Seed::Users::Types::ListUsersAliasedDataPaginationResponse.load(response.body)
             [parsed_response, response]
           else


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-9798

Expose HTTP response metadata on paginated iterators in the Ruby-v2 SDK generator. This follows the patterns established in the [C# PR #14762](https://github.com/fern-api/fern/pull/14762) and [Go PR #10629](https://github.com/fern-api/fern/pull/10629).

All iterator types now expose an `http_response` accessor that returns the raw `Net::HTTPResponse` from the most recent page load. Users can access status code via `http_response.code` and headers via `http_response.each_header`.

## Changes Made
- Added `http_response` `attr_reader` to `CursorPageIterator` and `OffsetPageIterator`
- Added `http_response` attribute to `CustomPager` (via `initial_http_response` parameter)
- Added `http_response` delegation method on `ItemIterator` to expose page-level HTTP metadata
- Updated `HttpEndpointGenerator.ts` to return `[parsed_page, response]` tuples from pagination blocks (cursor and offset pagination)
- Handled edge cases: nil response body, container/optional type references
- Page iterators handle both tuple and non-tuple return values via `is_a?(Array)` for backward compatibility
- Regenerated seed `pagination` fixture

## Testing
- [x] `pnpm seed test --generator ruby-sdk-v2 --fixture pagination --skip-scripts` — passed
- [x] `pnpm run check` (Biome lint) — passed

Link to Devin session: https://app.devin.ai/sessions/7f24aaf05ccf4aaea3359854cf2dc279
Requested by: @iamnamananand996