### PR TITLE
chore(generator-cli): add 0.9.12 version entry for autoversion pipeline + replay 0.12.0

### DIFF
--- a/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.12.yml
+++ b/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.12.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.12, which ships the FER-9980 autoversion
+    pipeline (AutoVersionStep runs between the [fern-generated] commit and replay
+    apply, diffing pure generator output across runs to drive a semver bump and
+    changelog entry via FAI) and pins @fern-api/replay to 0.12.0.
+  type: chore

--- a/generators/typescript/sdk/changes/unreleased/bump-generator-cli-0.9.12.yml
+++ b/generators/typescript/sdk/changes/unreleased/bump-generator-cli-0.9.12.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.12, which ships the FER-9980 autoversion
+    pipeline (AutoVersionStep runs between the [fern-generated] commit and replay
+    apply, diffing pure generator output across runs to drive a semver bump and
+    changelog entry via FAI) and pins @fern-api/replay to 0.12.0.
+  type: chore

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,20 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Implement the FER-9980 autoversion pipeline. A new `GenerationCommitStep` +
+        `AutoVersionStep` run between the `[fern-generated]` commit and replay
+        detect/apply, diffing prev vs new `[fern-generated]` SHAs (both pure
+        generator output), calling Fern AI for a semver bump + changelog entry,
+        rewriting the placeholder version, prepending `changelog.md`, and committing
+        `[fern-autoversion]`. Consumes the two-phase `@fern-api/replay@0.12.0` API
+        (replay is pinned at 0.12.0). Opt-in via `config.autoVersion.enabled`; no
+        behavior change for non-replay flows.
+      type: feat
+  createdAt: "2026-04-23"
+  version: 0.9.12
+
+- changelogEntry:
+    - summary: |
         Sign commits pushed by the GitHub pipeline step. Previously, pull-request
         and push modes in the replay pipeline committed and pushed via plain git
         CLI, producing unsigned commits. Commits are now created via the GitHub

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,7 +60,7 @@ catalog:
   "@fern-api/docs-parsers": 0.0.65
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.1.13-c1ad12a2b8
-  "@fern-api/generator-cli": 0.9.11
+  "@fern-api/generator-cli": 0.9.12
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,7 +60,7 @@ catalog:
   "@fern-api/docs-parsers": 0.0.65
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.1.13-c1ad12a2b8
-  "@fern-api/generator-cli": 0.9.12
+  "@fern-api/generator-cli": 0.9.11
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Description

Pins `@fern-api/generator-cli` to `0.9.12` to cover the FER-9980 autoversion pipeline work merged in #15228, which:
- Added the new `GenerationCommitStep` + `AutoVersionStep` and split replay into `replayPrepare()` / `replayApply()` to enable autoversion between the `[fern-generated]` commit and replay apply.
- Bumped `@fern-api/replay` from `0.11.0` → `0.12.0` (pinned, no caret) in `packages/generator-cli/package.json` to pick up the two-phase API.
- Relocated `AutoVersioningService` / `AutoVersioningCache` / `VersionUtils` from `@fern-api/local-workspace-runner` into `@fern-api/generator-cli/autoversion`.

That PR bumped the Fern CLI (`packages/cli/cli/versions.yml` → `4.90.0`) but did not add a matching `packages/generator-cli/versions.yml` entry, so `@fern-api/generator-cli@0.9.11` on npm is missing the autoversion pipeline. This PR adds `0.9.12` so CI publishes a new `@fern-api/generator-cli` with the feature, and bumps the TS + Python SDK changelogs so they pull in the new generator-cli.

A companion PR in fern-api/fiddle (fern-api/fiddle#712) bumps the `fiddle-coordinator/Dockerfile` from `0.9.11` → `0.9.12` once this is published to npm.

The `pnpm-workspace.yaml` catalog pin for `@fern-api/generator-cli` is intentionally left at `0.9.11` here — bumping it to `0.9.12` in the same PR fails `pnpm install --frozen-lockfile` in CI because the new version isn't on npm yet. The release automation (the same one that produced commit `2f92e7203` "chore(cli): release 4.90.0") will bump the catalog pin after publish completes.

## Changes Made

- `packages/generator-cli/versions.yml`: new `0.9.12` entry (`feat`) documenting the autoversion pipeline + replay `0.12.0` pin.
- `generators/typescript/sdk/changes/unreleased/bump-generator-cli-0.9.12.yml`: `chore` entry on the TS SDK generator.
- `generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.12.yml`: `chore` entry on the Python SDK generator.
- [ ] Updated README.md generator (if applicable) — N/A.

No source/generator behavior is changed in this diff; package.json already pins `@fern-api/replay@0.12.0` (from #15228), and the autoversion code paths were also shipped in that PR.

## Testing

- [x] `pnpm run check` (biome) passes (1 pre-existing unrelated warning in `chunking-large-diff.e2e.test.ts`).
- [x] `pnpm install --frozen-lockfile` passes locally (after reverting the catalog pin change).
- [x] Confirmed `@fern-api/replay@0.12.0` is live on npm and currently pinned in `packages/generator-cli/package.json`.
- [ ] Unit tests added/updated — N/A, versioning + changelog only.
- [ ] Manual testing — N/A; CI will handle publishing `@fern-api/generator-cli@0.9.12`.

## Reviewer checklist

- [ ] Confirm `feat` is the right type for the `0.9.12` entry (autoversion pipeline is a new pipeline step, even though it's opt-in).
- [ ] Confirm scope is correct: only TS + Python SDK generators get changelog bumps; other generators (Java, Go, C#, PHP, Ruby-v2, Rust, Swift) intentionally not bumped, matching the precedent set by #15106 / #14939.
- [ ] Confirm it's fine to leave the `pnpm-workspace.yaml` catalog pin at `0.9.11` in this PR (release automation will bump it after `0.9.12` publishes).

Link to Devin session: https://app.devin.ai/sessions/6683cff4f28846199889da8f8a4bcc43
Requested by: @tstanmay13