### PR TITLE
chore(deps): bump uuid from 9.0.1 to 14.0.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -553,8 +553,8 @@ catalogs:
       specifier: ^5.0.0
       version: 5.1.0
     uuid:
-      specifier: ^9.0.1
-      version: 9.0.1
+      specifier: ^14.0.0
+      version: 14.0.0
     validate-npm-package-name:
       specifier: ^5.0.1
       version: 5.0.1
@@ -4925,7 +4925,7 @@ importers:
         version: 5.9.3
       uuid:
         specifier: 'catalog:'
-        version: 9.0.1
+        version: 14.0.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -5363,7 +5363,7 @@ importers:
         version: 3.0.3
       uuid:
         specifier: 'catalog:'
-        version: 9.0.1
+        version: 14.0.0
       watcher:
         specifier: 'catalog:'
         version: 2.3.1
@@ -5823,7 +5823,7 @@ importers:
         version: 4.0.1
       uuid:
         specifier: 'catalog:'
-        version: 9.0.1
+        version: 14.0.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -6599,7 +6599,7 @@ importers:
         version: 5.29.1(rxjs@7.8.2)
       uuid:
         specifier: 'catalog:'
-        version: 9.0.1
+        version: 14.0.0
     devDependencies:
       '@fern-api/configs':
         specifier: workspace:*
@@ -7038,7 +7038,7 @@ importers:
         version: 3.0.3
       uuid:
         specifier: 'catalog:'
-        version: 9.0.1
+        version: 14.0.0
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -14914,6 +14914,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -22842,6 +22846,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@14.0.0: {}
 
   uuid@9.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -241,7 +241,7 @@ catalog:
   unified: ^11.0.5
   unist-util-visit: ^5.0.0
   url-join: ^4.0.1
-  uuid: ^9.0.1
+  uuid: ^14.0.0
   validate-npm-package-name: ^5.0.1
   "@vitest/coverage-v8": 4.1.4
   vitest: 4.1.4


### PR DESCRIPTION
## Description

Re-opens Dependabot PR #15284 from a non-dependabot branch so CI has access to `FERN_ORG_TOKEN_DEV` (Dependabot workflows only see Dependabot-scoped secrets, which made `test-ete` fail on #15284 with `Authentication required. Please run 'fern login' or set the FERN_TOKEN environment variable` and a `Missing redirects check skipped: could not reach FDR` snapshot mismatch in `validate > docs`).

Bumps the catalog pin for [`uuid`](https://github.com/uuidjs/uuid) from `^9.0.1` to `^14.0.0`.

### Why this is safe

- The repo only uses `v4()` and `validate()` (verified via grep across `packages/` and `generators/`). None of `v3()`/`v5()`/`v6()` are used, so the 14.0.0 security fix (`RangeError` on out-of-bounds `offset`) does not affect us.
- `uuid@14` requires Node 20+. `package.json` already pins `"node": ">=20.0.0"` and `devbox.json` uses Node 24, so the engine requirement is already met.
- `uuid@12` dropped CJS and `uuid@13` made browser exports the default. Consumers in this repo import via ESM syntax (`import { v4 as uuidv4 } from "uuid"`) and are bundled by tsup/esbuild, so the export-map changes are handled by the bundler. I verified this by running `pnpm ete:build` locally on this branch — all 77 compile/build tasks succeeded.

## Changes Made

- Updated `uuid` catalog entry in `pnpm-workspace.yaml` from `^9.0.1` to `^14.0.0`.
- Refreshed `pnpm-lock.yaml` to resolve `uuid@14.0.0`.

## Testing

- [x] `pnpm install --lockfile-only` regenerates the lockfile cleanly.
- [x] `pnpm ete:build` succeeds (compiles all CLI packages and the dev CLI + seed CLI that depend on `uuid`).
- [ ] Full CI on this PR.


Link to Devin session: https://app.devin.ai/sessions/8f29adea439249b8abac5ded7eaf4f62
Requested by: @davidkonigsberg