### PR TITLE
fix(generator-cli): sign commits pushed by replay pipeline via GitHub API

### DIFF
--- a/generators/csharp/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
+++ b/generators/csharp/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.11. The GitHub pipeline step now creates
+    signed commits via the GitHub REST API (matching fiddle's legacy InMemoryGitRepo
+    push path), restoring verified fern-api[bot] commits on replay-enabled orgs.
+  type: chore

--- a/generators/go/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
+++ b/generators/go/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.11. The GitHub pipeline step now creates
+    signed commits via the GitHub REST API (matching fiddle's legacy InMemoryGitRepo
+    push path), restoring verified fern-api[bot] commits on replay-enabled orgs.
+  type: chore

--- a/generators/java/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
+++ b/generators/java/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.11. The GitHub pipeline step now creates
+    signed commits via the GitHub REST API (matching fiddle's legacy InMemoryGitRepo
+    push path), restoring verified fern-api[bot] commits on replay-enabled orgs.
+  type: chore

--- a/generators/php/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
+++ b/generators/php/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.11. The GitHub pipeline step now creates
+    signed commits via the GitHub REST API (matching fiddle's legacy InMemoryGitRepo
+    push path), restoring verified fern-api[bot] commits on replay-enabled orgs.
+  type: chore

--- a/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
+++ b/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.11. The GitHub pipeline step now creates
+    signed commits via the GitHub REST API (matching fiddle's legacy InMemoryGitRepo
+    push path), restoring verified fern-api[bot] commits on replay-enabled orgs.
+  type: chore

--- a/generators/ruby-v2/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.11. The GitHub pipeline step now creates
+    signed commits via the GitHub REST API (matching fiddle's legacy InMemoryGitRepo
+    push path), restoring verified fern-api[bot] commits on replay-enabled orgs.
+  type: chore

--- a/generators/ruby/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
+++ b/generators/ruby/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.11. The GitHub pipeline step now creates
+    signed commits via the GitHub REST API (matching fiddle's legacy InMemoryGitRepo
+    push path), restoring verified fern-api[bot] commits on replay-enabled orgs.
+  type: chore

--- a/generators/rust/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
+++ b/generators/rust/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.11. The GitHub pipeline step now creates
+    signed commits via the GitHub REST API (matching fiddle's legacy InMemoryGitRepo
+    push path), restoring verified fern-api[bot] commits on replay-enabled orgs.
+  type: chore

--- a/generators/swift/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
+++ b/generators/swift/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.11. The GitHub pipeline step now creates
+    signed commits via the GitHub REST API (matching fiddle's legacy InMemoryGitRepo
+    push path), restoring verified fern-api[bot] commits on replay-enabled orgs.
+  type: chore

--- a/generators/typescript/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
+++ b/generators/typescript/sdk/changes/unreleased/bump-generator-cli-0.9.11.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.11. The GitHub pipeline step now creates
+    signed commits via the GitHub REST API (matching fiddle's legacy InMemoryGitRepo
+    push path), restoring verified fern-api[bot] commits on replay-enabled orgs.
+  type: chore

--- a/packages/commons/github/src/ClonedRepository.ts
+++ b/packages/commons/github/src/ClonedRepository.ts
@@ -315,10 +315,19 @@ export class ClonedRepository {
     /**
      * Pushes a specific object (commit SHA) to a remote ref.
      * Used to upload tree and blob objects to the remote without moving a branch.
+     *
+     * Pass `force: true` when overwriting a ref that may already point to an
+     * unrelated commit (e.g. retrying a temp ref after a local rebase rewrites
+     * history so the new SHA is not a descendant of the previous one).
      */
-    public async pushObjectToRef(localSha: string, remoteRef: string): Promise<void> {
+    public async pushObjectToRef(
+        localSha: string,
+        remoteRef: string,
+        { force = false }: { force?: boolean } = {}
+    ): Promise<void> {
         await this.git.cwd(this.clonePath);
-        await this.git.raw(["push", "origin", `${localSha}:${remoteRef}`]);
+        const spec = force ? `+${localSha}:${remoteRef}` : `${localSha}:${remoteRef}`;
+        await this.git.raw(["push", "origin", spec]);
     }
 
     /**

--- a/packages/commons/github/src/ClonedRepository.ts
+++ b/packages/commons/github/src/ClonedRepository.ts
@@ -297,6 +297,48 @@ export class ClonedRepository {
         return result.trim();
     }
 
+    public async getHeadCommitMessage(): Promise<string> {
+        await this.git.cwd(this.clonePath);
+        const result = await this.git.raw(["log", "-1", "--format=%B", "HEAD"]);
+        // git log appends a trailing newline; strip exactly one to preserve any intentional blank lines.
+        return result.replace(/\n$/, "");
+    }
+
+    public async getHeadParents(): Promise<string[]> {
+        await this.git.cwd(this.clonePath);
+        // `git rev-list --parents -n 1 HEAD` prints "<commit> <parent1> <parent2> ..." (empty parents for root commit).
+        const result = await this.git.raw(["rev-list", "--parents", "-n", "1", "HEAD"]);
+        const parts = result.trim().split(/\s+/);
+        return parts.slice(1);
+    }
+
+    /**
+     * Pushes a specific object (commit SHA) to a remote ref.
+     * Used to upload tree and blob objects to the remote without moving a branch.
+     */
+    public async pushObjectToRef(localSha: string, remoteRef: string): Promise<void> {
+        await this.git.cwd(this.clonePath);
+        await this.git.raw(["push", "origin", `${localSha}:${remoteRef}`]);
+    }
+
+    /**
+     * Resets the current branch HEAD to the given SHA. After fetching a newly-created remote
+     * signed commit, use this to align the local branch so subsequent operations (tag push,
+     * getHeadSha(), etc.) see the signed SHA.
+     */
+    public async resetHardToSha(sha: string): Promise<void> {
+        await this.git.cwd(this.clonePath);
+        await this.git.raw(["reset", "--hard", sha]);
+    }
+
+    /**
+     * Rebases the current branch onto the given remote branch (`git pull --rebase origin <branch>`).
+     */
+    public async pullWithRebase(branch: string): Promise<void> {
+        await this.git.cwd(this.clonePath);
+        await this.git.raw(["pull", "origin", branch, "--rebase"]);
+    }
+
     public async getCommitTreeHash(commitSha: string): Promise<string> {
         await this.git.cwd(this.clonePath);
         const result = await this.git.raw(["rev-parse", `${commitSha}^{tree}`]);

--- a/packages/generator-cli/src/__test__/pushSignedCommit.test.ts
+++ b/packages/generator-cli/src/__test__/pushSignedCommit.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { isNonFastForwardError, pushSignedCommit } from "../pipeline/github/pushSignedCommit.js";
+
+interface MockedRepository {
+    getHeadSha: ReturnType<typeof vi.fn>;
+    getHeadTreeHash: ReturnType<typeof vi.fn>;
+    getHeadCommitMessage: ReturnType<typeof vi.fn>;
+    getHeadParents: ReturnType<typeof vi.fn>;
+    pushObjectToRef: ReturnType<typeof vi.fn>;
+    pullWithRebase: ReturnType<typeof vi.fn>;
+    resetHardToSha: ReturnType<typeof vi.fn>;
+    fetch: ReturnType<typeof vi.fn>;
+}
+
+function buildRepository(overrides: Partial<MockedRepository> = {}): MockedRepository {
+    return {
+        getHeadSha: vi.fn().mockResolvedValue("local-sha"),
+        getHeadTreeHash: vi.fn().mockResolvedValue("tree-sha"),
+        getHeadCommitMessage: vi.fn().mockResolvedValue("SDK Generation"),
+        getHeadParents: vi.fn().mockResolvedValue(["parent-sha"]),
+        pushObjectToRef: vi.fn().mockResolvedValue(undefined),
+        pullWithRebase: vi.fn().mockResolvedValue(undefined),
+        resetHardToSha: vi.fn().mockResolvedValue(undefined),
+        fetch: vi.fn().mockResolvedValue(undefined),
+        ...overrides
+    };
+}
+
+interface MockedOctokit {
+    git: {
+        createCommit: ReturnType<typeof vi.fn>;
+        updateRef: ReturnType<typeof vi.fn>;
+        createRef: ReturnType<typeof vi.fn>;
+        deleteRef: ReturnType<typeof vi.fn>;
+    };
+}
+
+function buildOctokit(overrides: Partial<MockedOctokit["git"]> = {}): MockedOctokit {
+    return {
+        git: {
+            createCommit: vi.fn().mockResolvedValue({ data: { sha: "signed-sha-1" } }),
+            updateRef: vi.fn().mockResolvedValue({ data: {} }),
+            createRef: vi.fn().mockResolvedValue({ data: {} }),
+            deleteRef: vi.fn().mockResolvedValue({ data: {} }),
+            ...overrides
+        }
+    };
+}
+
+const silentLogger = {
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined
+};
+
+// The helper accepts concrete ClonedRepository / Octokit types; our tests use structural mocks
+// that implement only the methods the helper invokes. This cast is local to the test file.
+type Caller = (args: Parameters<typeof pushSignedCommit>[0]) => Promise<string>;
+
+function makeCaller(repository: MockedRepository, octokit: MockedOctokit): Caller {
+    return (rest) =>
+        pushSignedCommit({
+            ...rest,
+            repository: repository as unknown as Parameters<typeof pushSignedCommit>[0]["repository"],
+            octokit: octokit as unknown as Parameters<typeof pushSignedCommit>[0]["octokit"]
+        });
+}
+
+describe("pushSignedCommit", () => {
+    const baseArgs = {
+        owner: "acme",
+        repo: "acme-sdk",
+        branch: "fern-bot/2026-04-22_00-00-00",
+        force: true,
+        logger: silentLogger
+    } as const;
+
+    it("pushes the local commit to a temp ref, creates a signed commit, and updates the branch ref", async () => {
+        const repository = buildRepository();
+        const octokit = buildOctokit();
+
+        const result = await makeCaller(
+            repository,
+            octokit
+        )({
+            ...baseArgs,
+            repository: repository as never,
+            octokit: octokit as never
+        });
+
+        expect(result).toBe("signed-sha-1");
+        expect(repository.pushObjectToRef).toHaveBeenCalledWith(
+            "local-sha",
+            expect.stringMatching(/^refs\/temp\/fern-/)
+        );
+        expect(octokit.git.createCommit).toHaveBeenCalledWith({
+            owner: "acme",
+            repo: "acme-sdk",
+            message: "SDK Generation",
+            tree: "tree-sha",
+            parents: ["parent-sha"]
+        });
+        expect(octokit.git.updateRef).toHaveBeenCalledWith({
+            owner: "acme",
+            repo: "acme-sdk",
+            ref: "heads/fern-bot/2026-04-22_00-00-00",
+            sha: "signed-sha-1",
+            force: true
+        });
+        expect(octokit.git.createRef).not.toHaveBeenCalled();
+        expect(octokit.git.deleteRef).toHaveBeenCalledWith({
+            owner: "acme",
+            repo: "acme-sdk",
+            ref: expect.stringMatching(/^temp\/fern-/)
+        });
+        expect(repository.resetHardToSha).toHaveBeenCalledWith("signed-sha-1");
+    });
+
+    it("falls back to createRef when the branch does not yet exist on the remote", async () => {
+        const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+        const repository = buildRepository();
+        const octokit = buildOctokit({
+            updateRef: vi.fn().mockRejectedValue(notFound)
+        });
+
+        const result = await makeCaller(
+            repository,
+            octokit
+        )({
+            ...baseArgs,
+            force: false,
+            repository: repository as never,
+            octokit: octokit as never
+        });
+
+        expect(result).toBe("signed-sha-1");
+        expect(octokit.git.createRef).toHaveBeenCalledWith({
+            owner: "acme",
+            repo: "acme-sdk",
+            ref: "refs/heads/fern-bot/2026-04-22_00-00-00",
+            sha: "signed-sha-1"
+        });
+    });
+
+    it("does not retry on non-fast-forward when force=true (trusts caller's force intent)", async () => {
+        const nonFF = Object.assign(new Error("Update is not a fast forward"), { status: 422 });
+        const repository = buildRepository();
+        const octokit = buildOctokit({
+            updateRef: vi.fn().mockRejectedValue(nonFF)
+        });
+
+        await expect(
+            makeCaller(
+                repository,
+                octokit
+            )({
+                ...baseArgs,
+                force: true,
+                repository: repository as never,
+                octokit: octokit as never
+            })
+        ).rejects.toBe(nonFF);
+
+        expect(octokit.git.createCommit).toHaveBeenCalledTimes(1);
+        expect(repository.pullWithRebase).not.toHaveBeenCalled();
+        // Temp ref is still cleaned up on failure.
+        expect(octokit.git.deleteRef).toHaveBeenCalled();
+    });
+
+    it("throws on non-fast-forward when force=false and rebaseOnConflict is not set", async () => {
+        const nonFF = Object.assign(new Error("Update is not a fast forward"), { status: 422 });
+        const repository = buildRepository();
+        const octokit = buildOctokit({
+            updateRef: vi.fn().mockRejectedValue(nonFF)
+        });
+
+        await expect(
+            makeCaller(
+                repository,
+                octokit
+            )({
+                ...baseArgs,
+                force: false,
+                repository: repository as never,
+                octokit: octokit as never
+            })
+        ).rejects.toBe(nonFF);
+
+        expect(repository.pullWithRebase).not.toHaveBeenCalled();
+    });
+
+    it("rebases and retries on non-fast-forward when rebaseOnConflict=true", async () => {
+        const nonFF = Object.assign(new Error("Update is not a fast forward"), { status: 422 });
+        const repository = buildRepository({
+            getHeadSha: vi.fn().mockResolvedValueOnce("local-sha-1").mockResolvedValue("local-sha-2"),
+            getHeadTreeHash: vi.fn().mockResolvedValueOnce("tree-sha-1").mockResolvedValue("tree-sha-2"),
+            getHeadParents: vi.fn().mockResolvedValueOnce(["parent-sha-1"]).mockResolvedValue(["parent-sha-2"])
+        });
+        const octokit = buildOctokit({
+            createCommit: vi
+                .fn()
+                .mockResolvedValueOnce({ data: { sha: "signed-sha-1" } })
+                .mockResolvedValueOnce({ data: { sha: "signed-sha-2" } }),
+            updateRef: vi.fn().mockRejectedValueOnce(nonFF).mockResolvedValueOnce({ data: {} })
+        });
+
+        const result = await makeCaller(
+            repository,
+            octokit
+        )({
+            ...baseArgs,
+            force: false,
+            rebaseOnConflict: true,
+            repository: repository as never,
+            octokit: octokit as never
+        });
+
+        expect(result).toBe("signed-sha-2");
+        expect(repository.pullWithRebase).toHaveBeenCalledWith("fern-bot/2026-04-22_00-00-00");
+        expect(octokit.git.createCommit).toHaveBeenNthCalledWith(2, {
+            owner: "acme",
+            repo: "acme-sdk",
+            message: "SDK Generation",
+            tree: "tree-sha-2",
+            parents: ["parent-sha-2"]
+        });
+        // Temp ref re-push happens on the rebase retry too.
+        expect(repository.pushObjectToRef).toHaveBeenCalledTimes(2);
+    });
+
+    it("cleans up the temp ref even when the push fails", async () => {
+        const boom = new Error("boom");
+        const repository = buildRepository();
+        const octokit = buildOctokit({
+            createCommit: vi.fn().mockRejectedValue(boom)
+        });
+
+        await expect(
+            makeCaller(
+                repository,
+                octokit
+            )({
+                ...baseArgs,
+                repository: repository as never,
+                octokit: octokit as never
+            })
+        ).rejects.toBe(boom);
+
+        expect(octokit.git.deleteRef).toHaveBeenCalled();
+    });
+});
+
+describe("isNonFastForwardError", () => {
+    it("recognizes 422 + 'not a fast forward'", () => {
+        expect(isNonFastForwardError(Object.assign(new Error("Update is not a fast forward"), { status: 422 }))).toBe(
+            true
+        );
+    });
+
+    it("ignores 422 errors with unrelated messages", () => {
+        expect(isNonFastForwardError(Object.assign(new Error("Validation failed"), { status: 422 }))).toBe(false);
+    });
+
+    it("ignores non-422 statuses", () => {
+        expect(isNonFastForwardError(Object.assign(new Error("Not a fast forward"), { status: 409 }))).toBe(false);
+    });
+
+    it("handles non-error inputs safely", () => {
+        expect(isNonFastForwardError(undefined)).toBe(false);
+        expect(isNonFastForwardError("nope")).toBe(false);
+        expect(isNonFastForwardError({})).toBe(false);
+    });
+});

--- a/packages/generator-cli/src/__test__/pushSignedCommit.test.ts
+++ b/packages/generator-cli/src/__test__/pushSignedCommit.test.ts
@@ -91,7 +91,9 @@ describe("pushSignedCommit", () => {
         });
 
         expect(result).toBe("signed-sha-1");
-        expect(repository.pushObjectToRef).toHaveBeenCalledWith(
+        expect(repository.pushObjectToRef).toHaveBeenCalledTimes(1);
+        expect(repository.pushObjectToRef).toHaveBeenNthCalledWith(
+            1,
             "local-sha",
             expect.stringMatching(/^refs\/temp\/fern-/)
         );
@@ -226,8 +228,45 @@ describe("pushSignedCommit", () => {
             tree: "tree-sha-2",
             parents: ["parent-sha-2"]
         });
-        // Temp ref re-push happens on the rebase retry too.
+        // Temp ref re-push on the rebase retry must force, because the rebased commit
+        // is not a descendant of the original tempRef tip.
         expect(repository.pushObjectToRef).toHaveBeenCalledTimes(2);
+        expect(repository.pushObjectToRef).toHaveBeenNthCalledWith(
+            1,
+            "local-sha-1",
+            expect.stringMatching(/^refs\/temp\/fern-/)
+        );
+        expect(repository.pushObjectToRef).toHaveBeenNthCalledWith(
+            2,
+            "local-sha-2",
+            expect.stringMatching(/^refs\/temp\/fern-/),
+            { force: true }
+        );
+    });
+
+    it("propagates errors from the post-update local sync (does not swallow stale-HEAD risk)", async () => {
+        const resetBoom = new Error("reset --hard failed");
+        const repository = buildRepository({
+            resetHardToSha: vi.fn().mockRejectedValue(resetBoom)
+        });
+        const octokit = buildOctokit();
+
+        await expect(
+            makeCaller(
+                repository,
+                octokit
+            )({
+                ...baseArgs,
+                repository: repository as never,
+                octokit: octokit as never
+            })
+        ).rejects.toBe(resetBoom);
+
+        // Signed commit was created and the remote ref was updated before sync failed.
+        expect(octokit.git.createCommit).toHaveBeenCalledTimes(1);
+        expect(octokit.git.updateRef).toHaveBeenCalledTimes(1);
+        // Temp ref still cleaned up.
+        expect(octokit.git.deleteRef).toHaveBeenCalled();
     });
 
     it("cleans up the temp ref even when the push fails", async () => {

--- a/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
+++ b/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
@@ -1,0 +1,196 @@
+import { extractErrorMessage } from "@fern-api/core-utils";
+import type { ClonedRepository } from "@fern-api/github";
+import type { Octokit } from "@octokit/rest";
+
+import type { PipelineLogger } from "../PipelineLogger";
+
+const MAX_CONCURRENT_PUSH_RETRIES = 3;
+
+export interface PushSignedCommitOptions {
+    repository: ClonedRepository;
+    octokit: Octokit;
+    owner: string;
+    repo: string;
+    /** The branch name whose ref will be updated to the signed commit. */
+    branch: string;
+    /**
+     * Force-update the branch ref (non-fast-forward allowed).
+     * Use `true` when updating bot-owned branches (e.g. `fern-bot/*`) that the pipeline exclusively owns.
+     */
+    force: boolean;
+    /**
+     * When `force` is false and the ref update fails with a non-fast-forward error, rebase the
+     * local branch onto the remote and retry. Only safe when the branch may contain real
+     * upstream commits that must be preserved (e.g. push mode onto a shared branch).
+     * Defaults to false; re-parenting onto remote HEAD with the local tree (which discards
+     * remote changes) is only safe for bot-owned branches and is therefore never done here.
+     */
+    rebaseOnConflict?: boolean;
+    logger: PipelineLogger;
+}
+
+/**
+ * Pushes the current branch HEAD to GitHub as a signed commit by:
+ * 1. Pushing the local commit to a temporary ref (uploads tree + blob objects).
+ * 2. Creating a new commit via the GitHub REST API (which GitHub signs with the App's key
+ *    when the octokit instance is authenticated with a GitHub App installation token).
+ * 3. Updating the branch ref to point to the signed commit.
+ * 4. Deleting the temporary ref.
+ * 5. Fast-forwarding the local branch to the signed commit SHA.
+ *
+ * Returns the SHA of the signed commit on the remote (which differs from the local HEAD SHA).
+ */
+export async function pushSignedCommit({
+    repository,
+    octokit,
+    owner,
+    repo,
+    branch,
+    force,
+    rebaseOnConflict = false,
+    logger
+}: PushSignedCommitOptions): Promise<string> {
+    const tempRef = `refs/temp/fern-${Date.now()}`;
+    let tempRefPushed = false;
+
+    try {
+        let localHeadSha = await repository.getHeadSha();
+        let treeSha = await repository.getHeadTreeHash();
+        let message = await repository.getHeadCommitMessage();
+        let parents = await repository.getHeadParents();
+
+        await repository.pushObjectToRef(localHeadSha, tempRef);
+        tempRefPushed = true;
+
+        for (let attempt = 0; attempt < MAX_CONCURRENT_PUSH_RETRIES; attempt++) {
+            const { data: signedCommit } = await octokit.git.createCommit({
+                owner,
+                repo,
+                message,
+                tree: treeSha,
+                parents
+            });
+            const signedSha = signedCommit.sha;
+
+            try {
+                await upsertBranchRef({ octokit, owner, repo, branch, sha: signedSha, force });
+                logger.debug(`Updated refs/heads/${branch} to signed commit ${signedSha}`);
+                await syncLocalToSignedCommit({ repository, branch, signedSha, logger });
+                return signedSha;
+            } catch (err) {
+                if (!isNonFastForwardError(err) || force || attempt >= MAX_CONCURRENT_PUSH_RETRIES - 1) {
+                    throw err;
+                }
+
+                if (rebaseOnConflict) {
+                    logger.warn(
+                        `Non-fast-forward on refs/heads/${branch} (attempt ${attempt + 1}/${MAX_CONCURRENT_PUSH_RETRIES}); rebasing locally and retrying.`
+                    );
+                    await repository.pullWithRebase(branch);
+                    localHeadSha = await repository.getHeadSha();
+                    treeSha = await repository.getHeadTreeHash();
+                    message = await repository.getHeadCommitMessage();
+                    parents = await repository.getHeadParents();
+                    await repository.pushObjectToRef(localHeadSha, tempRef);
+                } else {
+                    throw err;
+                }
+            }
+        }
+
+        throw new Error(
+            `Failed to push signed commit to refs/heads/${branch} after ${MAX_CONCURRENT_PUSH_RETRIES} attempts`
+        );
+    } finally {
+        if (tempRefPushed) {
+            try {
+                await octokit.git.deleteRef({ owner, repo, ref: tempRef.replace(/^refs\//, "") });
+            } catch (err) {
+                logger.debug(`Failed to delete temp ref ${tempRef}: ${extractErrorMessage(err)}`);
+            }
+        }
+    }
+}
+
+async function upsertBranchRef({
+    octokit,
+    owner,
+    repo,
+    branch,
+    sha,
+    force
+}: {
+    octokit: Octokit;
+    owner: string;
+    repo: string;
+    branch: string;
+    sha: string;
+    force: boolean;
+}): Promise<void> {
+    try {
+        await octokit.git.updateRef({
+            owner,
+            repo,
+            ref: `heads/${branch}`,
+            sha,
+            force
+        });
+    } catch (err) {
+        if (isNotFoundError(err)) {
+            await octokit.git.createRef({
+                owner,
+                repo,
+                ref: `refs/heads/${branch}`,
+                sha
+            });
+            return;
+        }
+        throw err;
+    }
+}
+
+async function syncLocalToSignedCommit({
+    repository,
+    branch,
+    signedSha,
+    logger
+}: {
+    repository: ClonedRepository;
+    branch: string;
+    signedSha: string;
+    logger: PipelineLogger;
+}): Promise<void> {
+    try {
+        await repository.fetch(["origin", branch]);
+        await repository.resetHardToSha(signedSha);
+    } catch (err) {
+        logger.debug(
+            `Could not sync local branch ${branch} to signed commit ${signedSha}: ${extractErrorMessage(err)}`
+        );
+    }
+}
+
+function hasNumericStatus(err: unknown): err is { status: number } {
+    return (
+        typeof err === "object" &&
+        err != null &&
+        "status" in err &&
+        typeof (err as { status: unknown }).status === "number"
+    );
+}
+
+function isNotFoundError(err: unknown): boolean {
+    return hasNumericStatus(err) && err.status === 404;
+}
+
+export function isNonFastForwardError(err: unknown): boolean {
+    if (!hasNumericStatus(err) || err.status !== 422) {
+        return false;
+    }
+    const message = extractErrorMessage(err).toLowerCase();
+    return (
+        message.includes("not a fast forward") ||
+        message.includes("not a fast-forward") ||
+        message.includes("update is not a fast forward")
+    );
+}

--- a/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
+++ b/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
@@ -77,7 +77,7 @@ export async function pushSignedCommit({
             try {
                 await upsertBranchRef({ octokit, owner, repo, branch, sha: signedSha, force });
                 logger.debug(`Updated refs/heads/${branch} to signed commit ${signedSha}`);
-                await syncLocalToSignedCommit({ repository, branch, signedSha, logger });
+                await syncLocalToSignedCommit({ repository, branch, signedSha });
                 return signedSha;
             } catch (err) {
                 if (!isNonFastForwardError(err) || force || attempt >= MAX_CONCURRENT_PUSH_RETRIES - 1) {
@@ -95,7 +95,9 @@ export async function pushSignedCommit({
                         repository.getHeadCommitMessage(),
                         repository.getHeadParents()
                     ]);
-                    await repository.pushObjectToRef(localHeadSha, tempRef);
+                    // The rebased commit is not a descendant of the original tempRef tip,
+                    // so force-push is required to overwrite it.
+                    await repository.pushObjectToRef(localHeadSha, tempRef, { force: true });
                 } else {
                     throw err;
                 }
@@ -156,22 +158,17 @@ async function upsertBranchRef({
 async function syncLocalToSignedCommit({
     repository,
     branch,
-    signedSha,
-    logger
+    signedSha
 }: {
     repository: ClonedRepository;
     branch: string;
     signedSha: string;
-    logger: PipelineLogger;
 }): Promise<void> {
-    try {
-        await repository.fetch(["origin", branch]);
-        await repository.resetHardToSha(signedSha);
-    } catch (err) {
-        logger.debug(
-            `Could not sync local branch ${branch} to signed commit ${signedSha}: ${extractErrorMessage(err)}`
-        );
-    }
+    // Intentionally does not swallow errors: if the signed commit exists on the remote but the
+    // local branch cannot be aligned to it, downstream operations (tag push, getHeadSha() used
+    // for changelog URLs) would silently use the stale local SHA.
+    await repository.fetch(["origin", branch]);
+    await repository.resetHardToSha(signedSha);
 }
 
 function hasNumericStatus(err: unknown): err is { status: number } {

--- a/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
+++ b/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
@@ -54,10 +54,12 @@ export async function pushSignedCommit({
     let tempRefPushed = false;
 
     try {
-        let localHeadSha = await repository.getHeadSha();
-        let treeSha = await repository.getHeadTreeHash();
-        let message = await repository.getHeadCommitMessage();
-        let parents = await repository.getHeadParents();
+        let [localHeadSha, treeSha, message, parents] = await Promise.all([
+            repository.getHeadSha(),
+            repository.getHeadTreeHash(),
+            repository.getHeadCommitMessage(),
+            repository.getHeadParents()
+        ]);
 
         await repository.pushObjectToRef(localHeadSha, tempRef);
         tempRefPushed = true;
@@ -87,10 +89,12 @@ export async function pushSignedCommit({
                         `Non-fast-forward on refs/heads/${branch} (attempt ${attempt + 1}/${MAX_CONCURRENT_PUSH_RETRIES}); rebasing locally and retrying.`
                     );
                     await repository.pullWithRebase(branch);
-                    localHeadSha = await repository.getHeadSha();
-                    treeSha = await repository.getHeadTreeHash();
-                    message = await repository.getHeadCommitMessage();
-                    parents = await repository.getHeadParents();
+                    [localHeadSha, treeSha, message, parents] = await Promise.all([
+                        repository.getHeadSha(),
+                        repository.getHeadTreeHash(),
+                        repository.getHeadCommitMessage(),
+                        repository.getHeadParents()
+                    ]);
                     await repository.pushObjectToRef(localHeadSha, tempRef);
                 } else {
                     throw err;

--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -6,6 +6,7 @@ import { join } from "path";
 import { createReplayBranch } from "../github/createReplayBranch";
 import { findExistingUpdatablePR } from "../github/findExistingUpdatablePR";
 import { parseCommitMessageForPR } from "../github/parseCommitMessage";
+import { pushSignedCommit } from "../github/pushSignedCommit";
 import type { PipelineLogger } from "../PipelineLogger";
 import { formatReplayPrBody } from "../replay-summary";
 import type { GithubStepConfig, GithubStepResult, PipelineContext, ReplayStepResult } from "../types";
@@ -177,13 +178,18 @@ export class GithubStep extends BaseStep {
         };
 
         if (!this.config.previewMode) {
-            if (isUpdatingExistingPR) {
-                // Force push is safe: fern-bot/* branches are exclusively owned by this pipeline,
-                // and required when the clone lacks remote tracking refs (e.g., shallow clone from fiddle).
-                await repository.forcePush();
-            } else {
-                await repository.push();
-            }
+            // Create a signed commit via the GitHub API. Using the App installation token causes
+            // GitHub to sign the commit with the App's key. `force=true` when updating an existing
+            // fern-bot/* PR branch (bot-owned, pipeline-owned) — same safety posture as forcePush().
+            await pushSignedCommit({
+                repository,
+                octokit,
+                owner,
+                repo,
+                branch: prBranch,
+                force: isUpdatingExistingPR,
+                logger: this.logger
+            });
             const pushedBranch = await repository.getCurrentBranch();
             result.branchUrl = `https://github.com/${this.config.uri}/tree/${pushedBranch}`;
             this.logger.info(`Pushed branch: ${result.branchUrl}`);
@@ -319,7 +325,18 @@ export class GithubStep extends BaseStep {
         };
 
         if (!this.config.previewMode) {
-            await repository.pushWithRebasingRemote();
+            const octokit = new Octokit({ auth: this.config.token });
+            const { owner, repo } = parseRepository(this.config.uri);
+            await pushSignedCommit({
+                repository,
+                octokit,
+                owner,
+                repo,
+                branch: baseBranch,
+                force: false,
+                rebaseOnConflict: true,
+                logger: this.logger
+            });
 
             const pushedBranch = await repository.getCurrentBranch();
             result.branchUrl = `https://github.com/${this.config.uri}/tree/${pushedBranch}`;

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,18 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Sign commits pushed by the GitHub pipeline step. Previously, pull-request
+        and push modes in the replay pipeline committed and pushed via plain git
+        CLI, producing unsigned commits. Commits are now created via the GitHub
+        REST API using the App installation token, which GitHub signs with the
+        App's key — matching the behavior of fiddle's legacy InMemoryGitRepo push
+        path and restoring verified fern-api[bot] commits on replay-enabled orgs.
+      type: fix
+  createdAt: "2026-04-22"
+  version: 0.9.11
+
+- changelogEntry:
+    - summary: |
         Only push the fern-generation-base tag when replay has unresolved conflicts, and skip syncFromDivergentMerge when the tag is not reachable from HEAD. Prevents stale tags from clean replay PRs from poisoning subsequent runs.
       type: fix
   createdAt: "2026-04-16"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,7 +60,7 @@ catalog:
   "@fern-api/docs-parsers": 0.0.65
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.1.13-c1ad12a2b8
-  "@fern-api/generator-cli": 0.9.8
+  "@fern-api/generator-cli": 0.9.11
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,7 +60,7 @@ catalog:
   "@fern-api/docs-parsers": 0.0.65
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.1.13-c1ad12a2b8
-  "@fern-api/generator-cli": 0.9.11
+  "@fern-api/generator-cli": 0.9.8
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Description
Linear ticket: Refs

Restores verified `fern-api[bot]` commits on replay-enabled orgs.

**Background.** On 2026-04-14, fiddle added concurrent-push handling in `InMemoryGitRepo.push()` ([fiddle#697](https://github.com/fern-api/fiddle/pull/697)), which continued to create signed commits via the GitHub REST API (`GHRepository.createCommit()`) using the App installation token. The next day, auth0 was added to `replay-enabled-orgs.json` in [fiddle#696](https://github.com/fern-api/fiddle/pull/696). After that change, auth0 SDK regenerations stopped going through `InMemoryGitRepo` entirely — they are routed through `invokeGeneratorCliPipeline`, which runs `@fern-api/generator-cli`'s `GithubStep`. That step commits and pushes using plain `git` CLI (`ClonedRepository.commitAllChanges` + `ClonedRepository.push`/`forcePush`/`pushWithRebasingRemote`), which produces unsigned commits.

**Evidence.** In `auth0/auth0.net`:
- Apr 9 `21a2b48f32` and Apr 13 `957361f2e0` (fern-api[bot]): `verification.verified = true`
- Apr 22 `eb38432c` (fern-api[bot], [auth0/auth0.net#983](https://github.com/auth0/auth0.net/pull/983)): `verification.verified = false`, `reason = "unsigned"` — first regen after replay was enabled for auth0.

**Fix.** Port fiddle's signed-commit-via-API trick into `@fern-api/generator-cli`. A new `pushSignedCommit()` helper:
1. Pushes the local HEAD commit to a temporary ref (`refs/temp/fern-<timestamp>`), which uploads the tree and blob objects to GitHub.
2. Creates a new commit via `octokit.git.createCommit({ owner, repo, message, tree, parents })`. Because the Octokit client is authenticated with a GitHub App installation token, GitHub signs the commit with the App's key.
3. Updates `refs/heads/<branch>` to the signed commit via `octokit.git.updateRef` (or `createRef` if the branch is new). Passes `force=true` when we're updating an existing `fern-bot/*` PR branch — same safety posture as the previous `repository.forcePush()`.
4. Deletes the temporary ref.
5. Fast-forwards the local branch to the signed SHA so subsequent ops (tag push, `getHeadSha()` used for changelog URLs) see the signed commit.

The helper also supports `rebaseOnConflict=true` for push mode (into shared branches), where a non-fast-forward error triggers a local `git pull --rebase` + retry. On retry the tempRef push is force-pushed (`+<sha>:<ref>`), because the rebased commit is not a descendant of the previous tempRef tip and would otherwise be rejected. TempRef is invocation-scoped (`refs/temp/fern-<Date.now()>`) so force is safe.

Local-sync errors are propagated, not swallowed: if the signed commit exists on the remote but the local branch cannot be aligned to it, throwing is better than silently using the stale local SHA in downstream ops (tag push, `getHeadSha()` used for changelog URLs).

Safety: the helper only signs commits whose tree we pushed from the local clone in this pipeline invocation — matching fiddle's invariant of only ever signing commits we created locally.

## Changes Made
- New `pushSignedCommit()` helper in `packages/generator-cli/src/pipeline/github/pushSignedCommit.ts`.
- `GithubStep.executePullRequestMode` now calls `pushSignedCommit` (with `force=isUpdatingExistingPR`) instead of `repository.push()` / `repository.forcePush()`.
- `GithubStep.executePushMode` now calls `pushSignedCommit` (with `rebaseOnConflict=true`) instead of `repository.pushWithRebasingRemote()`.
- Added `ClonedRepository.getHeadCommitMessage`, `getHeadParents`, `pushObjectToRef` (now supports `{ force: true }`), `resetHardToSha`, `pullWithRebase` helpers to support the signed-push flow.
- Added a new `0.9.11` entry in `packages/generator-cli/versions.yml` so CI publishes this fix to npm on merge.
- Added per-generator unreleased `changes/unreleased/bump-generator-cli-0.9.11.yml` entries for all 10 SDK generators (csharp, go, java, php, python, ruby, ruby-v2, rust, swift, typescript) so their next version bumps rebuild Docker images against the fixed `generator-cli`.
- The catalog pin in `pnpm-workspace.yaml` is intentionally **not** bumped here. It can't be bumped in the same PR that publishes `0.9.11` — the version doesn't exist on npm yet, so `pnpm install --frozen-lockfile` would fail in CI. The catalog bump will land in a follow-up PR immediately after this merges and `0.9.11` publishes, same pattern as [#15078](https://github.com/fern-api/fern/pull/15078) which bumped the catalog to `0.9.8` after earlier PRs had already published `0.9.8` / `0.9.9` / `0.9.10`.
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated — `packages/generator-cli/src/__test__/pushSignedCommit.test.ts` covers: happy path, first push on a new branch (falls back to `createRef`), non-fast-forward with `force=true` (propagates), non-fast-forward with `force=false` and no rebase (propagates), non-fast-forward with `rebaseOnConflict=true` (rebases locally, retries with updated tree/parent, and force-pushes tempRef), temp-ref cleanup on failure, `isNonFastForwardError` classification, and post-update local-sync error propagation.
- [x] Full `@fern-api/generator-cli` and `@fern-api/github` test suites pass (201 + 18 tests).
- [x] `pnpm turbo run compile` passes for both packages.
- [x] CI green on this PR (39 passed, 0 failed).
- [ ] Manual testing in a staging generator image against a test SDK repo is recommended before rolling out to replay-enabled orgs — verifying that (a) the pushed commit appears on GitHub as `verified=true` and (b) branch/PR creation/update still works for both fresh and existing `fern-bot/*` branches.

## Release path (post-merge)
1. This PR merges → CI auto-publishes `@fern-api/generator-cli@0.9.11` to npm.
2. Follow-up PR bumps the `@fern-api/generator-cli` pin in `pnpm-workspace.yaml` from `0.9.8` → `0.9.11` and regenerates the lockfile.
3. Each generator's next version bump will rebuild its Docker image against `0.9.11`, picking up the signed-commit fix. The per-generator `bump-generator-cli-0.9.11.yml` changelog entries in this PR will surface in those next releases.


Link to Devin session: https://app.devin.ai/sessions/c808d5f1e8b740c98618e2ffff3fdec1
Requested by: @patrickthornton