### PR TITLE
feat(cli-v2): add `fern schema` command for JSON Schema introspection

### DIFF
--- a/packages/cli/cli-v2/src/cli.ts
+++ b/packages/cli/cli-v2/src/cli.ts
@@ -15,6 +15,7 @@ import { addDocsCommand } from "./commands/docs/index.js";
 import { addInitCommand } from "./commands/init/index.js";
 import { addOrgCommand } from "./commands/org/index.js";
 import { addReplayCommand } from "./commands/replay/index.js";
+import { addSchemaCommand } from "./commands/schema/index.js";
 import { addSdkCommand } from "./commands/sdk/index.js";
 import { addTelemetryCommand } from "./commands/telemetry/index.js";
 import { isCompletionMode } from "./completion.js";
@@ -142,6 +143,7 @@ function createCliV2(argv?: string[]): Argv<GlobalArgs> {
     addInitCommand(cli);
     addOrgCommand(cli);
     addReplayCommand(cli);
+    addSchemaCommand(cli);
     addSdkCommand(cli);
     addTelemetryCommand(cli);
 

--- a/packages/cli/cli-v2/src/commands/schema/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/schema/__test__/command.test.ts
@@ -1,0 +1,136 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { CliError } from "@fern-api/task-context";
+import { randomUUID } from "crypto";
+import { mkdir, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTestContextWithCapture } from "../../../__test__/utils/createTestContext.js";
+import { SchemaCommand } from "../command.js";
+
+describe("fern schema", () => {
+    let testDir: AbsoluteFilePath;
+
+    beforeEach(async () => {
+        testDir = AbsoluteFilePath.of(join(tmpdir(), `fern-schema-test-${randomUUID()}`));
+        await mkdir(testDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("lists all available schemas when no name is provided", async () => {
+        const { context, getStdout, getStderr } = await createTestContextWithCapture({ cwd: testDir });
+        const cmd = new SchemaCommand();
+
+        await cmd.handle(context, { "log-level": "info", pretty: true });
+
+        const stderr = getStderr();
+        expect(stderr).toBe("");
+
+        const parsed = JSON.parse(getStdout());
+        expect(Array.isArray(parsed.schemas)).toBe(true);
+        expect(parsed.schemas.length).toBeGreaterThan(0);
+
+        const names = parsed.schemas.map((s: { name: string }) => s.name);
+        expect(names).toContain("fern-yml");
+        expect(names).toContain("sdks");
+        expect(names).toContain("api");
+        expect(names).toContain("docs");
+
+        for (const entry of parsed.schemas) {
+            expect(typeof entry.name).toBe("string");
+            expect(typeof entry.description).toBe("string");
+        }
+    });
+
+    it("prints the fern-yml JSON Schema when requested", async () => {
+        const { context, getStdout, getStderr } = await createTestContextWithCapture({ cwd: testDir });
+        const cmd = new SchemaCommand();
+
+        await cmd.handle(context, { "log-level": "info", pretty: true, name: "fern-yml" });
+
+        expect(getStderr()).toBe("");
+
+        const parsed = JSON.parse(getStdout());
+        expect(parsed.type).toBe("object");
+        expect(parsed.properties).toBeDefined();
+        expect(parsed.properties.org).toBeDefined();
+        expect(parsed.properties.sdks).toBeDefined();
+        expect(parsed.required).toContain("org");
+    });
+
+    it("prints the sdks JSON Schema when requested", async () => {
+        const { context, getStdout } = await createTestContextWithCapture({ cwd: testDir });
+        const cmd = new SchemaCommand();
+
+        await cmd.handle(context, { "log-level": "info", pretty: true, name: "sdks" });
+
+        const parsed = JSON.parse(getStdout());
+        expect(parsed.type).toBe("object");
+        expect(parsed.properties.targets).toBeDefined();
+        expect(parsed.required).toContain("targets");
+    });
+
+    it("prints the api JSON Schema when requested", async () => {
+        const { context, getStdout } = await createTestContextWithCapture({ cwd: testDir });
+        const cmd = new SchemaCommand();
+
+        await cmd.handle(context, { "log-level": "info", pretty: true, name: "api" });
+
+        const parsed = JSON.parse(getStdout());
+        expect(parsed.type).toBe("object");
+        expect(parsed.properties.specs).toBeDefined();
+        expect(parsed.required).toContain("specs");
+    });
+
+    it("emits minified JSON when --no-pretty is set", async () => {
+        const { context, getStdout } = await createTestContextWithCapture({ cwd: testDir });
+        const cmd = new SchemaCommand();
+
+        await cmd.handle(context, { "log-level": "info", pretty: false, name: "cli" });
+
+        const raw = getStdout();
+        // Minified output should not contain newlines inside the JSON payload.
+        // The logger always appends a trailing newline, so trim before asserting.
+        const trimmed = raw.trimEnd();
+        expect(trimmed.includes("\n")).toBe(false);
+
+        const parsed = JSON.parse(trimmed);
+        expect(parsed.type).toBe("object");
+        expect(parsed.properties.version).toBeDefined();
+    });
+
+    it("supports 'list' as an explicit subcommand-like name", async () => {
+        const { context, getStdout } = await createTestContextWithCapture({ cwd: testDir });
+        const cmd = new SchemaCommand();
+
+        await cmd.handle(context, { "log-level": "info", pretty: true, name: "list" });
+
+        const parsed = JSON.parse(getStdout());
+        expect(Array.isArray(parsed.schemas)).toBe(true);
+    });
+
+    it("throws a helpful CliError for an unknown schema name", async () => {
+        const { context } = await createTestContextWithCapture({ cwd: testDir });
+        const cmd = new SchemaCommand();
+
+        await expect(
+            cmd.handle(context, { "log-level": "info", pretty: true, name: "not-a-real-schema" })
+        ).rejects.toMatchObject({
+            message: expect.stringContaining("Unknown schema 'not-a-real-schema'"),
+            code: CliError.Code.ConfigError
+        });
+    });
+
+    it("does not require a workspace to exist", async () => {
+        // testDir is an empty scratch directory — no fern.yml in sight.
+        const { context, getStderr } = await createTestContextWithCapture({ cwd: testDir });
+        const cmd = new SchemaCommand();
+
+        await cmd.handle(context, { "log-level": "info", pretty: true, name: "fern-yml" });
+
+        expect(getStderr()).toBe("");
+    });
+});

--- a/packages/cli/cli-v2/src/commands/schema/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/schema/__test__/command.test.ts
@@ -37,6 +37,8 @@ describe("fern schema", () => {
         expect(names).toContain("fern-yml");
         expect(names).toContain("fern-yml.sdks");
         expect(names).toContain("fern-yml.api");
+        expect(names).toContain("fern-yml.apis");
+        expect(names).toContain("fern-yml.apis.api");
         expect(names).toContain("fern-yml.docs");
 
         for (const entry of parsed.schemas) {

--- a/packages/cli/cli-v2/src/commands/schema/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/schema/__test__/command.test.ts
@@ -20,38 +20,11 @@ describe("fern schema", () => {
         await rm(testDir, { recursive: true, force: true });
     });
 
-    it("lists all available schemas when no name is provided", async () => {
+    it("prints the full fern.yml JSON Schema when no name is provided", async () => {
         const { context, getStdout, getStderr } = await createTestContextWithCapture({ cwd: testDir });
         const cmd = new SchemaCommand();
 
         await cmd.handle(context, { "log-level": "info", pretty: true });
-
-        const stderr = getStderr();
-        expect(stderr).toBe("");
-
-        const parsed = JSON.parse(getStdout());
-        expect(Array.isArray(parsed.schemas)).toBe(true);
-        expect(parsed.schemas.length).toBeGreaterThan(0);
-
-        const names = parsed.schemas.map((s: { name: string }) => s.name);
-        expect(names).toContain("fern-yml");
-        expect(names).toContain("fern-yml.sdks");
-        expect(names).toContain("fern-yml.api");
-        expect(names).toContain("fern-yml.apis");
-        expect(names).toContain("fern-yml.apis.api");
-        expect(names).toContain("fern-yml.docs");
-
-        for (const entry of parsed.schemas) {
-            expect(typeof entry.name).toBe("string");
-            expect(typeof entry.description).toBe("string");
-        }
-    });
-
-    it("prints the fern-yml JSON Schema when requested", async () => {
-        const { context, getStdout, getStderr } = await createTestContextWithCapture({ cwd: testDir });
-        const cmd = new SchemaCommand();
-
-        await cmd.handle(context, { "log-level": "info", pretty: true, name: "fern-yml" });
 
         expect(getStderr()).toBe("");
 
@@ -63,11 +36,11 @@ describe("fern schema", () => {
         expect(parsed.required).toContain("org");
     });
 
-    it("prints the fern-yml.sdks JSON Schema when requested", async () => {
+    it("prints the sdks JSON Schema when requested", async () => {
         const { context, getStdout } = await createTestContextWithCapture({ cwd: testDir });
         const cmd = new SchemaCommand();
 
-        await cmd.handle(context, { "log-level": "info", pretty: true, name: "fern-yml.sdks" });
+        await cmd.handle(context, { "log-level": "info", pretty: true, name: "sdks" });
 
         const parsed = JSON.parse(getStdout());
         expect(parsed.type).toBe("object");
@@ -75,11 +48,11 @@ describe("fern schema", () => {
         expect(parsed.required).toContain("targets");
     });
 
-    it("prints the fern-yml.api JSON Schema when requested", async () => {
+    it("prints the api JSON Schema when requested", async () => {
         const { context, getStdout } = await createTestContextWithCapture({ cwd: testDir });
         const cmd = new SchemaCommand();
 
-        await cmd.handle(context, { "log-level": "info", pretty: true, name: "fern-yml.api" });
+        await cmd.handle(context, { "log-level": "info", pretty: true, name: "api" });
 
         const parsed = JSON.parse(getStdout());
         expect(parsed.type).toBe("object");
@@ -87,11 +60,21 @@ describe("fern schema", () => {
         expect(parsed.required).toContain("specs");
     });
 
+    it("prints the sdks.targets JSON Schema (single target shape) when requested", async () => {
+        const { context, getStdout } = await createTestContextWithCapture({ cwd: testDir });
+        const cmd = new SchemaCommand();
+
+        await cmd.handle(context, { "log-level": "info", pretty: true, name: "sdks.targets" });
+
+        const parsed = JSON.parse(getStdout());
+        expect(parsed).toBeDefined();
+    });
+
     it("emits minified JSON when --no-pretty is set", async () => {
         const { context, getStdout } = await createTestContextWithCapture({ cwd: testDir });
         const cmd = new SchemaCommand();
 
-        await cmd.handle(context, { "log-level": "info", pretty: false, name: "fern-yml.cli" });
+        await cmd.handle(context, { "log-level": "info", pretty: false, name: "cli" });
 
         const raw = getStdout();
         // Minified output should not contain newlines inside the JSON payload.
@@ -102,16 +85,6 @@ describe("fern schema", () => {
         const parsed = JSON.parse(trimmed);
         expect(parsed.type).toBe("object");
         expect(parsed.properties.version).toBeDefined();
-    });
-
-    it("supports 'list' as an explicit subcommand-like name", async () => {
-        const { context, getStdout } = await createTestContextWithCapture({ cwd: testDir });
-        const cmd = new SchemaCommand();
-
-        await cmd.handle(context, { "log-level": "info", pretty: true, name: "list" });
-
-        const parsed = JSON.parse(getStdout());
-        expect(Array.isArray(parsed.schemas)).toBe(true);
     });
 
     it("throws a helpful CliError for an unknown schema name", async () => {
@@ -131,7 +104,7 @@ describe("fern schema", () => {
         const { context, getStderr } = await createTestContextWithCapture({ cwd: testDir });
         const cmd = new SchemaCommand();
 
-        await cmd.handle(context, { "log-level": "info", pretty: true, name: "fern-yml" });
+        await cmd.handle(context, { "log-level": "info", pretty: true });
 
         expect(getStderr()).toBe("");
     });

--- a/packages/cli/cli-v2/src/commands/schema/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/schema/__test__/command.test.ts
@@ -35,9 +35,9 @@ describe("fern schema", () => {
 
         const names = parsed.schemas.map((s: { name: string }) => s.name);
         expect(names).toContain("fern-yml");
-        expect(names).toContain("sdks");
-        expect(names).toContain("api");
-        expect(names).toContain("docs");
+        expect(names).toContain("fern-yml.sdks");
+        expect(names).toContain("fern-yml.api");
+        expect(names).toContain("fern-yml.docs");
 
         for (const entry of parsed.schemas) {
             expect(typeof entry.name).toBe("string");
@@ -61,11 +61,11 @@ describe("fern schema", () => {
         expect(parsed.required).toContain("org");
     });
 
-    it("prints the sdks JSON Schema when requested", async () => {
+    it("prints the fern-yml.sdks JSON Schema when requested", async () => {
         const { context, getStdout } = await createTestContextWithCapture({ cwd: testDir });
         const cmd = new SchemaCommand();
 
-        await cmd.handle(context, { "log-level": "info", pretty: true, name: "sdks" });
+        await cmd.handle(context, { "log-level": "info", pretty: true, name: "fern-yml.sdks" });
 
         const parsed = JSON.parse(getStdout());
         expect(parsed.type).toBe("object");
@@ -73,11 +73,11 @@ describe("fern schema", () => {
         expect(parsed.required).toContain("targets");
     });
 
-    it("prints the api JSON Schema when requested", async () => {
+    it("prints the fern-yml.api JSON Schema when requested", async () => {
         const { context, getStdout } = await createTestContextWithCapture({ cwd: testDir });
         const cmd = new SchemaCommand();
 
-        await cmd.handle(context, { "log-level": "info", pretty: true, name: "api" });
+        await cmd.handle(context, { "log-level": "info", pretty: true, name: "fern-yml.api" });
 
         const parsed = JSON.parse(getStdout());
         expect(parsed.type).toBe("object");
@@ -89,7 +89,7 @@ describe("fern schema", () => {
         const { context, getStdout } = await createTestContextWithCapture({ cwd: testDir });
         const cmd = new SchemaCommand();
 
-        await cmd.handle(context, { "log-level": "info", pretty: false, name: "cli" });
+        await cmd.handle(context, { "log-level": "info", pretty: false, name: "fern-yml.cli" });
 
         const raw = getStdout();
         // Minified output should not contain newlines inside the JSON payload.

--- a/packages/cli/cli-v2/src/commands/schema/command.ts
+++ b/packages/cli/cli-v2/src/commands/schema/command.ts
@@ -1,0 +1,75 @@
+import { getJsonSchemaByName, getJsonSchemaNames, JSON_SCHEMA_ENTRIES } from "@fern-api/config";
+import { CliError } from "@fern-api/task-context";
+
+import type { Argv } from "yargs";
+import type { Context } from "../../context/Context.js";
+import type { GlobalArgs } from "../../context/GlobalArgs.js";
+import { command } from "../_internal/command.js";
+
+export declare namespace SchemaCommand {
+    export interface Args extends GlobalArgs {
+        /** Name of the schema to print. When omitted, lists all schemas. */
+        name?: string;
+        /** Pretty-print JSON output. Defaults to true. */
+        pretty: boolean;
+    }
+}
+
+/**
+ * Emits JSON Schemas describing Fern configuration surfaces.
+ *
+ * This exists primarily for AI agents: rather than relying on stale prose
+ * documentation, agents can introspect the exact shape of `fern.yml`, `sdks:`,
+ * `api:`, and related blocks at runtime.
+ *
+ * All output goes to stdout as pure JSON so it is pipe-safe (e.g. `fern schema
+ * fern-yml | jq .properties.sdks`). Human-readable messages go to stderr only
+ * on error.
+ */
+export class SchemaCommand {
+    public async handle(context: Context, args: SchemaCommand.Args): Promise<void> {
+        if (args.name == null || args.name === "list") {
+            this.writeJson(context, { schemas: [...JSON_SCHEMA_ENTRIES] }, args.pretty);
+            return;
+        }
+
+        const schema = getJsonSchemaByName(args.name);
+        if (schema == null) {
+            const available = getJsonSchemaNames().join(", ");
+            throw new CliError({
+                message: `Unknown schema '${args.name}'. Available schemas: ${available}.`,
+                code: CliError.Code.ConfigError
+            });
+        }
+
+        this.writeJson(context, schema, args.pretty);
+    }
+
+    private writeJson(context: Context, value: unknown, pretty: boolean): void {
+        const json = pretty ? JSON.stringify(value, null, 2) : JSON.stringify(value);
+        context.stdout.info(json);
+    }
+}
+
+export function addSchemaCommand(cli: Argv<GlobalArgs>): void {
+    const cmd = new SchemaCommand();
+    command(
+        cli,
+        "schema [name]",
+        "Print a JSON Schema for a Fern config surface (e.g. fern.yml, sdks, api)",
+        (context, args) => cmd.handle(context, args as SchemaCommand.Args),
+        (yargs) =>
+            yargs
+                .positional("name", {
+                    type: "string",
+                    description:
+                        "Name of the schema to print. Omit (or use 'list') to list all available schemas. " +
+                        `Available: ${getJsonSchemaNames().join(", ")}.`
+                })
+                .option("pretty", {
+                    type: "boolean",
+                    default: true,
+                    description: "Pretty-print the JSON output"
+                })
+    );
+}

--- a/packages/cli/cli-v2/src/commands/schema/command.ts
+++ b/packages/cli/cli-v2/src/commands/schema/command.ts
@@ -56,7 +56,7 @@ export function addSchemaCommand(cli: Argv<GlobalArgs>): void {
     command(
         cli,
         "schema [name]",
-        "Print a JSON Schema for a Fern config surface (e.g. fern.yml, sdks, api)",
+        "Print a JSON Schema for a Fern config surface (e.g. fern-yml, fern-yml.sdks, fern-yml.api)",
         (context, args) => cmd.handle(context, args as SchemaCommand.Args),
         (yargs) =>
             yargs

--- a/packages/cli/cli-v2/src/commands/schema/command.ts
+++ b/packages/cli/cli-v2/src/commands/schema/command.ts
@@ -1,4 +1,4 @@
-import { getJsonSchemaByName, getJsonSchemaNames, JSON_SCHEMA_ENTRIES } from "@fern-api/config";
+import { getFernYmlJsonSchema, getJsonSchemaByName, getJsonSchemaNames } from "@fern-api/config";
 import { CliError } from "@fern-api/task-context";
 
 import type { Argv } from "yargs";
@@ -8,7 +8,10 @@ import { command } from "../_internal/command.js";
 
 export declare namespace SchemaCommand {
     export interface Args extends GlobalArgs {
-        /** Name of the schema to print. When omitted, lists all schemas. */
+        /**
+         * Dot-delimited path inside fern.yml (e.g. `api`, `sdks.targets`).
+         * When omitted, the full fern.yml schema is printed.
+         */
         name?: string;
         /** Pretty-print JSON output. Defaults to true. */
         pretty: boolean;
@@ -16,20 +19,20 @@ export declare namespace SchemaCommand {
 }
 
 /**
- * Emits JSON Schemas describing Fern configuration surfaces.
+ * Emits a JSON Schema describing the Fern `fern.yml` config (or a subsection).
  *
- * This exists primarily for AI agents: rather than relying on stale prose
- * documentation, agents can introspect the exact shape of `fern.yml`, `sdks:`,
- * `api:`, and related blocks at runtime.
+ * Intended primarily for AI agents: rather than relying on stale prose
+ * documentation, agents can introspect the exact shape of `fern.yml` at
+ * runtime. With no name, prints the full schema. With a dot-delimited name
+ * (e.g. `api`, `sdks.targets`), prints just that subsection.
  *
- * All output goes to stdout as pure JSON so it is pipe-safe (e.g. `fern schema
- * fern-yml | jq .properties.sdks`). Human-readable messages go to stderr only
- * on error.
+ * Output is pure JSON on stdout so it is pipe-safe (e.g.
+ * `fern schema | jq .properties.sdks`).
  */
 export class SchemaCommand {
     public async handle(context: Context, args: SchemaCommand.Args): Promise<void> {
-        if (args.name == null || args.name === "list") {
-            this.writeJson(context, { schemas: [...JSON_SCHEMA_ENTRIES] }, args.pretty);
+        if (args.name == null) {
+            this.writeJson(context, getFernYmlJsonSchema(), args.pretty);
             return;
         }
 
@@ -37,7 +40,7 @@ export class SchemaCommand {
         if (schema == null) {
             const available = getJsonSchemaNames().join(", ");
             throw new CliError({
-                message: `Unknown schema '${args.name}'. Available schemas: ${available}.`,
+                message: `Unknown schema '${args.name}'. Available subsections: ${available}.`,
                 code: CliError.Code.ConfigError
             });
         }
@@ -56,15 +59,15 @@ export function addSchemaCommand(cli: Argv<GlobalArgs>): void {
     command(
         cli,
         "schema [name]",
-        "Print a JSON Schema for a Fern config surface (e.g. fern-yml, fern-yml.sdks, fern-yml.api)",
+        "Print a JSON Schema for fern.yml (or a dot-delimited subsection like `sdks` or `sdks.targets`)",
         (context, args) => cmd.handle(context, args as SchemaCommand.Args),
         (yargs) =>
             yargs
                 .positional("name", {
                     type: "string",
                     description:
-                        "Name of the schema to print. Omit (or use 'list') to list all available schemas. " +
-                        `Available: ${getJsonSchemaNames().join(", ")}.`
+                        "Dot-delimited subsection of fern.yml. Omit to print the full schema. " +
+                        `Available subsections: ${getJsonSchemaNames().join(", ")}.`
                 })
                 .option("pretty", {
                     type: "boolean",

--- a/packages/cli/cli-v2/src/commands/schema/index.ts
+++ b/packages/cli/cli-v2/src/commands/schema/index.ts
@@ -1,0 +1,1 @@
+export { addSchemaCommand, SchemaCommand } from "./command.js";

--- a/packages/cli/cli/changes/unreleased/cli-v2-schema-command.yml
+++ b/packages/cli/cli/changes/unreleased/cli-v2-schema-command.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Add `fern schema [name]` command (CLI v2) that emits a JSON Schema for
+    each Fern configuration surface (fern.yml, api, apis, sdks, sdk-target,
+    docs, ai, cli). Running `fern schema` with no argument prints the list of
+    available schemas. Intended primarily for AI agents that need to generate
+    or validate Fern config at runtime without consulting external docs.
+  type: feat

--- a/packages/cli/cli/changes/unreleased/cli-v2-schema-command.yml
+++ b/packages/cli/cli/changes/unreleased/cli-v2-schema-command.yml
@@ -1,8 +1,8 @@
 - summary: |
     Add `fern schema [name]` command (CLI v2) that emits a JSON Schema for
     each Fern configuration surface (fern-yml, fern-yml.api, fern-yml.apis,
-    fern-yml.sdks, fern-yml.sdks.target, fern-yml.docs, fern-yml.ai,
-    fern-yml.cli). Running `fern schema` with no argument prints the list of
+    fern-yml.apis.api, fern-yml.sdks, fern-yml.sdks.target, fern-yml.docs,
+    fern-yml.ai, fern-yml.cli). Running `fern schema` with no argument prints the list of
     available schemas. Intended primarily for AI agents that need to generate
     or validate Fern config at runtime without consulting external docs.
   type: feat

--- a/packages/cli/cli/changes/unreleased/cli-v2-schema-command.yml
+++ b/packages/cli/cli/changes/unreleased/cli-v2-schema-command.yml
@@ -1,8 +1,8 @@
 - summary: |
     Add `fern schema [name]` command (CLI v2) that emits a JSON Schema for
-    each Fern configuration surface (fern-yml, fern-yml.api, fern-yml.apis,
-    fern-yml.apis.api, fern-yml.sdks, fern-yml.sdks.target, fern-yml.docs,
-    fern-yml.ai, fern-yml.cli). Running `fern schema` with no argument prints the list of
-    available schemas. Intended primarily for AI agents that need to generate
-    or validate Fern config at runtime without consulting external docs.
+    `fern.yml`. Running `fern schema` with no argument prints the full schema;
+    passing a dot-delimited subsection (e.g. `fern schema sdks`,
+    `fern schema sdks.targets`, `fern schema api`) prints just that block.
+    Intended primarily for AI agents that need to generate or validate Fern
+    config at runtime without consulting external docs.
   type: feat

--- a/packages/cli/cli/changes/unreleased/cli-v2-schema-command.yml
+++ b/packages/cli/cli/changes/unreleased/cli-v2-schema-command.yml
@@ -1,7 +1,8 @@
 - summary: |
     Add `fern schema [name]` command (CLI v2) that emits a JSON Schema for
-    each Fern configuration surface (fern.yml, api, apis, sdks, sdk-target,
-    docs, ai, cli). Running `fern schema` with no argument prints the list of
+    each Fern configuration surface (fern-yml, fern-yml.api, fern-yml.apis,
+    fern-yml.sdks, fern-yml.sdks.target, fern-yml.docs, fern-yml.ai,
+    fern-yml.cli). Running `fern schema` with no argument prints the list of
     available schemas. Intended primarily for AI agents that need to generate
     or validate Fern config at runtime without consulting external docs.
   type: feat

--- a/packages/cli/config/src/index.ts
+++ b/packages/cli/config/src/index.ts
@@ -1,2 +1,8 @@
+export {
+    getJsonSchemaByName,
+    getJsonSchemaNames,
+    JSON_SCHEMA_ENTRIES,
+    type JsonSchemaName
+} from "./jsonSchemas.js";
 export * as schemas from "./schemas/index.js";
 export { createEmptyFernRcSchema, FernRcSchema, FernYmlSchema } from "./schemas/index.js";

--- a/packages/cli/config/src/index.ts
+++ b/packages/cli/config/src/index.ts
@@ -1,4 +1,5 @@
 export {
+    getFernYmlJsonSchema,
     getJsonSchemaByName,
     getJsonSchemaNames,
     JSON_SCHEMA_ENTRIES,

--- a/packages/cli/config/src/jsonSchemas.ts
+++ b/packages/cli/config/src/jsonSchemas.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+import { AiConfigSchema } from "./schemas/AiConfigSchema.js";
+import { ApiDefinitionSchema } from "./schemas/ApiDefinitionSchema.js";
+import { ApisSchema } from "./schemas/ApisSchema.js";
+import { CliSchema } from "./schemas/CliSchema.js";
+import { DocsSchema } from "./schemas/docs/DocsSchema.js";
+import { FernYmlSchema } from "./schemas/FernYmlSchema.js";
+import { SdksSchema } from "./schemas/SdksSchema.js";
+import { SdkTargetSchema } from "./schemas/SdkTargetSchema.js";
+
+/**
+ * Name of a named JSON Schema exported by this package.
+ *
+ * Each name corresponds to a top-level or frequently referenced section of
+ * `fern.yml`. Agents can introspect these via `fern schema <name>`.
+ */
+export type JsonSchemaName = "fern-yml" | "api" | "apis" | "sdks" | "sdk-target" | "docs" | "ai" | "cli";
+
+type SchemaEntry = {
+    name: JsonSchemaName;
+    description: string;
+    // biome-ignore lint/suspicious/noExplicitAny: zod schemas have heterogeneous shapes; we only convert them to JSON Schema.
+    schema: z.ZodType<any>;
+};
+
+const SCHEMA_ENTRIES: readonly SchemaEntry[] = [
+    {
+        name: "fern-yml",
+        description: "The full fern.yml configuration schema.",
+        schema: FernYmlSchema
+    },
+    {
+        name: "api",
+        description: "A single API definition (the `api:` block in fern.yml).",
+        schema: ApiDefinitionSchema
+    },
+    {
+        name: "apis",
+        description: "A map of named API definitions (the `apis:` block in fern.yml).",
+        schema: ApisSchema
+    },
+    {
+        name: "sdks",
+        description: "The `sdks:` block in fern.yml, including defaultGroup, targets, and readme.",
+        schema: SdksSchema
+    },
+    {
+        name: "sdk-target",
+        description: "A single SDK target (a value inside `sdks.targets`).",
+        schema: SdkTargetSchema
+    },
+    {
+        name: "docs",
+        description: "The `docs:` block in fern.yml (documentation configuration).",
+        schema: DocsSchema
+    },
+    {
+        name: "ai",
+        description: "The `ai:` block in fern.yml (AI-powered example generation config).",
+        schema: AiConfigSchema
+    },
+    {
+        name: "cli",
+        description: "The `cli:` block in fern.yml (CLI version pinning).",
+        schema: CliSchema
+    }
+] as const;
+
+/**
+ * A short, machine-readable description of every schema available via
+ * `getJsonSchemaByName`. Intended for `fern schema list`.
+ */
+export const JSON_SCHEMA_ENTRIES: readonly { name: JsonSchemaName; description: string }[] = SCHEMA_ENTRIES.map(
+    ({ name, description }) => ({ name, description })
+);
+
+/**
+ * Convert a named Fern config schema to a JSON Schema object.
+ *
+ * Returns `undefined` if `name` is not a recognized schema.
+ */
+export function getJsonSchemaByName(name: string): Record<string, unknown> | undefined {
+    const entry = SCHEMA_ENTRIES.find((e) => e.name === name);
+    if (entry == null) {
+        return undefined;
+    }
+    return z.toJSONSchema(entry.schema) as Record<string, unknown>;
+}
+
+/**
+ * Returns the list of all recognized schema names.
+ */
+export function getJsonSchemaNames(): readonly JsonSchemaName[] {
+    return SCHEMA_ENTRIES.map((e) => e.name);
+}

--- a/packages/cli/config/src/jsonSchemas.ts
+++ b/packages/cli/config/src/jsonSchemas.ts
@@ -14,7 +14,15 @@ import { SdkTargetSchema } from "./schemas/SdkTargetSchema.js";
  * Each name corresponds to a top-level or frequently referenced section of
  * `fern.yml`. Agents can introspect these via `fern schema <name>`.
  */
-export type JsonSchemaName = "fern-yml" | "api" | "apis" | "sdks" | "sdk-target" | "docs" | "ai" | "cli";
+export type JsonSchemaName =
+    | "fern-yml"
+    | "fern-yml.api"
+    | "fern-yml.apis"
+    | "fern-yml.sdks"
+    | "fern-yml.sdks.target"
+    | "fern-yml.docs"
+    | "fern-yml.ai"
+    | "fern-yml.cli";
 
 type SchemaEntry = {
     name: JsonSchemaName;
@@ -30,37 +38,37 @@ const SCHEMA_ENTRIES: readonly SchemaEntry[] = [
         schema: FernYmlSchema
     },
     {
-        name: "api",
+        name: "fern-yml.api",
         description: "A single API definition (the `api:` block in fern.yml).",
         schema: ApiDefinitionSchema
     },
     {
-        name: "apis",
+        name: "fern-yml.apis",
         description: "A map of named API definitions (the `apis:` block in fern.yml).",
         schema: ApisSchema
     },
     {
-        name: "sdks",
+        name: "fern-yml.sdks",
         description: "The `sdks:` block in fern.yml, including defaultGroup, targets, and readme.",
         schema: SdksSchema
     },
     {
-        name: "sdk-target",
+        name: "fern-yml.sdks.target",
         description: "A single SDK target (a value inside `sdks.targets`).",
         schema: SdkTargetSchema
     },
     {
-        name: "docs",
+        name: "fern-yml.docs",
         description: "The `docs:` block in fern.yml (documentation configuration).",
         schema: DocsSchema
     },
     {
-        name: "ai",
+        name: "fern-yml.ai",
         description: "The `ai:` block in fern.yml (AI-powered example generation config).",
         schema: AiConfigSchema
     },
     {
-        name: "cli",
+        name: "fern-yml.cli",
         description: "The `cli:` block in fern.yml (CLI version pinning).",
         schema: CliSchema
     }

--- a/packages/cli/config/src/jsonSchemas.ts
+++ b/packages/cli/config/src/jsonSchemas.ts
@@ -18,6 +18,7 @@ export type JsonSchemaName =
     | "fern-yml"
     | "fern-yml.api"
     | "fern-yml.apis"
+    | "fern-yml.apis.api"
     | "fern-yml.sdks"
     | "fern-yml.sdks.target"
     | "fern-yml.docs"
@@ -46,6 +47,11 @@ const SCHEMA_ENTRIES: readonly SchemaEntry[] = [
         name: "fern-yml.apis",
         description: "A map of named API definitions (the `apis:` block in fern.yml).",
         schema: ApisSchema
+    },
+    {
+        name: "fern-yml.apis.api",
+        description: "A single API definition as it appears as an entry inside the `apis:` map in fern.yml.",
+        schema: ApiDefinitionSchema
     },
     {
         name: "fern-yml.sdks",

--- a/packages/cli/config/src/jsonSchemas.ts
+++ b/packages/cli/config/src/jsonSchemas.ts
@@ -11,19 +11,10 @@ import { SdkTargetSchema } from "./schemas/SdkTargetSchema.js";
 /**
  * Name of a named JSON Schema exported by this package.
  *
- * Each name corresponds to a top-level or frequently referenced section of
- * `fern.yml`. Agents can introspect these via `fern schema <name>`.
+ * Names mirror the dot-delimited path inside `fern.yml`. The root (the full
+ * fern.yml schema) is reachable by passing no name to `fern schema`.
  */
-export type JsonSchemaName =
-    | "fern-yml"
-    | "fern-yml.api"
-    | "fern-yml.apis"
-    | "fern-yml.apis.api"
-    | "fern-yml.sdks"
-    | "fern-yml.sdks.target"
-    | "fern-yml.docs"
-    | "fern-yml.ai"
-    | "fern-yml.cli";
+export type JsonSchemaName = "api" | "apis" | "sdks" | "sdks.targets" | "docs" | "ai" | "cli";
 
 type SchemaEntry = {
     name: JsonSchemaName;
@@ -34,64 +25,53 @@ type SchemaEntry = {
 
 const SCHEMA_ENTRIES: readonly SchemaEntry[] = [
     {
-        name: "fern-yml",
-        description: "The full fern.yml configuration schema.",
-        schema: FernYmlSchema
-    },
-    {
-        name: "fern-yml.api",
+        name: "api",
         description: "A single API definition (the `api:` block in fern.yml).",
         schema: ApiDefinitionSchema
     },
     {
-        name: "fern-yml.apis",
+        name: "apis",
         description: "A map of named API definitions (the `apis:` block in fern.yml).",
         schema: ApisSchema
     },
     {
-        name: "fern-yml.apis.api",
-        description: "A single API definition as it appears as an entry inside the `apis:` map in fern.yml.",
-        schema: ApiDefinitionSchema
-    },
-    {
-        name: "fern-yml.sdks",
+        name: "sdks",
         description: "The `sdks:` block in fern.yml, including defaultGroup, targets, and readme.",
         schema: SdksSchema
     },
     {
-        name: "fern-yml.sdks.target",
+        name: "sdks.targets",
         description: "A single SDK target (a value inside `sdks.targets`).",
         schema: SdkTargetSchema
     },
     {
-        name: "fern-yml.docs",
+        name: "docs",
         description: "The `docs:` block in fern.yml (documentation configuration).",
         schema: DocsSchema
     },
     {
-        name: "fern-yml.ai",
+        name: "ai",
         description: "The `ai:` block in fern.yml (AI-powered example generation config).",
         schema: AiConfigSchema
     },
     {
-        name: "fern-yml.cli",
+        name: "cli",
         description: "The `cli:` block in fern.yml (CLI version pinning).",
         schema: CliSchema
     }
 ] as const;
 
 /**
- * A short, machine-readable description of every schema available via
- * `getJsonSchemaByName`. Intended for `fern schema list`.
+ * A short, machine-readable description of every named subsection schema.
  */
 export const JSON_SCHEMA_ENTRIES: readonly { name: JsonSchemaName; description: string }[] = SCHEMA_ENTRIES.map(
     ({ name, description }) => ({ name, description })
 );
 
 /**
- * Convert a named Fern config schema to a JSON Schema object.
+ * Convert a named Fern config subsection schema to a JSON Schema object.
  *
- * Returns `undefined` if `name` is not a recognized schema.
+ * Returns `undefined` if `name` is not a recognized subsection.
  */
 export function getJsonSchemaByName(name: string): Record<string, unknown> | undefined {
     const entry = SCHEMA_ENTRIES.find((e) => e.name === name);
@@ -102,8 +82,15 @@ export function getJsonSchemaByName(name: string): Record<string, unknown> | und
 }
 
 /**
- * Returns the list of all recognized schema names.
+ * Returns the list of all recognized subsection names.
  */
 export function getJsonSchemaNames(): readonly JsonSchemaName[] {
     return SCHEMA_ENTRIES.map((e) => e.name);
+}
+
+/**
+ * Returns the full fern.yml JSON Schema (the root config).
+ */
+export function getFernYmlJsonSchema(): Record<string, unknown> {
+    return z.toJSONSchema(FernYmlSchema) as Record<string, unknown>;
 }


### PR DESCRIPTION
## Description
Linear ticket: Refs [FER-8788](https://linear.app/buildwithfern/issue/FER-8788/cli-v2-add-json-input-and-schema-commands)

Adds a new top-level `fern schema` command to CLI v2 that emits a JSON Schema for `fern.yml`. This is the first of the agent-facing CLI affordances requested in the Linear issue (inspired by [Justin Poehnelt's "Rewrite your CLI for AI agents"](https://justin.poehnelt.com/posts/rewrite-your-cli-for-ai-agents/)).

Rather than relying on stale prose docs, agents can introspect the exact shape of `fern.yml` at runtime:

```
$ fern schema                       # full fern.yml JSON Schema
$ fern schema api                   # the api: block
$ fern schema apis                  # the apis: map (Record<name, ApiDefinition>)
$ fern schema sdks                  # the sdks: block
$ fern schema sdks.targets          # a single SDK target shape (entry inside sdks.targets)
$ fern schema docs                  # the docs: block
$ fern schema ai                    # the ai: block
$ fern schema cli                   # the cli: block
$ fern schema --no-pretty           # minified (pipe-safe for jq etc.)
```

Per review feedback, the command stays simple to start: `fern schema` (no arg) returns the full `fern.yml` schema, and the optional positional accepts a dot-delimited subsection name that mirrors the YAML path (e.g. `sdks.targets` matches the `sdks.targets:` key). No `fern-yml.` prefix — the root is implied. If we ever want jq-style addressing later we can layer it on (`fern schema .api`) without breaking these names.

Design notes:
- Output goes **only to stdout** as pure JSON — no chalk, no stderr chatter — so it's pipe-safe (`fern schema | jq .properties.sdks`).
- Zero runtime dependency on a workspace: `fern.yml` does **not** need to exist for `fern schema` to work. An agent can introspect the schema before writing anything.
- Unknown schema names produce a `CliError` with the list of valid subsections.
- Pretty-printed by default; pass `--no-pretty` for minified output.
- Under the hood we use Zod 4's built-in `z.toJSONSchema()` against the existing `@fern-api/config` schemas — no new runtime dependencies.

Follow-up PRs (#15305, #15306) add `--params <json>` flags to `init`, `sdk add`, and `org` subcommands so agents can round-trip JSON in + JSON out symmetrically.

## Changes Made
- `packages/cli/config/src/jsonSchemas.ts` — new `getFernYmlJsonSchema()` (full root schema) plus `getJsonSchemaByName` / `getJsonSchemaNames` / `JSON_SCHEMA_ENTRIES` helpers for the named subsections (`api`, `apis`, `sdks`, `sdks.targets`, `docs`, `ai`, `cli`). All converted from existing Zod config schemas via `z.toJSONSchema`.
- `packages/cli/config/src/index.ts` — export the new helpers.
- `packages/cli/cli-v2/src/commands/schema/` — new `SchemaCommand` class, `addSchemaCommand` registration, and unit tests.
- `packages/cli/cli-v2/src/cli.ts` — register `addSchemaCommand`.
- `packages/cli/cli/changes/unreleased/cli-v2-schema-command.yml` — changelog entry (`feat`).
- [ ] Updated README.md generator (if applicable) — N/A

## Testing
- [x] Unit tests added/updated — 7 tests in `packages/cli/cli-v2/src/commands/schema/__test__/command.test.ts` covering: full schema (no arg), every named subsection, minified vs pretty output, unknown-name error path, and the no-workspace-required invariant.
- [x] Manual testing completed:
  - `fern schema` returns the full `fern.yml` JSON Schema
  - `fern schema sdks --no-pretty` returns single-line JSON, pipes cleanly through `jq`
  - `fern schema sdks.targets` returns the SdkTarget shape
  - `fern schema not-a-real` fails with `Unknown schema 'not-a-real'. Available subsections: api, apis, sdks, sdks.targets, docs, ai, cli.`
- [x] CI passing

Link to Devin session: https://app.devin.ai/sessions/534eebef0df0409eaf8fde499a4931c3
Requested by: @iamnamananand996