### PR TITLE
fix(generator-cli): rewrite version placeholder on NO_CHANGE and auto-wire GithubStep PR body from AutoVersionStep

### DIFF
--- a/packages/generator-cli/src/__test__/auto-version-step.execute.test.ts
+++ b/packages/generator-cli/src/__test__/auto-version-step.execute.test.ts
@@ -271,15 +271,13 @@ describe("AutoVersionStep.execute() — normal MINOR flow", () => {
         expect(pkg.version).toBe("1.0.1");
     });
 
-    it("returns NO_CHANGE without creating a new commit", async () => {
+    it("on NO_CHANGE, rewrites the placeholder to previousVersion and commits [fern-autoversion]", async () => {
         mockAnalyzeSdkDiff.mockResolvedValue({
             version_bump: "NO_CHANGE",
             message: "",
             changelog_entry: "",
             version_bump_reason: ""
         });
-
-        const headBefore = gitExec(["rev-parse", "HEAD"], repo.repoPath);
 
         const step = new AutoVersionStep(repo.repoPath, makeLogger(), baseConfig);
         const prepared = fakePreparedReplay({
@@ -290,11 +288,20 @@ describe("AutoVersionStep.execute() — normal MINOR flow", () => {
 
         const result = await step.execute(makeContext(prepared));
 
+        expect(result.success).toBe(true);
         expect(result.versionBump).toBe("NO_CHANGE");
-        expect(result.commitSha).toBeUndefined();
+        expect(result.version).toBe("1.0.0");
+        expect(result.previousVersion).toBe("1.0.0");
+        expect(result.commitSha).toMatch(/^[0-9a-f]{40}$/);
+        expect(result.commitMessage).toContain("SDK regeneration");
 
-        const headAfter = gitExec(["rev-parse", "HEAD"], repo.repoPath);
-        expect(headAfter).toBe(headBefore);
+        const pkg = JSON.parse(readFileSync(join(repo.repoPath, "package.json"), "utf-8")) as {
+            version: string;
+        };
+        expect(pkg.version).toBe("1.0.0");
+
+        const head = gitExec(["log", "-1", "--format=%B"], repo.repoPath);
+        expect(head).toContain("[fern-autoversion]");
     });
 
     it("omits the Fern trailer when isWhitelabel is true", async () => {

--- a/packages/generator-cli/src/__test__/github-step-autoversion-fallback.test.ts
+++ b/packages/generator-cli/src/__test__/github-step-autoversion-fallback.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import { parseCommitMessageForPR } from "../pipeline/github/parseCommitMessage.js";
+import { enrichPrBodyForAutomation, resolvePrFields, shouldEnableAutomerge } from "../pipeline/steps/GithubStep.js";
+import type { AutoVersionStepResult, GithubStepConfig } from "../pipeline/types.js";
+
+// Regression coverage for FER-10029: GithubStep must read autoVersion results
+// from `previousStepResults.autoVersion` as a fallback for PR-body fields that
+// consumers like fiddle cannot populate at config-emission time (because those
+// fields are pipeline outputs, not inputs).
+
+const baseConfig: GithubStepConfig = {
+    enabled: true,
+    uri: "owner/repo",
+    token: "tkn",
+    mode: "pull-request"
+};
+
+const autoVersion: AutoVersionStepResult = {
+    executed: true,
+    success: true,
+    version: "2.0.0",
+    previousVersion: "1.3.0",
+    versionBump: "MAJOR",
+    commitMessage: "feat!: drop support for legacy endpoints",
+    changelogEntry: "### 2.0.0\n- Removed legacy /v1 endpoints",
+    prDescription: "Removed legacy /v1 endpoints.\n\n```diff\n- client.v1.list()\n+ client.v2.list()\n```",
+    versionBumpReason: "Removed public methods on the generated client.",
+    commitSha: "a".repeat(40)
+};
+
+describe("resolvePrFields", () => {
+    it("falls back to autoVersion for every PR-body field when config is empty", () => {
+        const resolved = resolvePrFields(baseConfig, autoVersion);
+
+        expect(resolved.commitMessage).toBe("feat!: drop support for legacy endpoints");
+        expect(resolved.changelogEntry).toBe(autoVersion.changelogEntry);
+        expect(resolved.prDescription).toBe(autoVersion.prDescription);
+        expect(resolved.versionBumpReason).toBe(autoVersion.versionBumpReason);
+        expect(resolved.previousVersion).toBe("1.3.0");
+        expect(resolved.newVersion).toBe("2.0.0");
+        expect(resolved.versionBump).toBe("MAJOR");
+        expect(resolved.hasBreakingChanges).toBe(true);
+        expect(resolved.breakingChangesSummary).toBe(autoVersion.prDescription);
+    });
+
+    it("explicit config fields win over autoVersion (same policy as skipCommit / replayConflictInfo)", () => {
+        const resolved = resolvePrFields(
+            {
+                ...baseConfig,
+                commitMessage: "chore: manual override",
+                changelogEntry: "### manual",
+                prDescription: "manual description",
+                versionBumpReason: "manual reason",
+                previousVersion: "9.9.9",
+                newVersion: "10.0.0",
+                versionBump: "PATCH",
+                hasBreakingChanges: false,
+                breakingChangesSummary: "manual summary"
+            },
+            autoVersion
+        );
+
+        expect(resolved).toStrictEqual({
+            commitMessage: "chore: manual override",
+            changelogEntry: "### manual",
+            prDescription: "manual description",
+            versionBumpReason: "manual reason",
+            previousVersion: "9.9.9",
+            newVersion: "10.0.0",
+            versionBump: "PATCH",
+            hasBreakingChanges: false,
+            breakingChangesSummary: "manual summary"
+        });
+    });
+
+    it("defaults commitMessage to 'SDK Generation' when neither config nor autoVersion provides one", () => {
+        const resolved = resolvePrFields(baseConfig, undefined);
+        expect(resolved.commitMessage).toBe("SDK Generation");
+        expect(resolved.hasBreakingChanges).toBe(false);
+    });
+
+    it("NO_CHANGE autoVersion does not flip hasBreakingChanges to true", () => {
+        const resolved = resolvePrFields(baseConfig, {
+            executed: true,
+            success: true,
+            version: "1.3.0",
+            previousVersion: "1.3.0",
+            versionBump: "NO_CHANGE"
+        });
+
+        expect(resolved.hasBreakingChanges).toBe(false);
+        expect(resolved.newVersion).toBe("1.3.0");
+        expect(resolved.previousVersion).toBe("1.3.0");
+    });
+});
+
+describe("PR body composition with autoVersion fallback", () => {
+    it("renders a breaking-change version header from autoVersion context alone", () => {
+        const resolved = resolvePrFields(baseConfig, autoVersion);
+        const { prTitle, prBody } = parseCommitMessageForPR(
+            resolved.commitMessage,
+            resolved.changelogEntry,
+            resolved.prDescription,
+            resolved.versionBumpReason,
+            resolved.previousVersion,
+            resolved.newVersion,
+            resolved.versionBump
+        );
+
+        expect(prTitle).toBe("feat!: drop support for legacy endpoints");
+        expect(prBody).toContain("## \u26A0\uFE0F 1.3.0 \u2192 2.0.0");
+        expect(prBody).toContain("**Breaking:** Removed public methods on the generated client.");
+        expect(prBody).toContain("Removed legacy /v1 endpoints.");
+    });
+
+    it("automationMode breaking-changes section is populated from autoVersion.prDescription", () => {
+        const resolved = resolvePrFields({ ...baseConfig, automationMode: true }, autoVersion);
+        const enriched = enrichPrBodyForAutomation(
+            "body",
+            { ...baseConfig, automationMode: true },
+            { hasBreakingChanges: resolved.hasBreakingChanges, breakingChangesSummary: resolved.breakingChangesSummary }
+        );
+
+        expect(enriched).toContain("## \u26A0\uFE0F Breaking Changes");
+        expect(enriched).toContain("Removed legacy /v1 endpoints.");
+    });
+
+    it("autoVersion MAJOR bump blocks automerge even when config.hasBreakingChanges is unset", () => {
+        const resolved = resolvePrFields({ ...baseConfig, automationMode: true, autoMerge: true }, autoVersion);
+
+        expect(
+            shouldEnableAutomerge(
+                { ...baseConfig, automationMode: true, autoMerge: true },
+                { hasBreakingChanges: resolved.hasBreakingChanges }
+            )
+        ).toBe(false);
+    });
+
+    it("non-MAJOR autoVersion bump allows automerge in automation mode", () => {
+        const minorAutoVersion: AutoVersionStepResult = {
+            executed: true,
+            success: true,
+            version: "1.4.0",
+            previousVersion: "1.3.0",
+            versionBump: "MINOR"
+        };
+        const resolved = resolvePrFields({ ...baseConfig, automationMode: true, autoMerge: true }, minorAutoVersion);
+
+        expect(
+            shouldEnableAutomerge(
+                { ...baseConfig, automationMode: true, autoMerge: true },
+                { hasBreakingChanges: resolved.hasBreakingChanges }
+            )
+        ).toBe(true);
+    });
+});

--- a/packages/generator-cli/src/pipeline/steps/AutoVersionStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/AutoVersionStep.ts
@@ -145,14 +145,28 @@ export class AutoVersionStep extends BaseStep {
         const { prepared, service, language, mappedMagicVersion, previousGenerationSha } = params;
 
         const rawDiff = this.gitDiff(previousGenerationSha, prepared.currentGenerationSha);
-        if (rawDiff.trim().length === 0) {
-            this.logger.info("AutoVersionStep: empty diff between generations; skipping autoversion.");
-            return { executed: true, success: true };
-        }
 
         const previousVersion = await this.resolvePreviousVersion({ service, rawDiff, mappedMagicVersion });
         if (previousVersion == null) {
             return await this.handleFirstGeneration({ service, language, mappedMagicVersion });
+        }
+
+        // Even when the two [fern-generated] trees are byte-identical, the
+        // current working tree still has the placeholder from this run's
+        // generator output. We must rewrite it to `previousVersion` before
+        // exiting or the SDK ships with `0.0.0-fern-placeholder` baked into
+        // its manifests and user-agent strings.
+        if (rawDiff.trim().length === 0) {
+            this.logger.info(
+                `AutoVersionStep: empty diff between generations; rewriting placeholder to ${previousVersion}.`
+            );
+            return await this.finalizeNoChange({
+                service,
+                language,
+                mappedMagicVersion,
+                previousVersion,
+                reason: "no diff between generations"
+            });
         }
 
         const cleanedDiff = service.cleanDiffForAI(rawDiff, mappedMagicVersion);
@@ -164,8 +178,16 @@ export class AutoVersionStep extends BaseStep {
         );
 
         if (cleanedDiff.trim().length === 0) {
-            this.logger.info("AutoVersionStep: cleaned diff is empty; no semantic changes.");
-            return { executed: true, success: true };
+            this.logger.info(
+                `AutoVersionStep: cleaned diff is empty; no semantic changes — rewriting placeholder to ${previousVersion}.`
+            );
+            return await this.finalizeNoChange({
+                service,
+                language,
+                mappedMagicVersion,
+                previousVersion,
+                reason: "no semantic changes"
+            });
         }
 
         if (cleanedBytes > MAX_RAW_DIFF_BYTES) {
@@ -204,13 +226,14 @@ export class AutoVersionStep extends BaseStep {
         }
 
         if (analysis == null) {
-            this.logger.info("AutoVersionStep: FAI returned NO_CHANGE; skipping autoversion commit.");
-            return {
-                executed: true,
-                success: true,
+            this.logger.info(`AutoVersionStep: FAI returned NO_CHANGE; rewriting placeholder to ${previousVersion}.`);
+            return await this.finalizeNoChange({
+                service,
+                language,
+                mappedMagicVersion,
                 previousVersion,
-                versionBump: "NO_CHANGE"
-            };
+                reason: "FAI returned NO_CHANGE"
+            });
         }
 
         return await this.finalizeWithBump({
@@ -220,6 +243,56 @@ export class AutoVersionStep extends BaseStep {
             previousVersion,
             analysis
         });
+    }
+
+    /**
+     * Terminal path for runs that determine no semver bump is needed. The
+     * current working tree still contains `0.0.0-fern-placeholder` from this
+     * run's generator output, so we must rewrite it to `previousVersion`
+     * before exiting — otherwise the SDK ships with the placeholder embedded
+     * in manifests (package.json, pyproject.toml, .fern/metadata.json) and
+     * user-agent strings (e.g. `X-Fern-SDK-Version`). Commits the rewrite as
+     * `[fern-autoversion]` so the replay + github steps see a stable base.
+     */
+    private async finalizeNoChange(params: {
+        service: AutoVersioningService;
+        language: string;
+        mappedMagicVersion: string;
+        previousVersion: string;
+        reason: string;
+    }): Promise<AutoVersionStepResult> {
+        const { service, language, mappedMagicVersion, previousVersion, reason } = params;
+
+        // `previousVersion` flows into the same `bash -c` + single-quoted sed
+        // expression that `handleFirstGeneration` guards against with
+        // `isValidSemver`. Extraction (regex), metadata.json, and git tags
+        // are all user-influenced surfaces — reject anything that isn't a
+        // clean semver rather than let it escape shell quoting.
+        if (!isValidSemver(previousVersion)) {
+            const errorMessage =
+                `AutoVersionStep: resolved previousVersion ${JSON.stringify(previousVersion)} is not a ` +
+                `valid semver string. Refusing to rewrite placeholder to avoid shell injection.`;
+            this.logger.error(errorMessage);
+            return { executed: true, success: false, errorMessage };
+        }
+
+        await service.replaceMagicVersion(this.outputDir, mappedMagicVersion, previousVersion);
+        if (language === "go") {
+            await service.addGoMajorVersionSuffix(this.outputDir, previousVersion);
+        }
+
+        const commitMessage = this.brandMessage(`SDK regeneration (no semver change: ${reason})`);
+        const commitSha = this.commitAutoversion(commitMessage);
+
+        return {
+            executed: true,
+            success: true,
+            version: previousVersion,
+            previousVersion,
+            versionBump: "NO_CHANGE",
+            commitMessage,
+            commitSha
+        };
     }
 
     private async finalizeWithBump(params: {

--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -9,7 +9,13 @@ import { parseCommitMessageForPR } from "../github/parseCommitMessage";
 import { pushSignedCommit } from "../github/pushSignedCommit";
 import type { PipelineLogger } from "../PipelineLogger";
 import { formatReplayPrBody } from "../replay-summary";
-import type { GithubStepConfig, GithubStepResult, PipelineContext, ReplayStepResult } from "../types";
+import type {
+    AutoVersionStepResult,
+    GithubStepConfig,
+    GithubStepResult,
+    PipelineContext,
+    ReplayStepResult
+} from "../types";
 import { BaseStep } from "./BaseStep";
 
 export class GithubStep extends BaseStep {
@@ -25,8 +31,10 @@ export class GithubStep extends BaseStep {
 
     async execute(context: PipelineContext): Promise<GithubStepResult> {
         const replayResult = context.previousStepResults.replay;
+        const autoVersionResult = context.previousStepResults.autoVersion;
         const skipCommit = this.config.skipCommit ?? this.deriveSkipCommit(replayResult);
         const replayConflictInfo = this.config.replayConflictInfo ?? this.deriveReplayConflictInfo(replayResult);
+        const resolvedPrFields = this.resolvePrFields(autoVersionResult);
 
         try {
             this.logger.debug("Starting GitHub self-hosted flow in directory: " + this.outputDir);
@@ -59,10 +67,11 @@ export class GithubStep extends BaseStep {
                         newPrBranch,
                         skipCommit,
                         replayConflictInfo,
-                        replayResult
+                        replayResult,
+                        resolvedPrFields
                     );
                 case "push":
-                    return await this.executePushMode(repository);
+                    return await this.executePushMode(repository, resolvedPrFields);
                 default: {
                     const exhaustive: never = mode;
                     throw new Error(`Unexpected GitHub mode: ${String(exhaustive)}`);
@@ -89,7 +98,8 @@ export class GithubStep extends BaseStep {
                   currentGenerationSha: string;
               }
             | undefined,
-        replayResult: ReplayStepResult | undefined
+        replayResult: ReplayStepResult | undefined,
+        resolved: ResolvedPrFields
     ): Promise<GithubStepResult> {
         const baseBranch = this.config.branch ?? (await repository.getDefaultBranch());
         const octokit = new Octokit({ auth: this.config.token });
@@ -130,7 +140,7 @@ export class GithubStep extends BaseStep {
                     generationBaseSha = await createReplayBranch(
                         repository,
                         prBranch,
-                        this.config.commitMessage,
+                        resolved.commitMessage,
                         replayConflictInfo,
                         this.logger
                     );
@@ -154,8 +164,7 @@ export class GithubStep extends BaseStep {
             await this.ensureFernignore();
 
             this.logger.debug("Committing changes...");
-            const finalCommitMessage = this.config.commitMessage ?? "SDK Generation";
-            await repository.commitAllChanges(finalCommitMessage);
+            await repository.commitAllChanges(resolved.commitMessage);
             this.logger.debug(`Committed changes to local copy of GitHub repository at ${this.outputDir}`);
         }
 
@@ -208,24 +217,23 @@ export class GithubStep extends BaseStep {
             }
         }
 
-        const finalCommitMessage = this.config.commitMessage ?? "SDK Generation";
         const headSha = await repository.getHeadSha();
-        const changelogUrl = this.config.changelogEntry
+        const changelogUrl = resolved.changelogEntry
             ? `https://github.com/${this.config.uri}/blob/${headSha}/changelog.md`
             : undefined;
         const { prTitle, prBody } = parseCommitMessageForPR(
-            finalCommitMessage,
-            this.config.changelogEntry,
-            this.config.prDescription,
-            this.config.versionBumpReason,
-            this.config.previousVersion,
-            this.config.newVersion,
-            this.config.versionBump,
+            resolved.commitMessage,
+            resolved.changelogEntry,
+            resolved.prDescription,
+            resolved.versionBumpReason,
+            resolved.previousVersion,
+            resolved.newVersion,
+            resolved.versionBump,
             changelogUrl
         );
         const replaySection = formatReplayPrBody(replayResult, { branchName: prBranch, repoUri: this.config.uri });
         let enrichedBody = replaySection != null ? prBody + "\n\n---\n\n" + replaySection : prBody;
-        enrichedBody = enrichPrBodyForAutomation(enrichedBody, this.config);
+        enrichedBody = enrichPrBodyForAutomation(enrichedBody, this.config, resolved);
 
         if (isUpdatingExistingPR && existingPR != null) {
             this.logger.info(`Updated existing pull request: ${existingPR.htmlUrl}`);
@@ -264,7 +272,7 @@ export class GithubStep extends BaseStep {
                 // In automation mode, enable GitHub automerge on non-breaking PRs.
                 // Uses the built-in octokit.graphql() from @octokit/core (no extra dependency).
                 // The SDK repo's own branch protection rules govern whether the PR actually merges.
-                if (shouldEnableAutomerge(this.config) && pullRequest.node_id) {
+                if (shouldEnableAutomerge(this.config, resolved) && pullRequest.node_id) {
                     try {
                         await octokit.graphql(
                             `mutation($pullRequestId: ID!) {
@@ -295,7 +303,7 @@ export class GithubStep extends BaseStep {
         return result;
     }
 
-    private async executePushMode(repository: ClonedRepository): Promise<GithubStepResult> {
+    private async executePushMode(repository: ClonedRepository, resolved: ResolvedPrFields): Promise<GithubStepResult> {
         const baseBranch = this.config.branch ?? (await repository.getDefaultBranch());
 
         if (this.config.branch != null) {
@@ -306,8 +314,7 @@ export class GithubStep extends BaseStep {
         await this.ensureFernignore();
 
         this.logger.debug("Committing changes...");
-        const finalCommitMessage = this.config.commitMessage ?? "SDK Generation";
-        await repository.commitAllChanges(finalCommitMessage);
+        await repository.commitAllChanges(resolved.commitMessage);
         this.logger.debug(`Committed changes to local copy of GitHub repository at ${this.outputDir}`);
 
         // When skipIfNoDiff is enabled, detect no-diff before pushing
@@ -384,25 +391,85 @@ export class GithubStep extends BaseStep {
         }
         return undefined;
     }
+
+    private resolvePrFields(autoVersion: AutoVersionStepResult | undefined): ResolvedPrFields {
+        return resolvePrFields(this.config, autoVersion);
+    }
+}
+
+export interface ResolvedPrFields {
+    /** Always populated — falls back to "SDK Generation" when neither config nor autoVersion provides one. */
+    commitMessage: string;
+    changelogEntry: string | undefined;
+    prDescription: string | undefined;
+    versionBumpReason: string | undefined;
+    previousVersion: string | undefined;
+    newVersion: string | undefined;
+    versionBump: string | undefined;
+    hasBreakingChanges: boolean;
+    breakingChangesSummary: string | undefined;
+}
+
+/**
+ * Merges PR-body fields from explicit `GithubStepConfig` with `AutoVersionStep`
+ * results in `previousStepResults.autoVersion`. Explicit config values always
+ * win — same policy as `skipCommit` / `replayConflictInfo`.
+ *
+ * Consumers that delegate autoversion to the pipeline (e.g. fiddle post-FER-9982)
+ * cannot populate these fields at config-emission time because they're pipeline
+ * outputs, not inputs. Without this fallback the PR body would ship without a
+ * version header, changelog entry, or breaking-change warning even when
+ * `AutoVersionStep` computed real values.
+ *
+ * `hasBreakingChanges` / `breakingChangesSummary` are derived from the autoVersion
+ * result as well so automerge (which disables on breaking changes) and the
+ * automation-mode Breaking Changes section stay consistent with the version
+ * header rendered by `parseCommitMessageForPR`.
+ *
+ * Exported for testing.
+ */
+export function resolvePrFields(
+    config: GithubStepConfig,
+    autoVersion: AutoVersionStepResult | undefined
+): ResolvedPrFields {
+    const autoVersionBreaking = autoVersion?.versionBump === "MAJOR";
+    return {
+        commitMessage: config.commitMessage ?? autoVersion?.commitMessage ?? "SDK Generation",
+        changelogEntry: config.changelogEntry ?? autoVersion?.changelogEntry,
+        prDescription: config.prDescription ?? autoVersion?.prDescription,
+        versionBumpReason: config.versionBumpReason ?? autoVersion?.versionBumpReason,
+        previousVersion: config.previousVersion ?? autoVersion?.previousVersion,
+        newVersion: config.newVersion ?? autoVersion?.version,
+        versionBump: config.versionBump ?? autoVersion?.versionBump,
+        hasBreakingChanges: config.hasBreakingChanges ?? autoVersionBreaking,
+        breakingChangesSummary: config.breakingChangesSummary ?? autoVersion?.prDescription
+    };
 }
 
 /**
  * Appends automation-specific sections to the PR body.
  * Exported for testing.
+ *
+ * `breaking` carries the derived hasBreakingChanges + breakingChangesSummary that
+ * may come from either explicit config or `AutoVersionStep`'s result. Callers
+ * outside the step pass an empty object to preserve the config-only behavior.
  */
 export function enrichPrBodyForAutomation(
     body: string,
-    config: { automationMode?: boolean; hasBreakingChanges?: boolean; breakingChangesSummary?: string; runId?: string }
+    config: { automationMode?: boolean; hasBreakingChanges?: boolean; breakingChangesSummary?: string; runId?: string },
+    breaking: { hasBreakingChanges?: boolean; breakingChangesSummary?: string } = {}
 ): string {
     if (!config.automationMode) {
         return body;
     }
+    const hasBreakingChanges = breaking.hasBreakingChanges ?? config.hasBreakingChanges;
+    const breakingChangesSummary = breaking.breakingChangesSummary ?? config.breakingChangesSummary;
     let result = body;
-    if (config.hasBreakingChanges && config.breakingChangesSummary) {
+    if (hasBreakingChanges && breakingChangesSummary) {
         result +=
             "\n\n---\n\n## ⚠️ Breaking Changes\n\n" +
             "This release contains breaking changes that require manual review:\n\n" +
-            config.breakingChangesSummary;
+            breakingChangesSummary;
     }
     if (config.runId) {
         result += `\n\n---\n\n_Fern Run ID: \`${config.runId}\`_`;
@@ -413,13 +480,17 @@ export function enrichPrBodyForAutomation(
 /**
  * Determines whether automerge should be enabled on a PR.
  * Exported for testing.
+ *
+ * `breaking` carries the derived hasBreakingChanges that may come from either
+ * explicit config or `AutoVersionStep`'s result. Callers outside the step pass
+ * an empty object to preserve the config-only behavior.
  */
-export function shouldEnableAutomerge(config: {
-    automationMode?: boolean;
-    autoMerge?: boolean;
-    hasBreakingChanges?: boolean;
-}): boolean {
-    return config.automationMode === true && config.autoMerge === true && config.hasBreakingChanges !== true;
+export function shouldEnableAutomerge(
+    config: { automationMode?: boolean; autoMerge?: boolean; hasBreakingChanges?: boolean },
+    breaking: { hasBreakingChanges?: boolean } = {}
+): boolean {
+    const hasBreakingChanges = breaking.hasBreakingChanges ?? config.hasBreakingChanges;
+    return config.automationMode === true && config.autoMerge === true && hasBreakingChanges !== true;
 }
 
 /**

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,38 +1,9 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
-        Fix `AutoVersionStep` shipping `0.0.0-fern-placeholder` in manifests
-        (package.json, pyproject.toml, .fern/metadata.json) and user-agent
-        strings (e.g. `X-Fern-SDK-Version`) on steady-state regenerations.
-        Previously, `handleNormalFlow` returned early without replacing the
-        magic version placeholder when (a) the raw git diff between the
-        previous and current `[fern-generated]` commits was empty, or (b) the
-        FAI analyzer returned NO_CHANGE after diff cleaning. The working tree
-        still carried the placeholder from the current generator output, so
-        the SDK shipped unreplaced. `handleNormalFlow` now funnels both
-        short-circuits through a new `finalizeNoChange` that rewrites the
-        placeholder to `previousVersion`, applies the Go v2+ module-path
-        suffix when relevant, and commits the rewrite as `[fern-autoversion]`
-        so the replay + github steps see a stable base. `previousVersion` is
-        validated with `isValidSemver` before being embedded in the
-        `replaceMagicVersion` bash/sed pipeline, mirroring the first-generation
-        path (FER-10028).
-      type: fix
-    - summary: |
-        `GithubStep` now auto-wires the `AutoVersionStep` result from
-        `PipelineContext.previousStepResults.autoVersion` when the
-        corresponding explicit config fields are unset, mirroring the existing
-        fallback policy for `skipCommit` and `replayConflictInfo`. Without
-        this, consumers that delegate autoversion to the pipeline (fiddle
-        post-FER-9982) could not populate `commitMessage`, `changelogEntry`,
-        `prDescription`, `versionBumpReason`, `previousVersion`, `newVersion`,
-        or `versionBump` at config-emission time — those fields are pipeline
-        outputs, not inputs — so PR bodies shipped without version headers,
-        changelog sections, or breaking-change warnings even on successful
-        autoversion runs. `hasBreakingChanges` is also derived from the
-        autoVersion result (`versionBump === "MAJOR"`) so automerge and the
-        automation-mode Breaking Changes section stay consistent with the
-        rendered version header (FER-10029).
+        Fix autoversion placeholder leak on NO_CHANGE runs and auto-wire
+        `GithubStep` PR body from the `AutoVersionStep` result (FER-10028,
+        FER-10029).
       type: fix
   createdAt: "2026-04-23"
   version: 0.9.15

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,44 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix `AutoVersionStep` shipping `0.0.0-fern-placeholder` in manifests
+        (package.json, pyproject.toml, .fern/metadata.json) and user-agent
+        strings (e.g. `X-Fern-SDK-Version`) on steady-state regenerations.
+        Previously, `handleNormalFlow` returned early without replacing the
+        magic version placeholder when (a) the raw git diff between the
+        previous and current `[fern-generated]` commits was empty, or (b) the
+        FAI analyzer returned NO_CHANGE after diff cleaning. The working tree
+        still carried the placeholder from the current generator output, so
+        the SDK shipped unreplaced. `handleNormalFlow` now funnels both
+        short-circuits through a new `finalizeNoChange` that rewrites the
+        placeholder to `previousVersion`, applies the Go v2+ module-path
+        suffix when relevant, and commits the rewrite as `[fern-autoversion]`
+        so the replay + github steps see a stable base. `previousVersion` is
+        validated with `isValidSemver` before being embedded in the
+        `replaceMagicVersion` bash/sed pipeline, mirroring the first-generation
+        path (FER-10028).
+      type: fix
+    - summary: |
+        `GithubStep` now auto-wires the `AutoVersionStep` result from
+        `PipelineContext.previousStepResults.autoVersion` when the
+        corresponding explicit config fields are unset, mirroring the existing
+        fallback policy for `skipCommit` and `replayConflictInfo`. Without
+        this, consumers that delegate autoversion to the pipeline (fiddle
+        post-FER-9982) could not populate `commitMessage`, `changelogEntry`,
+        `prDescription`, `versionBumpReason`, `previousVersion`, `newVersion`,
+        or `versionBump` at config-emission time — those fields are pipeline
+        outputs, not inputs — so PR bodies shipped without version headers,
+        changelog sections, or breaking-change warnings even on successful
+        autoversion runs. `hasBreakingChanges` is also derived from the
+        autoVersion result (`versionBump === "MAJOR"`) so automerge and the
+        automation-mode Breaking Changes section stay consistent with the
+        rendered version header (FER-10029).
+      type: fix
+  createdAt: "2026-04-23"
+  version: 0.9.15
+
+- changelogEntry:
+    - summary: |
         Fix `pipeline run` crashing on stdout emission for replay-enabled runs.
         `GenerationCommitStep`'s `preparedReplay` handle holds a live `simple-git`
         instance whose internal `GitExecutor`/`GitExecutorChain` form a cycle, so


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-10028](https://linear.app/buildwithfern/issue/FER-10028/generator-cli-0914-autoversionstep-empty-cleaneddiff-short-circuit), Closes [FER-10029](https://linear.app/buildwithfern/issue/FER-10029/generator-cli-0914-githubstep-doesnt-auto-wire-autoversionstep-result)

Fixes two sequential bugs in `@fern-api/generator-cli`'s post-generation pipeline, both surfaced after autoversion moved into the pipeline (epic [FER-9978](https://linear.app/buildwithfern/issue/FER-9978/epic-move-sdk-autoversioning-into-the-genator-cli-pipeline)).

### FER-10028 — `AutoVersionStep` ships `0.0.0-fern-placeholder` on steady-state regens (Urgent)

`handleNormalFlow` returned early without rewriting the magic version placeholder when either (a) the raw git diff between the previous and current `[fern-generated]` commits was empty, or (b) the FAI analyzer returned `NO_CHANGE` after `cleanDiffForAI`. The working tree still carried the placeholder from the current generator output, so the SDK shipped `0.0.0-fern-placeholder` in `package.json`, `pyproject.toml`, `.fern/metadata.json`, and user-agent strings (`X-Fern-SDK-Version`) — fired on every steady-state regen (real incident on Java SDK PR #153).

The fix funnels both short-circuits through a new `finalizeNoChange()` that:
1. Validates `previousVersion` with `isValidSemver` before embedding it in the `replaceMagicVersion` `bash -c` + single-quoted `sed` pipeline (mirrors the first-generation path — `previousVersion` comes from user-influenced surfaces: regex extraction, `.fern/metadata.json`, git tags).
2. Rewrites the placeholder to `previousVersion` via `service.replaceMagicVersion`.
3. Applies the Go v2+ module-path suffix when `language === "go"`.
4. Commits the rewrite as `[fern-autoversion]` so the replay + github steps see a stable base.

### FER-10029 — `GithubStep` does not auto-wire `AutoVersionStep` results (High)

`GithubStep.execute()` only read PR-body fields (`commitMessage`, `changelogEntry`, `prDescription`, `versionBumpReason`, `previousVersion`, `newVersion`, `versionBump`) from explicit config, so consumers that delegate autoversion to the pipeline (fiddle post-FER-9982) shipped PRs with no version header, no changelog section, and no breaking-change warning even on successful autoversion runs — those fields are pipeline outputs, not config inputs.

The fix extracts a new `resolvePrFields(config, autoVersion)` helper that merges explicit config with `context.previousStepResults.autoVersion` using the same "config wins" policy as `skipCommit` and `replayConflictInfo`. `hasBreakingChanges` is derived from `autoVersion.versionBump === "MAJOR"` so `shouldEnableAutomerge` and the automation-mode Breaking Changes section stay consistent with the version header rendered by `parseCommitMessageForPR`. `enrichPrBodyForAutomation` and `shouldEnableAutomerge` take an optional `breaking` override parameter so the existing 15 `automation.test.ts` assertions keep their config-only behavior unchanged.

## Changes Made
- `packages/generator-cli/src/pipeline/steps/AutoVersionStep.ts` — added `finalizeNoChange()` + rewired both empty-diff and FAI `NO_CHANGE` paths through it; added semver validation before `replaceMagicVersion`.
- `packages/generator-cli/src/pipeline/steps/GithubStep.ts` — added `resolvePrFields()` helper + `ResolvedPrFields` type; rewired both `executePullRequestMode` and `executePushMode` to consume the resolved fields; extended `enrichPrBodyForAutomation`/`shouldEnableAutomerge` with an optional `breaking` override.
- `packages/generator-cli/src/__test__/github-step-autoversion-fallback.test.ts` — new file, 8 tests covering `resolvePrFields` precedence, autoVersion→PR-body composition, and MAJOR/non-MAJOR automerge gating.
- `packages/generator-cli/src/__test__/auto-version-step.execute.test.ts` — updated the `NO_CHANGE` test to assert the placeholder is rewritten to `previousVersion` and committed as `[fern-autoversion]`.
- `packages/generator-cli/versions.yml` — bumps `@fern-api/generator-cli` to `0.9.15` with both fix entries.

## Testing
- [x] Unit tests added/updated — 8 new tests in `github-step-autoversion-fallback.test.ts`, updated `auto-version-step.execute.test.ts` `NO_CHANGE` coverage.
- [x] Full package test suite: `pnpm turbo run test --filter @fern-api/generator-cli` → 367 passed / 1 skipped (up from 359).
- [x] Biome `check` clean on all changed files.
- [x] `tsc --project tsconfig.build.json` clean on `packages/generator-cli`.
- [x] Existing 15 `automation.test.ts` assertions for `enrichPrBodyForAutomation` / `shouldEnableAutomerge` still pass with the added optional `breaking` override (backwards-compatible signature).


Link to Devin session: https://app.devin.ai/sessions/01f7eefaa9b14116bf42272dcc6f7ae7
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
