### PR TITLE
fix(cli): populate apiNameToId in fern docs dev preview server

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-docs-preview-api-name-to-id.yml
+++ b/packages/cli/cli/changes/unreleased/fix-docs-preview-api-name-to-id.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Populate `apiNameToId` in `fern docs dev` so MDX widgets that resolve APIs by
+    user-facing name (e.g. `<MergeSupportedFieldsByIntegrationWidget apiName="hris_v2" ... />`)
+    work in local preview. Previously the preview server hardcoded this mapping to
+    `{}`, causing such widgets to throw `MergeWidgetResolutionError` and render the
+    affected pages as 500 Internal Server Error.
+  type: fix

--- a/packages/cli/docs-preview/package.json
+++ b/packages/cli/docs-preview/package.json
@@ -38,6 +38,7 @@
     "@fern-api/fdr-sdk": "catalog:",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/ir-sdk": "workspace:*",
+    "@fern-api/ir-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
     "@fern-api/project-loader": "workspace:*",

--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -24,6 +24,7 @@ import {
 } from "@fern-api/fdr-sdk";
 import { AbsoluteFilePath, convertToFernHostAbsoluteFilePath, doesPathExist, relative } from "@fern-api/fs-utils";
 import { IntermediateRepresentation } from "@fern-api/ir-sdk";
+import { getOriginalName } from "@fern-api/ir-utils";
 import { Project } from "@fern-api/project-loader";
 import { convertIrToFdrApi } from "@fern-api/register";
 import { CliError, TaskContext } from "@fern-api/task-context";
@@ -316,7 +317,7 @@ export async function getPreviewDocsDefinition({
         filesV2,
         pages: dbDocsDefinition.pages,
         jsFiles: dbDocsDefinition.jsFiles,
-        apiNameToId: {},
+        apiNameToId: apiCollector.getApiNameToId(),
         id: undefined
     };
 
@@ -338,6 +339,7 @@ type APIDefinitionID = string;
 
 class ReferencedAPICollector {
     private readonly apis: Record<APIDefinitionID, APIV1Read.ApiDefinition> = {};
+    private readonly apiNameToId: Record<string, string> = {};
 
     constructor(private readonly context: TaskContext) {}
 
@@ -382,6 +384,14 @@ class ReferencedAPICollector {
             const readApiDefinition = convertDbAPIDefinitionToRead(dbApiDefinition);
 
             this.apis[id] = readApiDefinition;
+            // Mirror the FDR publish path (registerApi.ts, publishDocs.ts), which registers
+            // each API under `apiName ?? getOriginalName(ir.apiName)`. Without this mapping,
+            // features like type resolution in MDX widgets (MergeSupportedFieldsByIntegrationWidget,
+            // etc.) that look up APIs by user-facing name fail in `fern docs dev`.
+            const resolvedApiName = apiName ?? getOriginalName(ir.apiName);
+            if (resolvedApiName) {
+                this.apiNameToId[resolvedApiName] = id;
+            }
             return id;
         } catch (e) {
             // Print Error
@@ -399,6 +409,13 @@ class ReferencedAPICollector {
 
     public getAPIsForDefinition(): Record<FdrAPI.ApiDefinitionId, APIV1Read.ApiDefinition> {
         return this.apis;
+    }
+
+    public getApiNameToId(): Record<string, DocsV1Read.ApiDefinitionId> {
+        // IDs originate from uuidv4() and are used as-is alongside this.apis (which is keyed by
+        // the same raw uuids). ApiDefinitionId branding is purely a nominal-type marker
+        // and carries no runtime information, so this cast is safe.
+        return this.apiNameToId as Record<string, DocsV1Read.ApiDefinitionId>;
     }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5313,6 +5313,9 @@ importers:
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../ir-sdk
+      '@fern-api/ir-utils':
+        specifier: workspace:*
+        version: link:../../commons/ir-utils
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../logger


### PR DESCRIPTION
## Description

In `fern docs dev`, pages whose markdown embeds MDX widgets that resolve APIs by user-facing name (e.g. Merge's `<MergeSupportedFieldsByIntegrationWidget apiName="hris_v2" model="Dependent" />`) rendered as **500 Internal Server Error**. Reproduced on [merge-api/merge-docs-new](https://github.com/merge-api/merge-docs-new) — every common-model `.../list` and `.../retrieve` page (308 endpoints × 5 unified APIs) 500s.

**Root cause:** the preview server hardcoded `DocsDefinition.apiNameToId = {}`. The fern-platform bundle uses this mapping to resolve a user-facing API name (`"hris_v2"`) to a UUID definition ID before calling `resolveTypes` / `getTypes`. With an empty map, `resolveTypes` returns `{}`, the `typeByName` lookup misses, `resolveWidgetTypeData` returns `null`, and `MergeSupportedFieldsByIntegrationServer` throws `MergeWidgetResolutionError`. The error isn't caught by any error boundary, so Next.js falls back to the pages-router `_error` page → 500.

In prod, `apiNameToId` is populated from a DB column written at docs-publish time (see `registerApi.ts` / `publishDocs.ts`, which register each API under `apiName ?? getOriginalName(ir.apiName)`). The preview server had all the data in hand — `ReferencedAPICollector.addReferencedAPI` already received both `apiName` and the generated `id` — it just threw the mapping away.

## Changes Made

- `packages/cli/docs-preview/src/previewDocs.ts`
  - Add `apiNameToId: Record<string, string>` field to `ReferencedAPICollector`
  - Populate it in `addReferencedAPI` using `apiName ?? getOriginalName(ir.apiName)` to mirror the FDR publish path
  - Expose via `getApiNameToId()`; use it in the `DocsDefinition` returned by `getPreviewDocsDefinition` (replacing the hardcoded `{}`)
- `packages/cli/docs-preview/package.json` — add `@fern-api/ir-utils` workspace dependency for `getOriginalName`
- `packages/cli/cli/changes/unreleased/fix-docs-preview-api-name-to-id.yml` — unreleased changelog entry (`fix`)

`EMPTY_DOCS_DEFINITION` in `runAppPreviewServer.ts` / `runPreviewServer.ts` keeps `apiNameToId: {}` — it's only used as a fallback when the initial docs load fails, so no data exists to populate the mapping.

## Testing

Tested locally against a clone of `merge-api/merge-docs-new` using the locally built `packages/cli/cli/dist/dev/cli.cjs`.

**Before:**
- `POST /v2/registry/docs/load-with-url` → `definition.apiNameToId === {}`
- `GET /merge-unified/hris/common-models/dependents/list` → **HTTP 500** (`MergeWidgetResolutionError`)

**After:**
- `POST /v2/registry/docs/load-with-url` → `definition.apiNameToId` populated with all 10 APIs:
  ```
  accounting_v2 → 5a9685e3-…    crm_v2 → ece79e17-…
  agent-handler → ee2812df-…    filestorage_v2 → e3d3e5d7-…
  ats_v2 → ee0c31e4-…           gateway → d16422b2-…
  chat_v2 → 0cab7d26-…          hris_v2 → 1a575748-…
  knowledge-base → c8d26bb2-…   ticketing_v2 → b4df9026-…
  ```
- `GET /merge-unified/hris/common-models/dependents/list` → **HTTP 200** (the model name `Dependent` resolves and the supported-fields widget renders)
- Spot-checked 4 additional common-model endpoints across `ats`, `crm`, `accounting`, `filestorage` → all HTTP 200

- [x] Manual testing completed against merge-docs-new clone
- [ ] Unit tests added/updated — N/A; no preview-server tests exist for `DocsDefinition` shape today. Happy to add one if desired.


Link to Devin session: https://app.devin.ai/sessions/028a970692f245219cf9612e03feed16
Requested by: @Ryan-Amirthan