### PR TITLE
chore(deps): bump @fern-api/generator-cli catalog pin to 0.9.16

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: 0.0.6-2ee1b7e28
       version: 0.0.6-2ee1b7e28
     '@fern-api/generator-cli':
-      specifier: 0.9.11
-      version: 0.9.11
+      specifier: 0.9.16
+      version: 0.9.16
     '@fern-api/venus-api-sdk':
       specifier: 0.22.34
       version: 0.22.34
@@ -628,7 +628,7 @@ importers:
         version: link:packages/configs
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.11
+        version: 0.9.16
       '@rolldown/binding-darwin-arm64':
         specifier: 'catalog:'
         version: 1.0.0-rc.5
@@ -697,7 +697,7 @@ importers:
         version: link:../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.11
+        version: 0.9.16
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../packages/ir-sdk
@@ -2437,7 +2437,7 @@ importers:
         version: link:../../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.11
+        version: 0.9.16
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../packages/cli/logger
@@ -9399,13 +9399,8 @@ packages:
   '@fern-api/fdr-sdk@1.1.23-d25ead8e05':
     resolution: {integrity: sha512-fkcBIQSCI8Pj8k+sLf7p/rfwVCIdNjB3Na5XpsAc/af30JTgVlCmcAip7TgxxFeGjfpBprD7k6XDN162E0ppXQ==}
 
-  '@fern-api/generator-cli@0.9.11':
-    resolution: {integrity: sha512-pEaz2APvTjddQ8ohuXuxBvyzfk1QhvSRkDT50GzWZcApPZN0bq8pj+7GRwapjF9K9sM5REo5sTC8XIENWT7EvA==}
-    hasBin: true
-
-  '@fern-api/replay@0.11.0':
-    resolution: {integrity: sha512-RdJMZc3zpmYVHH5UM7ogstG28wycS74Vw8lInT4YD70bJ2LhjgmEnntWLtpHOBAaEhw3nCz8aTk8KUkTXTp4SA==}
-    engines: {node: '>=18'}
+  '@fern-api/generator-cli@0.9.16':
+    resolution: {integrity: sha512-e+vIQog5IKNVIUca/xjxUCxNmUHAiJ3yIdtr+VQ7r1wQt3O55prQhlVtjcSX812+CWP4l3xpf89ON4WdmzDIrQ==}
     hasBin: true
 
   '@fern-api/replay@0.12.0':
@@ -16434,21 +16429,14 @@ snapshots:
       - encoding
       - typescript
 
-  '@fern-api/generator-cli@0.9.11':
+  '@fern-api/generator-cli@0.9.16':
     dependencies:
-      '@fern-api/replay': 0.11.0
+      '@boundaryml/baml': 0.219.0
+      '@fern-api/replay': 0.12.0
       '@octokit/rest': 22.0.1
       es-toolkit: 1.45.1
+      semver: 7.7.4
       tmp-promise: 3.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@fern-api/replay@0.11.0':
-    dependencies:
-      minimatch: 10.2.5
-      node-diff3: 3.2.0
-      simple-git: 3.35.2
-      yaml: 2.8.3
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,7 +59,7 @@ catalog:
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.1.23-d25ead8e05
-  "@fern-api/generator-cli": 0.9.11
+  "@fern-api/generator-cli": 0.9.16
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Description
Linear ticket: Refs FER-9980

Bump the `@fern-api/generator-cli` catalog pin in `pnpm-workspace.yaml` from `0.9.11` to `0.9.16` so that consumer packages (CLI, generators) pick up the autoversion pipeline + replay `0.12.0` shipped in `0.9.12`/`0.9.15`, plus the bundling fix shipped in `0.9.16` ([#15314](https://github.com/fern-api/fern/pull/15314)).

The release automation that previously bumped the catalog after publish stopped doing so with `0.9.12+`, so this is a manual catch-up.

## Why 0.9.16 and not 0.9.13/0.9.14/0.9.15
`0.9.13`/`0.9.14`/`0.9.15` all shipped a phantom dep in `dist/api.js` — `require("@fern-api/logging-execa")` (etc.) without a matching entry in the published `package.json` `dependencies`. This worked at install-time via pnpm hoisting but broke Vite/Vitest module resolution in consumer packages with:

```
Error: Cannot find module '.../logging-execa/src/createLoggingExecutable.js' imported from .../logging-execa/src/index.ts
  code: 'ERR_MODULE_NOT_FOUND'
```

Notably this manifested in `@fern-api/openapi-generator` tests on the previous version of this PR. `0.9.16` ([#15314](https://github.com/fern-api/fern/pull/15314)) bundles the workspace deps into `dist/api.js` so the phantom dep is gone.

## Changes
- `pnpm-workspace.yaml`: catalog pin `0.9.11` → `0.9.16`.
- `pnpm-lock.yaml`: regenerated via `pnpm install`. New transitive deps: `@boundaryml/baml@0.219.0` (resolved at runtime by the published bundle, kept external in `dist/api.js`), `semver@7.7.4`. Old `@fern-api/generator-cli@0.9.11` and `@fern-api/replay@0.11.0` entries dropped.

## Testing
- [x] `pnpm install` clean.
- [x] Locally re-ran the previously failing test on this branch state:
  ```
  $ cd generators/openapi && pnpm vitest run src/__test__/nullability.test.ts
  Test Files  1 passed (1)
       Tests  6 passed (6)
  ```
- [ ] CI on this PR.


Link to Devin session: https://app.devin.ai/sessions/6683cff4f28846199889da8f8a4bcc43
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
