### PR TITLE
fix(cli-v2): reference `fern auth login` in auth error messages

### DIFF
--- a/packages/cli/cli-v2/src/docs/publisher/LegacyDocsPublisher.ts
+++ b/packages/cli/cli-v2/src/docs/publisher/LegacyDocsPublisher.ts
@@ -78,7 +78,8 @@ export class LegacyDocsPublisher {
                 previewId,
                 disableTemplates: undefined,
                 skipUpload,
-                cliVersion: process.env.CLI_VERSION
+                cliVersion: process.env.CLI_VERSION,
+                loginCommand: "fern auth login"
             });
 
             if (taskContext.getResult() === TaskResult.Failure) {

--- a/packages/cli/cli-v2/src/sdk/generator/GeneratorPipeline.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/GeneratorPipeline.ts
@@ -175,7 +175,9 @@ export class GeneratorPipeline {
 
     private async runRemoteGeneration(args: GeneratorPipeline.RunArgs): Promise<GeneratorPipeline.Result> {
         if (args.token == null) {
-            throw CliError.authRequired();
+            throw CliError.authRequired(
+                "Authentication required. Please run 'fern auth login' or set the FERN_TOKEN environment variable."
+            );
         }
         const runner = new LegacyRemoteGenerationRunner({
             context: this.context,

--- a/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
@@ -129,6 +129,7 @@ export class LegacyRemoteGenerationRunner {
                 token: args.token,
                 mode: this.mapMode(args.target),
                 fernignorePath: args.fernignorePath,
+                loginCommand: "fern auth login",
                 skipFernignore: args.skipFernignore,
                 absolutePathToPreview,
                 whitelabel: undefined,

--- a/packages/cli/cli/changes/unreleased/cli-v2-auth-login-command-hint.yml
+++ b/packages/cli/cli/changes/unreleased/cli-v2-auth-login-command-hint.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Update CLI v2 authentication error messages to reference `fern auth login` instead of `fern login`.
+    This covers SDK generation permission errors, docs publish auth failures, and missing-token hints
+    produced by CLI v2 code paths. The legacy `fern login` wording is preserved for the v1 CLI.
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/publishDocs.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/publishDocs.test.ts
@@ -1,6 +1,86 @@
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
+// Auth message helpers are defined locally to avoid transitive import issues
+// (publishDocs.ts has heavy dependencies). The logic here must stay in sync with publishDocs.ts.
+const FORBIDDEN_ORG_MEMBERSHIP_PATTERNS = ["does not belong to organization", "User does not belong"];
+
+function extractServerError(content: Record<string, unknown> | undefined): {
+    code: string | undefined;
+    message: string | undefined;
+} {
+    if (content == null) {
+        return { code: undefined, message: undefined };
+    }
+    const body = content.body as Record<string, unknown> | string | undefined;
+    if (body != null && typeof body === "object") {
+        const code = typeof body.code === "string" ? body.code : undefined;
+        const message = typeof body.message === "string" ? body.message : undefined;
+        return { code, message };
+    }
+    const message =
+        typeof body === "string" && body.length > 0
+            ? body
+            : typeof content.errorMessage === "string"
+              ? content.errorMessage
+              : typeof content.message === "string"
+                ? content.message
+                : undefined;
+    return { code: undefined, message };
+}
+
+function buildForbiddenMessage(
+    domain: string,
+    organization: string,
+    message: string | undefined,
+    loginCommand: string
+): string {
+    if (message == null) {
+        return `You do not have permission to publish docs to '${domain}' under organization '${organization}'.`;
+    }
+    if (FORBIDDEN_ORG_MEMBERSHIP_PATTERNS.some((pattern) => message.includes(pattern))) {
+        return (
+            `You are not a member of organization '${organization}'. ` +
+            `Please run '${loginCommand}' to ensure you are logged in with the correct account.\n\n` +
+            "Please ensure you have membership at https://dashboard.buildwithfern.com, and ask a team member for an invite if not."
+        );
+    }
+    return message;
+}
+
+function buildUnauthorizedMessage(organization: string, message: string | undefined, loginCommand: string): string {
+    if (message != null && message.includes("Invalid authorization token")) {
+        return "Your authentication token is invalid or expired. " + `Please run '${loginCommand}' to re-authenticate.`;
+    }
+    return (
+        `You are not authorized to publish docs under organization '${organization}'. ` +
+        `Please run '${loginCommand}' to ensure you are logged in with the correct account.\n\n` +
+        "Please ensure you have membership at https://dashboard.buildwithfern.com, and ask a team member for an invite if not."
+    );
+}
+
+function buildAuthFailureMessage(
+    domain: string,
+    organization: string,
+    errorContent: Record<string, unknown> | undefined,
+    loginCommand: string
+): string {
+    const { code, message } = extractServerError(errorContent);
+    switch (code) {
+        case "FORBIDDEN":
+            return buildForbiddenMessage(domain, organization, message, loginCommand);
+        case "UNAUTHORIZED":
+            return buildUnauthorizedMessage(organization, message, loginCommand);
+        case "INTERNAL_SERVER_ERROR":
+            return `An internal server error occurred while publishing docs to '${domain}'. Please try again or reach out to support@buildwithfern.com for assistance.`;
+        default:
+            if (message != null) {
+                return message;
+            }
+            return `Failed to publish docs to '${domain}'. Please reach out to support@buildwithfern.com for assistance.`;
+    }
+}
+
 // Define the function locally to avoid import issues - tests the same logic
 function sanitizeRelativePathForS3(relativeFilePath: RelativeFilePath): RelativeFilePath {
     // Replace ../ segments with _dot_dot_/ to prevent HTTP client normalization issues
@@ -198,6 +278,112 @@ describe("publishDocs S3 path sanitization", () => {
             // "../assets/logo.svg" would become "assets/logo.svg"
             // But our sanitized path "_dot_dot_/assets/logo.svg" stays unchanged
             expect(result).not.toBe("assets/logo.svg");
+        });
+    });
+});
+
+describe("auth error message builders", () => {
+    const ORG = "my-org";
+    const DOMAIN = "docs.example.com";
+    const V1_CMD = "fern login";
+    const V2_CMD = "fern auth login";
+
+    describe("buildForbiddenMessage", () => {
+        it("returns generic permission message when message is undefined", () => {
+            const result = buildForbiddenMessage(DOMAIN, ORG, undefined, V1_CMD);
+            expect(result).toBe(
+                `You do not have permission to publish docs to '${DOMAIN}' under organization '${ORG}'.`
+            );
+        });
+
+        it("returns org membership hint with v1 login command when message matches membership pattern", () => {
+            const result = buildForbiddenMessage(DOMAIN, ORG, "User does not belong to org", V1_CMD);
+            expect(result).toContain(`run '${V1_CMD}'`);
+            expect(result).toContain(`not a member of organization '${ORG}'`);
+        });
+
+        it("returns org membership hint with v2 login command when message matches membership pattern", () => {
+            const result = buildForbiddenMessage(DOMAIN, ORG, "does not belong to organization acme", V2_CMD);
+            expect(result).toContain(`run '${V2_CMD}'`);
+            expect(result).not.toContain(V1_CMD);
+        });
+
+        it("passes through unrecognized server messages unchanged", () => {
+            const serverMessage = "Your plan does not include this feature.";
+            const result = buildForbiddenMessage(DOMAIN, ORG, serverMessage, V1_CMD);
+            expect(result).toBe(serverMessage);
+        });
+    });
+
+    describe("buildUnauthorizedMessage", () => {
+        it("returns token-expired hint with v1 login command for invalid token message", () => {
+            const result = buildUnauthorizedMessage(ORG, "Invalid authorization token", V1_CMD);
+            expect(result).toContain(`run '${V1_CMD}'`);
+            expect(result).toContain("invalid or expired");
+        });
+
+        it("returns token-expired hint with v2 login command for invalid token message", () => {
+            const result = buildUnauthorizedMessage(ORG, "Invalid authorization token", V2_CMD);
+            expect(result).toContain(`run '${V2_CMD}'`);
+            expect(result).not.toContain(V1_CMD);
+        });
+
+        it("returns generic unauthorized message when message is undefined", () => {
+            const result = buildUnauthorizedMessage(ORG, undefined, V1_CMD);
+            expect(result).toContain(`run '${V1_CMD}'`);
+            expect(result).toContain(`not authorized to publish docs under organization '${ORG}'`);
+        });
+
+        it("returns generic unauthorized message for unrecognized message", () => {
+            const result = buildUnauthorizedMessage(ORG, "Some other auth error", V2_CMD);
+            expect(result).toContain(`run '${V2_CMD}'`);
+            expect(result).toContain(`not authorized to publish docs under organization '${ORG}'`);
+        });
+    });
+
+    describe("buildAuthFailureMessage", () => {
+        it("routes FORBIDDEN to buildForbiddenMessage with correct loginCommand", () => {
+            const content: Record<string, unknown> = {
+                reason: "status-code",
+                statusCode: 403,
+                body: { code: "FORBIDDEN", message: "does not belong to organization" }
+            };
+            const result = buildAuthFailureMessage(DOMAIN, ORG, content, V2_CMD);
+            expect(result).toContain(`run '${V2_CMD}'`);
+        });
+
+        it("routes UNAUTHORIZED to buildUnauthorizedMessage with correct loginCommand", () => {
+            const content: Record<string, unknown> = {
+                reason: "status-code",
+                statusCode: 401,
+                body: { code: "UNAUTHORIZED", message: "Invalid authorization token" }
+            };
+            const result = buildAuthFailureMessage(DOMAIN, ORG, content, V2_CMD);
+            expect(result).toContain(`run '${V2_CMD}'`);
+            expect(result).toContain("invalid or expired");
+        });
+
+        it("returns internal server error message for INTERNAL_SERVER_ERROR code", () => {
+            const content: Record<string, unknown> = {
+                body: { code: "INTERNAL_SERVER_ERROR" }
+            };
+            const result = buildAuthFailureMessage(DOMAIN, ORG, content, V1_CMD);
+            expect(result).toContain("internal server error");
+            expect(result).toContain(DOMAIN);
+        });
+
+        it("returns server message directly when code is unrecognized but message is present", () => {
+            const content: Record<string, unknown> = {
+                body: { code: "SOME_OTHER_CODE", message: "Custom server error" }
+            };
+            const result = buildAuthFailureMessage(DOMAIN, ORG, content, V1_CMD);
+            expect(result).toBe("Custom server error");
+        });
+
+        it("returns fallback message when content is undefined", () => {
+            const result = buildAuthFailureMessage(DOMAIN, ORG, undefined, V1_CMD);
+            expect(result).toContain("Failed to publish docs");
+            expect(result).toContain(DOMAIN);
         });
     });
 });

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -41,7 +41,8 @@ export async function createAndStartJob({
     retryRateLimited,
     automationMode,
     autoMerge,
-    skipIfNoDiff
+    skipIfNoDiff,
+    loginCommand = "fern login"
 }: {
     projectConfig: fernConfigJson.ProjectConfig;
     workspace: FernWorkspace;
@@ -65,6 +66,11 @@ export async function createAndStartJob({
     automationMode?: boolean;
     autoMerge?: boolean;
     skipIfNoDiff?: boolean;
+    /**
+     * CLI command to reference in auth-failure hints (e.g. 'fern login' for v1,
+     * 'fern auth login' for CLI v2). Defaults to 'fern login'.
+     */
+    loginCommand?: string;
 }): Promise<FernFiddle.remoteGen.CreateJobResponse> {
     // Determine fernignore contents:
     // - If --skip-fernignore is set, upload an empty .fernignore so nothing is ignored
@@ -101,7 +107,8 @@ export async function createAndStartJob({
                 fernignoreContents,
                 automationMode,
                 autoMerge,
-                skipIfNoDiff
+                skipIfNoDiff,
+                loginCommand
             }),
         retryRateLimited,
         logger: context.logger,
@@ -130,7 +137,8 @@ async function createJob({
     fiddlePreview,
     pushPreviewBranch,
     fernignoreContents,
-    skipIfNoDiff
+    skipIfNoDiff,
+    loginCommand
 }: {
     projectConfig: fernConfigJson.ProjectConfig;
     workspace: FernWorkspace;
@@ -150,6 +158,7 @@ async function createJob({
     automationMode?: boolean;
     autoMerge?: boolean;
     skipIfNoDiff?: boolean;
+    loginCommand: string;
 }): Promise<FernFiddle.remoteGen.CreateJobResponse> {
     const remoteGenerationService = createFiddleService({ token: token.value });
 
@@ -247,7 +256,7 @@ async function createJob({
             },
             insufficientPermissions: () => {
                 return context.failAndThrow(
-                    `You do not have permission to run this generator for organization '${organization}'. Please run 'fern login' to ensure you are logged in with the correct account.\n\n` +
+                    `You do not have permission to run this generator for organization '${organization}'. Please run '${loginCommand}' to ensure you are logged in with the correct account.\n\n` +
                         "Please ensure you have membership at https://dashboard.buildwithfern.com, and ask a team member for an invite if not.",
                     undefined,
                     { code: CliError.Code.AuthError }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -801,11 +801,15 @@ function getAuthenticationErrorMessage(
     domain: string,
     loginCommand: string
 ): string | undefined {
-    const errorObj = error as Record<string, unknown>;
-    const content = errorObj?.content as Record<string, unknown> | undefined;
+    if (typeof error !== "object" || error == null) {
+        return undefined;
+    }
+    const rawContent = (error as Record<string, unknown>).content;
+    const content: Record<string, unknown> | undefined =
+        typeof rawContent === "object" && rawContent != null ? (rawContent as Record<string, unknown>) : undefined;
 
     if (content?.reason === "status-code") {
-        const statusCode = content.statusCode as number | undefined;
+        const statusCode = typeof content.statusCode === "number" ? content.statusCode : undefined;
 
         if (statusCode === 401 || statusCode === 403) {
             return buildAuthFailureMessage(domain, organization, content, loginCommand);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -130,7 +130,8 @@ export async function publishDocs({
     docsUrl,
     cliVersion,
     ciSource,
-    deployerAuthor
+    deployerAuthor,
+    loginCommand = "fern login"
 }: {
     token: FernToken;
     organization: string;
@@ -152,6 +153,11 @@ export async function publishDocs({
     cliVersion?: string;
     ciSource?: CISource;
     deployerAuthor?: { username?: string; email?: string };
+    /**
+     * CLI command to reference in auth-failure hints (e.g. 'fern login' for v1,
+     * 'fern auth login' for CLI v2). Defaults to 'fern login'.
+     */
+    loginCommand?: string;
 }): Promise<string> {
     const fdrOrigin = process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
     const isAirGapped = await detectAirGappedMode(`${fdrOrigin}/health`, context.logger);
@@ -321,7 +327,7 @@ export async function publishDocs({
                             previewId: previewId != null ? sanitizePreviewId(previewId) : undefined
                         });
                     } catch (error) {
-                        return await startDocsRegisterFailed(error, context, organization, domain);
+                        return await startDocsRegisterFailed(error, context, organization, domain, loginCommand);
                     }
                     urlToOutput = startDocsRegisterResponse.previewUrl;
                     docsRegistrationId = startDocsRegisterResponse.docsRegistrationId;
@@ -371,7 +377,7 @@ export async function publishDocs({
                             ...(isBasepathAware && { basepathAware: true })
                         });
                     } catch (error) {
-                        return startDocsRegisterFailed(error, context, organization, domain);
+                        return startDocsRegisterFailed(error, context, organization, domain, loginCommand);
                     }
                     docsRegistrationId = startDocsRegisterResponse.docsRegistrationId;
                     deployLocked = true;
@@ -723,7 +729,8 @@ async function startDocsRegisterFailed(
     error: unknown,
     context: TaskContext,
     organization: string,
-    domain: string
+    domain: string,
+    loginCommand: string
 ): Promise<never> {
     context.instrumentPostHogEvent({
         command: "docs-generation",
@@ -743,7 +750,7 @@ async function startDocsRegisterFailed(
         throw new DocsPublishConflictError();
     }
 
-    const authErrorMessage = getAuthenticationErrorMessage(error, organization, domain);
+    const authErrorMessage = getAuthenticationErrorMessage(error, organization, domain, loginCommand);
     if (authErrorMessage != null) {
         return context.failAndThrow(authErrorMessage, undefined, { code: CliError.Code.AuthError });
     }
@@ -763,12 +770,16 @@ async function startDocsRegisterFailed(
                 { code: CliError.Code.ConfigError }
             );
         case "UnauthorizedError":
-            return context.failAndThrow(buildAuthFailureMessage(domain, organization, errorContent), undefined, {
-                code: CliError.Code.AuthError
-            });
+            return context.failAndThrow(
+                buildAuthFailureMessage(domain, organization, errorContent, loginCommand),
+                undefined,
+                {
+                    code: CliError.Code.AuthError
+                }
+            );
         case "UserNotInOrgError":
             return context.failAndThrow(
-                `You do not belong to organization '${organization}'. Please run 'fern login' to ensure you are logged in with the correct account.\n\n` +
+                `You do not belong to organization '${organization}'. Please run '${loginCommand}' to ensure you are logged in with the correct account.\n\n` +
                     "Please ensure you have membership at https://dashboard.buildwithfern.com, and ask a team member for an invite if not.",
                 undefined,
                 { code: CliError.Code.AuthError }
@@ -784,7 +795,12 @@ async function startDocsRegisterFailed(
     }
 }
 
-function getAuthenticationErrorMessage(error: unknown, organization: string, domain: string): string | undefined {
+function getAuthenticationErrorMessage(
+    error: unknown,
+    organization: string,
+    domain: string,
+    loginCommand: string
+): string | undefined {
     const errorObj = error as Record<string, unknown>;
     const content = errorObj?.content as Record<string, unknown> | undefined;
 
@@ -792,7 +808,7 @@ function getAuthenticationErrorMessage(error: unknown, organization: string, dom
         const statusCode = content.statusCode as number | undefined;
 
         if (statusCode === 401 || statusCode === 403) {
-            return buildAuthFailureMessage(domain, organization, content);
+            return buildAuthFailureMessage(domain, organization, content, loginCommand);
         }
     }
 
@@ -802,15 +818,16 @@ function getAuthenticationErrorMessage(error: unknown, organization: string, dom
 function buildAuthFailureMessage(
     domain: string,
     organization: string,
-    errorContent: Record<string, unknown> | undefined
+    errorContent: Record<string, unknown> | undefined,
+    loginCommand: string
 ): string {
     const { code, message } = extractServerError(errorContent);
 
     switch (code) {
         case "FORBIDDEN":
-            return buildForbiddenMessage(domain, organization, message);
+            return buildForbiddenMessage(domain, organization, message, loginCommand);
         case "UNAUTHORIZED":
-            return buildUnauthorizedMessage(organization, message);
+            return buildUnauthorizedMessage(organization, message, loginCommand);
         case "INTERNAL_SERVER_ERROR":
             return `An internal server error occurred while publishing docs to '${domain}'. Please try again or reach out to support@buildwithfern.com for assistance.`;
         default:
@@ -827,7 +844,12 @@ function buildAuthFailureMessage(
 // admin contact guidance, so we pass them through directly.
 const FORBIDDEN_ORG_MEMBERSHIP_PATTERNS = ["does not belong to organization", "User does not belong"];
 
-function buildForbiddenMessage(domain: string, organization: string, message: string | undefined): string {
+function buildForbiddenMessage(
+    domain: string,
+    organization: string,
+    message: string | undefined,
+    loginCommand: string
+): string {
     if (message == null) {
         return `You do not have permission to publish docs to '${domain}' under organization '${organization}'.`;
     }
@@ -835,7 +857,7 @@ function buildForbiddenMessage(domain: string, organization: string, message: st
     if (FORBIDDEN_ORG_MEMBERSHIP_PATTERNS.some((pattern) => message.includes(pattern))) {
         return (
             `You are not a member of organization '${organization}'. ` +
-            "Please run 'fern login' to ensure you are logged in with the correct account.\n\n" +
+            `Please run '${loginCommand}' to ensure you are logged in with the correct account.\n\n` +
             "Please ensure you have membership at https://dashboard.buildwithfern.com, and ask a team member for an invite if not."
         );
     }
@@ -843,14 +865,14 @@ function buildForbiddenMessage(domain: string, organization: string, message: st
     return message;
 }
 
-function buildUnauthorizedMessage(organization: string, message: string | undefined): string {
+function buildUnauthorizedMessage(organization: string, message: string | undefined, loginCommand: string): string {
     if (message != null && message.includes("Invalid authorization token")) {
-        return "Your authentication token is invalid or expired. " + "Please run 'fern login' to re-authenticate.";
+        return "Your authentication token is invalid or expired. " + `Please run '${loginCommand}' to re-authenticate.`;
     }
 
     return (
         `You are not authorized to publish docs under organization '${organization}'. ` +
-        "Please run 'fern login' to ensure you are logged in with the correct account.\n\n" +
+        `Please run '${loginCommand}' to ensure you are logged in with the correct account.\n\n` +
         "Please ensure you have membership at https://dashboard.buildwithfern.com, and ask a team member for an invite if not."
     );
 }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
@@ -45,7 +45,8 @@ export async function runRemoteGenerationForAPIWorkspace({
     automationMode,
     autoMerge,
     skipIfNoDiff,
-    automation
+    automation,
+    loginCommand
 }: {
     projectConfig: fernConfigJson.ProjectConfig;
     organization: string;
@@ -84,6 +85,11 @@ export async function runRemoteGenerationForAPIWorkspace({
      * throws.
      */
     automation?: AutomationRunOptions;
+    /**
+     * CLI command to reference in auth-failure hints (e.g. 'fern login' for v1,
+     * 'fern auth login' for CLI v2). Defaults to 'fern login'.
+     */
+    loginCommand?: string;
 }): Promise<RemoteGenerationForAPIWorkspaceResponse | null> {
     if (generatorGroup.generators.length === 0) {
         context.logger.warn("No generators specified.");
@@ -123,6 +129,7 @@ export async function runRemoteGenerationForAPIWorkspace({
                     autoMerge,
                     skipIfNoDiff,
                     automation,
+                    loginCommand,
                     onSnippetsProduced: (invocation) => snippetsProducedBy.push(invocation)
                 })
             )
@@ -173,6 +180,7 @@ async function generateOne({
     autoMerge,
     skipIfNoDiff,
     automation,
+    loginCommand,
     onSnippetsProduced
 }: {
     generatorInvocation: generatorsYml.GeneratorInvocation;
@@ -201,6 +209,7 @@ async function generateOne({
     autoMerge: boolean | undefined;
     skipIfNoDiff: boolean | undefined;
     automation: AutomationRunOptions | undefined;
+    loginCommand: string | undefined;
     /** Invoked post-success when the generator produced snippets. */
     onSnippetsProduced: (invocation: generatorsYml.GeneratorInvocation) => void;
 }): Promise<void> {
@@ -279,7 +288,8 @@ async function generateOne({
             requireEnvVars,
             automationMode,
             autoMerge,
-            skipIfNoDiff
+            skipIfNoDiff,
+            loginCommand
         });
 
         if (remoteTaskHandlerResponse?.createdSnippets) {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -35,7 +35,8 @@ export async function runRemoteGenerationForDocsWorkspace({
     skipUpload,
     cliVersion,
     ciSource,
-    deployerAuthor
+    deployerAuthor,
+    loginCommand
 }: {
     organization: string;
     apiWorkspaces: AbstractAPIWorkspace<unknown>[];
@@ -51,6 +52,11 @@ export async function runRemoteGenerationForDocsWorkspace({
     cliVersion?: string;
     ciSource?: CISource;
     deployerAuthor?: { username?: string; email?: string };
+    /**
+     * CLI command to reference in auth-failure hints (e.g. 'fern login' for v1,
+     * 'fern auth login' for CLI v2). Defaults to 'fern login'.
+     */
+    loginCommand?: string;
 }): Promise<string | undefined> {
     // Substitute templated environment variables:
     // If substitute-env-vars is enabled, we'll attempt to read and replace the templated
@@ -144,7 +150,8 @@ export async function runRemoteGenerationForDocsWorkspace({
                 docsUrl: maybeInstance.url,
                 cliVersion,
                 ciSource,
-                deployerAuthor
+                deployerAuthor,
+                loginCommand
             });
 
         for (let attempt = 0; ; attempt++) {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -51,7 +51,8 @@ export async function runRemoteGenerationForGenerator({
     requireEnvVars,
     automationMode,
     autoMerge,
-    skipIfNoDiff
+    skipIfNoDiff,
+    loginCommand
 }: {
     projectConfig: fernConfigJson.ProjectConfig;
     organization: string;
@@ -80,6 +81,11 @@ export async function runRemoteGenerationForGenerator({
     automationMode?: boolean;
     autoMerge?: boolean;
     skipIfNoDiff?: boolean;
+    /**
+     * CLI command to reference in auth-failure hints (e.g. 'fern login' for v1,
+     * 'fern auth login' for CLI v2). Defaults to 'fern login'.
+     */
+    loginCommand?: string;
 }): Promise<RemoteTaskHandler.Response | undefined> {
     const fdr = createFdrService({ token: token.value });
 
@@ -308,7 +314,8 @@ export async function runRemoteGenerationForGenerator({
         retryRateLimited,
         automationMode,
         autoMerge,
-        skipIfNoDiff
+        skipIfNoDiff,
+        loginCommand
     });
     interactiveTaskContext.logger.debug(`Job ID: ${job.jobId}`);
 

--- a/packages/generator-cli/src/__e2e__/chunking-large-diff.e2e.test.ts
+++ b/packages/generator-cli/src/__e2e__/chunking-large-diff.e2e.test.ts
@@ -233,7 +233,6 @@ function createMockLogger() {
 /** Creates an AutoVersioningService with a mock logger. */
 function createService(): AutoVersioningService {
     return new AutoVersioningService({
-        // biome-ignore lint/suspicious/noExplicitAny: test logger mock
         logger: createMockLogger() as any
     });
 }


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-8579](https://linear.app/buildwithfern/issue/FER-8579/cli-v2-update-authentication-errors-to-reference-new-commands)

CLI v2 uses `fern auth login` for authentication but several auth-failure error messages surfaced from shared generation/publish code still instructed users to run the legacy `fern login`. This threads an optional `loginCommand` hint through the shared remote-generation + docs-publish code paths so CLI v2 callers can surface the new command while CLI v1 continues to print `fern login` unchanged.


<img width="978" height="314" alt="iScreen Shoter - Cursor - 260423204130" src="https://github.com/user-attachments/assets/1bfd8660-9f1e-4267-a5e5-95b08a33e0e0" />


## Changes Made
- Added an optional `loginCommand?: string` parameter (default `"fern login"`) to `runRemoteGenerationForAPIWorkspace`, `generateOne`, `runRemoteGenerationForGenerator`, `createAndStartJob`, and the `createJob` helper, and use it in the `insufficientPermissions` error from Fiddle's `createJobV3` (the exact error shown in the Linear issue for `fern sdk generate`).
- Threaded the same `loginCommand` through `runRemoteGenerationForDocsWorkspace` → `publishDocs` → `startDocsRegisterFailed` → `getAuthenticationErrorMessage` → `buildAuthFailureMessage` → `buildForbiddenMessage` / `buildUnauthorizedMessage`, so `UserNotInOrgError`, `UnauthorizedError`, FORBIDDEN org-membership, and invalid-token messages pick up the right command.
- CLI v2's `LegacyRemoteGenerationRunner` and `LegacyDocsPublisher` now pass `loginCommand: "fern auth login"` when invoking the shared runners. CLI v1 entry points are unchanged and continue to get the `"fern login"` default.
- CLI v2's `GeneratorPipeline.runRemoteGeneration` now throws `CliError.authRequired(...)` with an explicit `fern auth login` message instead of the shared default (which remains `fern login` for v1).
- Added changelog entry `packages/cli/cli/changes/unreleased/cli-v2-auth-login-command-hint.yml`.
- [ ] Updated README.md generator (if applicable)

Not changed (per scope): v1-only command files (`packages/cli/cli/src/commands/**`), `CliError.authRequired()` default, `askToLogin.ts`, and `missing-redirects.ts` rule — all keep `fern login` since v1 still ships with that command.

## Testing
- [x] Unit tests added/updated — existing tests in `@fern-api/remote-workspace-runner` and `@fern-api/cli-v2` still pass (`pnpm turbo run test --filter=@fern-api/remote-workspace-runner --filter=@fern-api/cli-v2`).
- [x] Manual testing completed — compiled both packages (`pnpm turbo run compile --filter=@fern-api/remote-workspace-runner --filter=@fern-api/cli-v2`) and ran `pnpm biome check` over the touched directories.


Link to Devin session: https://app.devin.ai/sessions/8bbc61756ff74964a77a2156f79c13ba
Requested by: @iamnamananand996