### PR TITLE
chore(ci): update docs bundle smoke test matrix to Node 22/24/26 with retry

### DIFF
--- a/.github/workflows/docs-bundle-smoke-test.yml
+++ b/.github/workflows/docs-bundle-smoke-test.yml
@@ -79,12 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [20, 22, 24]
-        exclude:
-          # Node 20 lacks the `navigator` global (added in Node 21/22),
-          # which causes ReferenceError during SSR on Windows.
-          - os: windows-latest
-            node-version: 20
+        node-version: [22, 24, 26]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
 
@@ -237,9 +232,13 @@ jobs:
 
       - name: Run Playwright smoke tests (Unix)
         if: steps.node-check.outputs.available == 'true' && runner.os != 'Windows'
-        shell: bash
-        working-directory: docs-preview-smoke-test/playwright
-        run: npx playwright test smoke.spec.ts --config playwright.config.ts
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 15
+          max_attempts: 2
+          retry_wait_seconds: 10
+          shell: bash
+          command: cd docs-preview-smoke-test/playwright && npx playwright test smoke.spec.ts --config playwright.config.ts
 
       # On Windows, background processes (&) are killed when the parent bash
       # step exits. We must start the server and run Playwright in the SAME
@@ -325,7 +324,18 @@ jobs:
 
           echo "Running Playwright smoke tests..."
           cd "$GITHUB_WORKSPACE/docs-preview-smoke-test/playwright"
-          npx playwright test smoke.spec.ts --config playwright.config.ts
+          for attempt in 1 2; do
+            if npx playwright test smoke.spec.ts --config playwright.config.ts; then
+              echo "Playwright passed on attempt ${attempt}"
+              break
+            fi
+            if [ $attempt -eq 2 ]; then
+              echo "Playwright failed after 2 attempts"
+              exit 1
+            fi
+            echo "Playwright failed on attempt ${attempt}, retrying after 10s..."
+            sleep 10
+          done
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v6

--- a/.github/workflows/docs-bundle-smoke-test.yml
+++ b/.github/workflows/docs-bundle-smoke-test.yml
@@ -232,7 +232,7 @@ jobs:
 
       - name: Run Playwright smoke tests (Unix)
         if: steps.node-check.outputs.available == 'true' && runner.os != 'Windows'
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
           max_attempts: 2


### PR DESCRIPTION
## Description

Updates the Docs Bundle Smoke Test workflow to:
1. Replace Node 20 with Node 26 in the test matrix (now Node 22/24/26 across Ubuntu/macOS/Windows).
2. Remove the Windows + Node 20 exclusion (no longer needed since Node 20 is dropped, and all remaining versions have `navigator`).
3. Add retry logic for the Playwright smoke tests so a flaky matrix cell retries automatically without affecting other matrix cells.

The existing "Node.js version availability" fallback (`steps.node-check`) continues to skip any matrix cell where the Node major hasn't been released yet (e.g., Node 26 on day one). Because `fail-fast: false` is set and the retry is scoped to the Playwright step inside each matrix cell, a failed cell retries only itself.

## Changes Made
- `node-version: [20, 22, 24]` → `node-version: [22, 24, 26]`
- Removed `windows-latest` + `node-version: 20` exclude entry
- Unix Playwright step now uses `nick-fields/retry@v4` (2 attempts, 15min timeout, 10s backoff)
- Windows Playwright command now runs in a bash retry loop inside the combined start-server-and-test step (server state is preserved between attempts)
- [ ] Updated README.md generator (if applicable) — N/A

## Testing
- [ ] Unit tests added/updated — N/A (CI-only change)
- [x] Manual testing completed — YAML syntax validated locally with `python3 -c "import yaml; yaml.safe_load(...)"`


Link to Devin session: https://app.devin.ai/sessions/dd285e01eae5431c9fac6db9e5a4d5da
Requested by: @thesandlord