### PR TITLE
chore(cli): improve error message when GitHub repository does not exist --- CLI-v2

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-github-app-not-installed-error-surface.yml
+++ b/packages/cli/cli/changes/unreleased/fix-github-app-not-installed-error-surface.yml
@@ -7,4 +7,4 @@
     receives `core.Fetcher.Error` directly (`{ reason, statusCode, body }`), but
     `extractErrorMessage` was looking one level too deep under `.content`, so
     the descriptive message was never extracted.
-  type: fix
+  type: chore

--- a/packages/cli/cli/changes/unreleased/fix-github-app-not-installed-error-surface.yml
+++ b/packages/cli/cli/changes/unreleased/fix-github-app-not-installed-error-surface.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Surface descriptive Fiddle error messages (e.g. `GithubAppNotInstalled`) in
+    the CLI instead of the generic "Failed to create job. Please try again or
+    contact support@buildwithfern.com" fallback. The `_other` visitor callback
+    receives `core.Fetcher.Error` directly (`{ reason, statusCode, body }`), but
+    `extractErrorMessage` was looking one level too deep under `.content`, so
+    the descriptive message was never extracted.
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/extractErrorMessage.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/extractErrorMessage.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { extractErrorMessage } from "../createAndStartJob.js";
+
+describe("extractErrorMessage", () => {
+    it("extracts message from unwrapped Fetcher.Error (the shape passed to _other visitor)", () => {
+        // This is the exact shape logged by the CLI for a GithubAppNotInstalled response
+        // when Fiddle returns a typed error the SDK can't route to a known case.
+        const fetcherError = {
+            reason: "status-code",
+            statusCode: 400,
+            body: {
+                error: "GithubAppNotInstalled",
+                errorInstanceId: "63b0b27d-6e52-4d9e-9220-e69572ad8b9d",
+                content: {
+                    message:
+                        "Could not find GitHub repository owner/repo. Please check that the repository exists and that the Fern GitHub App (https://github.com/apps/fern-api) is installed on owner/repo.",
+                    repositoryName: "owner/repo"
+                }
+            }
+        };
+        expect(extractErrorMessage(fetcherError)).toBe(
+            "Could not find GitHub repository owner/repo. Please check that the repository exists and that the Fern GitHub App (https://github.com/apps/fern-api) is installed on owner/repo."
+        );
+    });
+
+    it("extracts message from wrapped SDK error (the shape of createResponse.error)", () => {
+        const wrappedError = {
+            content: {
+                reason: "status-code",
+                statusCode: 400,
+                body: {
+                    error: "GithubAppNotInstalled",
+                    content: {
+                        message: "The Fern GitHub App is not installed on owner/repo.",
+                        repositoryName: "owner/repo"
+                    }
+                }
+            }
+        };
+        expect(extractErrorMessage(wrappedError)).toBe("The Fern GitHub App is not installed on owner/repo.");
+    });
+
+    it("falls back to body.message when body.content.message is missing", () => {
+        const fetcherError = {
+            reason: "status-code",
+            statusCode: 500,
+            body: { message: "Something broke" }
+        };
+        expect(extractErrorMessage(fetcherError)).toBe("Something broke");
+    });
+
+    it("returns undefined when the body has no message", () => {
+        const fetcherError = {
+            reason: "status-code",
+            statusCode: 500,
+            body: { _error: "_unknown" }
+        };
+        expect(extractErrorMessage(fetcherError)).toBeUndefined();
+    });
+
+    it("returns undefined for non-status-code errors", () => {
+        expect(extractErrorMessage({ reason: "timeout" })).toBeUndefined();
+        expect(extractErrorMessage({ reason: "unknown", errorMessage: "boom" })).toBeUndefined();
+        expect(extractErrorMessage(undefined)).toBeUndefined();
+        expect(extractErrorMessage(null)).toBeUndefined();
+    });
+
+    it("ignores non-string message fields", () => {
+        const fetcherError = {
+            reason: "status-code",
+            statusCode: 400,
+            body: { content: { message: { not: "a string" } } }
+        };
+        expect(extractErrorMessage(fetcherError)).toBeUndefined();
+    });
+});

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -397,12 +397,24 @@ async function startJob({
 /**
  * Attempts to extract a human-readable error message from the raw error response body.
  * Fiddle's ErrorBody serializes as { error: "...", content: { message: "..." } }.
- * The SDK wraps this as { content: { reason: "status-code", body: <ErrorBody> } }.
+ *
+ * Two shapes are supported because this helper is reachable from two call sites:
+ *   1. The `_other` visitor callback, which receives `core.Fetcher.Error` directly:
+ *        { reason: "status-code", statusCode: N, body: <ErrorBody> }
+ *   2. The raw `createResponse.error` wrapper from the SDK, before it is unpacked:
+ *        { content: { reason: "status-code", statusCode: N, body: <ErrorBody> } }
+ *
  * Returns undefined if no message could be extracted.
  */
 // biome-ignore lint/suspicious/noExplicitAny: the error shape from the SDK is not well-typed
-function extractErrorMessage(error: any): string | undefined {
-    const body = error?.content?.reason === "status-code" ? error.content.body : undefined;
+export function extractErrorMessage(error: any): string | undefined {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional dynamic navigation
+    let body: any;
+    if (error?.reason === "status-code") {
+        body = error.body;
+    } else if (error?.content?.reason === "status-code") {
+        body = error.content.body;
+    }
     if (typeof body?.content?.message === "string") {
         return body.content.message;
     }


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-8576](https://linear.app/buildwithfern/issue/FER-8576/cli-v2-improve-error-message-when-github-repository-does-not-exist)

Fiddle has been returning a typed `GithubAppNotInstalled` error with a descriptive `message` field since [fiddle#652](https://github.com/fern-api/fiddle/pull/652) (tag `0.112.0`), and [fern#13288](https://github.com/fern-api/fern/pull/13288) added an `extractErrorMessage` helper meant to surface that message through the `_other` visitor callback. But the helper was never actually extracting anything — it expected the wrong shape:

- `_other` is called with `core.Fetcher.Error` directly: `{ reason: "status-code", statusCode: N, body: ... }`
- The helper looked one level too deep: `error?.content?.reason === "status-code"`

Result: users still saw the generic `"Failed to create job. Please try again or contact support@buildwithfern.com for assistance."` even though the CLI's debug log contained the real message. Confirmed against a real `fern-v2 sdk generate` invocation whose debug log showed:

```
Failed to create job: {"reason":"status-code","statusCode":400,"body":{"error":"GithubAppNotInstalled","errorInstanceId":"...","content":{"message":"Could not find GitHub repository ...","repositoryName":"..."}}}
```

This PR fixes `extractErrorMessage` to handle both shapes (the unwrapped `Fetcher.Error` from the `_other` visitor and the wrapped raw SDK error used by `convertCreateJobError`), exports it so it can be unit-tested, and adds a test suite pinning the behavior against the exact payload from that debug log.

<img width="959" height="318" alt="iScreen Shoter - Cursor - 260422194136" src="https://github.com/user-attachments/assets/dc06e4d3-a249-4c92-a7ec-926c08b51c9d" />




## Changes Made
- `packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts`: Make `extractErrorMessage` accept both the `{ reason, statusCode, body }` and `{ content: { reason, statusCode, body } }` shapes, and export it.
- `packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/extractErrorMessage.test.ts`: New unit tests covering both shapes, the `body.message` fallback, and the undefined-on-no-message path.
- `packages/cli/cli/changes/unreleased/fix-github-app-not-installed-error-surface.yml`: `fix` changelog entry.

## Testing
- [x] Unit tests added (`extractErrorMessage.test.ts`) — pins the exact payload shape from a real-world debug log.
- [x] `pnpm turbo run test --filter @fern-api/remote-workspace-runner` — 58/58 passing, including 6 new tests.
- [x] `pnpm run check` clean (biome).
- [ ] End-to-end CLI verification against Fiddle: not repeated here; the debug log provided by the user is sufficient to validate the payload shape, and the unit tests lock that shape in.

## Follow-up
Once this ships, `fern sdk generate` / `fern-v2 sdk generate` will print the full server-provided remediation message, e.g.:

> `Could not find GitHub repository owner/repo. Please check that the repository exists and that the Fern GitHub App (https://github.com/apps/fern-api) is installed on owner/repo. If the repository is private, make sure the Fern GitHub App has access to it.`

...instead of the generic "Failed to create job" fallback.


Link to Devin session: https://app.devin.ai/sessions/0313fd28dd2a4e0d97ec960bf89f3edc
Requested by: @iamnamananand996