### PR TITLE
feat(cli): allow multiple --api flags in fern generate

### DIFF
--- a/packages/cli/cli/changes/unreleased/generate-multiple-apis.yml
+++ b/packages/cli/cli/changes/unreleased/generate-multiple-apis.yml
@@ -1,0 +1,7 @@
+- summary: |
+    `fern generate` now accepts multiple `--api` flags. Previously, running
+    `fern generate --api api1 --api api2` failed because yargs collapsed the values into a single
+    comma-joined string that was then looked up as a workspace name. `--api` is now declared as an
+    array option, so each `--api <name>` value is parsed individually and the command generates for
+    the union of the specified API workspaces (de-duplicated).
+  type: feat

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -646,8 +646,10 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
         (yargs) =>
             yargs
                 .option("api", {
-                    string: true,
-                    description: "If multiple APIs, specify the name with --api <name>. Otherwise, just --api."
+                    type: "string",
+                    array: true,
+                    description:
+                        "If multiple APIs, specify the name with --api <name>. Pass --api multiple times to generate for several APIs at once."
                 })
                 .option("docs", {
                     string: true,
@@ -792,7 +794,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                         "Skip opening a PR / pushing when the generated output has no diff from the base branch."
                 }),
         async (argv) => {
-            if (argv.api != null && argv.docs != null) {
+            if (argv.api != null && argv.api.length > 0 && argv.docs != null) {
                 return cliContext.failWithoutThrowing(
                     "Cannot specify both --api and --docs. Please choose one.",
                     undefined,
@@ -875,7 +877,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
             const correctedGeneratorFilter =
                 argv.generator != null ? warnAndCorrectIncorrectDockerOrg(argv.generator, cliContext) : undefined;
             const { generatorName, generatorIndex } = parseGeneratorArg(correctedGeneratorFilter);
-            if (argv.api != null) {
+            if (argv.api != null && argv.api.length > 0) {
                 return await generateAPIWorkspaces({
                     project: await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
                         commandLineApiWorkspace: argv.api,

--- a/packages/cli/cli/src/commands/generate/__test__/resolveGroupsForWorkspace.test.ts
+++ b/packages/cli/cli/src/commands/generate/__test__/resolveGroupsForWorkspace.test.ts
@@ -1,0 +1,153 @@
+import type { generatorsYml } from "@fern-api/configuration-loader";
+import { createLogger } from "@fern-api/logger";
+import { createMockTaskContext, TaskAbortSignal } from "@fern-api/task-context";
+import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
+import { describe, expect, it } from "vitest";
+
+import { resolveGroupsForWorkspace } from "../resolveGroupsForWorkspace.js";
+
+function makeConfig(
+    overrides: Partial<generatorsYml.GeneratorsConfiguration> = {}
+): generatorsYml.GeneratorsConfiguration {
+    return {
+        groups: [],
+        defaultGroup: undefined,
+        groupAliases: {},
+        rawConfiguration: {},
+        ...overrides
+    } as unknown as generatorsYml.GeneratorsConfiguration;
+}
+
+function makeGroup(name: string): generatorsYml.GeneratorGroup {
+    return { groupName: name } as unknown as generatorsYml.GeneratorGroup;
+}
+
+function makeWorkspace(
+    generatorsConfiguration: generatorsYml.GeneratorsConfiguration | undefined
+): AbstractAPIWorkspace<unknown> {
+    return { generatorsConfiguration } as unknown as AbstractAPIWorkspace<unknown>;
+}
+
+function silentContext() {
+    // Silence the logger so test output stays clean; `resolveGroupsOrFail.test.ts`
+    // already covers error-message formatting.
+    return createMockTaskContext({ logger: createLogger(() => undefined) });
+}
+
+describe("resolveGroupsForWorkspace", () => {
+    describe("skip paths (preserve today's warn-and-return behavior in generateWorkspace)", () => {
+        it("returns undefined when the workspace has no generators.yml", () => {
+            const result = resolveGroupsForWorkspace({
+                workspace: makeWorkspace(undefined),
+                groupNames: ["ts"],
+                isAutomation: false,
+                context: silentContext()
+            });
+            expect(result).toBeUndefined();
+        });
+
+        it("returns undefined when the workspace defines no groups", () => {
+            const result = resolveGroupsForWorkspace({
+                workspace: makeWorkspace(makeConfig({ groups: [] })),
+                groupNames: ["ts"],
+                isAutomation: false,
+                context: silentContext()
+            });
+            expect(result).toBeUndefined();
+        });
+
+        it("returns undefined for an empty-groups workspace even when no --group was passed", () => {
+            const result = resolveGroupsForWorkspace({
+                workspace: makeWorkspace(makeConfig({ groups: [] })),
+                groupNames: undefined,
+                isAutomation: false,
+                context: silentContext()
+            });
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe("happy path (passes through to resolveGroupsOrFail)", () => {
+        it("resolves a single --group that exists in the workspace", () => {
+            const result = resolveGroupsForWorkspace({
+                workspace: makeWorkspace(makeConfig({ groups: [makeGroup("ts"), makeGroup("py")] })),
+                groupNames: ["ts"],
+                isAutomation: false,
+                context: silentContext()
+            });
+            expect(result).toEqual(["ts"]);
+        });
+
+        it("resolves multiple --group values to their union (de-duplicated, order-preserving)", () => {
+            const result = resolveGroupsForWorkspace({
+                workspace: makeWorkspace(makeConfig({ groups: [makeGroup("ts"), makeGroup("java"), makeGroup("py")] })),
+                groupNames: ["ts", "java", "py"],
+                isAutomation: false,
+                context: silentContext()
+            });
+            expect(result).toEqual(["ts", "java", "py"]);
+        });
+
+        it("falls back to default-group when no --group is passed", () => {
+            const result = resolveGroupsForWorkspace({
+                workspace: makeWorkspace(
+                    makeConfig({ groups: [makeGroup("ts"), makeGroup("py")], defaultGroup: "py" })
+                ),
+                groupNames: undefined,
+                isAutomation: false,
+                context: silentContext()
+            });
+            expect(result).toEqual(["py"]);
+        });
+
+        it("fans out across every group in automation mode when no --group is passed", () => {
+            const result = resolveGroupsForWorkspace({
+                workspace: makeWorkspace(makeConfig({ groups: [makeGroup("ts"), makeGroup("py"), makeGroup("java")] })),
+                groupNames: undefined,
+                isAutomation: true,
+                context: silentContext()
+            });
+            expect(result).toEqual(["ts", "py", "java"]);
+        });
+    });
+
+    describe("failure paths (bubble through to the caller's Promise.all so generation never starts)", () => {
+        it("throws when the requested --group does not exist in this workspace", () => {
+            // This is the cross-workspace scenario from the review question: workspace A has
+            // `typescript` but workspace B doesn't. The pre-flight catches B's misconfiguration
+            // and aborts the whole command before A's generation starts.
+            expect(() =>
+                resolveGroupsForWorkspace({
+                    workspace: makeWorkspace(makeConfig({ groups: [makeGroup("java"), makeGroup("py")] })),
+                    groupNames: ["typescript"],
+                    isAutomation: false,
+                    context: silentContext()
+                })
+            ).toThrow(TaskAbortSignal);
+        });
+
+        it("throws when no --group was passed and the workspace has no default-group", () => {
+            // Other-cross-workspace scenario: workspace A has `default-group: ts`, workspace B
+            // has no default. The pre-flight fails on B.
+            expect(() =>
+                resolveGroupsForWorkspace({
+                    workspace: makeWorkspace(makeConfig({ groups: [makeGroup("ts"), makeGroup("py")] })),
+                    groupNames: undefined,
+                    isAutomation: false,
+                    context: silentContext()
+                })
+            ).toThrow(TaskAbortSignal);
+        });
+
+        it("throws when the first of several --group values is unknown (fail-fast)", () => {
+            expect(() =>
+                resolveGroupsForWorkspace({
+                    workspace: makeWorkspace(makeConfig({ groups: [makeGroup("ts"), makeGroup("py")] })),
+                    groupNames: ["nonexistent", "ts"],
+                    isAutomation: false,
+                    context: silentContext()
+                })
+            ).toThrow(TaskAbortSignal);
+        });
+    });
+});

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -11,7 +11,6 @@ import { FernFiddle } from "@fern-fern/fiddle-sdk";
 import { isTelemetryDisabled } from "../../telemetry/isTelemetryDisabled.js";
 import { filterGenerators } from "./filterGenerators.js";
 import { GenerationMode } from "./generateAPIWorkspaces.js";
-import { resolveGroupsOrFail } from "./resolveGroupsOrFail.js";
 import { buildAutomationTargeting, selectGeneratorsForAutomation } from "./selectGeneratorsForAutomation.js";
 import { shouldSkipMissingGenerator } from "./shouldSkipMissingGenerator.js";
 
@@ -20,7 +19,7 @@ export async function generateWorkspace({
     workspace,
     projectConfig,
     context,
-    groupNames,
+    resolvedGroupNames,
     generatorName,
     generatorIndex,
     version,
@@ -49,8 +48,11 @@ export async function generateWorkspace({
     projectConfig: fernConfigJson.ProjectConfig;
     context: TaskContext;
     version: string | undefined;
-    /** One or more `--group` values. `undefined` means no `--group` was passed. */
-    groupNames: string[] | undefined;
+    /**
+     * The resolved group names to run for this workspace, already validated and alias-expanded
+     * by the pre-flight pass in {@link generateAPIWorkspaces}. Must be non-empty.
+     */
+    resolvedGroupNames: string[];
     generatorName: string | undefined;
     generatorIndex: number | undefined;
     shouldLogS3Url: boolean;
@@ -87,13 +89,6 @@ export async function generateWorkspace({
         context.logger.warn(`This workspace has no groups specified in ${GENERATORS_CONFIGURATION_FILENAME}`);
         return;
     }
-
-    const resolvedGroupNames = resolveGroupsOrFail({
-        groupNames,
-        generatorsConfiguration: workspace.generatorsConfiguration,
-        isAutomation: automation != null,
-        context
-    });
 
     const { ai, replay } = workspace.generatorsConfiguration;
 

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
@@ -12,7 +12,7 @@ import { checkOutputDirectory } from "./checkOutputDirectory.js";
 import { expandGroupFilter } from "./expandGroupFilter.js";
 import { filterGenerators } from "./filterGenerators.js";
 import { generateWorkspace } from "./generateAPIWorkspace.js";
-import { resolveGroupsOrFail } from "./resolveGroupsOrFail.js";
+import { resolveGroupsForWorkspace } from "./resolveGroupsForWorkspace.js";
 import { resolvePosthogCommandLabel } from "./resolvePosthogCommandLabel.js";
 import { shouldPreflightGenerator } from "./shouldPreflightGenerator.js";
 
@@ -206,19 +206,15 @@ async function resolveGroupsForAllWorkspaces({
     await Promise.all(
         project.apiWorkspaces.map(async (workspace) => {
             await cliContext.runTaskForWorkspace(workspace, async (context) => {
-                if (
-                    workspace.generatorsConfiguration == null ||
-                    workspace.generatorsConfiguration.groups.length === 0
-                ) {
-                    return;
-                }
-                const resolved = resolveGroupsOrFail({
+                const resolved = resolveGroupsForWorkspace({
+                    workspace,
                     groupNames,
-                    generatorsConfiguration: workspace.generatorsConfiguration,
                     isAutomation: automation != null,
                     context
                 });
-                resolvedGroupNamesByWorkspace.set(workspace, resolved);
+                if (resolved != null) {
+                    resolvedGroupNamesByWorkspace.set(workspace, resolved);
+                }
             });
         })
     );

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
@@ -5,12 +5,14 @@ import { askToLogin } from "@fern-api/login";
 import { Project } from "@fern-api/project-loader";
 import type { AutomationRunOptions } from "@fern-api/remote-workspace-runner";
 import { CliError } from "@fern-api/task-context";
+import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
 import { CliContext } from "../../cli-context/CliContext.js";
 import { PREVIEW_DIRECTORY } from "../../constants.js";
 import { checkOutputDirectory } from "./checkOutputDirectory.js";
 import { expandGroupFilter } from "./expandGroupFilter.js";
 import { filterGenerators } from "./filterGenerators.js";
 import { generateWorkspace } from "./generateAPIWorkspace.js";
+import { resolveGroupsOrFail } from "./resolveGroupsOrFail.js";
 import { resolvePosthogCommandLabel } from "./resolvePosthogCommandLabel.js";
 import { shouldPreflightGenerator } from "./shouldPreflightGenerator.js";
 
@@ -116,8 +118,25 @@ export async function generateAPIWorkspaces({
         }
     });
 
+    // Pre-flight: resolve groups for every selected workspace up front. If any workspace is
+    // misconfigured for this invocation (e.g. `--group foo` targets a group that doesn't exist
+    // in one of the `--api`-selected workspaces, or no `--group` was passed and one workspace
+    // lacks a `default-group`), `resolveGroupsOrFail` throws before we start any generation.
+    // We keep the resolved names so `generateWorkspace` doesn't need to re-run the resolver
+    // (and re-log "Using default group '…' from generators.yml").
+    const resolvedGroupNamesByWorkspace = await resolveGroupsForAllWorkspaces({
+        project,
+        groupNames,
+        automation,
+        cliContext
+    });
+
     await Promise.all(
         project.apiWorkspaces.map(async (workspace) => {
+            const resolvedGroupNames = resolvedGroupNamesByWorkspace.get(workspace);
+            // Workspaces skipped by the pre-flight (no generators.yml or no configured groups)
+            // still need to run through `generateWorkspace` so the existing warning paths fire.
+            // An undefined entry means "skipped"; an empty array would mean "resolved to nothing".
             await cliContext.runTaskForWorkspace(workspace, async (context) => {
                 const absolutePathToPreview = preview
                     ? outputDir != null
@@ -135,7 +154,7 @@ export async function generateAPIWorkspaces({
                     projectConfig: project.config,
                     context,
                     version,
-                    groupNames,
+                    resolvedGroupNames: resolvedGroupNames ?? [],
                     generatorName,
                     generatorIndex,
                     shouldLogS3Url,
@@ -161,6 +180,49 @@ export async function generateAPIWorkspaces({
             });
         })
     );
+}
+
+/**
+ * Pre-flight pass that resolves (and validates) the group list for every workspace the user
+ * selected via `--api`. Any misconfiguration surfaces here — before generation starts — via
+ * {@link resolveGroupsOrFail}'s `failAndThrow`, matching today's error rendering (workspace-
+ * prefixed, same message text).
+ *
+ * Skips workspaces that have no `generators.yml` or no configured groups; those hit the
+ * corresponding warn-and-return paths inside {@link generateWorkspace}.
+ */
+async function resolveGroupsForAllWorkspaces({
+    project,
+    groupNames,
+    automation,
+    cliContext
+}: {
+    project: Project;
+    groupNames: string[] | undefined;
+    automation: AutomationRunOptions | undefined;
+    cliContext: CliContext;
+}): Promise<Map<AbstractAPIWorkspace<unknown>, string[]>> {
+    const resolvedGroupNamesByWorkspace = new Map<AbstractAPIWorkspace<unknown>, string[]>();
+    await Promise.all(
+        project.apiWorkspaces.map(async (workspace) => {
+            await cliContext.runTaskForWorkspace(workspace, async (context) => {
+                if (
+                    workspace.generatorsConfiguration == null ||
+                    workspace.generatorsConfiguration.groups.length === 0
+                ) {
+                    return;
+                }
+                const resolved = resolveGroupsOrFail({
+                    groupNames,
+                    generatorsConfiguration: workspace.generatorsConfiguration,
+                    isAutomation: automation != null,
+                    context
+                });
+                resolvedGroupNamesByWorkspace.set(workspace, resolved);
+            });
+        })
+    );
+    return resolvedGroupNamesByWorkspace;
 }
 
 /**

--- a/packages/cli/cli/src/commands/generate/resolveGroupsForWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/resolveGroupsForWorkspace.ts
@@ -1,0 +1,43 @@
+import { TaskContext } from "@fern-api/task-context";
+import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
+
+import { resolveGroupsOrFail } from "./resolveGroupsOrFail.js";
+
+/**
+ * Pre-flight resolution of the `--group` list for a single API workspace.
+ *
+ * Returns the resolved group names on success, or `undefined` when the workspace has no
+ * `generators.yml` or defines no groups — callers should forward these "skipped" workspaces
+ * to {@link generateWorkspace} so its existing warn-and-return paths fire, matching today's
+ * behavior.
+ *
+ * On misconfiguration (e.g. `--group foo` targeting a workspace that doesn't define `foo`,
+ * or no `--group` passed and the workspace has no `default-group`), {@link resolveGroupsOrFail}
+ * calls `context.failAndThrow`, which throws a `TaskAbortSignal`. Collecting these via
+ * `Promise.all` in the caller aborts the whole command before any generation starts.
+ */
+export function resolveGroupsForWorkspace({
+    workspace,
+    groupNames,
+    isAutomation,
+    context
+}: {
+    workspace: AbstractAPIWorkspace<unknown>;
+    /** One or more `--group` values, or `undefined` if `--group` was not passed. */
+    groupNames: string[] | undefined;
+    isAutomation: boolean;
+    context: TaskContext;
+}): string[] | undefined {
+    if (workspace.generatorsConfiguration == null) {
+        return undefined;
+    }
+    if (workspace.generatorsConfiguration.groups.length === 0) {
+        return undefined;
+    }
+    return resolveGroupsOrFail({
+        groupNames,
+        generatorsConfiguration: workspace.generatorsConfiguration,
+        isAutomation,
+        context
+    });
+}

--- a/packages/cli/project-loader/src/__test__/normalizeCommandLineApiWorkspace.test.ts
+++ b/packages/cli/project-loader/src/__test__/normalizeCommandLineApiWorkspace.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeCommandLineApiWorkspace } from "../normalizeCommandLineApiWorkspace.js";
+
+describe("normalizeCommandLineApiWorkspace", () => {
+    it("returns undefined when no --api is passed", () => {
+        expect(normalizeCommandLineApiWorkspace(undefined)).toBeUndefined();
+    });
+
+    it("wraps a single --api string in a one-element array (back-compat for single-api callers)", () => {
+        expect(normalizeCommandLineApiWorkspace("foo")).toEqual(["foo"]);
+    });
+
+    it("treats an empty array the same as undefined (matches yargs when the flag is not passed)", () => {
+        expect(normalizeCommandLineApiWorkspace([])).toBeUndefined();
+    });
+
+    it("returns a single-element array unchanged", () => {
+        expect(normalizeCommandLineApiWorkspace(["foo"])).toEqual(["foo"]);
+    });
+
+    it("preserves order and contents when every name is distinct", () => {
+        expect(normalizeCommandLineApiWorkspace(["foo", "bar", "baz"])).toEqual(["foo", "bar", "baz"]);
+    });
+
+    it("de-duplicates repeated names, keeping the first occurrence's position", () => {
+        expect(normalizeCommandLineApiWorkspace(["foo", "bar", "foo", "baz", "bar"])).toEqual(["foo", "bar", "baz"]);
+    });
+
+    it("de-duplicates `--api foo --api foo` to a single name", () => {
+        expect(normalizeCommandLineApiWorkspace(["foo", "foo"])).toEqual(["foo"]);
+    });
+
+    it("preserves user-specified order (not alphabetical)", () => {
+        expect(normalizeCommandLineApiWorkspace(["zeta", "alpha", "mu"])).toEqual(["zeta", "alpha", "mu"]);
+    });
+});

--- a/packages/cli/project-loader/src/loadProject.ts
+++ b/packages/cli/project-loader/src/loadProject.ts
@@ -18,6 +18,7 @@ import { handleFailedWorkspaceParserResult, loadAPIWorkspace, loadDocsWorkspace 
 import chalk from "chalk";
 import { readdir } from "fs/promises";
 
+import { normalizeCommandLineApiWorkspace } from "./normalizeCommandLineApiWorkspace.js";
 import { Project } from "./Project.js";
 
 export declare namespace loadProject {
@@ -147,14 +148,7 @@ export async function loadApis({
     // strings narrows to the named workspace(s). Passing `--api` multiple times produces an
     // array (e.g. `fern generate --api foo --api bar`); callers that still take a single
     // `--api` pass a single string.
-    const commandLineApiWorkspaceNames: string[] | undefined =
-        commandLineApiWorkspace == null
-            ? undefined
-            : Array.isArray(commandLineApiWorkspace)
-              ? commandLineApiWorkspace.length === 0
-                  ? undefined
-                  : Array.from(new Set(commandLineApiWorkspace))
-              : [commandLineApiWorkspace];
+    const commandLineApiWorkspaceNames = normalizeCommandLineApiWorkspace(commandLineApiWorkspace);
 
     const apisDirectory = join(fernDirectory, RelativeFilePath.of(APIS_DIRECTORY));
     const apisDirectoryExists = await doesPathExist(apisDirectory);

--- a/packages/cli/project-loader/src/loadProject.ts
+++ b/packages/cli/project-loader/src/loadProject.ts
@@ -24,7 +24,13 @@ export declare namespace loadProject {
     export interface Args {
         cliName: string;
         cliVersion: string;
-        commandLineApiWorkspace: string | undefined;
+        /**
+         * The API workspace name(s) supplied via `--api` on the command line. A single string
+         * preserves the historical single-`--api` behavior; an array allows callers that accept
+         * `--api` multiple times (e.g. `fern generate`) to filter to a union of workspaces.
+         * `undefined` means no `--api` flag was supplied.
+         */
+        commandLineApiWorkspace: string | string[] | undefined;
         /**
          * if false and commandLineWorkspace it not defined,
          * loadProject will cause the CLI to fail
@@ -134,9 +140,22 @@ export async function loadApis({
     fernDirectory: AbsoluteFilePath;
     context: TaskContext;
     cliVersion: string;
-    commandLineApiWorkspace: string | undefined;
+    commandLineApiWorkspace: string | string[] | undefined;
     defaultToAllApiWorkspaces: boolean;
 }): Promise<AbstractAPIWorkspace<unknown>[]> {
+    // Normalize `--api` input. `undefined` means no filter; a single string or an array of
+    // strings narrows to the named workspace(s). Passing `--api` multiple times produces an
+    // array (e.g. `fern generate --api foo --api bar`); callers that still take a single
+    // `--api` pass a single string.
+    const commandLineApiWorkspaceNames: string[] | undefined =
+        commandLineApiWorkspace == null
+            ? undefined
+            : Array.isArray(commandLineApiWorkspace)
+              ? commandLineApiWorkspace.length === 0
+                  ? undefined
+                  : Array.from(new Set(commandLineApiWorkspace))
+              : [commandLineApiWorkspace];
+
     const apisDirectory = join(fernDirectory, RelativeFilePath.of(APIS_DIRECTORY));
     const apisDirectoryExists = await doesPathExist(apisDirectory);
     if (apisDirectoryExists) {
@@ -149,11 +168,16 @@ export async function loadApis({
             return all;
         }, []);
 
-        if (commandLineApiWorkspace != null) {
-            if (!apiWorkspaceDirectoryNames.includes(commandLineApiWorkspace)) {
-                return context.failAndThrow("API does not exist: " + commandLineApiWorkspace, undefined, {
-                    code: CliError.Code.ConfigError
-                });
+        if (commandLineApiWorkspaceNames != null) {
+            const missing = commandLineApiWorkspaceNames.filter((name) => !apiWorkspaceDirectoryNames.includes(name));
+            if (missing.length > 0) {
+                return context.failAndThrow(
+                    missing.length === 1
+                        ? "API does not exist: " + missing[0]
+                        : "APIs do not exist: " + missing.join(", "),
+                    undefined,
+                    { code: CliError.Code.ConfigError }
+                );
             }
         } else if (apiWorkspaceDirectoryNames.length === 0) {
             return context.failAndThrow("No APIs found.", undefined, { code: CliError.Code.ConfigError });
@@ -176,10 +200,8 @@ export async function loadApis({
         const apiWorkspaces: AbstractAPIWorkspace<unknown>[] = [];
 
         const filteredWorkspaces =
-            commandLineApiWorkspace != null
-                ? apiWorkspaceDirectoryNames.filter((api) => {
-                      return api === commandLineApiWorkspace;
-                  })
+            commandLineApiWorkspaceNames != null
+                ? apiWorkspaceDirectoryNames.filter((api) => commandLineApiWorkspaceNames.includes(api))
                 : apiWorkspaceDirectoryNames;
 
         await Promise.all(

--- a/packages/cli/project-loader/src/normalizeCommandLineApiWorkspace.ts
+++ b/packages/cli/project-loader/src/normalizeCommandLineApiWorkspace.ts
@@ -1,0 +1,22 @@
+/**
+ * Normalizes the `--api` CLI input into a canonical form for downstream filtering.
+ *
+ * - `undefined` → `undefined` (no filter; fall through to default workspace selection)
+ * - single string → one-element array (preserves historical single-`--api` callers)
+ * - empty array → `undefined` (treated the same as no `--api`; matches yargs when the
+ *   flag isn't passed and keeps call sites that forward `argv.api` from working)
+ * - array of strings → de-duplicated, order-preserving array
+ */
+export function normalizeCommandLineApiWorkspace(input: string | string[] | undefined): string[] | undefined {
+    if (input == null) {
+        return undefined;
+    }
+    if (!Array.isArray(input)) {
+        return [input];
+    }
+    if (input.length === 0) {
+        return undefined;
+    }
+    // `new Set(...)` preserves insertion order, so the first occurrence of each name wins.
+    return Array.from(new Set(input));
+}


### PR DESCRIPTION
## Description
Linear ticket: Refs

Follow-up to #15272. `fern generate` now accepts multiple `--api` flags, mirroring the recent widening of `--group`. Previously, `fern generate --api api1 --api api2` failed because yargs collapsed the repeated flag into a single comma-joined string (`"api1,api2"`), which `loadApis` then looked up as a single workspace name and failed with `API does not exist: api1,api2`.

With this change:

```bash
fern generate --api api1 --api api2 --group typescript --preview
```

loads the union of the named API workspaces (de-duplicated, order-preserving) and runs the generation pipeline for each, just like it already does for multi-`--group`.

## Changes Made
- `packages/cli/cli/src/cli.ts`: declare `--api` on `fern generate` as `type: "string", array: true` so repeated flags collect into an array. Update the `--api` + `--docs` mutual-exclusion guard and the `argv.api != null` branch to gate on `.length > 0` as well.
- `packages/cli/project-loader/src/loadProject.ts`: widen `loadProject.Args.commandLineApiWorkspace` to `string | string[] | undefined`. Inside `loadApis`, normalize the input via a new `normalizeCommandLineApiWorkspace` helper and:
  - collect *all* missing workspace names into a single `APIs do not exist: foo, bar` error (previously a single-name-only message);
  - filter the directory listing by set membership instead of equality.
- `packages/cli/project-loader/src/normalizeCommandLineApiWorkspace.ts`: new helper that collapses `undefined | string | string[]` to `string[] | undefined` (de-duplicated, order-preserving; empty array → `undefined`, matching yargs when the flag isn't passed).
- `packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts`: add a pre-flight pass (`resolveGroupsForAllWorkspaces`) that resolves `--group` for every selected workspace before any generation starts. Misconfigurations — `--group foo` targeting a workspace that doesn't have `foo`, or no `--group` + no `default-group` in one of the selected workspaces — now fail fast via the existing `resolveGroupsOrFail` path instead of only surfacing after other workspaces have already written output.
- `packages/cli/cli/src/commands/generate/resolveGroupsForWorkspace.ts`: new per-workspace helper used by the pre-flight. Returns `undefined` for workspaces with no `generators.yml` / no groups (so `generateWorkspace`'s existing warn-and-return paths still fire), otherwise delegates to `resolveGroupsOrFail`.
- `packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts`: `generateWorkspace` now takes the already-resolved `resolvedGroupNames: string[]` from the pre-flight instead of re-running `resolveGroupsOrFail` itself. Keeps the existing resolver logic untouched and avoids double-logging `Using default group '…' from generators.yml`.
- `packages/cli/cli/changes/unreleased/generate-multiple-apis.yml`: unreleased `feat` changelog entry.
- [ ] Updated README.md generator (if applicable) — N/A, CLI-only change.

### Scope note
Only `fern generate` was widened. The other commands that accept `--api` (`fern ir`, `fern register`, `fern check`, `fern api update`, `fern fdr-api-definition`, …) still take a single `--api` value. Since the loader now accepts `string | string[] | undefined`, widening any of those in a follow-up is a one-line change per command — happy to do it if you want parity, but keeping this PR minimal to match the scope of the original bug report.

### Pre-flight semantics
The pre-flight pass runs `resolveGroupsOrFail` in parallel (`Promise.all`) per workspace, using the same `runTaskForWorkspace` error-rendering path as today (workspace-prefixed, same message text). First workspace to fail aborts the command; workspaces that would have succeeded never start generation, so you no longer end up with half-written api1 output when api2 is misconfigured.

## Testing
- [x] Unit tests added/updated. CLI suite 544 → 554 (10 new) and `project-loader` 8 → 16 (8 new):
  - `normalizeCommandLineApiWorkspace.test.ts` (8 cases): `undefined`, single string, empty array, single-element array, all-distinct array, repeated names (de-dup + order preservation), `--api foo --api foo`, non-alphabetical order preservation.
  - `resolveGroupsForWorkspace.test.ts` (10 cases): skip paths (no `generators.yml`, empty groups, empty groups + no `--group`), happy paths (single `--group`, multiple `--group`, default-group fallback, automation fan-out), failure paths (the cross-workspace group-missing scenario from review, cross-workspace default-group-missing scenario, fail-fast on first bad name of several).
  - Existing `resolveGroupsOrFail.test.ts` (15 cases) still cover the resolver itself, now invoked once per workspace from the pre-flight instead of once per workspace from `generateWorkspace`.
- [x] Lint + typecheck: `pnpm check` and `pnpm compile` clean on the branch.
- [ ] Manual testing completed — relying on CI for the full suite.

Link to Devin session: https://app.devin.ai/sessions/28c2cd1545ea4e8492a529677adcb94c
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
