### PR TITLE
fix(csharp): emit Body property on wrapped bytes requests

### DIFF
--- a/generators/csharp/sdk/changes/unreleased/fix-wrapped-bytes-body-property.yml
+++ b/generators/csharp/sdk/changes/unreleased/fix-wrapped-bytes-body-property.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Emit a `Body` property of type `System.IO.Stream` on wrapped request records
+    for endpoints whose request body is `bytes`. Previously the endpoint client
+    method emitted `Body = request.Body` but the generated request record did
+    not declare a `Body` property, producing a CS1061 compile error on any
+    endpoint that combined a binary body with other wrapped parameters
+    (e.g. query parameters, headers, or path parameters).
+  type: fix

--- a/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
+++ b/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
@@ -239,7 +239,18 @@ export class WrappedRequestGenerator extends FileGenerator<CSharpFile, SdkGenera
                     }
                 }
             },
-            bytes: () => undefined,
+            bytes: (bytes) => {
+                class_.addField({
+                    origin: this.case.resolveNameOrString(this.wrapper.bodyKey),
+                    type: this.System.IO.Stream,
+                    access: ast.Access.Public,
+                    get: true,
+                    set: true,
+                    summary: bytes.docs,
+                    useRequired: !bytes.isOptional,
+                    annotations: [this.System.Text.Json.Serialization.JsonIgnore]
+                });
+            },
             _other: () => undefined
         });
 

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Service/Requests/UploadWithQueryParamsRequest.cs
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/Service/Requests/UploadWithQueryParamsRequest.cs
@@ -18,6 +18,9 @@ public record UploadWithQueryParamsRequest
     [JsonIgnore]
     public string? Language { get; set; }
 
+    [JsonIgnore]
+    public required Stream Body { get; set; }
+
     /// <inheritdoc />
     public override string ToString()
     {

--- a/seed/csharp-sdk/seed.yml
+++ b/seed/csharp-sdk/seed.yml
@@ -417,7 +417,6 @@ fixtures:
 allowedFailures:
   - allof
   - allof-inline
-  - bytes-upload
   - enum:forward-compatible-enums
   - imdb:exported-client-class-name
   - enum:plain-enums


### PR DESCRIPTION
## Description

Fixes a C# generator bug where endpoints with a `bytes` request body plus any
other wrapped parameters (query parameters, headers, or path parameters that
end up on the wrapped request record) fail to compile with:

```
error CS1061: 'XRequest' does not contain a definition for 'Body'
```

The generated client method emits `Body = request.Body` but `WrappedRequestGenerator`
was handling the `bytes` branch as `() => undefined`, so no `Body` property was
ever added to the generated request record.

This was surfaced by a DocuSign SDK regen — `PUT /users/{userId}/signatures/{signatureId}/{imageType}`
has a binary body plus a `transparent_png` query parameter, so the generated
`UserSignatureUpdateImageRequest` record only declared `TransparentPng` and the
C# build failed. TS generator handled the same IR correctly (binary passed as a
separate `uploadable` argument), confirming this was a C#-only issue.

The fix adds a `public System.IO.Stream Body { get; set; }` property (required
iff the IR's `BytesRequest.isOptional` is `false`, matching the pattern used for
the `reference` body branch). Example diff on the `bytes-upload` fixture's
`UploadWithQueryParamsRequest`:

```diff
 public record UploadWithQueryParamsRequest
 {
     [JsonIgnore]
     public required string Model { get; set; }

     [JsonIgnore]
     public string? Language { get; set; }

+    [JsonIgnore]
+    public required Stream Body { get; set; }

     public override string ToString() { ... }
 }
```

## Changes Made
- `generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts`: emit a
  `Body` field of type `System.IO.Stream` in the `bytes` branch of the request-body
  visitor, using `this.wrapper.bodyKey` for the name and `!bytes.isOptional` to
  decide `useRequired`. Matches the existing `reference` branch's pattern.
- `seed/csharp-sdk/seed.yml`: removed `bytes-upload` from `allowedFailures` now
  that the generated code compiles.
- `seed/csharp-sdk/bytes-upload/.../UploadWithQueryParamsRequest.cs`: updated
  snapshot (adds the `Body` property).
- `generators/csharp/sdk/changes/unreleased/fix-wrapped-bytes-body-property.yml`:
  `fix`-type changelog entry.
- [ ] Updated README.md generator (if applicable) — N/A

## Testing
- [ ] Unit tests added/updated — no new unit tests; behavior is covered by the
  existing `bytes-upload` seed fixture that was previously in `allowedFailures`.
- [x] Manual testing completed:
  - `pnpm turbo run compile --filter @fern-api/fern-csharp-sdk` — 16/16 tasks
    successful.
  - `pnpm seed test --generator csharp-sdk --fixture bytes-upload --skip-scripts`
    — fixture now passes (seed reported "1/1 test cases succeeded unexpectedly,
    consider removing from allowedFailures", which this PR does).
  - `pnpm seed test --generator csharp-sdk --fixture exhaustive --skip-scripts`
    — 6/6 output-folder variants still pass. `exhaustive` has a bytes-body
    endpoint with a path parameter (`UploadWithPath`) but the C# generator does
    not wrap it (it's emitted as `(string param, Stream request, ...)`), so the
    generated code is unchanged — confirming this fix doesn't regress the
    unwrapped case.
- Spec-level verification: the originally failing DocuSign `UserSignatureUpdateImageRequest`
  will now get `public required Stream Body { get; set; }` matching the
  `request.Body` reference emitted by the endpoint client.


Link to Devin session: https://app.devin.ai/sessions/1e1653c01c544ad88198c0fc8c1f4d82
Requested by: @fern-support