### PR TITLE
chore(ci): serialize write-changelogs-to-docs runs to prevent ref race

### DIFF
--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -10,6 +10,10 @@ permissions:
   pull-requests: write
   contents: write
 
+concurrency:
+  group: write-changelogs-to-docs
+  cancel-in-progress: false
+
 env:
   DO_NOT_TRACK: "1"
 


### PR DESCRIPTION
## Description

The `Write Changelogs to Docs` workflow intermittently fails when pushing to the `update-changelogs` branch on `fern-api/docs` with:

```
! [remote rejected] update-changelogs -> update-changelogs (cannot lock ref 'refs/heads/update-changelogs': unable to resolve reference 'refs/heads/update-changelogs')
error: failed to push some refs to 'https://github.com/fern-api/docs'
```

Example failing run: https://github.com/fern-api/fern/actions/runs/24792968067/job/72555172168

### Root cause

The workflow triggers on every push to `main`. Each run:
1. Checks out `fern-api/docs`
2. Regenerates the changelogs
3. Uses `peter-evans/create-pull-request` which force-pushes to `refs/heads/update-changelogs`

Multiple pushes to `main` land in quick succession (e.g. a generator release plus a feature commit a few minutes apart), so two runs can be pushing/auto-merging/deleting the same `update-changelogs` branch concurrently. The failing run had the branch present at fetch time, but the remote ref was being rewritten/deleted by the concurrent run, so the `--force-with-lease` push was rejected server-side with "cannot lock ref … unable to resolve reference".

### Fix

Add a workflow-level `concurrency` group so only one instance of this workflow runs at a time. `cancel-in-progress: false` queues new runs instead of cancelling the in-flight one, so we don't interrupt a partially-pushed PR — each queued run will regenerate from the latest `main` anyway.

## Changes Made
- Add `concurrency` group `write-changelogs-to-docs` with `cancel-in-progress: false` to `.github/workflows/write-changelogs-to-docs.yml`.

## Testing
- [ ] Verified via run-history analysis: a successful run (6m35s) was still in progress when the failing run started, confirming the race.
- [ ] Will be validated on the next merge to `main` — only one instance of the workflow should execute at a time going forward.


Link to Devin session: https://app.devin.ai/sessions/88865c3860f94128911e37f10bc66ccf
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
