### PR TITLE
feat(java): add clientDefault support to Java SDK generator

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/WrappedRequestGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/WrappedRequestGenerator.java
@@ -120,8 +120,8 @@ public final class WrappedRequestGenerator extends AbstractFileGenerator {
                 .forEach(httpHeader -> processHeader(httpHeader, headerWireValues, headerObjectProperties, "endpoint"));
         httpEndpoint.getQueryParameters().forEach(queryParameter -> {
             TypeReference valueType = queryParameter.getValueType();
-            boolean hasDefault = defaultValueExtractor.hasDefaultValue(valueType);
-            if (hasDefault) {
+            boolean hasDefault = defaultValueExtractor.hasAnyDefault(valueType, queryParameter.getClientDefault());
+            if (hasDefault && !isAlreadyOptional(valueType)) {
                 valueType = TypeReference.container(ContainerType.optional(valueType));
             }
             if (queryParameter.getAllowMultiple()) {
@@ -144,7 +144,8 @@ public final class WrappedRequestGenerator extends AbstractFileGenerator {
                     .filter(param -> param.getLocation().equals(PathParameterLocation.ENDPOINT))
                     .forEach(pathParameter -> {
                         TypeReference valueType = pathParameter.getValueType();
-                        if (defaultValueExtractor.hasDefaultValue(valueType)) {
+                        if (defaultValueExtractor.hasAnyDefault(valueType, pathParameter.getClientDefault())
+                                && !isAlreadyOptional(valueType)) {
                             valueType = TypeReference.container(ContainerType.optional(valueType));
                         }
                         pathParameterObjectProperties.add(ObjectProperty.builder()
@@ -291,7 +292,8 @@ public final class WrappedRequestGenerator extends AbstractFileGenerator {
             List<ObjectProperty> headerObjectProperties,
             String source) {
         TypeReference valueType = httpHeader.getValueType();
-        if (defaultValueExtractor.hasDefaultValue(valueType)) {
+        if (defaultValueExtractor.hasAnyDefault(valueType, httpHeader.getClientDefault())
+                && !isAlreadyOptional(valueType)) {
             valueType = TypeReference.container(ContainerType.optional(valueType));
         }
         String sdkName = NameUtils.getName(httpHeader.getName()).getCamelCase().getSafeName();
@@ -313,6 +315,10 @@ public final class WrappedRequestGenerator extends AbstractFileGenerator {
                 .valueType(valueType)
                 .docs(httpHeader.getDocs())
                 .build());
+    }
+
+    private static boolean isAlreadyOptional(TypeReference typeReference) {
+        return typeReference.isContainer() && typeReference.getContainer().get().isOptional();
     }
 
     private static final class RequestBodyGetterFactory implements HttpRequestBody.Visitor<RequestBodyGetter> {

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/DefaultValueExtractor.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/DefaultValueExtractor.java
@@ -7,6 +7,7 @@ import com.fern.ir.model.types.BooleanType;
 import com.fern.ir.model.types.ContainerType;
 import com.fern.ir.model.types.DoubleType;
 import com.fern.ir.model.types.IntegerType;
+import com.fern.ir.model.types.Literal;
 import com.fern.ir.model.types.LongType;
 import com.fern.ir.model.types.MapType;
 import com.fern.ir.model.types.NamedType;
@@ -19,7 +20,7 @@ import com.fern.java.client.ClientGeneratorContext;
 import com.squareup.javapoet.CodeBlock;
 import java.util.Optional;
 
-/** Utility class to detect and extract default values from PrimitiveTypeV2 types. */
+/** Utility class to detect and extract default values from PrimitiveTypeV2 types and clientDefault literals. */
 public final class DefaultValueExtractor {
 
     private final ClientGeneratorContext context;
@@ -110,12 +111,96 @@ public final class DefaultValueExtractor {
         });
     }
 
+    /**
+     * Checks whether a parameter has a client default (from x-fern-default). clientDefault is always applied regardless
+     * of the useDefaultRequestParameterValues flag.
+     */
+    public static boolean hasClientDefault(Optional<Literal> clientDefault) {
+        return clientDefault.isPresent();
+    }
+
+    /**
+     * Extracts a CodeBlock for a clientDefault literal value. Returns the string or boolean value as a CodeBlock
+     * suitable for use as a Java default.
+     */
+    public static Optional<CodeBlock> extractClientDefault(Optional<Literal> clientDefault) {
+        return clientDefault.map(literal -> literal.visit(new Literal.Visitor<CodeBlock>() {
+            @Override
+            public CodeBlock visitString(String value) {
+                return CodeBlock.of("$S", value);
+            }
+
+            @Override
+            public CodeBlock visitBoolean(boolean value) {
+                return CodeBlock.of("$L", value);
+            }
+
+            @Override
+            public CodeBlock _visitUnknown(Object unknown) {
+                return CodeBlock.of("$S", unknown.toString());
+            }
+        }));
+    }
+
     public Optional<CodeBlock> extractDefaultValue(TypeReference typeReference) {
         if (!hasDefaultValue(typeReference)) {
             return Optional.empty();
         }
 
         return extractDefaultValueInternal(typeReference);
+    }
+
+    /** Extracts the effective default value for a parameter, preferring clientDefault over type-level defaults. */
+    public Optional<CodeBlock> extractEffectiveDefault(TypeReference typeReference, Optional<Literal> clientDefault) {
+        if (isClientDefaultCompatible(typeReference, clientDefault)) {
+            Optional<CodeBlock> clientDefaultValue = extractClientDefault(clientDefault);
+            if (clientDefaultValue.isPresent()) {
+                return clientDefaultValue;
+            }
+        }
+        return extractDefaultValue(typeReference);
+    }
+
+    /** Checks whether a parameter has any default (clientDefault or type-level). */
+    public boolean hasAnyDefault(TypeReference typeReference, Optional<Literal> clientDefault) {
+        return (hasClientDefault(clientDefault) && isClientDefaultCompatible(typeReference, clientDefault))
+                || hasDefaultValue(typeReference);
+    }
+
+    /**
+     * Checks whether the clientDefault literal type is compatible with the parameter's resolved type. A String literal
+     * is only compatible with string-typed parameters, and a Boolean literal is only compatible with boolean-typed
+     * parameters. For other types (enums, integers, etc.), clientDefault cannot be used directly and must fall through
+     * to type-level defaults.
+     */
+    private boolean isClientDefaultCompatible(TypeReference typeReference, Optional<Literal> clientDefault) {
+        if (!clientDefault.isPresent()) {
+            return false;
+        }
+        TypeReference innerType = unwrapContainers(typeReference);
+        if (innerType.isPrimitive()) {
+            PrimitiveType primitive = innerType.getPrimitive().get();
+            boolean isString = clientDefault.get().isString()
+                    && primitive.getV1().equals(com.fern.ir.model.types.PrimitiveTypeV1.STRING);
+            boolean isBoolean = clientDefault.get().isBoolean()
+                    && primitive.getV1().equals(com.fern.ir.model.types.PrimitiveTypeV1.BOOLEAN);
+            return isString || isBoolean;
+        }
+        return false;
+    }
+
+    /** Unwraps optional and nullable containers to get the innermost type reference. */
+    private static TypeReference unwrapContainers(TypeReference typeReference) {
+        if (typeReference.isContainer()) {
+            ContainerType container = typeReference.getContainer().get();
+            if (container.isOptional()) {
+                return unwrapContainers(container.getOptional().get());
+            }
+            if (container.isNullable()) {
+                return unwrapContainers(container.getNullable().get());
+            }
+        }
+        return typeReference;
     }
 
     private Optional<CodeBlock> extractDefaultValueInternal(TypeReference typeReference) {

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/DefaultValueExtractor.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/DefaultValueExtractor.java
@@ -177,7 +177,7 @@ public final class DefaultValueExtractor {
         if (!clientDefault.isPresent()) {
             return false;
         }
-        TypeReference innerType = unwrapContainers(typeReference);
+        TypeReference innerType = resolveToLeafType(typeReference);
         if (innerType.isPrimitive()) {
             PrimitiveType primitive = innerType.getPrimitive().get();
             boolean isString = clientDefault.get().isString()
@@ -187,6 +187,24 @@ public final class DefaultValueExtractor {
             return isString || isBoolean;
         }
         return false;
+    }
+
+    /**
+     * Unwraps optional/nullable containers and resolves named type aliases to get the leaf type reference. This ensures
+     * clientDefault compatibility checks work correctly for aliased String/Boolean types.
+     */
+    private TypeReference resolveToLeafType(TypeReference typeReference) {
+        TypeReference unwrapped = unwrapContainers(typeReference);
+        if (unwrapped.isNamed()) {
+            TypeId typeId = unwrapped.getNamed().get().getTypeId();
+            TypeDeclaration typeDeclaration = context.getTypeDeclarations().get(typeId);
+            if (typeDeclaration != null && typeDeclaration.getShape().isAlias()) {
+                AliasTypeDeclaration alias =
+                        typeDeclaration.getShape().getAlias().get();
+                return resolveToLeafType(alias.getAliasOf());
+            }
+        }
+        return unwrapped;
     }
 
     /** Unwraps optional and nullable containers to get the innermost type reference. */

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/HttpUrlBuilder.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/HttpUrlBuilder.java
@@ -22,6 +22,8 @@ import com.fern.ir.model.http.HttpPathPart;
 import com.fern.ir.model.http.HttpService;
 import com.fern.ir.model.http.PathParameter;
 import com.fern.ir.model.http.PathParameterLocation;
+import com.fern.ir.model.http.QueryParameter;
+import com.fern.ir.model.types.Literal;
 import com.fern.ir.model.variables.VariableId;
 import com.fern.java.client.ClientGeneratorContext;
 import com.fern.java.client.GeneratedClientOptions;
@@ -161,9 +163,11 @@ public final class HttpUrlBuilder {
             boolean isOptionalNullable = isTypeNameOptionalNullable(queryParamProperty.poetTypeName());
             boolean isOptional = isJavaOptional || isOptionalNullable;
 
-            // Check if this parameter has a default value
-            Optional<CodeBlock> defaultValue = defaultValueExtractor.extractDefaultValue(
-                    queryParamProperty.objectProperty().getValueType());
+            // Check if this parameter has a default value (clientDefault takes precedence over type-level)
+            Optional<Literal> clientDefault =
+                    findQueryParamClientDefault(queryParamProperty.wireKey().get());
+            Optional<CodeBlock> defaultValue = defaultValueExtractor.extractEffectiveDefault(
+                    queryParamProperty.objectProperty().getValueType(), clientDefault);
 
             if (isOptional) {
                 if (defaultValue.isPresent()) {
@@ -294,22 +298,40 @@ public final class HttpUrlBuilder {
                             + "()";
                 }
                 if (typeNameIsOptional(poetPathParameter.poetParam().type)) {
-                    codeBlock.add(";\n");
-                    CodeBlock paramValue =
-                            PoetTypeNameStringifier.stringify(paramName + ".get()", poetPathParameter.poetParam().type);
+                    // Check for clientDefault on the path parameter
+                    Optional<CodeBlock> pathClientDefault = DefaultValueExtractor.extractClientDefault(
+                            poetPathParameter.irParam().getClientDefault());
 
-                    if (!prefixForNextParam.isEmpty()) {
-                        codeBlock
-                                .beginControlFlow("if ($L.isPresent())", poetPathParameter.poetParam().name)
-                                .addStatement("$L.addPathSegment($S + $L)", httpUrlname, prefixForNextParam, paramValue)
-                                .endControlFlow();
+                    if (pathClientDefault.isPresent()) {
+                        // Use clientDefault as fallback via .orElse()
+                        CodeBlock paramValue = PoetTypeNameStringifier.stringify(
+                                paramName + ".orElse(" + pathClientDefault.get().toString() + ")",
+                                poetPathParameter.poetParam().type);
+
+                        if (!prefixForNextParam.isEmpty()) {
+                            codeBlock.add("\n.addPathSegment($S + $L)", prefixForNextParam, paramValue);
+                        } else {
+                            codeBlock.add("\n.addPathSegment($L)", paramValue);
+                        }
                     } else {
-                        codeBlock
-                                .beginControlFlow("if ($L.isPresent())", poetPathParameter.poetParam().name)
-                                .addStatement("$L.addPathSegment($L)", httpUrlname, paramValue)
-                                .endControlFlow();
+                        codeBlock.add(";\n");
+                        CodeBlock paramValue = PoetTypeNameStringifier.stringify(
+                                paramName + ".get()", poetPathParameter.poetParam().type);
+
+                        if (!prefixForNextParam.isEmpty()) {
+                            codeBlock
+                                    .beginControlFlow("if ($L.isPresent())", poetPathParameter.poetParam().name)
+                                    .addStatement(
+                                            "$L.addPathSegment($S + $L)", httpUrlname, prefixForNextParam, paramValue)
+                                    .endControlFlow();
+                        } else {
+                            codeBlock
+                                    .beginControlFlow("if ($L.isPresent())", poetPathParameter.poetParam().name)
+                                    .addStatement("$L.addPathSegment($L)", httpUrlname, paramValue)
+                                    .endControlFlow();
+                        }
+                        endedWithStatement = true;
                     }
-                    endedWithStatement = true;
                 } else {
                     CodeBlock paramValue =
                             PoetTypeNameStringifier.stringify(paramName, poetPathParameter.poetParam().type);
@@ -375,6 +397,14 @@ public final class HttpUrlBuilder {
             codeBlock.add("\n");
         }
         return endedWithStatement;
+    }
+
+    /** Finds the clientDefault for a query parameter by matching on wire key. */
+    private Optional<Literal> findQueryParamClientDefault(String wireKey) {
+        return httpEndpoint.getQueryParameters().stream()
+                .filter(qp -> NameUtils.getWireValue(qp.getName()).equals(wireKey))
+                .findFirst()
+                .flatMap(QueryParameter::getClientDefault);
     }
 
     private static boolean typeNameIsOptional(TypeName typeName) {

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/HttpUrlBuilder.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/HttpUrlBuilder.java
@@ -298,8 +298,9 @@ public final class HttpUrlBuilder {
                             + "()";
                 }
                 if (typeNameIsOptional(poetPathParameter.poetParam().type)) {
-                    // Check for clientDefault on the path parameter
-                    Optional<CodeBlock> pathClientDefault = DefaultValueExtractor.extractClientDefault(
+                    // Use extractEffectiveDefault to check type compatibility before using clientDefault
+                    Optional<CodeBlock> pathClientDefault = defaultValueExtractor.extractEffectiveDefault(
+                            poetPathParameter.irParam().getValueType(),
                             poetPathParameter.irParam().getClientDefault());
 
                     if (pathClientDefault.isPresent()) {

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
@@ -56,6 +56,7 @@ import okhttp3.*;
 
 public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
 
+    private final HttpService httpService;
     private final HttpEndpoint httpEndpoint;
     private final GeneratedWrappedRequest generatedWrappedRequest;
     private final ClientGeneratorContext clientGeneratorContext;
@@ -90,6 +91,7 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
                 variables,
                 apiErrorClassName,
                 baseErrorClassName);
+        this.httpService = httpService;
         this.httpEndpoint = httpEndpoint;
         this.clientGeneratorContext = clientGeneratorContext;
         this.generatedWrappedRequest = generatedWrappedRequest;
@@ -224,17 +226,35 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
                         : NameUtils.getName(header.objectProperty().getName()).getOriginalName();
             }
             if (typeNameIsOptional(header.poetTypeName())) {
-                requestBodyCodeBlock
-                        .beginControlFlow("if ($L.$N().isPresent())", requestParameterName, header.getterProperty())
-                        .addStatement(
-                                "$L.addHeader($S, $L)",
-                                AbstractEndpointWriter.REQUEST_BUILDER_NAME,
-                                headerName,
-                                PoetTypeNameStringifier.stringify(
-                                        CodeBlock.of("$L.$N().get()", "request", header.getterProperty())
-                                                .toString(),
-                                        header.poetTypeName()))
-                        .endControlFlow();
+                // Check if this header has a clientDefault
+                Optional<CodeBlock> headerClientDefault = findHeaderClientDefault(headerName);
+                if (headerClientDefault.isPresent()) {
+                    // Use clientDefault as fallback via .orElse()
+                    requestBodyCodeBlock.addStatement(
+                            "$L.addHeader($S, $L)",
+                            AbstractEndpointWriter.REQUEST_BUILDER_NAME,
+                            headerName,
+                            PoetTypeNameStringifier.stringify(
+                                    CodeBlock.of(
+                                                    "$L.$N().orElse($L)",
+                                                    "request",
+                                                    header.getterProperty(),
+                                                    headerClientDefault.get())
+                                            .toString(),
+                                    header.poetTypeName()));
+                } else {
+                    requestBodyCodeBlock
+                            .beginControlFlow("if ($L.$N().isPresent())", requestParameterName, header.getterProperty())
+                            .addStatement(
+                                    "$L.addHeader($S, $L)",
+                                    AbstractEndpointWriter.REQUEST_BUILDER_NAME,
+                                    headerName,
+                                    PoetTypeNameStringifier.stringify(
+                                            CodeBlock.of("$L.$N().get()", "request", header.getterProperty())
+                                                    .toString(),
+                                            header.poetTypeName()))
+                            .endControlFlow();
+                }
             } else {
                 requestBodyCodeBlock.addStatement(
                         "$L.addHeader($S, $L)",
@@ -538,6 +558,16 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
                 .beginControlFlow("catch($T e)", Exception.class)
                 .addStatement("throw new $T(e)", RuntimeException.class)
                 .endControlFlow();
+    }
+
+    /** Finds the clientDefault for a header by matching on wire value across service and endpoint headers. */
+    private Optional<CodeBlock> findHeaderClientDefault(String headerWireValue) {
+        // Endpoint headers first so findFirst() prefers endpoint overrides over service headers
+        return java.util.stream.Stream.concat(httpEndpoint.getHeaders().stream(), httpService.getHeaders().stream())
+                .filter(h -> NameUtils.getWireValue(h.getName()).equals(headerWireValue))
+                .findFirst()
+                .flatMap(HttpHeader::getClientDefault)
+                .flatMap(literal -> DefaultValueExtractor.extractClientDefault(Optional.of(literal)));
     }
 
     private static boolean typeNameIsOptional(TypeName typeName) {

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
@@ -563,11 +563,11 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
     /** Finds the clientDefault for a header by matching on wire value across service and endpoint headers. */
     private Optional<CodeBlock> findHeaderClientDefault(String headerWireValue) {
         // Endpoint headers first so findFirst() prefers endpoint overrides over service headers
+        DefaultValueExtractor extractor = new DefaultValueExtractor(clientGeneratorContext);
         return java.util.stream.Stream.concat(httpEndpoint.getHeaders().stream(), httpService.getHeaders().stream())
                 .filter(h -> NameUtils.getWireValue(h.getName()).equals(headerWireValue))
                 .findFirst()
-                .flatMap(HttpHeader::getClientDefault)
-                .flatMap(literal -> DefaultValueExtractor.extractClientDefault(Optional.of(literal)));
+                .flatMap(header -> extractor.extractEffectiveDefault(header.getValueType(), header.getClientDefault()));
     }
 
     private static boolean typeNameIsOptional(TypeName typeName) {

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
@@ -62,6 +62,7 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
     private final ClientGeneratorContext clientGeneratorContext;
     private final SdkRequest sdkRequest;
     private final String requestParameterName;
+    private final DefaultValueExtractor defaultValueExtractor;
 
     public WrappedRequestEndpointWriter(
             HttpService httpService,
@@ -99,6 +100,7 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
         this.requestParameterName = NameUtils.toName(sdkRequest.getRequestParameterName())
                 .getCamelCase()
                 .getSafeName();
+        this.defaultValueExtractor = new DefaultValueExtractor(clientGeneratorContext);
     }
 
     @SuppressWarnings("checkstyle:CyclomaticComplexity")
@@ -563,11 +565,11 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
     /** Finds the clientDefault for a header by matching on wire value across service and endpoint headers. */
     private Optional<CodeBlock> findHeaderClientDefault(String headerWireValue) {
         // Endpoint headers first so findFirst() prefers endpoint overrides over service headers
-        DefaultValueExtractor extractor = new DefaultValueExtractor(clientGeneratorContext);
         return java.util.stream.Stream.concat(httpEndpoint.getHeaders().stream(), httpService.getHeaders().stream())
                 .filter(h -> NameUtils.getWireValue(h.getName()).equals(headerWireValue))
                 .findFirst()
-                .flatMap(header -> extractor.extractEffectiveDefault(header.getValueType(), header.getClientDefault()));
+                .flatMap(header -> defaultValueExtractor.extractEffectiveDefault(
+                        header.getValueType(), header.getClientDefault()));
     }
 
     private static boolean typeNameIsOptional(TypeName typeName) {

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -9,7 +9,7 @@
         `clientDefault` become optional in the wrapped request and use
         `.orElse(defaultValue)` to apply the fallback.
       type: feat
-  createdAt: "2026-04-03"
+  createdAt: "2026-04-21"
   irVersion: 66
 - version: 4.2.3
   changelogEntry:

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.3.0
+  changelogEntry:
+    - summary: |
+        Add `clientDefault` support for headers, query parameters, and path
+        parameters. When a parameter has a `clientDefault` value (set via the
+        `x-fern-default` OpenAPI extension), the generated SDK uses that value
+        as a fallback when the caller does not provide one. Parameters with
+        `clientDefault` become optional in the wrapped request and use
+        `.orElse(defaultValue)` to apply the fallback.
+      type: feat
+  createdAt: "2026-04-03"
+  irVersion: 66
 - version: 4.2.3
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/x-fern-default/src/main/java/com/seed/api/AsyncRawSeedApiClient.java
+++ b/seed/java-sdk/x-fern-default/src/main/java/com/seed/api/AsyncRawSeedApiClient.java
@@ -51,10 +51,7 @@ public class AsyncRawSeedApiClient {
                 .addPathSegments("test")
                 .addPathSegment(region)
                 .addPathSegments("resource");
-        if (request.getLimit().isPresent()) {
-            QueryStringMapper.addQueryParameter(
-                    httpUrl, "limit", request.getLimit().get(), false);
-        }
+        QueryStringMapper.addQueryParameter(httpUrl, "limit", request.getLimit().orElse("100"), false);
         if (requestOptions != null) {
             requestOptions.getQueryParameters().forEach((_key, _value) -> {
                 httpUrl.addQueryParameter(_key, _value);

--- a/seed/java-sdk/x-fern-default/src/main/java/com/seed/api/RawSeedApiClient.java
+++ b/seed/java-sdk/x-fern-default/src/main/java/com/seed/api/RawSeedApiClient.java
@@ -46,10 +46,7 @@ public class RawSeedApiClient {
                 .addPathSegments("test")
                 .addPathSegment(region)
                 .addPathSegments("resource");
-        if (request.getLimit().isPresent()) {
-            QueryStringMapper.addQueryParameter(
-                    httpUrl, "limit", request.getLimit().get(), false);
-        }
+        QueryStringMapper.addQueryParameter(httpUrl, "limit", request.getLimit().orElse("100"), false);
         if (requestOptions != null) {
             requestOptions.getQueryParameters().forEach((_key, _value) -> {
                 httpUrl.addQueryParameter(_key, _value);


### PR DESCRIPTION
## Description

Adds `clientDefault` support (from the `x-fern-default` OpenAPI extension) to the Java SDK generator. When a header, query parameter, or path parameter has a `clientDefault` value, the generated SDK uses it as a fallback when the caller does not provide one.

## Changes Made

- **`DefaultValueExtractor`**: Added `extractClientDefault()`, `hasClientDefault()`, `hasAnyDefault()`, and `extractEffectiveDefault()` methods to handle clientDefault literals. Added `isClientDefaultCompatible()` type guard that only applies String clientDefaults to string-typed params and Boolean clientDefaults to boolean-typed params (prevents type mismatches on enums/named types). Added `resolveToLeafType()` to correctly resolve named type aliases before checking primitive compatibility — without this, aliased String/Boolean types (e.g., `MyString` aliasing `String`) would silently skip clientDefault.
- **`WrappedRequestGenerator`**: Parameters with clientDefault become optional in the wrapped request object. Added `isAlreadyOptional()` guard to prevent double-wrapping types already marked as `Optional`.
- **`WrappedRequestEndpointWriter`**: Optional headers with clientDefault use `.orElse(defaultValue)` instead of the conditional `.isPresent()` / `.get()` pattern. Added `findHeaderClientDefault()` that searches endpoint then service headers by wire value. Uses `extractEffectiveDefault()` for type-safe lookup.
- **`HttpUrlBuilder`**: Query params use `extractEffectiveDefault()` (clientDefault preferred over type-level). Optional path params with clientDefault use `.orElse(defaultValue)`. Added `findQueryParamClientDefault()` lookup by wire key. Path params also use `extractEffectiveDefault()` for type compatibility.
- **`versions.yml`**: Added v4.3.0 entry for the new feature.

### Updates since last revision

- **Type compatibility fix**: Path params (`HttpUrlBuilder`) and headers (`WrappedRequestEndpointWriter.findHeaderClientDefault`) now use `extractEffectiveDefault(typeRef, clientDefault)` instead of calling `extractClientDefault()` directly. This ensures incompatible clientDefault literals (e.g., a boolean literal on a string-typed param) are rejected and fall through to the type-level default.
- **versions.yml date fix**: Changed `createdAt` for 4.3.0 from `"2026-04-03"` to `"2026-04-21"` to maintain monotonically decreasing date order relative to 4.2.3 (`"2026-04-20"`).

## Reviewer Checklist

- [ ] **`resolveToLeafType` recursion**: Verify recursive alias resolution terminates correctly and handles edge cases (e.g., alias chains, non-alias named types like enums). Circular aliases in valid IR should be impossible, but worth a glance.
- [ ] **`isAlreadyOptional` only checks `optional`, not `nullable`**: If a param is `nullable` but not `optional`, it would still get wrapped. Is this the intended behavior?
- [ ] **Path param `endedWithStatement` flag**: When clientDefault is present, `endedWithStatement` is NOT set to `true` (the `.orElse()` path chains the builder call inline). When no clientDefault, it IS set to `true` (uses `addStatement`). Verify this difference doesn't break URL builder chaining.
- [ ] **`findHeaderClientDefault` instantiates a new `DefaultValueExtractor`**: Minor — creates a new instance per call rather than reusing the class-level one. Not a bug but a possible cleanup.
- [ ] **`findQueryParamClientDefault` wire key matching**: The lookup matches by wire key from the `queryParamProperty` to the original IR `QueryParameter`. Verify no edge cases in key matching.
- [ ] **No seed snapshots**: Snapshot updates may need to be regenerated via `pnpm seed run`.

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed
- [ ] Spotless formatting applied (`cd generators/java && ./gradlew spotlessApply`)

Link to Devin session: https://app.devin.ai/sessions/dae61f87717a46d781e579e47b4758e5
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
