### PR TITLE
feat(cli): allow multiple --group flags in fern generate

### DIFF
--- a/packages/cli/cli/changes/unreleased/generate-multiple-groups.yml
+++ b/packages/cli/cli/changes/unreleased/generate-multiple-groups.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    `fern generate` now accepts multiple `--group` flags. Passing e.g.
+    `fern generate --group typescript --group java --group python` generates
+    for all of the listed groups instead of failing with
+    `'typescript,java,python' is not a valid group or alias`. Each value is
+    resolved independently (including aliases) and the union is generated.
+  type: feat

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -669,7 +669,9 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 })
                 .option("group", {
                     type: "string",
-                    description: "The group to generate"
+                    array: true,
+                    description:
+                        "The group to generate. Pass --group multiple times to generate for several groups at once."
                 })
                 .option("generator", {
                     type: "string",
@@ -881,7 +883,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     }),
                     cliContext,
                     version: argv.version,
-                    groupName: argv.group,
+                    groupNames: argv.group,
                     generatorName,
                     generatorIndex,
                     shouldLogS3Url: argv.printZipUrl,
@@ -904,7 +906,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 });
             }
             if (argv.docs != null) {
-                if (argv.group != null) {
+                if (argv.group != null && argv.group.length > 0) {
                     cliContext.logger.warn("--group is ignored when generating docs");
                 }
                 if (argv.generator != null) {
@@ -942,7 +944,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 }),
                 cliContext,
                 version: argv.version,
-                groupName: argv.group,
+                groupNames: argv.group,
                 generatorName,
                 generatorIndex,
                 shouldLogS3Url: argv.printZipUrl,

--- a/packages/cli/cli/src/commands/automations/generate/executeAutomationsGenerate.ts
+++ b/packages/cli/cli/src/commands/automations/generate/executeAutomationsGenerate.ts
@@ -62,7 +62,7 @@ export async function executeAutomationsGenerate({
                 }),
                 cliContext,
                 version: options.version,
-                groupName: options.group,
+                groupNames: options.group != null ? [options.group] : undefined,
                 generatorName,
                 generatorIndex,
                 shouldLogS3Url: false,

--- a/packages/cli/cli/src/commands/generate/__test__/expandGroupFilter.test.ts
+++ b/packages/cli/cli/src/commands/generate/__test__/expandGroupFilter.test.ts
@@ -1,0 +1,96 @@
+import type { generatorsYml } from "@fern-api/configuration-loader";
+import { describe, expect, it } from "vitest";
+
+import { expandGroupFilter } from "../expandGroupFilter.js";
+
+function makeConfig(
+    overrides: Partial<generatorsYml.GeneratorsConfiguration> = {}
+): generatorsYml.GeneratorsConfiguration {
+    return {
+        groups: [],
+        defaultGroup: undefined,
+        groupAliases: {},
+        rawConfiguration: {},
+        ...overrides
+    } as unknown as generatorsYml.GeneratorsConfiguration;
+}
+
+describe("expandGroupFilter", () => {
+    it("returns null when no filter is supplied", () => {
+        expect(expandGroupFilter(undefined, makeConfig())).toBeNull();
+    });
+
+    it("treats an empty array the same as no filter", () => {
+        // Yargs' array option can give us `[]` if a plugin normalizes things oddly; either shape
+        // should mean "match every group".
+        expect(expandGroupFilter([], makeConfig())).toBeNull();
+    });
+
+    it("returns the single name as-is when it is a concrete group", () => {
+        expect(expandGroupFilter(["python-sdk"], makeConfig())).toEqual(["python-sdk"]);
+    });
+
+    it("unions multiple concrete names in the order supplied", () => {
+        expect(expandGroupFilter(["typescript", "java", "python"], makeConfig())).toEqual([
+            "typescript",
+            "java",
+            "python"
+        ]);
+    });
+
+    it("expands an alias to its target list", () => {
+        expect(
+            expandGroupFilter(
+                ["all-sdks"],
+                makeConfig({ groupAliases: { "all-sdks": ["python-sdk", "ts-sdk", "go-sdk"] } })
+            )
+        ).toEqual(["python-sdk", "ts-sdk", "go-sdk"]);
+    });
+
+    it("de-duplicates when the same name is passed multiple times", () => {
+        // A user might pass `--group ts --group ts` by mistake (or by shell expansion). We should
+        // still only generate `ts` once.
+        expect(expandGroupFilter(["ts", "ts"], makeConfig())).toEqual(["ts"]);
+    });
+
+    it("de-duplicates when aliases and concrete names overlap", () => {
+        // `all-sdks` expands to `[ts, py]`; combined with an explicit `ts` we want `[ts, py]`,
+        // preserving first-occurrence order.
+        expect(
+            expandGroupFilter(["ts", "all-sdks"], makeConfig({ groupAliases: { "all-sdks": ["ts", "py"] } }))
+        ).toEqual(["ts", "py"]);
+    });
+
+    it("de-duplicates when two aliases overlap", () => {
+        expect(
+            expandGroupFilter(
+                ["a", "b"],
+                makeConfig({
+                    groupAliases: {
+                        a: ["ts", "py"],
+                        b: ["py", "go"]
+                    }
+                })
+            )
+        ).toEqual(["ts", "py", "go"]);
+    });
+
+    it("falls back to treating an unknown name as a concrete group (validation lives elsewhere)", () => {
+        // This helper is only used for the pre-flight / posthog pass; the authoritative validation
+        // is done by `resolveGroupAlias` inside generation. Keeping this permissive lets the
+        // downstream error surface the real "unknown group" message with suggestions.
+        expect(expandGroupFilter(["typo"], makeConfig({ groupAliases: { "all-sdks": ["ts"] } }))).toEqual(["typo"]);
+    });
+
+    it("treats a name as concrete when no generatorsConfiguration is available", () => {
+        // Some call sites pass `undefined` for the config when the workspace has none; we should
+        // still return the requested names without crashing.
+        expect(expandGroupFilter(["ts", "java"], undefined)).toEqual(["ts", "java"]);
+    });
+
+    it("contributes nothing when an alias resolves to an empty target list", () => {
+        // A malformed alias with `[]` is tolerated as a no-op here — the authoritative resolver
+        // will surface the real error when it tries to run.
+        expect(expandGroupFilter(["empty", "ts"], makeConfig({ groupAliases: { empty: [] } }))).toEqual(["ts"]);
+    });
+});

--- a/packages/cli/cli/src/commands/generate/__test__/resolveGroupsOrFail.test.ts
+++ b/packages/cli/cli/src/commands/generate/__test__/resolveGroupsOrFail.test.ts
@@ -1,0 +1,238 @@
+import type { generatorsYml } from "@fern-api/configuration-loader";
+import { createLogger } from "@fern-api/logger";
+import { createMockTaskContext, TaskAbortSignal } from "@fern-api/task-context";
+import { describe, expect, it } from "vitest";
+
+import { resolveGroupsOrFail } from "../resolveGroupsOrFail.js";
+
+function makeConfig(
+    overrides: Partial<generatorsYml.GeneratorsConfiguration> = {}
+): generatorsYml.GeneratorsConfiguration {
+    return {
+        groups: [],
+        defaultGroup: undefined,
+        groupAliases: {},
+        rawConfiguration: {},
+        ...overrides
+    } as unknown as generatorsYml.GeneratorsConfiguration;
+}
+
+function makeGroup(name: string): generatorsYml.GeneratorGroup {
+    return { groupName: name } as unknown as generatorsYml.GeneratorGroup;
+}
+
+function silentContext() {
+    // We exercise `failAndThrow` and don't care about the rendered message in these tests —
+    // `resolveGroupAlias.test.ts` and `resolveGroupNamesForGeneration.test.ts` cover the message
+    // logic. Silence the logger so test output stays clean.
+    return createMockTaskContext({ logger: createLogger(() => undefined) });
+}
+
+describe("resolveGroupsOrFail", () => {
+    describe("no --group passed", () => {
+        it("falls back to default-group when no --group is supplied", () => {
+            const result = resolveGroupsOrFail({
+                groupNames: undefined,
+                generatorsConfiguration: makeConfig({
+                    groups: [makeGroup("ts"), makeGroup("py")],
+                    defaultGroup: "ts"
+                }),
+                isAutomation: false,
+                context: silentContext()
+            });
+            expect(result).toEqual(["ts"]);
+        });
+
+        it("treats an empty array the same as `undefined` (no --group)", () => {
+            const result = resolveGroupsOrFail({
+                groupNames: [],
+                generatorsConfiguration: makeConfig({
+                    groups: [makeGroup("ts"), makeGroup("py")],
+                    defaultGroup: "py"
+                }),
+                isAutomation: false,
+                context: silentContext()
+            });
+            expect(result).toEqual(["py"]);
+        });
+
+        it("fans out across every group when in automation and no --group is supplied", () => {
+            const result = resolveGroupsOrFail({
+                groupNames: undefined,
+                generatorsConfiguration: makeConfig({
+                    groups: [makeGroup("ts"), makeGroup("py"), makeGroup("go")],
+                    defaultGroup: "ts"
+                }),
+                isAutomation: true,
+                context: silentContext()
+            });
+            expect(result).toEqual(["ts", "py", "go"]);
+        });
+
+        it("throws when no --group, no default-group, and not in automation", () => {
+            const context = silentContext();
+            expect(() =>
+                resolveGroupsOrFail({
+                    groupNames: undefined,
+                    generatorsConfiguration: makeConfig({ groups: [makeGroup("ts")] }),
+                    isAutomation: false,
+                    context
+                })
+            ).toThrow(TaskAbortSignal);
+        });
+    });
+
+    describe("single --group", () => {
+        it("returns the single requested concrete group", () => {
+            const result = resolveGroupsOrFail({
+                groupNames: ["py"],
+                generatorsConfiguration: makeConfig({
+                    groups: [makeGroup("ts"), makeGroup("py")]
+                }),
+                isAutomation: false,
+                context: silentContext()
+            });
+            expect(result).toEqual(["py"]);
+        });
+
+        it("expands an alias to its target list", () => {
+            const result = resolveGroupsOrFail({
+                groupNames: ["all-sdks"],
+                generatorsConfiguration: makeConfig({
+                    groups: [makeGroup("ts"), makeGroup("py"), makeGroup("go")],
+                    groupAliases: { "all-sdks": ["ts", "py", "go"] }
+                }),
+                isAutomation: false,
+                context: silentContext()
+            });
+            expect(result).toEqual(["ts", "py", "go"]);
+        });
+
+        it("throws when the single group is unknown", () => {
+            expect(() =>
+                resolveGroupsOrFail({
+                    groupNames: ["typo"],
+                    generatorsConfiguration: makeConfig({ groups: [makeGroup("ts"), makeGroup("py")] }),
+                    isAutomation: false,
+                    context: silentContext()
+                })
+            ).toThrow(TaskAbortSignal);
+        });
+
+        it("throws when an alias references a non-existent target", () => {
+            expect(() =>
+                resolveGroupsOrFail({
+                    groupNames: ["broken"],
+                    generatorsConfiguration: makeConfig({
+                        groups: [makeGroup("ts")],
+                        groupAliases: { broken: ["ts", "ghost"] }
+                    }),
+                    isAutomation: false,
+                    context: silentContext()
+                })
+            ).toThrow(TaskAbortSignal);
+        });
+    });
+
+    describe("multiple --group", () => {
+        it("unions multiple concrete groups in the order supplied", () => {
+            // This is the original bug report: `fern generate --group typescript --group java --group python`
+            // used to fail with "'typescript,java,python' is not a valid group or alias".
+            const result = resolveGroupsOrFail({
+                groupNames: ["typescript", "java", "python"],
+                generatorsConfiguration: makeConfig({
+                    groups: [makeGroup("typescript"), makeGroup("java"), makeGroup("python"), makeGroup("go")]
+                }),
+                isAutomation: false,
+                context: silentContext()
+            });
+            expect(result).toEqual(["typescript", "java", "python"]);
+        });
+
+        it("de-duplicates when the same --group is passed twice", () => {
+            const result = resolveGroupsOrFail({
+                groupNames: ["ts", "ts"],
+                generatorsConfiguration: makeConfig({
+                    groups: [makeGroup("ts"), makeGroup("py")]
+                }),
+                isAutomation: false,
+                context: silentContext()
+            });
+            expect(result).toEqual(["ts"]);
+        });
+
+        it("de-duplicates when explicit groups overlap with an alias expansion", () => {
+            // `--group ts --group all-sdks` where `all-sdks = [ts, py, go]` should run each group
+            // exactly once, with `ts` kept at its first-seen position.
+            const result = resolveGroupsOrFail({
+                groupNames: ["ts", "all-sdks"],
+                generatorsConfiguration: makeConfig({
+                    groups: [makeGroup("ts"), makeGroup("py"), makeGroup("go")],
+                    groupAliases: { "all-sdks": ["ts", "py", "go"] }
+                }),
+                isAutomation: false,
+                context: silentContext()
+            });
+            expect(result).toEqual(["ts", "py", "go"]);
+        });
+
+        it("de-duplicates when two aliases overlap", () => {
+            const result = resolveGroupsOrFail({
+                groupNames: ["a", "b"],
+                generatorsConfiguration: makeConfig({
+                    groups: [makeGroup("ts"), makeGroup("py"), makeGroup("go")],
+                    groupAliases: {
+                        a: ["ts", "py"],
+                        b: ["py", "go"]
+                    }
+                }),
+                isAutomation: false,
+                context: silentContext()
+            });
+            expect(result).toEqual(["ts", "py", "go"]);
+        });
+
+        it("fails fast on the first invalid name and does not attempt subsequent names", () => {
+            // If the first name is bad, we throw before inspecting the rest. The error surfaced
+            // mentions the first offender so the user fixes it top-down.
+            expect(() =>
+                resolveGroupsOrFail({
+                    groupNames: ["typo", "ts", "py"],
+                    generatorsConfiguration: makeConfig({
+                        groups: [makeGroup("ts"), makeGroup("py")]
+                    }),
+                    isAutomation: false,
+                    context: silentContext()
+                })
+            ).toThrow(TaskAbortSignal);
+        });
+
+        it("fails on a later bad name after earlier names resolve cleanly", () => {
+            // Sanity check the loop actually walks past the first entry.
+            expect(() =>
+                resolveGroupsOrFail({
+                    groupNames: ["ts", "typo"],
+                    generatorsConfiguration: makeConfig({
+                        groups: [makeGroup("ts"), makeGroup("py")]
+                    }),
+                    isAutomation: false,
+                    context: silentContext()
+                })
+            ).toThrow(TaskAbortSignal);
+        });
+
+        it("does not fall back to default-group when any --group is passed", () => {
+            // Passing `--group py` should run exactly `py`, not `default-group` + `py`.
+            const result = resolveGroupsOrFail({
+                groupNames: ["py"],
+                generatorsConfiguration: makeConfig({
+                    groups: [makeGroup("ts"), makeGroup("py")],
+                    defaultGroup: "ts"
+                }),
+                isAutomation: false,
+                context: silentContext()
+            });
+            expect(result).toEqual(["py"]);
+        });
+    });
+});

--- a/packages/cli/cli/src/commands/generate/expandGroupFilter.ts
+++ b/packages/cli/cli/src/commands/generate/expandGroupFilter.ts
@@ -1,0 +1,34 @@
+import type { generatorsYml } from "@fern-api/configuration-loader";
+
+/**
+ * Expands the caller's `--group` filters into a set of concrete group names.
+ *
+ * Returns null when no filter was supplied (meaning "match every group"). Otherwise expands each
+ * requested name through the alias table (when one is configured) and unions the results,
+ * preserving order and de-duplicating. Used only to pre-filter groups for the
+ * `checkOutputDirectory` pre-flight and posthog telemetry — the authoritative group resolution
+ * for generation lives in `resolveGroupNamesForGeneration` + `resolveGroupAlias`.
+ *
+ * `groupNames` of `undefined` or `[]` both mean "no filter"; aliases that resolve to an empty
+ * target list contribute nothing; the same group name appearing twice (directly or via alias
+ * overlap) contributes once.
+ */
+export function expandGroupFilter(
+    groupNames: string[] | undefined,
+    generatorsConfiguration: generatorsYml.GeneratorsConfiguration | undefined
+): string[] | null {
+    if (groupNames == null || groupNames.length === 0) {
+        return null;
+    }
+
+    const expanded: string[] = [];
+    for (const name of groupNames) {
+        const aliasGroups = generatorsConfiguration?.groupAliases[name];
+        for (const resolved of aliasGroups ?? [name]) {
+            if (!expanded.includes(resolved)) {
+                expanded.push(resolved);
+            }
+        }
+    }
+    return expanded;
+}

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -1,10 +1,5 @@
 import { FernToken } from "@fern-api/auth";
-import {
-    DEFAULT_GROUP_GENERATORS_CONFIG_KEY,
-    fernConfigJson,
-    GENERATORS_CONFIGURATION_FILENAME,
-    generatorsYml
-} from "@fern-api/configuration-loader";
+import { fernConfigJson, GENERATORS_CONFIGURATION_FILENAME, generatorsYml } from "@fern-api/configuration-loader";
 import { ContainerRunner } from "@fern-api/core-utils";
 import { AbsoluteFilePath, cwd, join, RelativeFilePath, resolve } from "@fern-api/fs-utils";
 import { runLocalGenerationForWorkspace } from "@fern-api/local-workspace-runner";
@@ -12,14 +7,11 @@ import { AutomationRunOptions, runRemoteGenerationForAPIWorkspace } from "@fern-
 import { CliError, TaskContext } from "@fern-api/task-context";
 import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
-import chalk from "chalk";
 
-import { GROUP_CLI_OPTION } from "../../constants.js";
 import { isTelemetryDisabled } from "../../telemetry/isTelemetryDisabled.js";
 import { filterGenerators } from "./filterGenerators.js";
 import { GenerationMode } from "./generateAPIWorkspaces.js";
-import { resolveGroupAlias } from "./resolveGroupAlias.js";
-import { resolveGroupNamesForGeneration } from "./resolveGroupNamesForGeneration.js";
+import { resolveGroupsOrFail } from "./resolveGroupsOrFail.js";
 import { buildAutomationTargeting, selectGeneratorsForAutomation } from "./selectGeneratorsForAutomation.js";
 import { shouldSkipMissingGenerator } from "./shouldSkipMissingGenerator.js";
 
@@ -279,124 +271,6 @@ function resolveRunnableGroup({
     }
 
     return group;
-}
-
-/**
- * Resolves the list of group names to run against, throwing a helpful `failAndThrow` for any
- * misconfiguration (missing group, unknown alias, alias pointing at a non-existent group).
- *
- * Composes two pure helpers:
- *   - `resolveGroupNamesForGeneration` — decides between fan-out / targeted / missing-group.
- *   - `resolveGroupAlias` — expands an alias to its targets, validating each.
- *
- * The helpers themselves are pure and live in their own modules; this wrapper owns the
- * error-message rendering and the throw.
- */
-function resolveGroupsOrFail({
-    groupNames,
-    generatorsConfiguration,
-    isAutomation,
-    context
-}: {
-    groupNames: string[] | undefined;
-    generatorsConfiguration: generatorsYml.GeneratorsConfiguration;
-    isAutomation: boolean;
-    context: TaskContext;
-}): string[] {
-    // No `--group`: delegate the fan-out vs. default-group vs. missing-group decision to the
-    // single-group resolver with `groupName: undefined`. Passing one explicit `--group` takes
-    // the same path with that name. Multiple `--group` values resolve each independently and
-    // union the results (de-duplicated, order-preserving).
-    if (groupNames == null || groupNames.length === 0) {
-        return resolveSingleGroupOrFail({
-            groupName: undefined,
-            generatorsConfiguration,
-            isAutomation,
-            context
-        });
-    }
-    const resolved: string[] = [];
-    for (const groupName of groupNames) {
-        for (const name of resolveSingleGroupOrFail({
-            groupName,
-            generatorsConfiguration,
-            isAutomation,
-            context
-        })) {
-            if (!resolved.includes(name)) {
-                resolved.push(name);
-            }
-        }
-    }
-    return resolved;
-}
-
-function resolveSingleGroupOrFail({
-    groupName,
-    generatorsConfiguration,
-    isAutomation,
-    context
-}: {
-    groupName: string | undefined;
-    generatorsConfiguration: generatorsYml.GeneratorsConfiguration;
-    isAutomation: boolean;
-    context: TaskContext;
-}): string[] {
-    const resolution = resolveGroupNamesForGeneration({ groupName, generatorsConfiguration, isAutomation });
-    if (resolution.type === "fan-out") {
-        return resolution.groupNames;
-    }
-    if (resolution.type === "missing-group") {
-        const longestGroupName = Math.max(...resolution.availableGroupNames.map((name) => name.length));
-        const currentArgs = process.argv.slice(2).join(" ");
-        const suggestions = resolution.availableGroupNames
-            .map((name) => {
-                const suggestedCommand = `fern ${currentArgs} --${GROUP_CLI_OPTION} ${name}`;
-                return ` › ${chalk.bold(name.padEnd(longestGroupName))}  ${chalk.dim(suggestedCommand)}`;
-            })
-            .join("\n");
-        context.failAndThrow(
-            `No group specified. Use the --${GROUP_CLI_OPTION} option, or set "${DEFAULT_GROUP_GENERATORS_CONFIG_KEY}" in ${GENERATORS_CONFIGURATION_FILENAME}:\n${suggestions}`,
-            undefined,
-            { code: CliError.Code.NetworkError }
-        );
-        return []; // unreachable — failAndThrow throws
-    }
-
-    // resolution.type === "targeted"
-    if (resolution.fromDefaultGroup) {
-        context.logger.info(
-            chalk.dim(`Using default group '${resolution.groupName}' from ${GENERATORS_CONFIGURATION_FILENAME}`)
-        );
-    }
-    const aliasResult = resolveGroupAlias({
-        name: resolution.groupName,
-        groupAliases: generatorsConfiguration.groupAliases,
-        availableGroupNames: generatorsConfiguration.groups.map((g) => g.groupName)
-    });
-    if (aliasResult.type === "alias-references-missing-group") {
-        context.failAndThrow(
-            `Group alias '${aliasResult.alias}' references non-existent group '${aliasResult.missingGroupName}'. ` +
-                `Available groups: ${aliasResult.availableGroupNames.join(", ")}`,
-            undefined,
-            { code: CliError.Code.NetworkError }
-        );
-        return [];
-    }
-    if (aliasResult.type === "unknown") {
-        const aliasesSuffix =
-            aliasResult.availableAliasNames.length > 0
-                ? `. Available aliases: ${aliasResult.availableAliasNames.join(", ")}`
-                : "";
-        context.failAndThrow(
-            `'${aliasResult.name}' is not a valid group or alias. ` +
-                `Available groups: ${aliasResult.availableGroupNames.join(", ")}${aliasesSuffix}`,
-            undefined,
-            { code: CliError.Code.NetworkError }
-        );
-        return [];
-    }
-    return aliasResult.groupNames;
 }
 
 function applyLfsOverride(

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -28,7 +28,7 @@ export async function generateWorkspace({
     workspace,
     projectConfig,
     context,
-    groupName,
+    groupNames,
     generatorName,
     generatorIndex,
     version,
@@ -57,7 +57,8 @@ export async function generateWorkspace({
     projectConfig: fernConfigJson.ProjectConfig;
     context: TaskContext;
     version: string | undefined;
-    groupName: string | undefined;
+    /** One or more `--group` values. `undefined` means no `--group` was passed. */
+    groupNames: string[] | undefined;
     generatorName: string | undefined;
     generatorIndex: number | undefined;
     shouldLogS3Url: boolean;
@@ -96,7 +97,7 @@ export async function generateWorkspace({
     }
 
     const resolvedGroupNames = resolveGroupsOrFail({
-        groupName,
+        groupNames,
         generatorsConfiguration: workspace.generatorsConfiguration,
         isAutomation: automation != null,
         context
@@ -292,6 +293,45 @@ function resolveRunnableGroup({
  * error-message rendering and the throw.
  */
 function resolveGroupsOrFail({
+    groupNames,
+    generatorsConfiguration,
+    isAutomation,
+    context
+}: {
+    groupNames: string[] | undefined;
+    generatorsConfiguration: generatorsYml.GeneratorsConfiguration;
+    isAutomation: boolean;
+    context: TaskContext;
+}): string[] {
+    // No `--group`: delegate the fan-out vs. default-group vs. missing-group decision to the
+    // single-group resolver with `groupName: undefined`. Passing one explicit `--group` takes
+    // the same path with that name. Multiple `--group` values resolve each independently and
+    // union the results (de-duplicated, order-preserving).
+    if (groupNames == null || groupNames.length === 0) {
+        return resolveSingleGroupOrFail({
+            groupName: undefined,
+            generatorsConfiguration,
+            isAutomation,
+            context
+        });
+    }
+    const resolved: string[] = [];
+    for (const groupName of groupNames) {
+        for (const name of resolveSingleGroupOrFail({
+            groupName,
+            generatorsConfiguration,
+            isAutomation,
+            context
+        })) {
+            if (!resolved.includes(name)) {
+                resolved.push(name);
+            }
+        }
+    }
+    return resolved;
+}
+
+function resolveSingleGroupOrFail({
     groupName,
     generatorsConfiguration,
     isAutomation,

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
@@ -1,5 +1,4 @@
 import { createOrganizationIfDoesNotExist, FernToken } from "@fern-api/auth";
-import { generatorsYml } from "@fern-api/configuration-loader";
 import { ContainerRunner, Values } from "@fern-api/core-utils";
 import { AbsoluteFilePath, cwd, join, RelativeFilePath, resolve } from "@fern-api/fs-utils";
 import { askToLogin } from "@fern-api/login";
@@ -9,6 +8,7 @@ import { CliError } from "@fern-api/task-context";
 import { CliContext } from "../../cli-context/CliContext.js";
 import { PREVIEW_DIRECTORY } from "../../constants.js";
 import { checkOutputDirectory } from "./checkOutputDirectory.js";
+import { expandGroupFilter } from "./expandGroupFilter.js";
 import { filterGenerators } from "./filterGenerators.js";
 import { generateWorkspace } from "./generateAPIWorkspace.js";
 import { resolvePosthogCommandLabel } from "./resolvePosthogCommandLabel.js";
@@ -250,33 +250,4 @@ function buildPosthogWorkspaces({
                 )
         };
     });
-}
-
-/**
- * Expands the caller's `--group` filters into a set of concrete group names.
- *
- * Returns null when no filter was supplied (meaning "match every group"). Otherwise expands each
- * requested name through the alias table (when one is configured) and unions the results,
- * preserving order and de-duplicating. Used only to pre-filter groups for the
- * checkOutputDirectory pre-flight and posthog telemetry — the authoritative group resolution
- * for generation lives in `resolveGroupNamesForGeneration`.
- */
-function expandGroupFilter(
-    groupNames: string[] | undefined,
-    generatorsConfiguration: generatorsYml.GeneratorsConfiguration | undefined
-): string[] | null {
-    if (groupNames == null || groupNames.length === 0) {
-        return null; // No filter - include all groups
-    }
-
-    const expanded: string[] = [];
-    for (const name of groupNames) {
-        const aliasGroups = generatorsConfiguration?.groupAliases[name];
-        for (const resolved of aliasGroups ?? [name]) {
-            if (!expanded.includes(resolved)) {
-                expanded.push(resolved);
-            }
-        }
-    }
-    return expanded;
 }

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
@@ -24,7 +24,7 @@ export async function generateAPIWorkspaces({
     project,
     cliContext,
     version,
-    groupName,
+    groupNames,
     generatorName,
     generatorIndex,
     shouldLogS3Url,
@@ -51,7 +51,8 @@ export async function generateAPIWorkspaces({
     project: Project;
     cliContext: CliContext;
     version: string | undefined;
-    groupName: string | undefined;
+    /** One or more `--group` values. `undefined` means no `--group` was passed. */
+    groupNames: string[] | undefined;
     generatorName: string | undefined;
     /** Index-based generator targeting (0-based). Used by `fern automations generate --generator 0`. */
     generatorIndex: number | undefined;
@@ -99,7 +100,7 @@ export async function generateAPIWorkspaces({
 
     await confirmOutputDirectoriesForEligibleGenerators({
         project,
-        groupName,
+        groupNames,
         generatorName,
         generatorIndex,
         automation,
@@ -111,7 +112,7 @@ export async function generateAPIWorkspaces({
         orgId: project.config.organization,
         command: resolvePosthogCommandLabel(automation),
         properties: {
-            workspaces: buildPosthogWorkspaces({ project, groupName, generatorName })
+            workspaces: buildPosthogWorkspaces({ project, groupNames, generatorName })
         }
     });
 
@@ -134,7 +135,7 @@ export async function generateAPIWorkspaces({
                     projectConfig: project.config,
                     context,
                     version,
-                    groupName,
+                    groupNames,
                     generatorName,
                     generatorIndex,
                     shouldLogS3Url,
@@ -171,7 +172,7 @@ export async function generateAPIWorkspaces({
  */
 async function confirmOutputDirectoriesForEligibleGenerators({
     project,
-    groupName,
+    groupNames,
     generatorName,
     generatorIndex,
     automation,
@@ -179,7 +180,7 @@ async function confirmOutputDirectoriesForEligibleGenerators({
     force
 }: {
     project: Project;
-    groupName: string | undefined;
+    groupNames: string[] | undefined;
     generatorName: string | undefined;
     generatorIndex: number | undefined;
     automation: AutomationRunOptions | undefined;
@@ -187,7 +188,7 @@ async function confirmOutputDirectoriesForEligibleGenerators({
     force: boolean;
 }): Promise<void> {
     for (const workspace of project.apiWorkspaces) {
-        const resolvedGroupNames = expandGroupFilter(groupName, workspace.generatorsConfiguration);
+        const resolvedGroupNames = expandGroupFilter(groupNames, workspace.generatorsConfiguration);
         const rootAutorelease = workspace.generatorsConfiguration?.rawConfiguration.autorelease;
         const groupsInScope =
             workspace.generatorsConfiguration?.groups.filter(
@@ -223,18 +224,18 @@ async function confirmOutputDirectoriesForEligibleGenerators({
 /** Builds the `workspaces` array for the posthog event, honoring `--group` / `--generator` filters. */
 function buildPosthogWorkspaces({
     project,
-    groupName,
+    groupNames,
     generatorName
 }: {
     project: Project;
-    groupName: string | undefined;
+    groupNames: string[] | undefined;
     generatorName: string | undefined;
 }) {
     return project.apiWorkspaces.map((workspace) => {
-        const resolvedGroupNames = expandGroupFilter(groupName, workspace.generatorsConfiguration);
+        const resolvedGroupNames = expandGroupFilter(groupNames, workspace.generatorsConfiguration);
         return {
             name: workspace.workspaceName,
-            group: groupName,
+            group: groupNames != null && groupNames.length === 1 ? groupNames[0] : groupNames,
             generators: workspace.generatorsConfiguration?.groups
                 .filter((group) => resolvedGroupNames == null || resolvedGroupNames.includes(group.groupName))
                 .map((group) =>
@@ -252,31 +253,30 @@ function buildPosthogWorkspaces({
 }
 
 /**
- * Expands the caller's `--group` filter into a set of concrete group names.
+ * Expands the caller's `--group` filters into a set of concrete group names.
  *
- * Returns null when no filter was supplied (meaning "match every group"), an alias's target
- * list when the name is an alias, or `[groupName]` otherwise. Used only to pre-filter groups
- * for the checkOutputDirectory pre-flight and posthog telemetry — the authoritative group
- * resolution for generation lives in `resolveGroupNamesForGeneration`.
+ * Returns null when no filter was supplied (meaning "match every group"). Otherwise expands each
+ * requested name through the alias table (when one is configured) and unions the results,
+ * preserving order and de-duplicating. Used only to pre-filter groups for the
+ * checkOutputDirectory pre-flight and posthog telemetry — the authoritative group resolution
+ * for generation lives in `resolveGroupNamesForGeneration`.
  */
 function expandGroupFilter(
-    groupName: string | undefined,
+    groupNames: string[] | undefined,
     generatorsConfiguration: generatorsYml.GeneratorsConfiguration | undefined
 ): string[] | null {
-    if (groupName == null) {
+    if (groupNames == null || groupNames.length === 0) {
         return null; // No filter - include all groups
     }
 
-    if (generatorsConfiguration == null) {
-        return [groupName]; // No configuration - just use the group name as-is
+    const expanded: string[] = [];
+    for (const name of groupNames) {
+        const aliasGroups = generatorsConfiguration?.groupAliases[name];
+        for (const resolved of aliasGroups ?? [name]) {
+            if (!expanded.includes(resolved)) {
+                expanded.push(resolved);
+            }
+        }
     }
-
-    // Check if it's an alias
-    const aliasGroups = generatorsConfiguration.groupAliases[groupName];
-    if (aliasGroups != null) {
-        return aliasGroups;
-    }
-
-    // Not an alias - return as single group
-    return [groupName];
+    return expanded;
 }

--- a/packages/cli/cli/src/commands/generate/resolveGroupsOrFail.ts
+++ b/packages/cli/cli/src/commands/generate/resolveGroupsOrFail.ts
@@ -1,0 +1,134 @@
+import {
+    DEFAULT_GROUP_GENERATORS_CONFIG_KEY,
+    GENERATORS_CONFIGURATION_FILENAME,
+    generatorsYml
+} from "@fern-api/configuration-loader";
+import { CliError, TaskContext } from "@fern-api/task-context";
+import chalk from "chalk";
+
+import { GROUP_CLI_OPTION } from "../../constants.js";
+import { resolveGroupAlias } from "./resolveGroupAlias.js";
+import { resolveGroupNamesForGeneration } from "./resolveGroupNamesForGeneration.js";
+
+/**
+ * Resolves the list of group names to run against, throwing a helpful `failAndThrow` for any
+ * misconfiguration (missing group, unknown alias, alias pointing at a non-existent group).
+ *
+ * Composes two pure helpers:
+ *   - `resolveGroupNamesForGeneration` — decides between fan-out / targeted / missing-group.
+ *   - `resolveGroupAlias` — expands an alias to its targets, validating each.
+ *
+ * The helpers themselves are pure and live in their own modules; this wrapper owns the
+ * error-message rendering and the throw.
+ *
+ * When the user passes multiple `--group` values (e.g. `fern generate --group ts --group java`),
+ * each value is resolved independently and the results are unioned, preserving first-occurrence
+ * order and de-duplicating. An invalid group name fails fast via `failAndThrow` — subsequent
+ * names are not attempted.
+ */
+export function resolveGroupsOrFail({
+    groupNames,
+    generatorsConfiguration,
+    isAutomation,
+    context
+}: {
+    groupNames: string[] | undefined;
+    generatorsConfiguration: generatorsYml.GeneratorsConfiguration;
+    isAutomation: boolean;
+    context: TaskContext;
+}): string[] {
+    // No `--group`: delegate the fan-out vs. default-group vs. missing-group decision to the
+    // single-group resolver with `groupName: undefined`. Passing one explicit `--group` takes
+    // the same path with that name. Multiple `--group` values resolve each independently and
+    // union the results (de-duplicated, order-preserving).
+    if (groupNames == null || groupNames.length === 0) {
+        return resolveSingleGroupOrFail({
+            groupName: undefined,
+            generatorsConfiguration,
+            isAutomation,
+            context
+        });
+    }
+    const resolved: string[] = [];
+    for (const groupName of groupNames) {
+        for (const name of resolveSingleGroupOrFail({
+            groupName,
+            generatorsConfiguration,
+            isAutomation,
+            context
+        })) {
+            if (!resolved.includes(name)) {
+                resolved.push(name);
+            }
+        }
+    }
+    return resolved;
+}
+
+function resolveSingleGroupOrFail({
+    groupName,
+    generatorsConfiguration,
+    isAutomation,
+    context
+}: {
+    groupName: string | undefined;
+    generatorsConfiguration: generatorsYml.GeneratorsConfiguration;
+    isAutomation: boolean;
+    context: TaskContext;
+}): string[] {
+    const resolution = resolveGroupNamesForGeneration({ groupName, generatorsConfiguration, isAutomation });
+    if (resolution.type === "fan-out") {
+        return resolution.groupNames;
+    }
+    if (resolution.type === "missing-group") {
+        const longestGroupName = Math.max(...resolution.availableGroupNames.map((name) => name.length));
+        const currentArgs = process.argv.slice(2).join(" ");
+        const suggestions = resolution.availableGroupNames
+            .map((name) => {
+                const suggestedCommand = `fern ${currentArgs} --${GROUP_CLI_OPTION} ${name}`;
+                return ` › ${chalk.bold(name.padEnd(longestGroupName))}  ${chalk.dim(suggestedCommand)}`;
+            })
+            .join("\n");
+        context.failAndThrow(
+            `No group specified. Use the --${GROUP_CLI_OPTION} option, or set "${DEFAULT_GROUP_GENERATORS_CONFIG_KEY}" in ${GENERATORS_CONFIGURATION_FILENAME}:\n${suggestions}`,
+            undefined,
+            { code: CliError.Code.NetworkError }
+        );
+        return []; // unreachable — failAndThrow throws
+    }
+
+    // resolution.type === "targeted"
+    if (resolution.fromDefaultGroup) {
+        context.logger.info(
+            chalk.dim(`Using default group '${resolution.groupName}' from ${GENERATORS_CONFIGURATION_FILENAME}`)
+        );
+    }
+    const aliasResult = resolveGroupAlias({
+        name: resolution.groupName,
+        groupAliases: generatorsConfiguration.groupAliases,
+        availableGroupNames: generatorsConfiguration.groups.map((g) => g.groupName)
+    });
+    if (aliasResult.type === "alias-references-missing-group") {
+        context.failAndThrow(
+            `Group alias '${aliasResult.alias}' references non-existent group '${aliasResult.missingGroupName}'. ` +
+                `Available groups: ${aliasResult.availableGroupNames.join(", ")}`,
+            undefined,
+            { code: CliError.Code.NetworkError }
+        );
+        return [];
+    }
+    if (aliasResult.type === "unknown") {
+        const aliasesSuffix =
+            aliasResult.availableAliasNames.length > 0
+                ? `. Available aliases: ${aliasResult.availableAliasNames.join(", ")}`
+                : "";
+        context.failAndThrow(
+            `'${aliasResult.name}' is not a valid group or alias. ` +
+                `Available groups: ${aliasResult.availableGroupNames.join(", ")}${aliasesSuffix}`,
+            undefined,
+            { code: CliError.Code.NetworkError }
+        );
+        return [];
+    }
+    return aliasResult.groupNames;
+}


### PR DESCRIPTION
## Description

`fern generate` previously rejected multiple `--group` flags with:

```
'typescript,java,python' is not a valid group or alias.
```

Yargs was collecting the repeated flag values into a single comma-joined string, which was then handed to the group/alias resolver as a single (invalid) name. This PR makes `--group` a proper array option and resolves each value independently, so commands like the one below do what the user expects:

```
fern generate --group typescript --group java --group python --preview
```

Each value goes through the usual alias expansion, and the resulting set of groups (de-duplicated, order-preserving) is generated in parallel — same path used today when fanning out in automation mode.

## Changes Made

- `--group` in `addGenerateCommand` is now `array: true`, and the description calls out the multi-flag usage.
- Threaded `groupNames: string[] | undefined` through `generateAPIWorkspaces` → `generateWorkspace` (replacing the old `groupName: string | undefined`), updated the two call sites in `cli.ts` and the one in `executeAutomationsGenerate.ts`.
- `resolveGroupsOrFail` now loops over the provided names, calling the existing single-name resolver (`resolveGroupNamesForGeneration` + alias expansion) for each and unioning results. Error paths (missing group, unknown alias, alias pointing at missing group) are preserved.
- `expandGroupFilter` (used by the `checkOutputDirectory` pre-flight and posthog telemetry) and `buildPosthogWorkspaces` take arrays.
- `--group is ignored when generating docs` warning now correctly checks `length > 0` instead of `!= null`.
- Changelog entry under `packages/cli/cli/changes/unreleased/`.

## Testing

- [x] Unit tests: `pnpm turbo run test --filter @fern-api/cli` — 518/518 passing.
- [x] `pnpm run check` (biome) passes.
- [ ] Manual end-to-end testing of `fern generate --group ts --group java --preview` against a real project — happy to run this on request.

Link to Devin session: https://app.devin.ai/sessions/28c2cd1545ea4e8492a529677adcb94c
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
