### PR TITLE
fix(generator-cli): strip preparedReplay from result before stdout emission

### DIFF
--- a/packages/generator-cli/src/__test__/post-generation-pipeline-serialization.test.ts
+++ b/packages/generator-cli/src/__test__/post-generation-pipeline-serialization.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PipelineLogger } from "../pipeline/index.js";
+import { PostGenerationPipeline } from "../pipeline/index.js";
+import { GenerationCommitStep } from "../pipeline/steps/GenerationCommitStep.js";
+import type { GenerationCommitStepResult } from "../pipeline/types.js";
+
+const silentLogger: PipelineLogger = {
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined
+};
+
+describe("PostGenerationPipeline serialization", () => {
+    it("produces a JSON-serializable result when GenerationCommitStep returns a circular preparedReplay", async () => {
+        // Simulate the real-world shape: `simple-git`'s internal `GitExecutor`/
+        // `GitExecutorChain` form a cycle that poisons `JSON.stringify` if the
+        // handle leaks onto `result.steps.generationCommit`.
+        const circular: { self?: unknown } = {};
+        circular.self = circular;
+
+        const mockResult = {
+            executed: true,
+            success: true,
+            preparedReplay: circular as never,
+            previousGenerationSha: "prev-sha",
+            currentGenerationSha: "curr-sha",
+            baseBranchHead: "base-sha",
+            flow: "normal-regeneration"
+        } satisfies GenerationCommitStepResult;
+
+        const executeSpy = vi.spyOn(GenerationCommitStep.prototype, "execute").mockResolvedValue(mockResult);
+
+        try {
+            const pipeline = new PostGenerationPipeline(
+                {
+                    outputDir: "/tmp/fake",
+                    replay: { enabled: true }
+                },
+                silentLogger
+            );
+            const result = await pipeline.run();
+
+            expect(() => JSON.stringify(result)).not.toThrow();
+
+            expect(result.steps.generationCommit?.previousGenerationSha).toBe("prev-sha");
+            expect(result.steps.generationCommit?.currentGenerationSha).toBe("curr-sha");
+            expect(result.steps.generationCommit?.baseBranchHead).toBe("base-sha");
+            expect(result.steps.generationCommit?.flow).toBe("normal-regeneration");
+            expect(result.steps.generationCommit?.preparedReplay).toBeUndefined();
+        } finally {
+            executeSpy.mockRestore();
+        }
+    });
+});

--- a/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
+++ b/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
@@ -121,8 +121,16 @@ export class PostGenerationPipeline {
                 const stepResult = await step.execute(pipelineContext);
 
                 if (step.name === "generationCommit") {
-                    result.steps.generationCommit = stepResult as GenerationCommitStepResult;
-                    pipelineContext.previousStepResults.generationCommit = stepResult as GenerationCommitStepResult;
+                    const gcResult = stepResult as GenerationCommitStepResult;
+                    // `preparedReplay` holds a live `simple-git` instance whose internal
+                    // `GitExecutor`/`GitExecutorChain` form a circular reference, which
+                    // causes `JSON.stringify(result)` at stdout emission to throw. Keep
+                    // the full object in the pipeline context so downstream steps
+                    // (AutoVersionStep, ReplayStep) still receive it, but strip it from
+                    // the serializable `result.steps.generationCommit`.
+                    const { preparedReplay: _preparedReplay, ...serializable } = gcResult;
+                    result.steps.generationCommit = serializable as GenerationCommitStepResult;
+                    pipelineContext.previousStepResults.generationCommit = gcResult;
                 } else if (step.name === "replay") {
                     result.steps.replay = stepResult as ReplayStepResult;
                     pipelineContext.previousStepResults.replay = stepResult as ReplayStepResult;

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,23 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix `pipeline run` crashing on stdout emission for replay-enabled runs.
+        `GenerationCommitStep`'s `preparedReplay` handle holds a live `simple-git`
+        instance whose internal `GitExecutor`/`GitExecutorChain` form a cycle, so
+        `JSON.stringify(result)` at the end of `PostGenerationPipeline` threw
+        `Converting circular structure to JSON` and the process exited non-zero
+        with empty stdout — blocking fiddle-coordinator from parsing
+        `PipelineResult` for replay-enabled orgs (FER-10026, FER-9982). The
+        `preparedReplay` field is now projected out of `result.steps.generationCommit`
+        before stdout emission while still flowing through
+        `pipelineContext.previousStepResults.generationCommit` to downstream steps
+        (AutoVersionStep, ReplayStep).
+      type: fix
+  createdAt: "2026-04-23"
+  version: 0.9.14
+
+- changelogEntry:
+    - summary: |
         Fix generator-cli publish: mark `@boundaryml/baml` as external in
         `build.mjs` so esbuild does not try to statically bundle baml's
         platform-specific `baml.<platform>.node` bindings. baml is now listed as a


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-10026](https://linear.app/buildwithfern/issue/FER-10026/generator-cli-0913-generator-cli-pipeline-run-crashes-with-circular). Refs [FER-9978](https://linear.app/buildwithfern/issue/FER-9978/epic-move-sdk-autoversioning-into-the-genator-cli-pipeline), [FER-9982](https://linear.app/buildwithfern/issue/FER-9982/fiddle-integration-pass-autoversionstepconfig-read-autoversionresult).

`@fern-api/generator-cli@0.9.13`'s `pipeline run` command crashes at the end of the pipeline when `replay.enabled: true`, emitting **no stdout** and exiting non-zero despite the pipeline itself running successfully. This blocks the FER-9978 epic's fiddle integration (FER-9982): `fiddle-coordinator` invokes `generator-cli pipeline run --config <json>` and parses stdout as `PipelineResult` — with empty stdout there is nothing to parse, so the delegation path to the pipeline-owned autoversion (for replay-enabled orgs) is broken.

### Root cause

`GenerationCommitStep` (added in [#15228](https://github.com/fern-api/fern/pull/15228) as part of FER-9980) returns a `GenerationCommitStepResult` that includes a `preparedReplay?: PreparedReplay` handle. `PreparedReplay` holds a live `simple-git` instance whose internal `GitExecutor`/`GitExecutorChain` form a true cycle (`_chain._executor` points back at its parent). `PostGenerationPipeline` assigned the full object onto `result.steps.generationCommit`, and `src/cli.ts` does:

```ts
process.stdout.write(JSON.stringify(result) + "\n");
```

`JSON.stringify` throws `Converting circular structure to JSON`, the exception is unhandled, the process exits 1 and never writes stdout. Observed failure mode:

```
Pipeline succeeded
Replay: 1 patches applied (0 conflicts)
Pipeline failed: Converting circular structure to JSON
    --> starting at object with constructor 'GitExecutor'
    |     property '_chain' -> object with constructor 'GitExecutorChain'
    --- property '_executor' closes the circle
```

### Fix

Project `preparedReplay` out of `result.steps.generationCommit` before stdout emission, but keep the full object on `pipelineContext.previousStepResults.generationCommit` so downstream steps (`AutoVersionStep`, `ReplayStep`) continue to consume the handle. The shape of the stdout JSON is the only thing that changes; the fiddle-side Java `PipelineResult` DTO doesn't consume `preparedReplay` anyway.

Aligned with the [FER-9978](https://linear.app/buildwithfern/issue/FER-9978/epic-move-sdk-autoversioning-into-the-genator-cli-pipeline) epic's pipeline order (GenerationCommit → AutoVersion → Replay → GitHub): every step still receives the prepared handle via `pipelineContext.previousStepResults`, only the terminal stdout serialization is sanitized.

## Changes Made
- `packages/generator-cli/src/pipeline/PostGenerationPipeline.ts`: destructure `preparedReplay` out of the serializable `result.steps.generationCommit`; keep the full `GenerationCommitStepResult` (including `preparedReplay`) on `pipelineContext.previousStepResults.generationCommit` for downstream steps.
- `packages/generator-cli/src/__test__/post-generation-pipeline-serialization.test.ts`: regression test that stubs `GenerationCommitStep.execute` to return a circular `preparedReplay`, runs the pipeline with `replay.enabled: true`, and asserts `JSON.stringify(result)` does not throw and that `result.steps.generationCommit` still carries `previousGenerationSha`, `currentGenerationSha`, `baseBranchHead`, and `flow` while `preparedReplay` is projected out.
- `packages/generator-cli/versions.yml`: add `0.9.14` entry.

## Testing
- [x] Unit tests added/updated — `post-generation-pipeline-serialization.test.ts` fails on `main` (circular JSON throws) and passes with the fix.
- [x] `pnpm turbo run test --filter @fern-api/generator-cli` — 37 test files / 359 tests passing (1 skipped, pre-existing).
- [x] `pnpm run check` — no new errors.


Link to Devin session: https://app.devin.ai/sessions/01f7eefaa9b14116bf42272dcc6f7ae7
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
