### PR TITLE
chore(ci): serialize publish-cli runs to prevent NPM publish race

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -23,6 +23,14 @@ permissions:
   contents: read # Required for checkout
   id-token: write # Required for OIDC
 
+# Serialize publish runs so queued runs wait for the in-flight publish to finish
+# instead of being cancelled. Without this, a newer release push can race with an
+# in-flight publish and cause a version (e.g. whose changelog was already written
+# to docs) to be skipped on NPM.
+concurrency:
+  group: publish-cli
+  cancel-in-progress: false
+
 env:
   DO_NOT_TRACK: "1"
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
## Description

Adds a `concurrency` block to `publish-cli.yml` so that in-flight CLI publish runs are never cancelled by a subsequent push to `main`, and newer runs queue instead.

Recently a CLI version (`4.87.1`) had its changelog written to docs (so it's visible at [the public CLI changelog](https://buildwithfern.com/learn/cli-api-reference/cli-reference/changelog)) but never landed on NPM — the repo jumped straight to `4.88.0`. Discussion in Slack confirmed the publish job was interrupted by the upstream `4.88.0` release commit before it could finish publishing `4.87.1`.

With `cancel-in-progress: false`, a second release push while a publish is still running will wait for the current one to complete instead of racing with it. This mirrors the same fix we just landed for `write-changelogs-to-docs` in #15268.

## Changes Made
- Add `concurrency: { group: publish-cli, cancel-in-progress: false }` to `.github/workflows/publish-cli.yml` so `push` and `workflow_dispatch` triggered runs serialize rather than overlap/cancel.
- [ ] Updated README.md generator (if applicable)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed — YAML-only workflow change; validated locally with the repo's pre-commit scripts. Concurrency behavior will be exercised by GitHub Actions on the next release.


Link to Devin session: https://app.devin.ai/sessions/e5b79a466fec40d1a84e9dfb0a2cdd33
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
