### PR TITLE
fix(cli): handle basePath in absolute link validation

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-basepath-link-validation.yml
+++ b/packages/cli/cli/changes/unreleased/fix-basepath-link-validation.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Fix `broken-links` false positives for absolute links on sites that configure a
+    `basePath` (e.g. `https://docs.example.com/product`). Page slugs are stored with
+    the basePath prepended (`product/about`), but authors commonly write site-relative
+    absolute links without it (`/about`, `/v2/guide`). The link validator now also
+    checks the basePath-prefixed form so both conventions resolve.
+  type: fix

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/__test__/check-if-pathname-exists.test.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/__test__/check-if-pathname-exists.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { withBasePathPrepended } from "../with-base-path-prepended.js";
+
+describe("withBasePathPrepended", () => {
+    it("returns null when no basePath is configured", () => {
+        expect(withBasePathPrepended("/about", undefined)).toBeNull();
+    });
+
+    it("returns null when basePath is empty or just `/`", () => {
+        expect(withBasePathPrepended("/about", "/")).toBeNull();
+        expect(withBasePathPrepended("/about", "")).toBeNull();
+    });
+
+    it("prepends a single-segment basePath to a site-relative path", () => {
+        expect(withBasePathPrepended("/about", "/docs")).toBe("docs/about");
+    });
+
+    it("prepends a multi-segment basePath to a site-relative path", () => {
+        // Repro for the Gym regression: `/latest/about` on a site with basePath
+        // `/nemo/gym` should resolve to `nemo/gym/latest/about` in pageSlugs.
+        expect(withBasePathPrepended("/latest/about", "/nemo/gym")).toBe("nemo/gym/latest/about");
+    });
+
+    it("returns null when the path already starts with the basePath", () => {
+        expect(withBasePathPrepended("/nemo/gym/about", "/nemo/gym")).toBeNull();
+        expect(withBasePathPrepended("/nemo/gym", "/nemo/gym")).toBeNull();
+    });
+
+    it("does not double-prepend when the path is exactly the basePath", () => {
+        expect(withBasePathPrepended("/docs", "/docs")).toBeNull();
+    });
+
+    it("handles basePath without leading or trailing slashes", () => {
+        expect(withBasePathPrepended("/about", "docs")).toBe("docs/about");
+        expect(withBasePathPrepended("/about", "/docs/")).toBe("docs/about");
+        expect(withBasePathPrepended("/about", "docs/")).toBe("docs/about");
+    });
+
+    it("still prepends when the path starts with a segment that only shares a prefix with basePath", () => {
+        // `docs-v2/about` must not match `docs/...` — the basePath segment must be
+        // followed by `/` to be considered already-prefixed.
+        expect(withBasePathPrepended("/docs-v2/about", "/docs")).toBe("docs/docs-v2/about");
+    });
+});

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/check-if-pathname-exists.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/check-if-pathname-exists.ts
@@ -3,6 +3,7 @@ import { AbsoluteFilePath, dirname, doesPathExist, join, RelativeFilePath } from
 
 import { getRedirectForPath } from "./redirect-for-path.js";
 import { addLeadingSlash, removeLeadingSlash, removeTrailingSlash } from "./url-utils.js";
+import { withBasePathPrepended } from "./with-base-path-prepended.js";
 
 /**
  * Checks if the given path exists in the docs.
@@ -75,6 +76,17 @@ export async function checkIfPathnameExists({
 
         if (markdown && pageSlugs.has(removeLeadingSlash(redirectedPath))) {
             return true;
+        }
+
+        // Page slugs always include the site's basePath (e.g. `docs/about`), but authors
+        // commonly write absolute links as site-relative paths without the basePath
+        // (e.g. `/about` or `/v2/guide`). Try matching with the basePath prepended so
+        // both forms resolve.
+        if (markdown) {
+            const basePathPrefixed = withBasePathPrepended(redirectedPath, baseUrl.basePath);
+            if (basePathPrefixed != null && pageSlugs.has(basePathPrefixed)) {
+                return true;
+            }
         }
 
         // For versioned/product pages, absolute links like `/about` resolve within the current context.

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/with-base-path-prepended.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/with-base-path-prepended.ts
@@ -1,0 +1,37 @@
+/**
+ * Returns the pathname with the site's basePath prepended, or null if prepending
+ * would not change the path (no basePath configured, or the pathname already
+ * starts with the basePath).
+ *
+ * Page slugs collected by the docs resolver always include the site's basePath
+ * (e.g. a page at `/docs/about` is stored as `docs/about`). Authors, however,
+ * commonly write absolute links as site-relative paths without the basePath
+ * (e.g. `/about` or `/v2/guide`). Link validation uses this helper to also
+ * check the basePath-prefixed form so both conventions resolve.
+ */
+export function withBasePathPrepended(pathname: string, basePath: string | undefined): string | null {
+    if (basePath == null) {
+        return null;
+    }
+    const basePathSlug = stripSlashes(basePath);
+    if (basePathSlug === "") {
+        return null;
+    }
+    const bare = stripLeadingSlash(pathname);
+    if (bare === basePathSlug || bare.startsWith(basePathSlug + "/")) {
+        return null;
+    }
+    return `${basePathSlug}/${bare}`;
+}
+
+function stripLeadingSlash(value: string): string {
+    return value.startsWith("/") ? value.slice(1) : value;
+}
+
+function stripTrailingSlash(value: string): string {
+    return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function stripSlashes(value: string): string {
+    return stripLeadingSlash(stripTrailingSlash(value));
+}


### PR DESCRIPTION
## Description

Fixes FER-10009

Fixes a `broken-links` false-positive regression that shows up on any docs instance configured with a `basePath` (e.g. `https://gym.docs.buildwithfern.com/nemo/gym`, basePath `/nemo/gym`).

**Repro:** on `NVIDIA-NeMo/Gym` PR #1045 (basePath `/nemo/gym`), running `fern check` reported 60 errors of the form:

```
broken link to /latest/about in versions/latest/pages/home.mdx
broken link to /latest/get-started/quickstart in ...
...
```

All of the links are valid — `/latest/about` resolves to the page served at `https://gym.docs.buildwithfern.com/nemo/gym/latest/about`.

**Root cause:** `DocsDefinitionResolver` collects page slugs with the site's basePath prepended — e.g. the page `/latest/about` is stored in `pageSlugs` as `nemo/gym/latest/about`. But `checkIfPathnameExists` only checks `pageSlugs.has("latest/about")` (no basePath), so it never finds a match.

Authors write site-relative absolute links as `/latest/about` or `/about`, not as `/nemo/gym/latest/about`. We now try both forms when resolving an absolute link. The existing version/product-context prefixing (#14755) still runs afterwards, so intra-version links like `/about` in a v0.2 page continue to resolve to `nemo/gym/v0.2/about`.

Confirmed on Gym with the rebuilt dev CLI: 60 errors → 0. No spurious matches introduced — the new prefix path only returns true when the basePath-prefixed slug is actually present in `pageSlugs`, and short-circuits when the author already wrote the full basePath.

## Changes Made
- Added `withBasePathPrepended(pathname, basePath)` helper in `packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/with-base-path-prepended.ts`. Returns `basePath + pathname` unless the basePath is empty, unset, or already present on the pathname.
- Wired it into `checkIfPathnameExists` for the `pathname.startsWith("/")` branch, before the version/product-context fallback.
- Unit tests for the helper covering: missing/empty/root basePath, single- and multi-segment basePaths, already-prefixed paths, trailing/leading-slash normalization, and prefix-look-alike segments (e.g. `/docs-v2/...` must not be treated as already basePath-prefixed when basePath is `/docs`).
- Unreleased changelog entry.

## Testing
- [x] Unit tests added/updated (`check-if-pathname-exists.test.ts`, 8 cases covering the helper).
- [x] Manual testing completed — rebuilt dev CLI, ran against `NVIDIA-NeMo/Gym` `lbliii/fix-fern-docs-fidelity-v2` branch: 60 → 0 broken-link errors. Also ran the full docs-validator vitest suite (all suites green).


Link to Devin session: https://app.devin.ai/sessions/1b55f7ca4ac14fdc9f1957b8adc56d9a
Requested by: @Ryan-Amirthan