### PR TITLE
fix(generator-cli): mark @boundaryml/baml external so dist:cli publishes 0.9.13

### DIFF
--- a/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.13.yml
+++ b/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.13.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.13, which fixes the publish of 0.9.12
+    (autoversion pipeline + @fern-api/replay 0.12.0) by marking @boundaryml/baml
+    as external in the generator-cli CLI bundle so esbuild no longer tries to
+    statically resolve baml's platform-specific native bindings.
+  type: chore

--- a/generators/typescript/sdk/changes/unreleased/bump-generator-cli-0.9.13.yml
+++ b/generators/typescript/sdk/changes/unreleased/bump-generator-cli-0.9.13.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.13, which fixes the publish of 0.9.12
+    (autoversion pipeline + @fern-api/replay 0.12.0) by marking @boundaryml/baml
+    as external in the generator-cli CLI bundle so esbuild no longer tries to
+    statically resolve baml's platform-specific native bindings.
+  type: chore

--- a/packages/generator-cli/build.mjs
+++ b/packages/generator-cli/build.mjs
@@ -25,11 +25,18 @@ async function main() {
         clean: true
     };
 
-    // CLI: bundle everything so it works as a standalone binary
+    // CLI: bundle everything so it works as a standalone binary.
+    // Keep @boundaryml/baml external so esbuild does not try to bundle its
+    // platform-specific native .node files; at runtime it's resolved from
+    // node_modules via the baml dep listed in the published package.json below.
     await tsup.build({
         ...commonConfig,
         entry: ["src/cli.ts"],
-        noExternal: [/.*/]
+        // Match everything EXCEPT @boundaryml/baml so esbuild does not try to
+        // statically bundle baml's platform-specific native .node files; baml
+        // is resolved from node_modules at runtime via the dep in package.json.
+        noExternal: [/^(?!@boundaryml\/baml(\/|$)).*/],
+        external: ["@boundaryml/baml"]
     });
 
     // API: bundle private workspace deps (@fern-api/github, @fern-api/fs-utils),
@@ -38,7 +45,7 @@ async function main() {
         ...commonConfig,
         entry: ["src/api.ts"],
         noExternal: ["@fern-api/github", "@fern-api/fs-utils", "@fern-api/core-utils"],
-        external: ["@fern-api/replay", "@octokit/rest", "es-toolkit", "tmp-promise"],
+        external: ["@fern-api/replay", "@octokit/rest", "es-toolkit", "tmp-promise", "@boundaryml/baml"],
         clean: false
     });
 

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -29,6 +29,7 @@
   },
   "files": ["bin", "dist", "lib"],
   "dependencies": {
+    "@boundaryml/baml": "catalog:",
     "@fern-api/cli-ai": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",

--- a/packages/generator-cli/src/__test__/AutoVersioningCache.test.ts
+++ b/packages/generator-cli/src/__test__/AutoVersioningCache.test.ts
@@ -1,6 +1,7 @@
-import { VersionBump } from "@fern-api/cli-ai";
 import { describe, expect, it } from "vitest";
+
 import { AutoVersioningCache, CachedAnalysis } from "../autoversion/AutoVersioningCache.js";
+import { VersionBump } from "../autoversion/VersionUtils.js";
 
 describe("AutoVersioningCache", () => {
     it("calls AI when no cache entry exists", async () => {

--- a/packages/generator-cli/src/autoversion/AutoVersioningCache.ts
+++ b/packages/generator-cli/src/autoversion/AutoVersioningCache.ts
@@ -1,5 +1,6 @@
-import { VersionBump } from "@fern-api/cli-ai";
 import crypto from "crypto";
+
+import { VersionBump } from "./VersionUtils.js";
 
 /**
  * The raw AI analysis result cached by AutoVersioningCache.

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,21 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix generator-cli publish: mark `@boundaryml/baml` as external in
+        `build.mjs` so esbuild does not try to statically bundle baml's
+        platform-specific `baml.<platform>.node` bindings. baml is now listed as a
+        direct dependency of `@fern-api/generator-cli` and resolved from
+        `node_modules` at runtime. Also switch `AutoVersioningCache` to the local
+        `VersionBump` enum from `./VersionUtils` so the autoversion cache no
+        longer pulls in `@fern-api/cli-ai` just for a type. Unblocks publishing
+        `0.9.12`, whose publish failed in `dist:cli` with repeated
+        `Cannot find module './baml.<platform>.node'` errors.
+      type: fix
+  createdAt: "2026-04-23"
+  version: 0.9.13
+
+- changelogEntry:
+    - summary: |
         Implement the FER-9980 autoversion pipeline. A new `GenerationCommitStep` +
         `AutoVersionStep` run between the `[fern-generated]` commit and replay
         detect/apply, diffing prev vs new `[fern-generated]` SHAs (both pure

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7853,6 +7853,9 @@ importers:
 
   packages/generator-cli:
     dependencies:
+      '@boundaryml/baml':
+        specifier: 'catalog:'
+        version: 0.219.0
       '@fern-api/cli-ai':
         specifier: workspace:*
         version: link:../cli/ai


### PR DESCRIPTION
## Description

Follow-up to #15285. The `0.9.12` entry added there never made it to npm — the `publish-generator-cli` workflow failed in `dist:cli` with 20+ `Cannot find module './baml.<platform>.node'` errors (e.g. run [24813515093](https://github.com/fern-api/fern/actions/runs/24813515093)).

Root cause: PR #15228 introduced `AutoVersionStep` + `AutoVersioningCache` under `packages/generator-cli/src/autoversion/`, which brings in `@fern-api/cli-ai` → `@boundaryml/baml@0.219.0`. `packages/generator-cli/build.mjs` bundles the CLI with `noExternal: [/.*/]` so the resulting `dist/cli.js` is a standalone binary, but esbuild then follows baml's `native.js` and tries to statically resolve every platform-specific `require('./baml.<platform>.node')` — those `.node` files only exist for the current dev platform, so the build errors out for all the others (android-arm, win32-x64, darwin-arm64, linux-s390x, …).

The fix keeps the "bundle everything" story for generator-cli but carves out baml as a true runtime dep:

1. `build.mjs` — `noExternal` regex is now `^(?!@boundaryml\/baml(\/|$)).*` so the bundler skips baml, and `external: ["@boundaryml/baml"]` is added to both the CLI and API builds. Bundled output now emits `require("@boundaryml/baml")`, which node resolves from `node_modules` at runtime.
2. `package.json` — `@boundaryml/baml: "catalog:"` added as a direct dep of `@fern-api/generator-cli` so the published package.json lists it and npm installs it alongside generator-cli.
3. `AutoVersioningCache.ts` (+ its test) — switches from `import { VersionBump } from "@fern-api/cli-ai"` to the local `VersionBump` enum in `./VersionUtils.js`. The file only used it as a type, and `VersionUtils.ts` already exports a compatible local enum (with a comment specifically noting that local and cli-ai enums can both be used). Removes a purely-static runtime import of `cli-ai` from the bundled tree; `AutoVersionStep` still dynamically imports `cli-ai` as before.
4. `versions.yml` — new `0.9.13` `fix` entry published on top of the never-published `0.9.12`; `generators/{typescript,python}/sdk/changes/unreleased/bump-generator-cli-0.9.13.yml` move the SDK chore bump from `0.9.12` to `0.9.13`.

Linear ticket: Refs FER-9980

## Changes Made
- `packages/generator-cli/build.mjs`: mark `@boundaryml/baml` as external in both the CLI (`src/cli.ts`) and API (`src/api.ts`) tsup builds; regex-based `noExternal` for the CLI excludes baml while still force-bundling everything else.
- `packages/generator-cli/package.json`: add `@boundaryml/baml: "catalog:"` to `dependencies` so the published package.json pulls baml as a runtime dep.
- `packages/generator-cli/src/autoversion/AutoVersioningCache.ts`: import `VersionBump` from the local `./VersionUtils.js` instead of `@fern-api/cli-ai`.
- `packages/generator-cli/src/__test__/AutoVersioningCache.test.ts`: matching import swap.
- `packages/generator-cli/versions.yml`: add `0.9.13` (`fix`) entry.
- `generators/typescript/sdk/changes/unreleased/bump-generator-cli-0.9.13.yml` + `generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.13.yml`: `chore` SDK bump entries (supersede the `0.9.12` chore entries already released in `typescript-sdk 3.65.3` / `python-sdk 5.5.10`).
- `pnpm-lock.yaml`: regenerated for the new baml dep.
- [ ] Updated README.md generator (if applicable) — N/A.

## Testing
- [x] `pnpm turbo run dist:cli --filter @fern-api/generator-cli` — previously failed with 20+ `Cannot find module './baml.<platform>.node'` errors, now passes. `dist/cli.js` references `require("@boundaryml/baml")` instead of inlining the native loader.
- [x] `pnpm turbo run test --filter @fern-api/generator-cli` — 358 passed / 1 skipped, including `AutoVersioningCache.test.ts` after the `VersionBump` import swap.
- [x] `pnpm run check` — clean (only a pre-existing unrelated biome warning).
- [x] `pnpm install` — resolves cleanly; `pnpm-workspace.yaml` catalog pin for `@fern-api/generator-cli` still at `0.9.11` to avoid a frozen-lockfile mismatch (same reason as #15285); the release automation bumps the catalog after npm publish.

## Follow-ups
- Once `0.9.13` publishes to npm, re-kick fiddle #712 — I'll also update that PR to pin `@fern-api/generator-cli@0.9.13`.


Link to Devin session: https://app.devin.ai/sessions/6683cff4f28846199889da8f8a4bcc43
Requested by: @tstanmay13