### PR TITLE
feat(typescript): add clientDefault support to TypeScript SDK generator

### DIFF
--- a/generators/typescript/model/type-generator/package.json
+++ b/generators/typescript/model/type-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/union-generator": "workspace:*",

--- a/generators/typescript/model/type-reference-converters/package.json
+++ b/generators/typescript/model/type-reference-converters/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/model/type-reference-example-generator/package.json
+++ b/generators/typescript/model/type-reference-example-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/model/type-schema-generator/package.json
+++ b/generators/typescript/model/type-schema-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/model/union-generator/package.json
+++ b/generators/typescript/model/union-generator/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/model/union-schema-generator/package.json
+++ b/generators/typescript/model/union-schema-generator/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/cli/package.json
+++ b/generators/typescript/sdk/cli/package.json
@@ -39,7 +39,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-api/typescript-ast": "workspace:*",
     "@fern-api/typescript-base": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/abstract-generator-cli": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/client-class-generator/package.json
+++ b/generators/typescript/sdk/client-class-generator/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/resolvers": "workspace:*",

--- a/generators/typescript/sdk/client-class-generator/src/BaseClientTypeGenerator.ts
+++ b/generators/typescript/sdk/client-class-generator/src/BaseClientTypeGenerator.ts
@@ -4,7 +4,7 @@ import type { FernIr } from "@fern-fern/ir-sdk";
 import { getPropertyKey, getTextOfTsNode } from "@fern-typescript/commons";
 import type { FileContext } from "@fern-typescript/contexts";
 import { ts } from "ts-morph";
-import { getLiteralValueForHeader } from "./endpoints/utils/index.js";
+import { getClientDefaultValue, getLiteralValueForHeader } from "./endpoints/utils/index.js";
 import type { GeneratedHeader } from "./GeneratedHeader.js";
 
 export declare namespace BaseClientTypeGenerator {
@@ -476,11 +476,48 @@ function withNoOpAuthProvider<T extends BaseClientOptions = BaseClientOptions>(
                             );
                         }
                     } else {
-                        value = ts.factory.createPropertyAccessChain(
-                            ts.factory.createIdentifier(OPTIONS_PARAMETER_NAME),
-                            ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
-                            ts.factory.createIdentifier(this.getOptionKeyForHeader(header, context))
-                        );
+                        const clientDefaultVal = getClientDefaultValue(header.clientDefault);
+                        if (clientDefaultVal != null) {
+                            if (typeof clientDefaultVal === "boolean") {
+                                const booleanLiteral = clientDefaultVal
+                                    ? ts.factory.createTrue()
+                                    : ts.factory.createFalse();
+                                value = ts.factory.createCallExpression(
+                                    ts.factory.createPropertyAccessExpression(
+                                        ts.factory.createParenthesizedExpression(
+                                            ts.factory.createBinaryExpression(
+                                                ts.factory.createPropertyAccessChain(
+                                                    ts.factory.createIdentifier(OPTIONS_PARAMETER_NAME),
+                                                    ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                                                    ts.factory.createIdentifier(headerName)
+                                                ),
+                                                ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                                                booleanLiteral
+                                            )
+                                        ),
+                                        ts.factory.createIdentifier("toString")
+                                    ),
+                                    undefined,
+                                    []
+                                );
+                            } else {
+                                value = ts.factory.createBinaryExpression(
+                                    ts.factory.createPropertyAccessChain(
+                                        ts.factory.createIdentifier(OPTIONS_PARAMETER_NAME),
+                                        ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                                        ts.factory.createIdentifier(headerName)
+                                    ),
+                                    ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                                    ts.factory.createStringLiteral(clientDefaultVal.toString())
+                                );
+                            }
+                        } else {
+                            value = ts.factory.createPropertyAccessChain(
+                                ts.factory.createIdentifier(OPTIONS_PARAMETER_NAME),
+                                ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                                ts.factory.createIdentifier(this.getOptionKeyForHeader(header, context))
+                            );
+                        }
                     }
 
                     return {

--- a/generators/typescript/sdk/client-class-generator/src/BaseClientTypeGenerator.ts
+++ b/generators/typescript/sdk/client-class-generator/src/BaseClientTypeGenerator.ts
@@ -4,7 +4,7 @@ import type { FernIr } from "@fern-fern/ir-sdk";
 import { getPropertyKey, getTextOfTsNode } from "@fern-typescript/commons";
 import type { FileContext } from "@fern-typescript/contexts";
 import { ts } from "ts-morph";
-import { getClientDefaultValue, getLiteralValueForHeader } from "./endpoints/utils/index.js";
+import { getClientDefaultValue, getLiteralValueForHeader, typeContainsNullable } from "./endpoints/utils/index.js";
 import type { GeneratedHeader } from "./GeneratedHeader.js";
 
 export declare namespace BaseClientTypeGenerator {
@@ -477,7 +477,7 @@ function withNoOpAuthProvider<T extends BaseClientOptions = BaseClientOptions>(
                         }
                     } else {
                         const clientDefaultVal = getClientDefaultValue(header.clientDefault);
-                        if (clientDefaultVal != null) {
+                        if (clientDefaultVal != null && !typeContainsNullable(header.valueType, context)) {
                             if (typeof clientDefaultVal === "boolean") {
                                 const booleanLiteral = clientDefaultVal
                                     ? ts.factory.createTrue()

--- a/generators/typescript/sdk/client-class-generator/src/GeneratedSdkClientClassImpl.ts
+++ b/generators/typescript/sdk/client-class-generator/src/GeneratedSdkClientClassImpl.ts
@@ -48,7 +48,7 @@ import { GeneratedThrowingEndpointResponse } from "./endpoints/default/endpoint-
 import { GeneratedDefaultEndpointImplementation } from "./endpoints/default/GeneratedDefaultEndpointImplementation.js";
 import { GeneratedFileDownloadEndpointImplementation } from "./endpoints/GeneratedFileDownloadEndpointImplementation.js";
 import { GeneratedStreamingEndpointImplementation } from "./endpoints/GeneratedStreamingEndpointImplementation.js";
-import { isLiteralHeader } from "./endpoints/utils/isLiteralHeader.js";
+import { getClientDefaultValue, isLiteralHeader } from "./endpoints/utils/isLiteralHeader.js";
 import { GeneratedWrappedService } from "./GeneratedWrappedService.js";
 import { GeneratedDefaultWebsocketImplementation } from "./websocket/GeneratedDefaultWebsocketImplementation.js";
 
@@ -1077,10 +1077,15 @@ return core.makePassthroughRequest(input, init, {
 
         for (const header of this.intermediateRepresentation.headers) {
             if (!isLiteralHeader(header, context)) {
+                const clientDefaultVal = getClientDefaultValue(header.clientDefault);
+                const snippetValue =
+                    clientDefaultVal != null
+                        ? ts.factory.createStringLiteral(clientDefaultVal.toString())
+                        : ts.factory.createStringLiteral(`YOUR_${this.case.screamingSnakeUnsafe(header.name)}`);
                 properties.push(
                     ts.factory.createPropertyAssignment(
                         getPropertyKey(this.getOptionKeyForHeader(header)),
-                        ts.factory.createStringLiteral(`YOUR_${this.case.screamingSnakeUnsafe(header.name)}`)
+                        snippetValue
                     )
                 );
             }

--- a/generators/typescript/sdk/client-class-generator/src/__test__/BaseClientTypeGenerator.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/BaseClientTypeGenerator.test.ts
@@ -42,6 +42,7 @@ function createHeader(opts: {
         env: undefined,
         availability: undefined,
         docs: undefined,
+        clientDefault: undefined,
         v2Examples: undefined
     };
 }

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
@@ -799,7 +799,8 @@ describe("GeneratedSdkClientClassImpl", () => {
                         env: undefined,
                         docs: undefined,
                         availability: undefined,
-                        v2Examples: undefined
+                        v2Examples: undefined,
+                        clientDefault: undefined
                     }
                 ],
                 authRequirement: "ALL",

--- a/generators/typescript/sdk/client-class-generator/src/__test__/RequestParameters.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/RequestParameters.test.ts
@@ -389,7 +389,8 @@ describe("FileUploadRequestParameter", () => {
             env: undefined,
             availability: undefined,
             docs: undefined,
-            v2Examples: undefined
+            v2Examples: undefined,
+            clientDefault: undefined
         };
         const ref = param.getReferenceToNonLiteralHeader(header, context);
         expect(getTextOfTsNode(ref)).toContain(".");
@@ -412,7 +413,8 @@ describe("FileUploadRequestParameter", () => {
             env: undefined,
             availability: undefined,
             docs: undefined,
-            v2Examples: undefined
+            v2Examples: undefined,
+            clientDefault: undefined
         };
         const ref = param.getReferenceToNonLiteralHeader(header, context);
         const text = getTextOfTsNode(ref);

--- a/generators/typescript/sdk/client-class-generator/src/__test__/isLiteralHeader.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/isLiteralHeader.test.ts
@@ -24,7 +24,8 @@ function createHeader(valueType?: FernIr.TypeReference): FernIr.HttpHeader {
         env: undefined,
         availability: undefined,
         docs: undefined,
-        v2Examples: undefined
+        v2Examples: undefined,
+        clientDefault: undefined
     };
 }
 

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/utils/GeneratedQueryParams.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/utils/GeneratedQueryParams.ts
@@ -126,8 +126,18 @@ export class GeneratedQueryParams {
             context
         });
 
+        // For allowMultiple params, apply clientDefault fallback to the scalar branch
+        const scalarWithDefault =
+            clientDefaultVal != null && !typeContainsNullable(queryParameter.valueType, context)
+                ? ts.factory.createBinaryExpression(
+                      scalarExpression,
+                      ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                      ts.factory.createStringLiteral(clientDefaultVal.toString())
+                  )
+                : scalarExpression;
+
         if (!needsArrayCheck) {
-            return scalarExpression;
+            return scalarWithDefault;
         }
 
         return ts.factory.createConditionalExpression(
@@ -142,7 +152,7 @@ export class GeneratedQueryParams {
             ts.factory.createToken(ts.SyntaxKind.QuestionToken),
             arrayExpression,
             ts.factory.createToken(ts.SyntaxKind.ColonToken),
-            scalarExpression
+            scalarWithDefault
         );
     }
 

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/utils/GeneratedQueryParams.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/utils/GeneratedQueryParams.ts
@@ -183,7 +183,7 @@ export class GeneratedQueryParams {
                         breadcrumbsPrefix: ["request", paramName],
                         omitUndefined: context.omitUndefined
                     });
-                if (this.isOptional(queryParameter.valueType)) {
+                if (this.isOptional(queryParameter.valueType) || queryParameter.clientDefault != null) {
                     return ts.factory.createConditionalExpression(
                         ts.factory.createBinaryExpression(
                             referenceToQueryParameter,

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/utils/GeneratedQueryParams.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/utils/GeneratedQueryParams.ts
@@ -2,6 +2,7 @@ import { getOriginalName, getWireValue } from "@fern-api/base-generator";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { FileContext } from "@fern-typescript/contexts";
 import { ts } from "ts-morph";
+import { getClientDefaultValue } from "./isLiteralHeader.js";
 import {
     REQUEST_OPTIONS_ADDITIONAL_QUERY_PARAMETERS_PROPERTY_NAME,
     REQUEST_OPTIONS_PARAMETER_NAME
@@ -102,7 +103,19 @@ export class GeneratedQueryParams {
             context
         });
 
+        // If clientDefault is set, add a fallback: value ?? "clientDefault"
+        // Skip when the type is nullable — explicit null means "don't send the parameter",
+        // and ?? would replace null with the clientDefault, preventing intentional omission.
+        const clientDefaultVal = getClientDefaultValue(queryParameter.clientDefault);
+
         if (!queryParameter.allowMultiple) {
+            if (clientDefaultVal != null && !typeContainsNullable(queryParameter.valueType, context)) {
+                return ts.factory.createBinaryExpression(
+                    scalarExpression,
+                    ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                    ts.factory.createStringLiteral(clientDefaultVal.toString())
+                );
+            }
             return scalarExpression;
         }
 
@@ -476,6 +489,29 @@ function primitiveTypeNeedsStringify(primitiveType: FernIr.PrimitiveType): boole
         case "DATE_TIME":
         case "DATE_TIME_RFC_2822":
             return true;
+        default:
+            return false;
+    }
+}
+
+function typeContainsNullable(type: FernIr.TypeReference, context: FileContext): boolean {
+    switch (type.type) {
+        case "container":
+            switch (type.container.type) {
+                case "nullable":
+                    return true;
+                case "optional":
+                    return typeContainsNullable(type.container.optional, context);
+                default:
+                    return false;
+            }
+        case "named": {
+            const declaration = context.type.getTypeDeclaration(type);
+            if (declaration.shape.type === "alias") {
+                return typeContainsNullable(declaration.shape.aliasOf, context);
+            }
+            return false;
+        }
         default:
             return false;
     }

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/utils/buildUrl.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/utils/buildUrl.ts
@@ -6,6 +6,7 @@ import { FileContext } from "@fern-typescript/contexts";
 import { ts } from "ts-morph";
 
 import { GeneratedSdkClientClassImpl } from "../../GeneratedSdkClientClassImpl.js";
+import { getClientDefaultValue } from "./isLiteralHeader.js";
 
 export type GetReferenceToPathParameterVariableFromRequest = (pathParameter: FernIr.PathParameter) => ts.Expression;
 
@@ -75,6 +76,17 @@ export function buildUrl({
                         breadcrumbsPrefix: [],
                         omitUndefined
                     });
+            }
+
+            // Apply clientDefault fallback AFTER serialization so the serializer
+            // only operates on properly-typed values.
+            const clientDefaultVal = getClientDefaultValue(pathParameter.clientDefault);
+            if (clientDefaultVal != null) {
+                referenceToPathParameterValue = ts.factory.createBinaryExpression(
+                    referenceToPathParameterValue,
+                    ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                    ts.factory.createStringLiteral(clientDefaultVal.toString())
+                );
             }
 
             return ts.factory.createTemplateSpan(

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/utils/buildUrl.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/utils/buildUrl.ts
@@ -63,8 +63,10 @@ export function buildUrl({
                 getReferenceToPathParameterVariableFromRequest
             });
 
+            const clientDefaultVal = getClientDefaultValue(pathParameter.clientDefault);
+
             if (includeSerdeLayer && pathParameter.valueType.type === "named") {
-                referenceToPathParameterValue = context.typeSchema
+                const serializerCall = context.typeSchema
                     .getSchemaOfNamedType(pathParameter.valueType, {
                         isGeneratingSchema: false
                     })
@@ -76,12 +78,25 @@ export function buildUrl({
                         breadcrumbsPrefix: [],
                         omitUndefined
                     });
-            }
-
-            // Apply clientDefault fallback AFTER serialization so the serializer
-            // only operates on properly-typed values.
-            const clientDefaultVal = getClientDefaultValue(pathParameter.clientDefault);
-            if (clientDefaultVal != null) {
+                if (clientDefaultVal != null) {
+                    // When clientDefault is set the param is optional, so guard
+                    // the serializer with a null check to avoid passing undefined.
+                    referenceToPathParameterValue = ts.factory.createConditionalExpression(
+                        ts.factory.createBinaryExpression(
+                            referenceToPathParameterValue,
+                            ts.factory.createToken(ts.SyntaxKind.ExclamationEqualsToken),
+                            ts.factory.createNull()
+                        ),
+                        ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+                        serializerCall,
+                        ts.factory.createToken(ts.SyntaxKind.ColonToken),
+                        ts.factory.createStringLiteral(clientDefaultVal.toString())
+                    );
+                } else {
+                    referenceToPathParameterValue = serializerCall;
+                }
+            } else if (clientDefaultVal != null) {
+                // No serde layer or not a named type — simple ?? fallback.
                 referenceToPathParameterValue = ts.factory.createBinaryExpression(
                     referenceToPathParameterValue,
                     ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/utils/generateHeaders.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/utils/generateHeaders.ts
@@ -349,8 +349,9 @@ function getOverridableRootHeaders({
 
                     // If clientDefault is set, chain it as final fallback:
                     // requestOptions?.header ?? this._options?.header ?? "clientDefault"
+                    // Skip when the type is nullable — explicit null means "don't send the header".
                     const clientDefaultVal = getClientDefaultValue(header.clientDefault);
-                    if (clientDefaultVal != null) {
+                    if (clientDefaultVal != null && !typeContainsNullable(header.valueType, context)) {
                         if (typeof clientDefaultVal === "boolean") {
                             const booleanLiteral = clientDefaultVal
                                 ? ts.factory.createTrue()
@@ -419,7 +420,7 @@ function getOptionKeyForHeader(header: FernIr.HttpHeader, context: FileContext):
     return context.case.camelUnsafe(header.name);
 }
 
-function typeContainsNullable(type: FernIr.TypeReference, context: FileContext): boolean {
+export function typeContainsNullable(type: FernIr.TypeReference, context: FileContext): boolean {
     switch (type.type) {
         case "container":
             switch (type.container.type) {

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/utils/generateHeaders.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/utils/generateHeaders.ts
@@ -6,7 +6,7 @@ import { ts } from "ts-morph";
 import { GeneratedHeader } from "../../GeneratedHeader.js";
 import { GeneratedSdkClientClassImpl } from "../../GeneratedSdkClientClassImpl.js";
 import { RequestParameter } from "../../request-parameter/RequestParameter.js";
-import { getLiteralValueForHeader } from "./isLiteralHeader.js";
+import { getClientDefaultValue, getLiteralValueForHeader } from "./isLiteralHeader.js";
 import { REQUEST_OPTIONS_PARAMETER_NAME } from "./requestOptionsParameter.js";
 
 export const HEADERS_VAR_NAME = "_headers";
@@ -204,6 +204,26 @@ function getValueExpressionForHeader({
                 { includeNullCheckIfOptional: true }
             );
         }
+        // If clientDefault is set, add a fallback: value ?? "clientDefault"
+        // Skip when the type is nullable — explicit null means "don't send the header",
+        // and ?? would replace null with the clientDefault, preventing intentional omission.
+        const clientDefaultVal = getClientDefaultValue(header.clientDefault);
+        if (clientDefaultVal != null && !typeContainsNullable(header.valueType, context)) {
+            valueExpression = ts.factory.createBinaryExpression(
+                valueExpression,
+                ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                typeof clientDefaultVal === "boolean"
+                    ? ts.factory.createCallExpression(
+                          ts.factory.createPropertyAccessExpression(
+                              clientDefaultVal ? ts.factory.createTrue() : ts.factory.createFalse(),
+                              ts.factory.createIdentifier("toString")
+                          ),
+                          undefined,
+                          []
+                      )
+                    : ts.factory.createStringLiteral(clientDefaultVal.toString())
+            );
+        }
         // If the header type is nullable, convert null to undefined using ?? undefined.
         // HTTP headers don't have a "null" concept — they're either present with a value
         // or absent. This ensures null values are treated as "don't send the header".
@@ -317,18 +337,51 @@ function getOverridableRootHeaders({
                     );
 
                     // Add nullish coalescing with this._options.{header}
+                    let fallbackExpr: ts.Expression = ts.factory.createPropertyAccessChain(
+                        ts.factory.createPropertyAccessChain(
+                            ts.factory.createThis(),
+                            undefined,
+                            GeneratedSdkClientClassImpl.OPTIONS_PRIVATE_MEMBER
+                        ),
+                        ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                        ts.factory.createIdentifier(getOptionKeyForHeader(header, context))
+                    );
+
+                    // If clientDefault is set, chain it as final fallback:
+                    // requestOptions?.header ?? this._options?.header ?? "clientDefault"
+                    const clientDefaultVal = getClientDefaultValue(header.clientDefault);
+                    if (clientDefaultVal != null) {
+                        if (typeof clientDefaultVal === "boolean") {
+                            const booleanLiteral = clientDefaultVal
+                                ? ts.factory.createTrue()
+                                : ts.factory.createFalse();
+                            fallbackExpr = ts.factory.createCallExpression(
+                                ts.factory.createPropertyAccessExpression(
+                                    ts.factory.createParenthesizedExpression(
+                                        ts.factory.createBinaryExpression(
+                                            fallbackExpr,
+                                            ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                                            booleanLiteral
+                                        )
+                                    ),
+                                    ts.factory.createIdentifier("toString")
+                                ),
+                                undefined,
+                                []
+                            );
+                        } else {
+                            fallbackExpr = ts.factory.createBinaryExpression(
+                                fallbackExpr,
+                                ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+                                ts.factory.createStringLiteral(clientDefaultVal.toString())
+                            );
+                        }
+                    }
+
                     value = ts.factory.createBinaryExpression(
                         originalExpr,
                         ts.SyntaxKind.QuestionQuestionToken,
-                        ts.factory.createPropertyAccessChain(
-                            ts.factory.createPropertyAccessChain(
-                                ts.factory.createThis(),
-                                undefined,
-                                GeneratedSdkClientClassImpl.OPTIONS_PRIVATE_MEMBER
-                            ),
-                            ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
-                            ts.factory.createIdentifier(getOptionKeyForHeader(header, context))
-                        )
+                        fallbackExpr
                     );
                 }
 

--- a/generators/typescript/sdk/client-class-generator/src/endpoints/utils/isLiteralHeader.ts
+++ b/generators/typescript/sdk/client-class-generator/src/endpoints/utils/isLiteralHeader.ts
@@ -25,3 +25,21 @@ export function getLiteralValueForHeader(
         return undefined;
     }
 }
+
+/**
+ * Extracts the client default value from a Literal union (string | boolean).
+ * Used for headers, query parameters, and path parameters with `clientDefault`.
+ */
+export function getClientDefaultValue(clientDefault: FernIr.Literal | undefined): string | boolean | undefined {
+    if (clientDefault == null) {
+        return undefined;
+    }
+    switch (clientDefault.type) {
+        case "boolean":
+            return clientDefault.boolean;
+        case "string":
+            return clientDefault.string;
+        default:
+            assertNever(clientDefault);
+    }
+}

--- a/generators/typescript/sdk/endpoint-error-union-generator/package.json
+++ b/generators/typescript/sdk/endpoint-error-union-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/resolvers": "workspace:*",

--- a/generators/typescript/sdk/environments-generator/package.json
+++ b/generators/typescript/sdk/environments-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/sdk/generator/package.json
+++ b/generators/typescript/sdk/generator/package.json
@@ -39,7 +39,7 @@
     "@fern-api/typescript-ast": "workspace:*",
     "@fern-fern/generator-cli-sdk": "^0.5.0",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/endpoint-error-union-generator": "workspace:*",

--- a/generators/typescript/sdk/generator/src/contexts/base-client/BaseClientContextImpl.ts
+++ b/generators/typescript/sdk/generator/src/contexts/base-client/BaseClientContextImpl.ts
@@ -221,7 +221,8 @@ export class BaseClientContextImpl implements BaseClientContext {
                         caseConverter: this.case
                     })
                 ),
-                type: getTextOfTsNode(context.type.getReferenceToType(pathParameter.valueType).typeNode)
+                type: getTextOfTsNode(context.type.getReferenceToType(pathParameter.valueType).typeNode),
+                hasQuestionToken: pathParameter.clientDefault != null
             });
         }
 
@@ -243,7 +244,7 @@ export class BaseClientContextImpl implements BaseClientContext {
                     kind: StructureKind.PropertySignature,
                     name: getPropertyKey(this.getOptionKeyForHeader(header)),
                     type: getTextOfTsNode(context.coreUtilities.fetcher.Supplier._getReferenceToType(type.typeNode)),
-                    hasQuestionToken: type.isOptional,
+                    hasQuestionToken: type.isOptional || header.clientDefault != null,
                     docs: [`Override the ${getWireValue(header.name)} header`]
                 });
             }

--- a/generators/typescript/sdk/request-wrapper-generator/package.json
+++ b/generators/typescript/sdk/request-wrapper-generator/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/sdk/request-wrapper-generator/src/GeneratedRequestWrapperImpl.ts
+++ b/generators/typescript/sdk/request-wrapper-generator/src/GeneratedRequestWrapperImpl.ts
@@ -196,12 +196,13 @@ export class GeneratedRequestWrapperImpl implements GeneratedRequestWrapper {
         for (const pathParameter of this.getPathParamsForRequestWrapper(context)) {
             const type = context.type.getReferenceToType(pathParameter.valueType);
             const hasDefaultValue = this.hasDefaultValue(pathParameter.valueType, context);
+            const hasClientDefault = pathParameter.clientDefault != null;
             const propertyName = this.getPropertyNameOfPathParameter(pathParameter);
             properties.push({
                 name: getPropertyKey(propertyName.propertyName),
                 safeName: getPropertyKey(propertyName.safeName),
                 type: type.typeNodeWithoutUndefined,
-                isOptional: type.isOptional || hasDefaultValue,
+                isOptional: type.isOptional || hasDefaultValue || hasClientDefault,
                 docs: pathParameter.docs ? [pathParameter.docs] : undefined
             });
         }
@@ -209,6 +210,7 @@ export class GeneratedRequestWrapperImpl implements GeneratedRequestWrapper {
         for (const queryParameter of this.getAllQueryParameters()) {
             const type = context.type.getReferenceToType(queryParameter.valueType);
             const hasDefaultValue = this.hasDefaultValue(queryParameter.valueType, context);
+            const hasClientDefault = queryParameter.clientDefault != null;
             const propertyName = collidingQueryParamWireValues.has(getWireValue(queryParameter.name))
                 ? this.getOverriddenPropertyNameOfQueryParameter(queryParameter)
                 : this.getPropertyNameOfQueryParameter(queryParameter);
@@ -221,7 +223,7 @@ export class GeneratedRequestWrapperImpl implements GeneratedRequestWrapper {
                           ts.factory.createArrayTypeNode(type.typeNodeWithoutUndefined)
                       ])
                     : type.typeNodeWithoutUndefined,
-                isOptional: type.isOptional || hasDefaultValue,
+                isOptional: type.isOptional || hasDefaultValue || hasClientDefault,
                 docs: queryParameter.docs ? [queryParameter.docs] : undefined
             });
         }
@@ -229,12 +231,13 @@ export class GeneratedRequestWrapperImpl implements GeneratedRequestWrapper {
         for (const header of this.getAllNonLiteralHeaders(context)) {
             const type = context.type.getReferenceToType(header.valueType);
             const hasDefaultValue = this.hasDefaultValue(header.valueType, context);
+            const hasClientDefault = header.clientDefault != null;
             const headerName = this.getPropertyNameOfNonLiteralHeader(header);
             properties.push({
                 name: getPropertyKey(headerName.propertyName),
                 safeName: getPropertyKey(headerName.safeName),
                 type: type.typeNodeWithoutUndefined,
-                isOptional: type.isOptional || hasDefaultValue,
+                isOptional: type.isOptional || hasDefaultValue || hasClientDefault,
                 docs: header.docs ? [header.docs] : undefined
             });
         }
@@ -608,18 +611,18 @@ export class GeneratedRequestWrapperImpl implements GeneratedRequestWrapper {
 
     private expensivelyComputeIfAllPropertiesAreOptional(context: FileContext): boolean {
         for (const pathParameter of this.getPathParamsForRequestWrapper(context)) {
-            if (!this.isTypeOptional(pathParameter.valueType, context)) {
+            if (!this.isTypeOptional(pathParameter.valueType, context) && pathParameter.clientDefault == null) {
                 return false;
             }
         }
 
         for (const queryParameter of this.getAllQueryParameters()) {
-            if (!this.isTypeOptional(queryParameter.valueType, context)) {
+            if (!this.isTypeOptional(queryParameter.valueType, context) && queryParameter.clientDefault == null) {
                 return false;
             }
         }
         for (const header of this.getAllNonLiteralHeaders(context)) {
-            if (!this.isTypeOptional(header.valueType, context)) {
+            if (!this.isTypeOptional(header.valueType, context) && header.clientDefault == null) {
                 return false;
             }
         }

--- a/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
+++ b/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/sdk-error-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-generator/package.json
@@ -32,7 +32,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/abstract-error-class-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/sdk-error-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-schema-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
@@ -32,7 +32,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/test-utils/package.json
+++ b/generators/typescript/sdk/test-utils/package.json
@@ -35,11 +35,11 @@
     "ts-morph": "catalog:"
   },
   "peerDependencies": {
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1"
+    "@fern-fern/ir-sdk": "66.0.0"
   },
   "devDependencies": {
     "@fern-api/configs": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/generators/typescript/sdk/test-utils/src/ir-factories.ts
+++ b/generators/typescript/sdk/test-utils/src/ir-factories.ts
@@ -138,7 +138,8 @@ export function createPathParameter(
         variable: undefined,
         v2Examples: undefined,
         docs: undefined,
-        explode: undefined
+        explode: undefined,
+        clientDefault: undefined
     };
 }
 
@@ -157,7 +158,8 @@ export function createQueryParameter(
         v2Examples: undefined,
         docs: undefined,
         availability: undefined,
-        explode: undefined
+        explode: undefined,
+        clientDefault: undefined
     };
 }
 
@@ -205,7 +207,8 @@ export function createHttpHeader(
         env: opts?.env,
         v2Examples: undefined,
         docs: opts?.docs,
-        availability: undefined
+        availability: undefined,
+        clientDefault: undefined
     };
 }
 

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -9,7 +9,7 @@
         `clientDefault` become optional in the client constructor and endpoint
         signatures.
       type: feat
-  createdAt: "2026-04-03"
+  createdAt: "2026-04-21"
   irVersion: 66
 - version: 3.64.2
   changelogEntry:

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.65.0
+  changelogEntry:
+    - summary: |
+        Add `clientDefault` support for headers, query parameters, and path
+        parameters. When a parameter has a `clientDefault` value (set via the
+        `x-fern-default` OpenAPI extension), the generated SDK uses that value
+        as a fallback when the caller does not provide one. Parameters with
+        `clientDefault` become optional in the client constructor and endpoint
+        signatures.
+      type: feat
+  createdAt: "2026-04-03"
+  irVersion: 66
 - version: 3.64.1
   changelogEntry:
     - summary: |

--- a/generators/typescript/sdk/websocket-type-schema-generator/package.json
+++ b/generators/typescript/sdk/websocket-type-schema-generator/package.json
@@ -32,7 +32,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/utils/abstract-generator-cli/package.json
+++ b/generators/typescript/utils/abstract-generator-cli/package.json
@@ -37,7 +37,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "tmp-promise": "catalog:"

--- a/generators/typescript/utils/commons/package.json
+++ b/generators/typescript/utils/commons/package.json
@@ -38,7 +38,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
     "@fern-api/typescript-base": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "decompress": "catalog:",
     "esutils": "catalog:",
     "eta": "^4.5.1",

--- a/generators/typescript/utils/contexts/package.json
+++ b/generators/typescript/utils/contexts/package.json
@@ -35,7 +35,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/commons": "workspace:*",
     "ts-morph": "catalog:"
   },

--- a/generators/typescript/utils/resolvers/package.json
+++ b/generators/typescript/utils/resolvers/package.json
@@ -31,7 +31,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "66.0.0-alpha.1",
+    "@fern-fern/ir-sdk": "66.0.0",
     "@fern-typescript/commons": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2597,8 +2597,8 @@ importers:
         specifier: workspace:*
         version: link:../../../base
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2637,8 +2637,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2674,8 +2674,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2711,8 +2711,8 @@ importers:
         specifier: workspace:*
         version: link:../../../base
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -2757,8 +2757,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2788,8 +2788,8 @@ importers:
         specifier: workspace:*
         version: link:../../../base
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -2843,8 +2843,8 @@ importers:
         specifier: workspace:*
         version: link:../../../typescript-v2/base
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/abstract-generator-cli':
         specifier: workspace:*
         version: link:../../utils/abstract-generator-cli
@@ -2873,8 +2873,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2922,8 +2922,8 @@ importers:
         specifier: workspace:*
         version: link:../../../base
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2965,8 +2965,8 @@ importers:
         specifier: workspace:*
         version: link:../../../base
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3020,8 +3020,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3145,8 +3145,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3185,8 +3185,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3228,8 +3228,8 @@ importers:
   generators/typescript/sdk/sdk-error-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/abstract-error-class-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-error-class-generator
@@ -3268,8 +3268,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3305,8 +3305,8 @@ importers:
   generators/typescript/sdk/sdk-inlined-request-body-schema-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3358,8 +3358,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17
@@ -3373,8 +3373,8 @@ importers:
   generators/typescript/sdk/websocket-type-schema-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3456,8 +3456,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../commons
@@ -3527,8 +3527,8 @@ importers:
         specifier: workspace:*
         version: link:../../../typescript-v2/base
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       decompress:
         specifier: 'catalog:'
         version: 4.2.1
@@ -3606,8 +3606,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../commons
@@ -3631,8 +3631,8 @@ importers:
   generators/typescript/utils/resolvers:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0-alpha.1
-        version: 66.0.0-alpha.1
+        specifier: 66.0.0
+        version: 66.0.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../commons
@@ -9379,10 +9379,6 @@ packages:
 
   '@fern-fern/ir-sdk@66.0.0':
     resolution: {integrity: sha512-uo1+fMnJOw5ApWVmKzb5wcLggjS4te3N8QorMClttA6DcBpgn0x1HbSl823oSyFvdqNV9U7GjmeQ+kzX1lWJUg==}
-    engines: {node: '>=18.0.0'}
-
-  '@fern-fern/ir-sdk@66.0.0-alpha.1':
-    resolution: {integrity: sha512-scSdUIo0E30ES3Jvx6ox7kby7ZB8jAVDB/52a4TaHquQOMJqrR626NtKHVSfKRCZ7Ut0AjeJ9TR4RRN3zoy6og==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/ir-sdk@66.1.0':
@@ -16498,8 +16494,6 @@ snapshots:
       - encoding
 
   '@fern-fern/ir-sdk@66.0.0': {}
-
-  '@fern-fern/ir-sdk@66.0.0-alpha.1': {}
 
   '@fern-fern/ir-sdk@66.1.0': {}
 

--- a/seed/ts-sdk/x-fern-default/README.md
+++ b/seed/ts-sdk/x-fern-default/README.md
@@ -41,7 +41,7 @@ Instantiate and use the client with the following:
 ```typescript
 import { SeedApiClient } from "@fern/x-fern-default";
 
-const client = new SeedApiClient({ environment: "YOUR_BASE_URL", apiVersion: "YOUR_API_VERSION" });
+const client = new SeedApiClient({ environment: "YOUR_BASE_URL", apiVersion: "2024-02-08" });
 await client.testGet({
     region: "region"
 });

--- a/seed/ts-sdk/x-fern-default/snippet.json
+++ b/seed/ts-sdk/x-fern-default/snippet.json
@@ -8,7 +8,7 @@
             },
             "snippet": {
                 "type": "typescript",
-                "client": "import { SeedApiClient } from \"@fern/x-fern-default\";\n\nconst client = new SeedApiClient({ environment: \"YOUR_BASE_URL\", apiVersion: \"YOUR_API_VERSION\" });\nawait client.testGet({\n    region: \"region\"\n});\n"
+                "client": "import { SeedApiClient } from \"@fern/x-fern-default\";\n\nconst client = new SeedApiClient({ environment: \"YOUR_BASE_URL\", apiVersion: \"2024-02-08\" });\nawait client.testGet({\n    region: \"region\"\n});\n"
             }
         }
     ],

--- a/seed/ts-sdk/x-fern-default/src/BaseClient.ts
+++ b/seed/ts-sdk/x-fern-default/src/BaseClient.ts
@@ -51,7 +51,7 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
             "User-Agent": "@fern/x-fern-default/0.0.1",
             "X-Fern-Runtime": core.RUNTIME.type,
             "X-Fern-Runtime-Version": core.RUNTIME.version,
-            "X-API-Version": options?.apiVersion,
+            "X-API-Version": options?.apiVersion ?? "2024-02-08",
         },
         options?.headers,
     );

--- a/seed/ts-sdk/x-fern-default/src/Client.ts
+++ b/seed/ts-sdk/x-fern-default/src/Client.ts
@@ -43,18 +43,20 @@ export class SeedApiClient {
     ): Promise<core.WithRawResponse<SeedApi.TestGetResponse>> {
         const { region, limit } = request;
         const _queryParams: Record<string, unknown> = {
-            limit,
+            limit: limit ?? "100",
         };
         const _headers: core.Fetcher.Args["headers"] = mergeHeaders(
             this._options?.headers,
-            mergeOnlyDefinedHeaders({ "X-API-Version": requestOptions?.apiVersion ?? this._options?.apiVersion }),
+            mergeOnlyDefinedHeaders({
+                "X-API-Version": requestOptions?.apiVersion ?? this._options?.apiVersion ?? "2024-02-08",
+            }),
             requestOptions?.headers,
         );
         const _response = await core.fetcher({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??
                     (await core.Supplier.get(this._options.environment)),
-                `test/${core.url.encodePathParam(region)}/resource`,
+                `test/${core.url.encodePathParam(region ?? "us-east-1")}/resource`,
             ),
             method: "GET",
             headers: _headers,


### PR DESCRIPTION
## Description

Adds `clientDefault` support (from the `x-fern-default` OpenAPI extension) to the TypeScript SDK generator. When a header, query parameter, or path parameter has a `clientDefault` value in the IR, the generated SDK uses it as a fallback when the caller omits the value.

## Changes Made

- **IR SDK bump**: `@fern-fern/ir-sdk` from `66.0.0-alpha.1` → `66.0.0` across all TS generator packages
- **`generateHeaders.ts`**: Endpoint headers with `clientDefault` emit `value ?? "defaultValue"`. Includes a `typeContainsNullable` guard so explicit `null` on nullable types is not replaced by the default.
- **`GeneratedQueryParams.ts`**: Query params with `clientDefault` emit `value ?? "defaultValue"`. Same nullable type guard added (mirrors the header logic).
- **`buildUrl.ts`**: Path params with `clientDefault` emit `region ?? "us-east-1"`.
- **`BaseClientTypeGenerator.ts`**: Constructor-level headers with `clientDefault` emit `options?.header ?? "defaultValue"` (string) or `(options?.header ?? true).toString()` (boolean).
- **`GeneratedSdkClientClassImpl.ts`**: Root/overridable headers chain: `requestOptions?.header ?? this._options?.header ?? "clientDefault"`. Code snippets show the default value instead of `YOUR_HEADER_NAME`.
- **`GeneratedRequestWrapperImpl.ts`**: Parameters with `clientDefault` become optional in the request wrapper type.
- **`isLiteralHeader.ts`**: New `getClientDefaultValue()` utility exported for extracting string/boolean from IR `Literal`.
- **`versions.yml`**: Added v3.65.0 changelog entry for this feature.
- **Seed snapshots**: Updated `x-fern-default` fixture outputs.

## Updates since last revision

- Fixed `versions.yml` `createdAt` date for v3.65.0 from `"2026-04-03"` to `"2026-04-21"` to maintain monotonically decreasing date order (addressed Devin Review finding).

## Reviewer Checklist

- [ ] **Nullable type guard on query params**: `GeneratedQueryParams.ts` adds `!typeContainsNullable(...)` guard, matching the header behavior. The `typeContainsNullable` function is duplicated from `generateHeaders.ts` — verify the implementations match and consider whether it should be extracted to a shared utility.
- [ ] **Root headers missing nullable guard**: In `generateHeaders.ts`, the `getOverridableRootHeaders` path applies `clientDefault` via `??` without a `typeContainsNullable` check, unlike the endpoint header path. Verify this is intentional — root headers go through a `requestOptions ?? this._options ?? default` chain which may make the guard unnecessary, but a nullable root header with a clientDefault could still override explicit `null`.
- [ ] **No new test cases for clientDefault-present paths**: The test file updates add `clientDefault: undefined` to existing fixtures to match the updated IR type shape, but there don't appear to be new test cases that exercise the generation logic when `clientDefault` is actually set. Consider whether this is sufficient coverage.
- [x] **`versions.yml` entry**: v3.65.0 entry present with corrected `createdAt` date.

## Testing
- [ ] Unit tests updated (existing tests adapted for new IR field)
- [x] Seed snapshot (`x-fern-default`) updated and verified
- [ ] Manual testing deferred to CI seed runs

Link to Devin session: https://app.devin.ai/sessions/dae61f87717a46d781e579e47b4758e5
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
