### PR TITLE
fix(cli): don't log [object Object] when automation generator fails

### DIFF
--- a/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
+++ b/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
@@ -33,6 +33,7 @@ import { TaskContextLogger } from "./TaskContextLogger.js";
  */
 export class TaskContextAdapter implements TaskContext {
     private result: TaskResult = TaskResult.Success;
+    private lastFailureMessage: string | undefined = undefined;
     private readonly context: Context;
 
     public readonly logger: Logger;
@@ -67,10 +68,15 @@ export class TaskContextAdapter implements TaskContext {
         }
         const fullMessage = this.getFullErrorMessage(message, error);
         if (fullMessage != null) {
+            this.lastFailureMessage = fullMessage;
             this.logger.error(fullMessage);
         }
 
         reportError(this.context, error, { ...options, message });
+    }
+
+    public getLastFailureMessage(): string | undefined {
+        return this.lastFailureMessage;
     }
 
     public captureException(error: unknown, code?: CliError.Code): void {
@@ -101,6 +107,7 @@ export class TaskContextAdapter implements TaskContext {
             failWithoutThrowing: this.failWithoutThrowing.bind(this),
             captureException: this.captureException.bind(this),
             getResult: () => this.result,
+            getLastFailureMessage: this.getLastFailureMessage.bind(this),
             addInteractiveTask: this.addInteractiveTask.bind(this),
             runInteractiveTask: this.runInteractiveTask.bind(this),
             instrumentPostHogEvent: this.instrumentPostHogEvent.bind(this),

--- a/packages/cli/cli/changes/unreleased/fix-automation-object-object-log.yml
+++ b/packages/cli/cli/changes/unreleased/fix-automation-object-object-log.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix `[object Object]` being logged (and recorded in the automation summary) when a
+    generator fails during `fern automations generate`. The automation-mode catch in the
+    remote workspace runner now propagates `TaskAbortSignal` instead of stringifying it,
+    and pulls the real failure message off the task context for the run summary. Also
+    makes `InteractiveTaskContextImpl.finish()` idempotent so the duplicate `Failed.`
+    line is gone.
+  type: fix

--- a/packages/cli/cli/src/cli-context/TaskContextImpl.ts
+++ b/packages/cli/cli/src/cli-context/TaskContextImpl.ts
@@ -39,6 +39,7 @@ export declare namespace TaskContextImpl {
 
 export class TaskContextImpl implements Startable<TaskContext>, Finishable, TaskContext {
     protected result = TaskResult.Success;
+    protected lastFailureMessage: string | undefined = undefined;
     protected logImmediately: (logs: Log[]) => void;
     protected logPrefix: string;
     public readonly title: string | undefined;
@@ -79,6 +80,9 @@ export class TaskContextImpl implements Startable<TaskContext>, Finishable, Task
     }
 
     public finish(): void {
+        if (this.status === "finished") {
+            return;
+        }
         this.status = "finished";
         this.flushLogs();
         this.onResult?.(this.getResult());
@@ -101,8 +105,15 @@ export class TaskContextImpl implements Startable<TaskContext>, Finishable, Task
         if (error instanceof TaskAbortSignal) {
             return;
         }
+        if (message != null) {
+            this.lastFailureMessage = message;
+        }
         logErrorMessage({ message, error, logger: this.logger });
         reportError(this, error, { ...options, message });
+    }
+
+    public getLastFailureMessage(): string | undefined {
+        return this.lastFailureMessage;
     }
 
     public captureException(error: unknown, code?: CliError.Code): void {
@@ -222,6 +233,9 @@ export class InteractiveTaskContextImpl
     }
 
     public finish(): void {
+        if (this.status === "finished") {
+            return;
+        }
         if (this.result === TaskResult.Success) {
             this.logAtLevelWithOverrides(LogLevel.Info, ["Finished."], {
                 omitOnTTY: true

--- a/packages/cli/cli/src/cli-context/__test__/TaskContextImpl.test.ts
+++ b/packages/cli/cli/src/cli-context/__test__/TaskContextImpl.test.ts
@@ -82,9 +82,7 @@ describe("InteractiveTaskContextImpl.finish", () => {
         // Simulate runInteractiveTask's `finally { subtask.finish() }`
         subtask.finish();
 
-        const failedLogs = getLogs().filter(
-            (log) => log.level === LogLevel.Error && log.parts.join(" ") === "Failed."
-        );
+        const failedLogs = getLogs().filter((log) => log.level === LogLevel.Error && log.parts.join(" ") === "Failed.");
         expect(failedLogs).toHaveLength(1);
         expect(subtask.getResult()).toBe(TaskResult.Failure);
     });

--- a/packages/cli/cli/src/cli-context/__test__/TaskContextImpl.test.ts
+++ b/packages/cli/cli/src/cli-context/__test__/TaskContextImpl.test.ts
@@ -1,0 +1,135 @@
+import { Log } from "@fern-api/cli-logger";
+import { LogLevel } from "@fern-api/logger";
+import { TaskAbortSignal, TaskResult } from "@fern-api/task-context";
+
+import { describe, expect, it } from "vitest";
+
+import { InteractiveTaskContextImpl, TaskContextImpl } from "../TaskContextImpl.js";
+
+function createContext(): { context: TaskContextImpl; getLogs: () => Log[] } {
+    const allLogs: Log[] = [];
+    const context = new TaskContextImpl({
+        logImmediately: (logs) => {
+            allLogs.push(...logs);
+        },
+        takeOverTerminal: async (run) => {
+            await run();
+        },
+        shouldBufferLogs: false,
+        instrumentPostHogEvent: () => undefined
+    });
+    return { context, getLogs: () => allLogs };
+}
+
+function createInteractiveContext(): { subtask: InteractiveTaskContextImpl; getLogs: () => Log[] } {
+    const allLogs: Log[] = [];
+    const subtask = new InteractiveTaskContextImpl({
+        name: "test-task",
+        subtitle: undefined,
+        logImmediately: (logs) => {
+            allLogs.push(...logs);
+        },
+        takeOverTerminal: async (run) => {
+            await run();
+        },
+        shouldBufferLogs: false,
+        instrumentPostHogEvent: () => undefined
+    });
+    return { subtask, getLogs: () => allLogs };
+}
+
+describe("TaskContextImpl.getLastFailureMessage", () => {
+    it("returns the message passed to failWithoutThrowing", () => {
+        const { context } = createContext();
+        context.failWithoutThrowing("boom");
+        expect(context.getLastFailureMessage()).toBe("boom");
+    });
+
+    it("returns the message passed to failAndThrow", () => {
+        const { context } = createContext();
+        context.start();
+        try {
+            context.failAndThrow("kaboom");
+        } catch (error) {
+            expect(error).toBeInstanceOf(TaskAbortSignal);
+        }
+        expect(context.getLastFailureMessage()).toBe("kaboom");
+    });
+
+    it("returns undefined when no message has been recorded", () => {
+        const { context } = createContext();
+        expect(context.getLastFailureMessage()).toBeUndefined();
+    });
+
+    it("does not overwrite the real message when a later failWithoutThrowing is called with only a TaskAbortSignal", () => {
+        const { context } = createContext();
+        context.failWithoutThrowing("the real error");
+        // Simulate the parent-context catch re-invoking failWithoutThrowing with the TaskAbortSignal
+        context.failWithoutThrowing(undefined, new TaskAbortSignal());
+        expect(context.getLastFailureMessage()).toBe("the real error");
+    });
+});
+
+describe("InteractiveTaskContextImpl.finish", () => {
+    it("is idempotent and does not log Failed. twice", () => {
+        const { subtask, getLogs } = createInteractiveContext();
+        subtask.start();
+        try {
+            subtask.failAndThrow("the real error");
+        } catch (error) {
+            expect(error).toBeInstanceOf(TaskAbortSignal);
+        }
+        // Simulate runInteractiveTask's `finally { subtask.finish() }`
+        subtask.finish();
+
+        const failedLogs = getLogs().filter(
+            (log) => log.level === LogLevel.Error && log.parts.join(" ") === "Failed."
+        );
+        expect(failedLogs).toHaveLength(1);
+        expect(subtask.getResult()).toBe(TaskResult.Failure);
+    });
+
+    it("logs Finished. once on success even if finish is called multiple times", () => {
+        const { subtask, getLogs } = createInteractiveContext();
+        subtask.start();
+        subtask.finish();
+        subtask.finish();
+
+        const finishedLogs = getLogs().filter(
+            (log) => log.level === LogLevel.Info && log.parts.join(" ") === "Finished."
+        );
+        expect(finishedLogs).toHaveLength(1);
+        expect(subtask.getResult()).toBe(TaskResult.Success);
+    });
+});
+
+describe("runInteractiveTask", () => {
+    it("swallows TaskAbortSignal thrown by failAndThrow and surfaces the message via getLastFailureMessage", async () => {
+        const { context } = createContext();
+        let captured: InteractiveTaskContextImpl | undefined;
+
+        const ok = await context.runInteractiveTask({ name: "child", subtitle: undefined }, (subtask) => {
+            captured = subtask as InteractiveTaskContextImpl;
+            subtask.failAndThrow("GitHub 422: PR already exists");
+        });
+
+        expect(ok).toBe(false);
+        expect(captured?.getLastFailureMessage()).toBe("GitHub 422: PR already exists");
+    });
+
+    it("does not emit a second log line when it swallows a TaskAbortSignal", async () => {
+        const { context, getLogs } = createContext();
+
+        await context.runInteractiveTask({ name: "child", subtitle: undefined }, (subtask) => {
+            subtask.failAndThrow("the real error");
+        });
+
+        const allText = getLogs()
+            .flatMap((log) => log.parts)
+            .join("\n");
+        // The task already logged "the real error" via failAndThrow; the parent catch must
+        // not stringify the TaskAbortSignal (which previously produced "[object Object]").
+        expect(allText).not.toContain("[object Object]");
+        expect(allText).toContain("the real error");
+    });
+});

--- a/packages/cli/cli/src/commands/generate-overrides/__test__/writeOverridesForWorkspaces.test.ts
+++ b/packages/cli/cli/src/commands/generate-overrides/__test__/writeOverridesForWorkspaces.test.ts
@@ -26,6 +26,7 @@ function createMockContext(): TaskContext {
         failWithoutThrowing: noop,
         captureException: noop,
         getResult: () => TaskResult.Success,
+        getLastFailureMessage: () => undefined,
         addInteractiveTask: () => {
             throw new Error("Not implemented in mock");
         },

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
@@ -4,7 +4,7 @@ import { fernConfigJson, generatorsYml } from "@fern-api/configuration";
 import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
-import { TaskContext } from "@fern-api/task-context";
+import { TaskAbortSignal, TaskContext } from "@fern-api/task-context";
 import {
     AbstractAPIWorkspace,
     getBaseOpenAPIWorkspaceSettingsFromGeneratorInvocation
@@ -297,6 +297,22 @@ async function generateOne({
         });
     } catch (error) {
         if (automation == null) {
+            throw error;
+        }
+        // A TaskAbortSignal means the task already logged its real error and marked
+        // itself failed via `failAndThrow`. Pull the original message off the context
+        // for the summary, then re-throw so it propagates up to `runInteractiveTask`,
+        // which silently swallows it (see TaskContextImpl.failWithoutThrowing).
+        // Re-logging here would produce `[object Object]` since `TaskAbortSignal`
+        // isn't an `Error` and has no serializable message.
+        if (error instanceof TaskAbortSignal) {
+            automation.recorder.recordFailure({
+                apiName: workspace.workspaceName,
+                groupName: generatorGroup.groupName,
+                generatorName: generatorInvocation.name,
+                errorMessage: interactiveTaskContext.getLastFailureMessage() ?? "Generator failed",
+                durationMs: Date.now() - startedAt
+            });
             throw error;
         }
         const message = extractErrorMessage(error);

--- a/packages/cli/task-context/src/MockTaskContext.ts
+++ b/packages/cli/task-context/src/MockTaskContext.ts
@@ -30,6 +30,7 @@ export function createMockTaskContext({ logger = CONSOLE_LOGGER }: { logger?: Lo
             // no-op in mock context
         },
         getResult: () => TaskResult.Success,
+        getLastFailureMessage: () => undefined,
         addInteractiveTask: () => {
             throw new Error("Not implemented");
         },

--- a/packages/cli/task-context/src/TaskContext.ts
+++ b/packages/cli/task-context/src/TaskContext.ts
@@ -9,6 +9,12 @@ export interface TaskContext {
     failWithoutThrowing: (message?: string, error?: unknown, options?: { code?: CliError.Code }) => void;
     captureException: (error: unknown, code?: CliError.Code) => void;
     getResult: () => TaskResult;
+    /**
+     * Returns the most recent message passed to `failAndThrow` / `failWithoutThrowing`,
+     * if any. Useful for callers that swallow a `TaskAbortSignal` and still need to
+     * surface the original failure reason (e.g. automation summaries).
+     */
+    getLastFailureMessage: () => string | undefined;
     addInteractiveTask: (params: CreateInteractiveTaskParams) => Startable<InteractiveTaskContext>;
     runInteractiveTask: (
         params: CreateInteractiveTaskParams,

--- a/packages/cli/workspace/lazy-fern-workspace/src/__test__/helpers/createMockTaskContext.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/__test__/helpers/createMockTaskContext.ts
@@ -22,6 +22,7 @@ export function createMockTaskContext(): TaskContext {
         failWithoutThrowing: noop,
         captureException: noop,
         getResult: () => TaskResult.Success,
+        getLastFailureMessage: () => undefined,
         addInteractiveTask: () => {
             throw new Error("Not implemented in mock");
         },

--- a/packages/cli/workspace/lazy-fern-workspace/src/__test__/resolveDescriptionMarkdownRefs.test.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/__test__/resolveDescriptionMarkdownRefs.test.ts
@@ -27,6 +27,7 @@ function createContextWithWarn(): { context: TaskContext; warn: ReturnType<typeo
         failWithoutThrowing: noop,
         captureException: noop,
         getResult: () => TaskResult.Success,
+        getLastFailureMessage: () => undefined,
         addInteractiveTask: () => {
             throw new Error("not implemented");
         },

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/__test__/ProtobufOpenAPIGeneratorResolution.test.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/__test__/ProtobufOpenAPIGeneratorResolution.test.ts
@@ -63,6 +63,7 @@ function createMockTaskContext(): TaskContext {
         failWithoutThrowing: vi.fn(),
         captureException: vi.fn(),
         getResult: () => TaskResult.Success,
+        getLastFailureMessage: () => undefined,
         addInteractiveTask: () => {
             throw new Error("Not implemented in mock");
         },

--- a/packages/seed/src/TaskContextImpl.ts
+++ b/packages/seed/src/TaskContextImpl.ts
@@ -69,6 +69,9 @@ export class TaskContextImpl implements Startable<TaskContext>, Finishable, Task
     }
 
     public finish(): void {
+        if (this.status === "finished") {
+            return;
+        }
         this.status = "finished";
         this.flushLogs();
         this.onResult?.(this.getResult());
@@ -222,6 +225,9 @@ export class InteractiveTaskContextImpl
     }
 
     public finish(): void {
+        if (this.status === "finished") {
+            return;
+        }
         if (this.result === TaskResult.Success) {
             this.logAtLevelWithOverrides(LogLevel.Info, ["Finished."], {
                 omitOnTTY: true

--- a/packages/seed/src/TaskContextImpl.ts
+++ b/packages/seed/src/TaskContextImpl.ts
@@ -34,6 +34,7 @@ export declare namespace TaskContextImpl {
 
 export class TaskContextImpl implements Startable<TaskContext>, Finishable, TaskContext {
     protected result = TaskResult.Success;
+    protected lastFailureMessage: string | undefined = undefined;
     protected logImmediately: (logs: Log[]) => void;
     protected logPrefix: string;
     protected subtasks: InteractiveTaskContextImpl[] = [];
@@ -86,8 +87,15 @@ export class TaskContextImpl implements Startable<TaskContext>, Finishable, Task
     }
 
     public failWithoutThrowing(message?: string, error?: unknown, _options?: { code?: CliError.Code }): void {
+        if (message != null) {
+            this.lastFailureMessage = message;
+        }
         logErrorMessage({ message, error, logger: this.logger });
         this.result = TaskResult.Failure;
+    }
+
+    public getLastFailureMessage(): string | undefined {
+        return this.lastFailureMessage;
     }
 
     public captureException(_error: unknown, _code?: CliError.Code): void {

--- a/packages/snippets/core/src/utils/createTaskContext.ts
+++ b/packages/snippets/core/src/utils/createTaskContext.ts
@@ -23,6 +23,7 @@ export function createTaskContext(): TaskContext {
             // no-op
         },
         getResult: () => TaskResult.Success,
+        getLastFailureMessage: () => undefined,
         addInteractiveTask: () => {
             throw new Error("unimplemented");
         },


### PR DESCRIPTION
## Description
Linear ticket: Refs

When a generator failed inside `fern automations generate` (e.g. GitHub PR creation rejected with a 422), the CLI logged a confusing `[object Object]` line and that same string was stored as the `errorMessage` in the automation run summary, obscuring the real failure reason. The `Failed.` line was also printed twice for the same task.

Root cause: `failAndThrow` throws a `TaskAbortSignal` (a marker class that is not an `Error` and carries no message). The automation-mode catch in `generateOne` treated it like a real error, ran `extractErrorMessage` on it — which fell through to `String(e)` → `"[object Object]"` — and then fed that string back into `failWithoutThrowing`, logging it and storing it in the recorder. The original error message had already been logged correctly by `failAndThrow` itself, so this was pure noise.

## Changes Made
- In `runRemoteGenerationForAPIWorkspace.generateOne`, detect `TaskAbortSignal` explicitly, record the failure using the task's last logged message, and re-throw so it propagates up to `runInteractiveTask`, which silently swallows it (as it already does for local generation). Non-`TaskAbortSignal` errors keep the existing `extractErrorMessage` + `failWithoutThrowing` path.
- Add `getLastFailureMessage()` to the `TaskContext` interface. `TaskContextImpl`, `TaskContextAdapter` (cli-v2), seed's `TaskContextImpl`, `MockTaskContext`, and the various test-only mocks/stubs now store and expose the most recent message passed to `failWithoutThrowing` / `failAndThrow`. This lets callers that swallow a `TaskAbortSignal` still surface the original reason in summaries without having to carry it on the signal itself (the signal remains a pure marker).
- Make `TaskContextImpl.finish()` and `InteractiveTaskContextImpl.finish()` idempotent (no-op once `status === "finished"`). Previously `failAndThrow` called `finish()` and then `runInteractiveTask`'s `finally` called it again, producing a duplicate `Failed.` log line.
- Added changelog entry under `packages/cli/cli/changes/unreleased/`.

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing: `pnpm turbo run compile` passes on all CLI packages affected by the interface change (`task-context`, `cli`, `cli-v2`, `remote-workspace-runner`, `lazy-fern-workspace`, `seed-cli`, `snippets-core`).


Link to Devin session: https://app.devin.ai/sessions/ff90a154c2594fd39b15d0e6197e54a3
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
