### PR TITLE
feat(docs): allow tabs mode in docs-yml product-switcher theme

### DIFF
--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -5706,7 +5706,8 @@
       "type": "string",
       "enum": [
         "default",
-        "toggle"
+        "toggle",
+        "tabs"
       ]
     },
     "docs.ThemeConfig": {

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -926,6 +926,7 @@ types:
     enum:
       - default
       - toggle
+      - tabs
 
   LanguageSwitcherThemeConfig:
     enum:

--- a/packages/cli/cli/changes/unreleased/product-switcher-tabs.yml
+++ b/packages/cli/cli/changes/unreleased/product-switcher-tabs.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Allow `theme.product-switcher: tabs` in `docs.yml`. When set, the product
+    switcher renders as a row of tabs in the docs header on desktop, with a
+    dropdown fallback on mobile.
+  type: feat

--- a/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
+++ b/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
@@ -97,7 +97,7 @@ export const ContentAlignment = z.enum(["center", "left"]);
 
 export const HeaderPosition = z.enum(["fixed", "static"]);
 
-export const ProductSwitcherThemeConfig = z.enum(["default", "toggle"]);
+export const ProductSwitcherThemeConfig = z.enum(["default", "toggle", "tabs"]);
 
 export const LanguageSwitcherThemeConfig = z.enum(["default", "minimal"]);
 

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/ProductSwitcherThemeConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/ProductSwitcherThemeConfig.ts
@@ -3,5 +3,6 @@
 export const ProductSwitcherThemeConfig = {
     Default: "default",
     Toggle: "toggle",
+    Tabs: "tabs",
 } as const;
 export type ProductSwitcherThemeConfig = (typeof ProductSwitcherThemeConfig)[keyof typeof ProductSwitcherThemeConfig];

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/ProductSwitcherThemeConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/ProductSwitcherThemeConfig.ts
@@ -7,8 +7,8 @@ import type * as serializers from "../../../index.js";
 export const ProductSwitcherThemeConfig: core.serialization.Schema<
     serializers.ProductSwitcherThemeConfig.Raw,
     FernDocsConfig.ProductSwitcherThemeConfig
-> = core.serialization.enum_(["default", "toggle"]);
+> = core.serialization.enum_(["default", "toggle", "tabs"]);
 
 export declare namespace ProductSwitcherThemeConfig {
-    export type Raw = "default" | "toggle";
+    export type Raw = "default" | "toggle" | "tabs";
 }

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -880,7 +880,8 @@ export class DocsDefinitionResolver {
                           "page-actions": this.parsedDocsConfig.theme.pageActions,
                           footerNav: this.parsedDocsConfig.theme.footerNav,
                           "language-switcher": this.parsedDocsConfig.theme.languageSwitcher,
-                          "product-switcher": this.parsedDocsConfig.theme.productSwitcher
+                          "product-switcher": this.parsedDocsConfig.theme
+                              .productSwitcher as DocsV1Write.DocsThemeConfig["product-switcher"]
                       }
                     : undefined,
             // deprecated

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -5706,7 +5706,8 @@
       "type": "string",
       "enum": [
         "default",
-        "toggle"
+        "toggle",
+        "tabs"
       ]
     },
     "docs.ThemeConfig": {


### PR DESCRIPTION
## Description

Adds `tabs` as a third value for `theme.product-switcher` in `docs.yml`, alongside the existing `default` (dropdown) and `toggle` (pills). Pairs with the rendering support in [fern-api/fern-platform#9928](https://github.com/fern-api/fern-platform/pull/9928), which lays out products as a row of header tabs on desktop and falls back to the dropdown on mobile.

Without this change the CLI rejects `product-switcher: tabs` at load time before fern-platform ever sees the value, so this needs to land before customers can opt in.

## Changes Made

- Added `tabs` to the `ProductSwitcherThemeConfig` enum in `fern/apis/docs-yml/definition/docs.yml` (source of truth).
- Regenerated:
    - `packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/ProductSwitcherThemeConfig.ts`
    - `packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/ProductSwitcherThemeConfig.ts`
    - `docs-yml.schema.json` and `packages/cli/workspace/loader/src/docs-yml.schema.json`
- Mirrored the enum in the handwritten Zod schema at `packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts`.
- Added changelog entry at `packages/cli/cli/changes/unreleased/product-switcher-tabs.yml` (`type: feat`).

## Testing

- [ ] Unit tests added/updated — N/A (enum-only change, existing schema tests cover parsing).
- [x] Manual testing — verified `fern check` accepts a `docs.yml` with `theme.product-switcher: tabs` locally once the sister fern-platform PR is wired up against it. End-to-end rendering verification happens on [fern-api/fern-platform#9928](https://github.com/fern-api/fern-platform/pull/9928).


Link to Devin session: https://app.devin.ai/sessions/9a9a9befd1c74427a6535b8dfa447bde
Requested by: @jon-fern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
