### PR TITLE
fix(cli): thread --version through to TS SDK for local-file-system output

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/fix-version-local-gen.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-version-local-gen.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Read the SDK version and package name from the IR's `publishConfig` when
+    available, not just for self-hosted orgs. This lets `--version` flow through
+    to the generated `package.json` and `X-Fern-SDK-Version` header when the
+    generator is invoked with `output.location: local-file-system` (where the
+    generator exec output mode is `downloadFiles` and does not itself carry a
+    version).
+  type: fix

--- a/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
@@ -78,20 +78,15 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
                 parse: serialization.IntermediateRepresentation.parse
             });
 
-            let npmPackage: NpmPackage | undefined;
-            if (ir.selfHosted) {
-                // Try to construct package from publish config
-                npmPackage = constructNpmPackageFromArgs(
-                    npmPackageInfoFromPublishConfig(config, ir.publishConfig, this.isPackagePrivate(customConfig))
-                );
-                // Fall back to generator config if publish config doesn't have the necessary info
-                if (npmPackage == null) {
-                    npmPackage = constructNpmPackage({
-                        generatorConfig: config,
-                        isPackagePrivate: this.isPackagePrivate(customConfig)
-                    });
-                }
-            } else {
+            // First try to construct the package from the IR's publishConfig. This is how
+            // self-hosted setups thread package metadata through, and it also carries the
+            // version + package name for local-file-system output (where the generator
+            // exec output mode is `downloadFiles` and does not itself carry a version).
+            let npmPackage: NpmPackage | undefined = constructNpmPackageFromArgs(
+                npmPackageInfoFromPublishConfig(config, ir.publishConfig, this.isPackagePrivate(customConfig))
+            );
+            // Fall back to deriving the package from the generator exec config (github/publish modes).
+            if (npmPackage == null) {
                 npmPackage = constructNpmPackage({
                     generatorConfig: config,
                     isPackagePrivate: this.isPackagePrivate(customConfig)
@@ -105,12 +100,13 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
                 })
             );
 
-            const version = config.output?.mode._visit({
-                downloadFiles: () => undefined,
-                github: (github) => github.version,
-                publish: (publish) => publish.version,
-                _other: () => undefined
-            });
+            const version =
+                config.output?.mode._visit({
+                    downloadFiles: () => undefined,
+                    github: (github) => github.version,
+                    publish: (publish) => publish.version,
+                    _other: () => undefined
+                }) ?? npmPackage?.version;
 
             const generatorContext = new GeneratorContextImpl(logger, version);
             const codeGenStartTime = Date.now();

--- a/packages/cli/cli/changes/unreleased/fix-ts-version-local-gen.yml
+++ b/packages/cli/cli/changes/unreleased/fix-ts-version-local-gen.yml
@@ -1,9 +1,12 @@
 - summary: |
-    Thread `--version` through to the TypeScript SDK when generating locally with
-    `output.location: local-file-system`. Previously, running
-    `fern generate --group <ts-group> --version <x.y.z> --local` would silently drop
-    the version and emit a `package.json` without a `version` field. The CLI now
-    populates `PublishingConfig.filesystem.publishTarget` with an npm target for
-    TypeScript generators so the generator can produce the correct
-    `package.json` and `X-Fern-SDK-Version` header.
+    Thread the explicit `--version` flag through to the TypeScript SDK when
+    generating locally with `output.location: local-file-system`. Previously,
+    running `fern generate --group <ts-group> --version <x.y.z> --local` would
+    silently drop the version and emit a `package.json` without a `version`
+    field. The CLI now populates `PublishingConfig.filesystem.publishTarget`
+    with an npm target (carrying the user-provided version and the
+    `config.packageJson.name`) so the generator can produce the correct
+    `package.json` and `X-Fern-SDK-Version` header. Only `--version` that was
+    explicitly passed is threaded through; auto-computed versions are not, to
+    avoid behavior changes for users who manage `package.json` themselves.
   type: fix

--- a/packages/cli/cli/changes/unreleased/fix-ts-version-local-gen.yml
+++ b/packages/cli/cli/changes/unreleased/fix-ts-version-local-gen.yml
@@ -1,0 +1,9 @@
+- summary: |
+    Thread `--version` through to the TypeScript SDK when generating locally with
+    `output.location: local-file-system`. Previously, running
+    `fern generate --group <ts-group> --version <x.y.z> --local` would silently drop
+    the version and emit a `package.json` without a `version` field. The CLI now
+    populates `PublishingConfig.filesystem.publishTarget` with an npm target for
+    TypeScript generators so the generator can produce the correct
+    `package.json` and `X-Fern-SDK-Version` header.
+  type: fix

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -208,6 +208,7 @@ export async function runLocalGenerationForWorkspace({
                     generatorInvocation,
                     org: organization.ok ? organization.body : undefined,
                     version,
+                    userProvidedVersion,
                     packageName,
                     context: interactiveTaskContext
                 });
@@ -473,12 +474,14 @@ function getPublishConfig({
     generatorInvocation,
     org,
     version,
+    userProvidedVersion,
     packageName,
     context
 }: {
     generatorInvocation: generatorsYml.GeneratorInvocation;
     org?: FernVenusApi.Organization;
     version?: string;
+    userProvidedVersion?: string;
     packageName?: string;
     context: TaskContext;
 }): FernIr.PublishingConfig | undefined {
@@ -507,17 +510,25 @@ function getPublishConfig({
             });
             context.logger.debug(`Created PyPiPublishTarget: version ${version} package name: ${packageName}`);
         } else if (generatorInvocation.language === "typescript") {
-            // Only populate the npm publish target when we actually have version or
-            // package name information to thread through. Emitting empty placeholders
-            // ("" / "0.0.0") would cause the generator to write phantom values into
-            // package.json and the X-Fern-SDK-Version header.
-            if (version != null || packageName != null) {
+            // Only populate the npm publish target when the user explicitly passed
+            // `--version`. We intentionally do NOT thread auto-computed versions or
+            // package names on their own — doing so would cause unrelated behavior
+            // changes (e.g. auto-bumping a version from the npm registry) for users
+            // who rely on managing `package.json` themselves.
+            if (userProvidedVersion != null) {
+                const tsPackageName =
+                    packageName ??
+                    (typeof generatorInvocation.raw?.config === "object" && generatorInvocation.raw?.config !== null
+                        ? (generatorInvocation.raw.config as { packageJson?: { name?: string } }).packageJson?.name
+                        : undefined);
                 publishTarget = PublishTarget.npm({
-                    version,
-                    packageName,
+                    version: userProvidedVersion,
+                    packageName: tsPackageName,
                     tokenEnvironmentVariable: ""
                 });
-                context.logger.debug(`Created NpmPublishTarget: version ${version} package name: ${packageName}`);
+                context.logger.debug(
+                    `Created NpmPublishTarget: version ${userProvidedVersion} package name: ${tsPackageName}`
+                );
             }
         } else if (generatorInvocation.language === "rust") {
             // Use Crates publish target for Rust (Cargo/crates.io)

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -506,6 +506,17 @@ function getPublishConfig({
                 packageName
             });
             context.logger.debug(`Created PyPiPublishTarget: version ${version} package name: ${packageName}`);
+        } else if (generatorInvocation.language === "typescript") {
+            // The TypeScript generator reads the npm PublishTarget from the IR's
+            // PublishingConfig to populate package.json (name + version) and the
+            // X-Fern-SDK-Version header when generating to a local-file-system
+            // output. Without this, --version is silently dropped.
+            publishTarget = PublishTarget.npm({
+                version: version ?? "0.0.0",
+                packageName: packageName ?? "",
+                tokenEnvironmentVariable: ""
+            });
+            context.logger.debug(`Created NpmPublishTarget: version ${version} package name: ${packageName}`);
         } else if (generatorInvocation.language === "rust") {
             // Use Crates publish target for Rust (Cargo/crates.io)
             publishTarget = PublishTarget.crates({

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -517,9 +517,7 @@ function getPublishConfig({
                     packageName,
                     tokenEnvironmentVariable: ""
                 });
-                context.logger.debug(
-                    `Created NpmPublishTarget: version ${version} package name: ${packageName}`
-                );
+                context.logger.debug(`Created NpmPublishTarget: version ${version} package name: ${packageName}`);
             }
         } else if (generatorInvocation.language === "rust") {
             // Use Crates publish target for Rust (Cargo/crates.io)

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -507,16 +507,20 @@ function getPublishConfig({
             });
             context.logger.debug(`Created PyPiPublishTarget: version ${version} package name: ${packageName}`);
         } else if (generatorInvocation.language === "typescript") {
-            // The TypeScript generator reads the npm PublishTarget from the IR's
-            // PublishingConfig to populate package.json (name + version) and the
-            // X-Fern-SDK-Version header when generating to a local-file-system
-            // output. Without this, --version is silently dropped.
-            publishTarget = PublishTarget.npm({
-                version: version ?? "0.0.0",
-                packageName: packageName ?? "",
-                tokenEnvironmentVariable: ""
-            });
-            context.logger.debug(`Created NpmPublishTarget: version ${version} package name: ${packageName}`);
+            // Only populate the npm publish target when we actually have version or
+            // package name information to thread through. Emitting empty placeholders
+            // ("" / "0.0.0") would cause the generator to write phantom values into
+            // package.json and the X-Fern-SDK-Version header.
+            if (version != null || packageName != null) {
+                publishTarget = PublishTarget.npm({
+                    version,
+                    packageName,
+                    tokenEnvironmentVariable: ""
+                });
+                context.logger.debug(
+                    `Created NpmPublishTarget: version ${version} package name: ${packageName}`
+                );
+            }
         } else if (generatorInvocation.language === "rust") {
             // Use Crates publish target for Rust (Cargo/crates.io)
             publishTarget = PublishTarget.crates({

--- a/packages/commons/api-workspace-commons/src/checkVersionExists.ts
+++ b/packages/commons/api-workspace-commons/src/checkVersionExists.ts
@@ -14,8 +14,7 @@ import { TaskContext } from "@fern-api/task-context";
  * 1. `output["package-name"]` — npm, PyPI, NuGet, RubyGems, crates.io
  * 2. `output.coordinate`      — Maven (Java)
  * 3. `config.package_name`    — fallback (some generators)
- * 4. `config.packageJson.name` — TypeScript SDK generator (local-file-system)
- * 5. `config.module.path`     — Go SDK generator
+ * 4. `config.module.path`     — Go SDK generator
  *
  * @internal Exported for testing and reuse in generation paths
  */
@@ -36,18 +35,11 @@ export function getPackageNameFromGeneratorConfig(
         }
     }
 
-    // Check config.package_name / config.packageJson.name if output.package-name is not set
+    // Check config.package_name if output.package-name is not set
     if (typeof generatorInvocation.raw?.config === "object" && generatorInvocation.raw?.config !== null) {
         const packageName = (generatorInvocation.raw.config as { package_name?: string }).package_name;
         if (packageName != null) {
             return packageName;
-        }
-
-        // typescript-sdk generator uses packageJson.name for the npm package name
-        const packageJsonName = (generatorInvocation.raw.config as { packageJson?: { name?: string } }).packageJson
-            ?.name;
-        if (packageJsonName != null) {
-            return packageJsonName;
         }
 
         // go-sdk generator uses module.path to set the package name

--- a/packages/commons/api-workspace-commons/src/checkVersionExists.ts
+++ b/packages/commons/api-workspace-commons/src/checkVersionExists.ts
@@ -13,8 +13,8 @@ import { TaskContext } from "@fern-api/task-context";
  * Lookup order:
  * 1. `output["package-name"]` — npm, PyPI, NuGet, RubyGems, crates.io
  * 2. `output.coordinate`      — Maven (Java)
- * 3. `config.packageJson.name` — TypeScript SDK generator (local-file-system)
- * 4. `config.package_name`    — fallback (some generators)
+ * 3. `config.package_name`    — fallback (some generators)
+ * 4. `config.packageJson.name` — TypeScript SDK generator (local-file-system)
  * 5. `config.module.path`     — Go SDK generator
  *
  * @internal Exported for testing and reuse in generation paths

--- a/packages/commons/api-workspace-commons/src/checkVersionExists.ts
+++ b/packages/commons/api-workspace-commons/src/checkVersionExists.ts
@@ -13,8 +13,9 @@ import { TaskContext } from "@fern-api/task-context";
  * Lookup order:
  * 1. `output["package-name"]` — npm, PyPI, NuGet, RubyGems, crates.io
  * 2. `output.coordinate`      — Maven (Java)
- * 3. `config.package_name`    — fallback (some generators)
- * 4. `config.module.path`     — Go SDK generator
+ * 3. `config.packageJson.name` — TypeScript SDK generator (local-file-system)
+ * 4. `config.package_name`    — fallback (some generators)
+ * 5. `config.module.path`     — Go SDK generator
  *
  * @internal Exported for testing and reuse in generation paths
  */
@@ -35,11 +36,18 @@ export function getPackageNameFromGeneratorConfig(
         }
     }
 
-    // Check config.package_name if output.package-name is not set
+    // Check config.package_name / config.packageJson.name if output.package-name is not set
     if (typeof generatorInvocation.raw?.config === "object" && generatorInvocation.raw?.config !== null) {
         const packageName = (generatorInvocation.raw.config as { package_name?: string }).package_name;
         if (packageName != null) {
             return packageName;
+        }
+
+        // typescript-sdk generator uses packageJson.name for the npm package name
+        const packageJsonName = (generatorInvocation.raw.config as { packageJson?: { name?: string } }).packageJson
+            ?.name;
+        if (packageJsonName != null) {
+            return packageJsonName;
         }
 
         // go-sdk generator uses module.path to set the package name


### PR DESCRIPTION
## Description

When running `fern generate --group <ts-group> --version <x.y.z> --local` against a TypeScript generator configured with `output.location: local-file-system`, the `--version` flag was silently dropped and the generated SDK's `package.json` was emitted without a `version` field (and the `X-Fern-SDK-Version` header came through as `undefined`).

Root cause:

1. For `local-file-system` output, the generator exec output mode becomes `downloadFiles`, which does not itself carry a version.
2. The CLI's `getPublishConfig` in `runLocalGenerationForWorkspace.ts` populated `PublishingConfig.filesystem.publishTarget` for Python / Rust / Java but not for TypeScript (or Go), so the IR never carried the version either.
3. The TypeScript generator's `AbstractGeneratorCli` only read the IR's `publishConfig` when `ir.selfHosted === true`, so even when `publishTarget` was populated it wouldn't be used for non-self-hosted orgs.

This PR fixes points 2 and 3 for TypeScript:

- The CLI now emits `PublishTarget.npm({ version, packageName })` on `PublishingConfig.filesystem` for TypeScript generators with `output.location: local-file-system`.
- The TypeScript generator always attempts `npmPackageInfoFromPublishConfig` first, falling back to `constructNpmPackage` from the exec config. Semantically this is a no-op for existing publish / github flows (publish config is undefined or has no `npm` target) but lets the `downloadFiles` path pick up version + package name from the IR.
- `getPackageNameFromGeneratorConfig` was extended to read `config.packageJson.name`, which is the TypeScript generator's convention for the npm package name.

Go `local-file-system` has the same gap but is intentionally scoped out of this PR.

## Changes Made
- Add TypeScript case to `getPublishConfig` in `runLocalGenerationForWorkspace.ts` so the IR's `PublishingConfig.filesystem.publishTarget` is populated with an `npm` target carrying the user-provided version and package name.
- Extend `getPackageNameFromGeneratorConfig` to also read `config.packageJson.name` (the TS SDK generator's package-name convention).
- Update `AbstractGeneratorCli` in the TypeScript generator to always consider `ir.publishConfig` when constructing the `NpmPackage`, not just for self-hosted orgs. Fall back to `npmPackage.version` when the generator exec output mode does not carry a version (e.g. `downloadFiles`).
- Add unreleased changelog entries under `packages/cli/cli/changes/unreleased/` and `generators/typescript/sdk/changes/unreleased/`.

## Testing
- [x] `pnpm turbo run compile --filter @fern-api/api-workspace-commons --filter @fern-api/local-workspace-runner --filter @fern-typescript/abstract-generator-cli`
- [x] `pnpm lint:biome`
- [ ] Manual end-to-end verification via Niels's `fern generate --group local-ts --version 3.2.1 --local` against Cohere's repo (pending CI + publish).


Link to Devin session: https://app.devin.ai/sessions/504e4b8d390b41c49545b1f63fb12f89
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
