### PR TITLE
feat(cli): add .env file support to CLI v2 with --env flag

### DIFF
--- a/packages/cli/cli-v2/package.json
+++ b/packages/cli/cli-v2/package.json
@@ -109,6 +109,7 @@
     "yargs": "^17.4.1"
   },
   "dependencies": {
+    "dotenv": "^16.0.0",
     "tmp-promise": "catalog:"
   }
 }

--- a/packages/cli/cli-v2/src/cli.ts
+++ b/packages/cli/cli-v2/src/cli.ts
@@ -77,6 +77,10 @@ function createCliV2(argv?: string[]): Argv<GlobalArgs> {
             choices: ["debug", "info", "warn", "error"] as const,
             default: "info"
         })
+        .option("env", {
+            type: "string",
+            description: "Path to a .env file to load environment variables from"
+        })
         .completion("completion", "Generate shell completion script", completionHandler)
         .strict()
         .demandCommand()

--- a/packages/cli/cli-v2/src/context/GlobalArgs.ts
+++ b/packages/cli/cli-v2/src/context/GlobalArgs.ts
@@ -1,3 +1,4 @@
 export interface GlobalArgs {
     "log-level": string;
+    env?: string;
 }

--- a/packages/cli/cli-v2/src/context/__test__/loadDotenvFile.test.ts
+++ b/packages/cli/cli-v2/src/context/__test__/loadDotenvFile.test.ts
@@ -88,7 +88,7 @@ describe("loadDotenvFile", () => {
 
             loadDotenvFile(envFile, logDebug);
 
-            const calls = logDebug.mock.calls.map(([msg]: [string]) => msg);
+            const calls = logDebug.mock.calls.map((args) => args[0] as string);
             expect(calls).toContain("SECRET_KEY=****");
             expect(calls).toContain("ANOTHER=****");
             // Values must never appear

--- a/packages/cli/cli-v2/src/context/__test__/loadDotenvFile.test.ts
+++ b/packages/cli/cli-v2/src/context/__test__/loadDotenvFile.test.ts
@@ -1,0 +1,95 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadDotenvFile } from "../loadDotenvFile.js";
+
+// Capture stderr writes
+const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+describe("loadDotenvFile", () => {
+    let tmpDir: string;
+    let originalEnv: NodeJS.ProcessEnv;
+    let originalCwd: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "fern-env-test-"));
+        originalEnv = { ...process.env };
+        originalCwd = process.cwd();
+        process.chdir(tmpDir);
+        stderrSpy.mockClear();
+    });
+
+    afterEach(() => {
+        process.chdir(originalCwd);
+        // Restore env (remove any vars loaded from .env files during tests)
+        for (const key of Object.keys(process.env)) {
+            if (!(key in originalEnv)) {
+                delete process.env[key];
+            }
+        }
+        Object.assign(process.env, originalEnv);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    describe("auto-discovery (no --env flag)", () => {
+        it("loads .env from cwd when it exists", () => {
+            fs.writeFileSync(path.join(tmpDir, ".env"), "MY_SECRET=hello\n");
+
+            loadDotenvFile(undefined);
+
+            expect(process.env.MY_SECRET).toBe("hello");
+        });
+
+        it("is silent when no .env file exists in cwd", () => {
+            loadDotenvFile(undefined);
+
+            expect(stderrSpy).not.toHaveBeenCalled();
+        });
+
+        it("does not overwrite an existing env var", () => {
+            process.env.EXISTING_VAR = "original";
+            fs.writeFileSync(path.join(tmpDir, ".env"), "EXISTING_VAR=overwritten\n");
+
+            loadDotenvFile(undefined);
+
+            expect(process.env.EXISTING_VAR).toBe("original");
+        });
+    });
+
+    describe("explicit --env flag", () => {
+        it("loads the specified file", () => {
+            const envFile = path.join(tmpDir, "custom.env");
+            fs.writeFileSync(envFile, "CUSTOM_VAR=world\n");
+
+            loadDotenvFile(envFile);
+
+            expect(process.env.CUSTOM_VAR).toBe("world");
+        });
+
+        it("resolves relative paths against cwd", () => {
+            fs.writeFileSync(path.join(tmpDir, ".env.local"), "LOCAL_VAR=local\n");
+
+            loadDotenvFile(".env.local");
+
+            expect(process.env.LOCAL_VAR).toBe("local");
+        });
+
+        it("warns to stderr when the specified file does not exist", () => {
+            loadDotenvFile("/nonexistent/path/.env");
+
+            expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(".env file not found"));
+            expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("/nonexistent/path/.env"));
+        });
+
+        it("does not overwrite an existing env var", () => {
+            process.env.EXISTING_VAR = "original";
+            const envFile = path.join(tmpDir, "custom.env");
+            fs.writeFileSync(envFile, "EXISTING_VAR=overwritten\n");
+
+            loadDotenvFile(envFile);
+
+            expect(process.env.EXISTING_VAR).toBe("original");
+        });
+    });
+});

--- a/packages/cli/cli-v2/src/context/__test__/loadDotenvFile.test.ts
+++ b/packages/cli/cli-v2/src/context/__test__/loadDotenvFile.test.ts
@@ -32,28 +32,15 @@ describe("loadDotenvFile", () => {
         fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    describe("auto-discovery (no --env flag)", () => {
-        it("loads .env from cwd when it exists", () => {
+    describe("no --env flag", () => {
+        it("does nothing when envFilePath is undefined", () => {
             fs.writeFileSync(path.join(tmpDir, ".env"), "MY_SECRET=hello\n");
 
             loadDotenvFile(undefined);
 
-            expect(process.env.MY_SECRET).toBe("hello");
-        });
-
-        it("is silent when no .env file exists in cwd", () => {
-            loadDotenvFile(undefined);
-
+            // Auto-discovery is intentionally disabled — .env in cwd must NOT be loaded
+            expect(process.env.MY_SECRET).toBeUndefined();
             expect(stderrSpy).not.toHaveBeenCalled();
-        });
-
-        it("does not overwrite an existing env var", () => {
-            process.env.EXISTING_VAR = "original";
-            fs.writeFileSync(path.join(tmpDir, ".env"), "EXISTING_VAR=overwritten\n");
-
-            loadDotenvFile(undefined);
-
-            expect(process.env.EXISTING_VAR).toBe("original");
         });
     });
 

--- a/packages/cli/cli-v2/src/context/__test__/loadDotenvFile.test.ts
+++ b/packages/cli/cli-v2/src/context/__test__/loadDotenvFile.test.ts
@@ -88,13 +88,12 @@ describe("loadDotenvFile", () => {
 
             loadDotenvFile(envFile, logDebug);
 
-            expect(logDebug).toHaveBeenCalledOnce();
-            const [msg] = logDebug.mock.calls[0] as [string];
-            expect(msg).toContain("SECRET_KEY=<SET>");
-            expect(msg).toContain("ANOTHER=<SET>");
+            const calls = logDebug.mock.calls.map(([msg]: [string]) => msg);
+            expect(calls).toContain("SECRET_KEY=****");
+            expect(calls).toContain("ANOTHER=****");
             // Values must never appear
-            expect(msg).not.toContain("super-secret");
-            expect(msg).not.toContain("also-secret");
+            expect(calls.join("")).not.toContain("super-secret");
+            expect(calls.join("")).not.toContain("also-secret");
         });
 
         it("does not call logDebug when no logDebug is provided", () => {

--- a/packages/cli/cli-v2/src/context/__test__/loadDotenvFile.test.ts
+++ b/packages/cli/cli-v2/src/context/__test__/loadDotenvFile.test.ts
@@ -89,8 +89,8 @@ describe("loadDotenvFile", () => {
             loadDotenvFile(envFile, logDebug);
 
             const calls = logDebug.mock.calls.map((args) => args[0] as string);
-            expect(calls).toContain("SECRET_KEY=****");
-            expect(calls).toContain("ANOTHER=****");
+            expect(calls).toContain("Loaded from --env: SECRET_KEY=****");
+            expect(calls).toContain("Loaded from --env: ANOTHER=****");
             // Values must never appear
             expect(calls.join("")).not.toContain("super-secret");
             expect(calls.join("")).not.toContain("also-secret");

--- a/packages/cli/cli-v2/src/context/__test__/loadDotenvFile.test.ts
+++ b/packages/cli/cli-v2/src/context/__test__/loadDotenvFile.test.ts
@@ -79,4 +79,30 @@ describe("loadDotenvFile", () => {
             expect(process.env.EXISTING_VAR).toBe("original");
         });
     });
+
+    describe("debug logging", () => {
+        it("calls logDebug with key names and <SET> placeholders, never the actual values", () => {
+            const envFile = path.join(tmpDir, "custom.env");
+            fs.writeFileSync(envFile, "SECRET_KEY=super-secret\nANOTHER=also-secret\n");
+            const logDebug = vi.fn();
+
+            loadDotenvFile(envFile, logDebug);
+
+            expect(logDebug).toHaveBeenCalledOnce();
+            const [msg] = logDebug.mock.calls[0] as [string];
+            expect(msg).toContain("SECRET_KEY=<SET>");
+            expect(msg).toContain("ANOTHER=<SET>");
+            // Values must never appear
+            expect(msg).not.toContain("super-secret");
+            expect(msg).not.toContain("also-secret");
+        });
+
+        it("does not call logDebug when no logDebug is provided", () => {
+            const envFile = path.join(tmpDir, "custom.env");
+            fs.writeFileSync(envFile, "SECRET_KEY=super-secret\n");
+
+            // Should not throw even without logDebug
+            expect(() => loadDotenvFile(envFile, undefined)).not.toThrow();
+        });
+    });
 });

--- a/packages/cli/cli-v2/src/context/loadDotenvFile.ts
+++ b/packages/cli/cli-v2/src/context/loadDotenvFile.ts
@@ -32,7 +32,7 @@ export function loadDotenvFile(envFilePath: string | undefined, logDebug?: (msg:
         for (const key of Object.keys(result.parsed)) {
             // Never log values — use **** so the user knows a key was loaded
             // without revealing the value or its length.
-            logDebug(`${key}=****`);
+            logDebug(`Loaded from --env: ${key}=****`);
         }
     }
 }

--- a/packages/cli/cli-v2/src/context/loadDotenvFile.ts
+++ b/packages/cli/cli-v2/src/context/loadDotenvFile.ts
@@ -1,0 +1,30 @@
+import chalk from "chalk";
+import { config as dotenvConfig } from "dotenv";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Loads environment variables from a .env file into process.env.
+ *
+ * Behavior:
+ * - If `envFilePath` is provided (via --env flag): load that file, warn if it doesn't exist.
+ * - Otherwise: silently try to load `.env` from the current working directory.
+ * - Existing env vars (set in the shell) are never overwritten (override: false).
+ */
+export function loadDotenvFile(envFilePath: string | undefined): void {
+    if (envFilePath != null) {
+        const resolved = path.resolve(process.cwd(), envFilePath);
+        if (!fs.existsSync(resolved)) {
+            process.stderr.write(`${chalk.yellow("warn")} .env file not found: ${resolved}\n`);
+            return;
+        }
+        dotenvConfig({ path: resolved, override: false });
+        return;
+    }
+
+    // Auto-discover .env in cwd — silent if not present.
+    const defaultEnvFile = path.join(process.cwd(), ".env");
+    if (fs.existsSync(defaultEnvFile)) {
+        dotenvConfig({ path: defaultEnvFile, override: false });
+    }
+}

--- a/packages/cli/cli-v2/src/context/loadDotenvFile.ts
+++ b/packages/cli/cli-v2/src/context/loadDotenvFile.ts
@@ -6,25 +6,23 @@ import path from "path";
 /**
  * Loads environment variables from a .env file into process.env.
  *
- * Behavior:
- * - If `envFilePath` is provided (via --env flag): load that file, warn if it doesn't exist.
- * - Otherwise: silently try to load `.env` from the current working directory.
- * - Existing env vars (set in the shell) are never overwritten (override: false).
+ * Only loads when the user explicitly passes --env <path>. There is no
+ * auto-discovery from the current working directory — silently loading an
+ * untrusted CWD .env could allow workspace-poisoning attacks where a
+ * malicious repo injects variables like FERN_FDR_ORIGIN to redirect API
+ * traffic and exfiltrate auth tokens.
+ *
+ * Existing env vars (set in the shell) are never overwritten (override: false).
  */
 export function loadDotenvFile(envFilePath: string | undefined): void {
-    if (envFilePath != null) {
-        const resolved = path.resolve(process.cwd(), envFilePath);
-        if (!fs.existsSync(resolved)) {
-            process.stderr.write(`${chalk.yellow("warn")} .env file not found: ${resolved}\n`);
-            return;
-        }
-        dotenvConfig({ path: resolved, override: false });
+    if (envFilePath == null) {
         return;
     }
 
-    // Auto-discover .env in cwd — silent if not present.
-    const defaultEnvFile = path.join(process.cwd(), ".env");
-    if (fs.existsSync(defaultEnvFile)) {
-        dotenvConfig({ path: defaultEnvFile, override: false });
+    const resolved = path.resolve(process.cwd(), envFilePath);
+    if (!fs.existsSync(resolved)) {
+        process.stderr.write(`${chalk.yellow("warn")} .env file not found: ${resolved}\n`);
+        return;
     }
+    dotenvConfig({ path: resolved, override: false });
 }

--- a/packages/cli/cli-v2/src/context/loadDotenvFile.ts
+++ b/packages/cli/cli-v2/src/context/loadDotenvFile.ts
@@ -13,8 +13,9 @@ import path from "path";
  * traffic and exfiltrate auth tokens.
  *
  * Existing env vars (set in the shell) are never overwritten (override: false).
+ * Values are never logged — only key names are shown, with <SET> as a placeholder.
  */
-export function loadDotenvFile(envFilePath: string | undefined): void {
+export function loadDotenvFile(envFilePath: string | undefined, logDebug?: (msg: string) => void): void {
     if (envFilePath == null) {
         return;
     }
@@ -24,5 +25,16 @@ export function loadDotenvFile(envFilePath: string | undefined): void {
         process.stderr.write(`${chalk.yellow("warn")} .env file not found: ${resolved}\n`);
         return;
     }
-    dotenvConfig({ path: resolved, override: false });
+
+    const result = dotenvConfig({ path: resolved, override: false });
+
+    if (logDebug != null && result.parsed != null) {
+        const keys = Object.keys(result.parsed);
+        if (keys.length > 0) {
+            // Never log values — use <SET> so the user knows a key was loaded
+            // without revealing the value or its length.
+            const redacted = keys.map((k) => `${k}=<SET>`).join(", ");
+            logDebug(`Loaded from ${resolved}: ${redacted}`);
+        }
+    }
 }

--- a/packages/cli/cli-v2/src/context/loadDotenvFile.ts
+++ b/packages/cli/cli-v2/src/context/loadDotenvFile.ts
@@ -29,12 +29,10 @@ export function loadDotenvFile(envFilePath: string | undefined, logDebug?: (msg:
     const result = dotenvConfig({ path: resolved, override: false });
 
     if (logDebug != null && result.parsed != null) {
-        const keys = Object.keys(result.parsed);
-        if (keys.length > 0) {
-            // Never log values — use <SET> so the user knows a key was loaded
+        for (const key of Object.keys(result.parsed)) {
+            // Never log values — use **** so the user knows a key was loaded
             // without revealing the value or its length.
-            const redacted = keys.map((k) => `${k}=<SET>`).join(", ");
-            logDebug(`Loaded from ${resolved}: ${redacted}`);
+            logDebug(`${key}=****`);
         }
     }
 }

--- a/packages/cli/cli-v2/src/context/withContext.ts
+++ b/packages/cli/cli-v2/src/context/withContext.ts
@@ -51,7 +51,11 @@ export function withContext<T extends GlobalArgs>(
 
 async function createContext(options: GlobalArgs): Promise<Context> {
     const logLevel = parseLogLevel(options["log-level"] ?? "info");
-    loadDotenvFile(options.env);
+    const logDebug =
+        logLevel === LogLevel.Debug
+            ? (msg: string) => process.stderr.write(`${chalk.dim("[debug]")} ${msg}\n`)
+            : undefined;
+    loadDotenvFile(options.env, logDebug);
     return Context.create({
         stdout: process.stdout,
         stderr: process.stderr,

--- a/packages/cli/cli-v2/src/context/withContext.ts
+++ b/packages/cli/cli-v2/src/context/withContext.ts
@@ -8,6 +8,7 @@ import { ValidationError } from "../errors/ValidationError.js";
 import { Icons } from "../ui/format.js";
 import { Context } from "./Context.js";
 import type { GlobalArgs } from "./GlobalArgs.js";
+import { loadDotenvFile } from "./loadDotenvFile.js";
 
 // It's standard to use 128 as the base exit code for signals.
 // https://en.wikipedia.org/wiki/Signal_(IPC)
@@ -50,6 +51,7 @@ export function withContext<T extends GlobalArgs>(
 
 async function createContext(options: GlobalArgs): Promise<Context> {
     const logLevel = parseLogLevel(options["log-level"] ?? "info");
+    loadDotenvFile(options.env);
     return Context.create({
         stdout: process.stdout,
         stderr: process.stderr,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4718,6 +4718,9 @@ importers:
 
   packages/cli/cli-v2:
     dependencies:
+      dotenv:
+        specifier: ^16.0.0
+        version: 16.6.1
       tmp-promise:
         specifier: 'catalog:'
         version: 3.0.3
@@ -11904,6 +11907,10 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
   dprint-node@1.0.8:
     resolution: {integrity: sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg==}
 
@@ -19081,6 +19088,8 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  dotenv@16.6.1: {}
 
   dprint-node@1.0.8:
     dependencies:


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-8737](https://linear.app/buildwithfern/issue/FER-8737/cli-v2-add-support-for-env-file-reading)

Adds `.env` file reading support to CLI v2. Users no longer need to manually re-export environment variables (e.g. `FERN_TOKEN`, `GITHUB_TOKEN`) referenced in `fern.yml` on every shell session.

<img width="817" height="307" alt="iScreen Shoter - Cursor - 260423023630" src="https://github.com/user-attachments/assets/31c286e1-4b8d-4c43-a05f-9768ca8b6811" />


## Changes Made
- Adds a global `--env <path>` flag to load environment variables from a specified file
- Shell env vars always take precedence over `.env` values (`override: false`) — existing exports are never clobbered
- Warns to stderr if `--env` is specified but the file doesn't exist
- No auto-discovery from CWD — avoids workspace-poisoning attacks where a malicious repo could inject `FERN_FDR_ORIGIN` to redirect API traffic and exfiltrate auth tokens
- Extracts `loadDotenvFile()` into its own module (`src/context/loadDotenvFile.ts`) for testability
- Adds `dotenv` as a dependency

## Testing
- [x] Unit tests added (`src/context/__test__/loadDotenvFile.test.ts`) — 5 tests covering explicit `--env`, relative paths, missing file warning, and shell-wins-over-file behavior
- [x] Manual testing completed — verified `--env` flag works with `fern2 auth status`