### PR TITLE
fix(ci): publish ruby sdk generator to fernapi/fern-ruby-sdk

### DIFF
--- a/generators/ruby-v2/sdk/changes/unreleased/publish-to-fern-ruby-sdk.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/publish-to-fern-ruby-sdk.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Publish the Ruby SDK generator to `fernapi/fern-ruby-sdk` on Docker Hub.
+    The `fernapi/fern-ruby-sdk-v2` image is still pushed as an alias for backward compatibility.
+  type: chore

--- a/seed/ruby-sdk-v2/seed.yml
+++ b/seed/ruby-sdk-v2/seed.yml
@@ -5,8 +5,8 @@ generatorType: SDK
 defaultOutputMode: github
 defaultCustomConfig:
   rubocopSeverity: error
-image: fernapi/fern-ruby-sdk-v2
-imageAliases: [fernapi/fern-ruby-sdk]
+image: fernapi/fern-ruby-sdk
+imageAliases: [fernapi/fern-ruby-sdk-v2]
 changelogLocation: ../../generators/ruby-v2/sdk/versions.yml
 
 buildScripts:
@@ -35,7 +35,9 @@ publish:
     - pnpm turbo run dist:cli --filter @fern-api/ruby-sdk
   docker:
     file: ./generators/ruby-v2/sdk/Dockerfile
-    image: fernapi/fern-ruby-sdk-v2
+    image: fernapi/fern-ruby-sdk
+    aliases:
+      - fernapi/fern-ruby-sdk-v2
     context: .
   sentry:
     name: fern-ruby-sdk-v2


### PR DESCRIPTION
## Description

Follow-up to #15136. That PR fixed the Ruby SDK publish workflow so it no longer errors out, but it also caused the generator image to be pushed exclusively to `fernapi/fern-ruby-sdk-v2` on Docker Hub, leaving the canonical [`fernapi/fern-ruby-sdk`](https://hub.docker.com/r/fernapi/fern-ruby-sdk) repository without any new versions.

This PR makes `fernapi/fern-ruby-sdk` the primary publish target again and keeps `fernapi/fern-ruby-sdk-v2` as an alias so existing `generators.yml` references (e.g. `benchmarks/fern/apis/square/generators.yml`) don't break.

## Changes Made

- `seed/ruby-sdk-v2/seed.yml`
  - Flipped the top-level `image` / `imageAliases` so `fernapi/fern-ruby-sdk` is the canonical registered image and `fernapi/fern-ruby-sdk-v2` is the alias.
  - Under `publish.docker`, set `image: fernapi/fern-ruby-sdk` and added `aliases: [fernapi/fern-ruby-sdk-v2]`. `publishGenerator.ts` only looks at `publish.docker.aliases` (not the top-level `imageAliases`) when building the list of tags to push, so the alias has to live here for both images to receive each new version.
- Added `generators/ruby-v2/sdk/changes/unreleased/publish-to-fern-ruby-sdk.yml` so a new patch version of the generator gets released and the new image gets pushed.

Left intentionally unchanged:
- `test.docker.image` / `package.json` `dockerTagLatest` / `podmanTagLatest` — these only affect local/test image tags.
- `publish.sentry.name: fern-ruby-sdk-v2` — Sentry release name; keeping it stable preserves error-tracking continuity.
- `seed/ruby-sdk-v2/**/.fern/metadata.json` — `generatorName` there records which generator produced each fixture; leaving as-is avoids a 130+ file regeneration unrelated to publishing.

## Testing

- [x] `pnpm run check` passes
- [ ] CI publish workflow next runs against `generators/ruby-v2/sdk/versions.yml` — the new changelog entry will trigger a patch release and we should see the new version on both [`fernapi/fern-ruby-sdk`](https://hub.docker.com/r/fernapi/fern-ruby-sdk) and [`fernapi/fern-ruby-sdk-v2`](https://hub.docker.com/r/fernapi/fern-ruby-sdk-v2).


Link to Devin session: https://app.devin.ai/sessions/3b216b6fe90c48028e512758cf055463
Requested by: @iamnamananand996