### PR TITLE
fix(parser): support `x-fern-discriminated: true` to override `prefer-undiscriminated-unions-with-literals`

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -914,9 +914,10 @@ export function convertSchemaObject(
             });
         }
 
+        const isDiscriminated = getExtension<boolean>(schema, FernOpenAPIExtension.IS_DISCRIMINATED);
+
         // handle oneOf with IS_DISCRIMINATED extension
         if (schema.oneOf != null && schema.oneOf.length > 0) {
-            const isDiscriminated = getExtension<boolean>(schema, FernOpenAPIExtension.IS_DISCRIMINATED);
             if (isDiscriminated === false) {
                 return convertUndiscriminatedOneOf({
                     nameOverride,
@@ -942,7 +943,11 @@ export function convertSchemaObject(
                 discriminator: schema.discriminator,
                 context
             });
-            if (!context.options.discriminatedUnionV2 || objectDiscriminatorContext === "protocol") {
+            if (
+                isDiscriminated === true ||
+                !context.options.discriminatedUnionV2 ||
+                objectDiscriminatorContext === "protocol"
+            ) {
                 return convertDiscriminatedOneOf({
                     nameOverride,
                     generatedName,
@@ -993,6 +998,7 @@ export function convertSchemaObject(
                     context
                 });
                 if (
+                    isDiscriminated !== true &&
                     (context.options.discriminatedUnionV2 || isUndiscriminated) &&
                     discriminatorContext !== "protocol"
                 ) {
@@ -1115,7 +1121,10 @@ export function convertSchemaObject(
                 }
 
                 const maybeDiscriminant = getDiscriminant({ schemas: schema.oneOf, context });
-                if (maybeDiscriminant != null && !context.options.discriminatedUnionV2 && !isUndiscriminated) {
+                if (
+                    maybeDiscriminant != null &&
+                    (isDiscriminated === true || (!context.options.discriminatedUnionV2 && !isUndiscriminated))
+                ) {
                     return convertDiscriminatedOneOfWithVariants({
                         nameOverride,
                         generatedName,

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-discriminated-true.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi-ir/x-fern-discriminated-true.json
@@ -1,0 +1,204 @@
+{
+  "title": "Test x-fern-discriminated override with unions v1",
+  "servers": [],
+  "websocketServers": [],
+  "tags": {
+    "tagsById": {}
+  },
+  "hasEndpointsMarkedInternal": false,
+  "endpoints": [],
+  "webhooks": [],
+  "channels": {},
+  "groupedSchemas": {
+    "rootSchemas": {
+      "Shape": {
+        "value": {
+          "commonProperties": [],
+          "discriminantProperty": "type",
+          "discriminatorContext": "data",
+          "generatedName": "Shape",
+          "schemas": {
+            "triangle": {
+              "generatedName": "ComponentsSchemasTriangle",
+              "schema": "Triangle",
+              "source": {
+                "file": "../openapi.yml",
+                "type": "openapi"
+              },
+              "type": "reference"
+            },
+            "square": {
+              "generatedName": "ComponentsSchemasSquare",
+              "schema": "Square",
+              "source": {
+                "file": "../openapi.yml",
+                "type": "openapi"
+              },
+              "type": "reference"
+            }
+          },
+          "groupName": [],
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "discriminated"
+        },
+        "type": "oneOf"
+      },
+      "UndiscriminatedShape": {
+        "value": {
+          "generatedName": "UndiscriminatedShape",
+          "schemas": [
+            {
+              "generatedName": "UndiscriminatedShapeZero",
+              "schema": "Triangle",
+              "source": {
+                "file": "../openapi.yml",
+                "type": "openapi"
+              },
+              "type": "reference"
+            },
+            {
+              "generatedName": "UndiscriminatedShapeOne",
+              "schema": "Square",
+              "source": {
+                "file": "../openapi.yml",
+                "type": "openapi"
+              },
+              "type": "reference"
+            }
+          ],
+          "groupName": [],
+          "source": {
+            "file": "../openapi.yml",
+            "type": "openapi"
+          },
+          "type": "undiscriminated"
+        },
+        "type": "oneOf"
+      },
+      "Triangle": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "triangleType",
+            "key": "type",
+            "schema": {
+              "generatedName": "TriangleType",
+              "values": [
+                {
+                  "generatedName": "triangle",
+                  "value": "triangle",
+                  "casing": {}
+                }
+              ],
+              "groupName": [],
+              "source": {
+                "file": "../openapi.yml",
+                "type": "openapi"
+              },
+              "type": "enum"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "triangleBase",
+            "key": "base",
+            "schema": {
+              "schema": {
+                "type": "double"
+              },
+              "generatedName": "TriangleBase",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "triangleHeight",
+            "key": "height",
+            "schema": {
+              "schema": {
+                "type": "double"
+              },
+              "generatedName": "TriangleHeight",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "Triangle",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      },
+      "Square": {
+        "allOf": [],
+        "properties": [
+          {
+            "conflict": {},
+            "generatedName": "squareType",
+            "key": "type",
+            "schema": {
+              "generatedName": "SquareType",
+              "values": [
+                {
+                  "generatedName": "square",
+                  "value": "square",
+                  "casing": {}
+                }
+              ],
+              "groupName": [],
+              "source": {
+                "file": "../openapi.yml",
+                "type": "openapi"
+              },
+              "type": "enum"
+            },
+            "audiences": []
+          },
+          {
+            "conflict": {},
+            "generatedName": "squareSideLength",
+            "key": "sideLength",
+            "schema": {
+              "schema": {
+                "type": "double"
+              },
+              "generatedName": "SquareSideLength",
+              "groupName": [],
+              "type": "primitive"
+            },
+            "audiences": []
+          }
+        ],
+        "allOfPropertyConflicts": [],
+        "generatedName": "Square",
+        "groupName": [],
+        "additionalProperties": false,
+        "source": {
+          "file": "../openapi.yml",
+          "type": "openapi"
+        },
+        "type": "object"
+      }
+    },
+    "namespacedSchemas": {}
+  },
+  "variables": {},
+  "nonRequestReferencedSchemas": {},
+  "securitySchemes": {},
+  "globalHeaders": [],
+  "idempotencyHeaders": [],
+  "groups": {}
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-discriminated-true.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/__snapshots__/openapi/x-fern-discriminated-true.json
@@ -1,0 +1,145 @@
+{
+  "absoluteFilePath": "/DUMMY_PATH",
+  "importedDefinitions": {},
+  "namedDefinitionFiles": {
+    "__package__.yml": {
+      "absoluteFilepath": "/DUMMY_PATH",
+      "contents": {
+        "types": {
+          "Shape": {
+            "availability": undefined,
+            "base-properties": {},
+            "default-variant": undefined,
+            "discriminant": {
+              "context": "data",
+              "value": "type",
+            },
+            "docs": undefined,
+            "encoding": undefined,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+            "union": {
+              "square": "Square",
+              "triangle": "Triangle",
+            },
+          },
+          "Square": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "sideLength": "double",
+              "type": "SquareType",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "SquareType": {
+            "enum": [
+              "square",
+            ],
+            "inline": true,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "Triangle": {
+            "docs": undefined,
+            "inline": undefined,
+            "properties": {
+              "base": "double",
+              "height": "double",
+              "type": "TriangleType",
+            },
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "TriangleType": {
+            "enum": [
+              "triangle",
+            ],
+            "inline": true,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+          },
+          "UndiscriminatedShape": {
+            "discriminated": false,
+            "docs": undefined,
+            "encoding": undefined,
+            "inline": undefined,
+            "source": {
+              "openapi": "../openapi.yml",
+            },
+            "union": [
+              "Triangle",
+              "Square",
+            ],
+          },
+        },
+      },
+      "rawContents": "types:
+  Shape:
+    discriminant:
+      value: type
+      context: data
+    base-properties: {}
+    union:
+      triangle: Triangle
+      square: Square
+    source:
+      openapi: ../openapi.yml
+  UndiscriminatedShape:
+    discriminated: false
+    union:
+      - Triangle
+      - Square
+    source:
+      openapi: ../openapi.yml
+  TriangleType:
+    enum:
+      - triangle
+    inline: true
+    source:
+      openapi: ../openapi.yml
+  Triangle:
+    properties:
+      type: TriangleType
+      base: double
+      height: double
+    source:
+      openapi: ../openapi.yml
+  SquareType:
+    enum:
+      - square
+    inline: true
+    source:
+      openapi: ../openapi.yml
+  Square:
+    properties:
+      type: SquareType
+      sideLength: double
+    source:
+      openapi: ../openapi.yml
+",
+    },
+  },
+  "packageMarkers": {},
+  "rootApiFile": {
+    "contents": {
+      "display-name": "Test x-fern-discriminated override with unions v1",
+      "error-discrimination": {
+        "strategy": "status-code",
+      },
+      "name": "api",
+    },
+    "defaultUrl": undefined,
+    "rawContents": "name: api
+error-discrimination:
+  strategy: status-code
+display-name: Test x-fern-discriminated override with unions v1
+",
+  },
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-discriminated-true/fern/fern.config.json
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-discriminated-true/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "fern",
+    "version": "*"
+}

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-discriminated-true/fern/generators.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-discriminated-true/fern/generators.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  path: ../openapi.yml
+  settings:
+    unions: v1

--- a/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-discriminated-true/openapi.yml
+++ b/packages/cli/api-importers/openapi/openapi-ir-to-fern-tests/src/__test__/fixtures/x-fern-discriminated-true/openapi.yml
@@ -1,0 +1,47 @@
+openapi: 3.0.3
+info:
+  title: Test x-fern-discriminated override with unions v1
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Shape:
+      type: object
+      x-fern-discriminated: true
+      discriminator:
+        propertyName: type
+      oneOf:
+        - $ref: "#/components/schemas/Triangle"
+        - $ref: "#/components/schemas/Square"
+    UndiscriminatedShape:
+      type: object
+      discriminator:
+        propertyName: type
+      oneOf:
+        - $ref: "#/components/schemas/Triangle"
+        - $ref: "#/components/schemas/Square"
+    Triangle:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: ["triangle"]
+        base:
+          type: number
+        height:
+          type: number
+      required:
+        - type
+        - base
+        - height
+    Square:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: ["square"]
+        sideLength:
+          type: number
+      required:
+        - type
+        - sideLength

--- a/packages/cli/cli/changes/unreleased/x-fern-discriminated-true-override.yml
+++ b/packages/cli/cli/changes/unreleased/x-fern-discriminated-true-override.yml
@@ -1,3 +1,3 @@
 - summary: |
-    Support `x-fern-discriminated: true` to override the global `prefer-undiscriminated-unions-with-literals` setting and keep specific schemas as discriminated unions.
-  type: feat
+    Fix `x-fern-discriminated: true` to correctly keep specific schemas as discriminated unions when `prefer-undiscriminated-unions-with-literals` is enabled.
+  type: fix

--- a/packages/cli/cli/changes/unreleased/x-fern-discriminated-true-override.yml
+++ b/packages/cli/cli/changes/unreleased/x-fern-discriminated-true-override.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Support `x-fern-discriminated: true` to override the global `prefer-undiscriminated-unions-with-literals` setting and keep specific schemas as discriminated unions.
+  type: feat


### PR DESCRIPTION
## Summary

- Adds support for `x-fern-discriminated: true` on individual schemas to override the global `prefer-undiscriminated-unions-with-literals` setting, keeping specific unions as discriminated.

## Example

When a customer has `prefer-undiscriminated-unions-with-literals: true` globally, all unions become undiscriminated — even those with explicit discriminators. Now they can opt specific schemas back into discriminated unions:

```yaml
components:
  schemas:
    Shape:
      x-fern-discriminated: true  # keeps this as a discriminated union
      discriminator:
        propertyName: type
      oneOf:
        - $ref: "#/components/schemas/Triangle"
        - $ref: "#/components/schemas/Square"
```

The `x-fern-discriminated` extension already existed and supported `false` (force undiscriminated). This change adds handling for `true` (force discriminated) across all three union conversion paths in `convertSchemas.ts`.

## Test plan

- [x] New `x-fern-discriminated-true` test fixture with `unions: v1` enabled globally — verifies `Shape` (with `x-fern-discriminated: true`) generates as discriminated while `UndiscriminatedShape` (without override) generates as undiscriminated
- [x] Existing `unions-v1` and `x-fern-discriminated` tests still pass
- [x] Compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)