### PR TITLE
feat(java): add opt-out flag to skip spotlessApply for dynamic snippets

### DIFF
--- a/packages/cli/cli/changes/unreleased/java-skip-spotless-opt-out.yml
+++ b/packages/cli/cli/changes/unreleased/java-skip-spotless-opt-out.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Allow skipping spotlessApply for Java dynamic snippet tests via
+    `skip-format-dynamic-snippets: true` custom config flag. This can
+    save ~30s of JVM startup and formatting time during Java SDK generation.
+  type: feat

--- a/packages/cli/cli/changes/unreleased/java-skip-spotless-opt-out.yml
+++ b/packages/cli/cli/changes/unreleased/java-skip-spotless-opt-out.yml
@@ -1,5 +1,5 @@
 - summary: |
     Add `skip-format-dynamic-snippets: true` custom config flag for Java
-    dynamic snippet tests. When `format-dynamic-snippets` is enabled, this
-    flag can be used to explicitly override and skip the spotlessApply step.
+    dynamic snippet tests. When set, skips the spotlessApply Gradle step
+    during dynamic snippet generation, saving ~30s of JVM startup time.
   type: feat

--- a/packages/cli/cli/changes/unreleased/java-skip-spotless-opt-out.yml
+++ b/packages/cli/cli/changes/unreleased/java-skip-spotless-opt-out.yml
@@ -1,5 +1,5 @@
 - summary: |
-    Allow skipping spotlessApply for Java dynamic snippet tests via
-    `skip-format-dynamic-snippets: true` custom config flag. This can
-    save ~30s of JVM startup and formatting time during Java SDK generation.
+    Add `skip-format-dynamic-snippets: true` custom config flag for Java
+    dynamic snippet tests. When `format-dynamic-snippets` is enabled, this
+    flag can be used to explicitly override and skip the spotlessApply step.
   type: feat

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts
@@ -73,9 +73,8 @@ export class DynamicSnippetsJavaTestGenerator {
         }
         const customConfig = this.generatorConfig.customConfig as Record<string, unknown> | undefined;
         const skipSpotless = customConfig?.["skip-format-dynamic-snippets"] === true;
-        if (skipSpotless) {
-            this.context.logger.debug("Skipping spotlessApply (skip-format-dynamic-snippets is set)");
-        } else {
+        const enableSpotless = !skipSpotless && customConfig?.["format-dynamic-snippets"] === true;
+        if (enableSpotless) {
             this.context.logger.debug("Dynamic snippets test files generated, running spotlessApply...");
             const gradlewPath = join(outputDir, RelativeFilePath.of("gradlew"));
             const gradlewExists = await doesPathExist(gradlewPath, "file");
@@ -108,6 +107,10 @@ export class DynamicSnippetsJavaTestGenerator {
                     this.context.failAndThrow("Failed to run spotlessApply", e, { code: CliError.Code.InternalError });
                 }
             }
+        } else if (skipSpotless) {
+            this.context.logger.debug("Skipping spotlessApply (skip-format-dynamic-snippets is set)");
+        } else {
+            this.context.logger.debug("Skipping spotlessApply (set format-dynamic-snippets: true to enable)");
         }
         this.context.logger.debug("Done generating dynamic snippet tests");
     }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts
@@ -73,8 +73,9 @@ export class DynamicSnippetsJavaTestGenerator {
         }
         const customConfig = this.generatorConfig.customConfig as Record<string, unknown> | undefined;
         const skipSpotless = customConfig?.["skip-format-dynamic-snippets"] === true;
-        const enableSpotless = !skipSpotless && customConfig?.["format-dynamic-snippets"] === true;
-        if (enableSpotless) {
+        if (skipSpotless) {
+            this.context.logger.debug("Skipping spotlessApply (skip-format-dynamic-snippets is set)");
+        } else {
             this.context.logger.debug("Dynamic snippets test files generated, running spotlessApply...");
             const gradlewPath = join(outputDir, RelativeFilePath.of("gradlew"));
             const gradlewExists = await doesPathExist(gradlewPath, "file");
@@ -107,10 +108,6 @@ export class DynamicSnippetsJavaTestGenerator {
                     this.context.failAndThrow("Failed to run spotlessApply", e, { code: CliError.Code.InternalError });
                 }
             }
-        } else if (skipSpotless) {
-            this.context.logger.debug("Skipping spotlessApply (skip-format-dynamic-snippets is set)");
-        } else {
-            this.context.logger.debug("Skipping spotlessApply (set format-dynamic-snippets: true to enable)");
         }
         this.context.logger.debug("Done generating dynamic snippet tests");
     }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts
@@ -71,38 +71,43 @@ export class DynamicSnippetsJavaTestGenerator {
                 );
             }
         }
-        this.context.logger.debug("Dynamic snippets test files generated, running spotlessApply...");
-        const gradlewPath = join(outputDir, RelativeFilePath.of("gradlew"));
-        const gradlewExists = await doesPathExist(gradlewPath, "file");
-        if (gradlewExists) {
-            try {
-                const customConfig = this.generatorConfig.customConfig as Record<string, unknown> | undefined;
-                const enableProfiling = customConfig?.["enable-gradle-profiling"] === true;
-                const gradleArgs = [":spotlessApply"];
-                if (enableProfiling) {
-                    gradleArgs.push("--profile");
-                    this.context.logger.info("Running spotlessApply with profiling enabled");
-                }
-                await loggingExeca(this.context.logger, "./gradlew", gradleArgs, {
-                    doNotPipeOutput: false,
-                    cwd: outputDir
-                });
-                this.context.logger.debug("Successfully ran spotlessApply");
-                if (enableProfiling) {
-                    // Copy build/reports/ to reports/ at the root so it's not gitignored
-                    const buildReportsPath = join(outputDir, RelativeFilePath.of("build/reports"));
-                    const reportsPath = join(outputDir, RelativeFilePath.of("reports"));
-                    const buildReportsExists = await doesPathExist(buildReportsPath, "directory");
-                    if (buildReportsExists) {
-                        await cp(buildReportsPath, reportsPath, { recursive: true });
-                        this.context.logger.info("Gradle profiling report copied to reports/");
-                    } else {
-                        this.context.logger.info("No profiling report found in build/reports/");
+        const customConfig = this.generatorConfig.customConfig as Record<string, unknown> | undefined;
+        const enableSpotless = customConfig?.["format-dynamic-snippets"] === true;
+        if (enableSpotless) {
+            this.context.logger.debug("Dynamic snippets test files generated, running spotlessApply...");
+            const gradlewPath = join(outputDir, RelativeFilePath.of("gradlew"));
+            const gradlewExists = await doesPathExist(gradlewPath, "file");
+            if (gradlewExists) {
+                try {
+                    const enableProfiling = customConfig?.["enable-gradle-profiling"] === true;
+                    const gradleArgs = [":spotlessApply"];
+                    if (enableProfiling) {
+                        gradleArgs.push("--profile");
+                        this.context.logger.info("Running spotlessApply with profiling enabled");
                     }
+                    await loggingExeca(this.context.logger, "./gradlew", gradleArgs, {
+                        doNotPipeOutput: false,
+                        cwd: outputDir
+                    });
+                    this.context.logger.debug("Successfully ran spotlessApply");
+                    if (enableProfiling) {
+                        // Copy build/reports/ to reports/ at the root so it's not gitignored
+                        const buildReportsPath = join(outputDir, RelativeFilePath.of("build/reports"));
+                        const reportsPath = join(outputDir, RelativeFilePath.of("reports"));
+                        const buildReportsExists = await doesPathExist(buildReportsPath, "directory");
+                        if (buildReportsExists) {
+                            await cp(buildReportsPath, reportsPath, { recursive: true });
+                            this.context.logger.info("Gradle profiling report copied to reports/");
+                        } else {
+                            this.context.logger.info("No profiling report found in build/reports/");
+                        }
+                    }
+                } catch (e) {
+                    this.context.failAndThrow("Failed to run spotlessApply", e, { code: CliError.Code.InternalError });
                 }
-            } catch (e) {
-                this.context.failAndThrow("Failed to run spotlessApply", e, { code: CliError.Code.InternalError });
             }
+        } else {
+            this.context.logger.debug("Skipping spotlessApply (set format-dynamic-snippets: true to enable)");
         }
         this.context.logger.debug("Done generating dynamic snippet tests");
     }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts
@@ -72,8 +72,10 @@ export class DynamicSnippetsJavaTestGenerator {
             }
         }
         const customConfig = this.generatorConfig.customConfig as Record<string, unknown> | undefined;
-        const enableSpotless = customConfig?.["format-dynamic-snippets"] === true;
-        if (enableSpotless) {
+        const skipSpotless = customConfig?.["skip-format-dynamic-snippets"] === true;
+        if (skipSpotless) {
+            this.context.logger.debug("Skipping spotlessApply (skip-format-dynamic-snippets is set)");
+        } else {
             this.context.logger.debug("Dynamic snippets test files generated, running spotlessApply...");
             const gradlewPath = join(outputDir, RelativeFilePath.of("gradlew"));
             const gradlewExists = await doesPathExist(gradlewPath, "file");
@@ -106,8 +108,6 @@ export class DynamicSnippetsJavaTestGenerator {
                     this.context.failAndThrow("Failed to run spotlessApply", e, { code: CliError.Code.InternalError });
                 }
             }
-        } else {
-            this.context.logger.debug("Skipping spotlessApply (set format-dynamic-snippets: true to enable)");
         }
         this.context.logger.debug("Done generating dynamic snippet tests");
     }


### PR DESCRIPTION
## Summary

- The Java v2 generator's dynamic snippet test generation runs `./gradlew :spotlessApply` to format all generated test files. This Gradle invocation takes ~30 seconds (JVM startup + formatting 650+ files) and is a significant bottleneck in Java SDK generation time.
- This change adds a `skip-format-dynamic-snippets: true` custom config flag that allows users to skip the spotless formatting step. By default, spotlessApply still runs (preserving existing behavior and keeping seed tests green).
- Users who want faster generation and are confident their snippets don't need Gradle-level formatting can opt in to skipping by setting `skip-format-dynamic-snippets: true` in their generator custom config.

## Test plan

- [x] Verify Java SDK seed tests pass with default config (spotless runs as before)
- [ ] Verify Java SDK generation with `skip-format-dynamic-snippets: true` skips spotless (log message confirms)
- [ ] Confirm generated snippet test files are correctly formatted without the spotless step

🤖 Generated with [Claude Code](https://claude.com/claude-code)