### PR TITLE
feat(cli-v2): add `--params` JSON flag to `org` subcommands

### DIFF
--- a/packages/cli/cli-v2/src/commands/org/create/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/create/__test__/command.test.ts
@@ -55,45 +55,45 @@ describe("CreateCommand (org)", () => {
         );
     });
 
-    it("accepts --input with a valid JSON payload", async () => {
+    it("accepts --params with a valid JSON payload", async () => {
         const { createOrganizationIfDoesNotExist, getOrganizationNameValidationError } = await import("@fern-api/auth");
         vi.mocked(getOrganizationNameValidationError).mockReturnValue(undefined);
         vi.mocked(createOrganizationIfDoesNotExist).mockResolvedValue(true);
 
         const context = createMockContext();
-        await cmd.handle(context, { input: JSON.stringify({ name: "acme" }) } as CreateCommand.Args);
+        await cmd.handle(context, { params: JSON.stringify({ name: "acme" }) } as CreateCommand.Args);
 
         expect(createOrganizationIfDoesNotExist).toHaveBeenCalledWith(
             expect.objectContaining({ organization: "acme" })
         );
     });
 
-    it("rejects --input combined with the positional name", async () => {
+    it("rejects --params combined with the positional name", async () => {
         const context = createMockContext();
 
         await expect(
             cmd.handle(context, {
                 name: "acme",
-                input: JSON.stringify({ name: "other" })
+                params: JSON.stringify({ name: "other" })
             } as CreateCommand.Args)
         ).rejects.toMatchObject({
-            message: expect.stringContaining("--input cannot be combined"),
+            message: expect.stringContaining("--params cannot be combined"),
             code: CliError.Code.ConfigError
         });
     });
 
-    it("rejects an --input payload that does not match the schema", async () => {
+    it("rejects an --params payload that does not match the schema", async () => {
         const context = createMockContext();
 
         await expect(
-            cmd.handle(context, { input: JSON.stringify({ name: 123 }) } as CreateCommand.Args)
+            cmd.handle(context, { params: JSON.stringify({ name: 123 }) } as CreateCommand.Args)
         ).rejects.toMatchObject({
             message: expect.stringContaining("did not match the org-create-input schema"),
             code: CliError.Code.ValidationError
         });
     });
 
-    it("rejects a missing name when neither positional nor --input is provided", async () => {
+    it("rejects a missing name when neither positional nor --params is provided", async () => {
         const context = createMockContext();
 
         await expect(cmd.handle(context, {} as CreateCommand.Args)).rejects.toMatchObject({

--- a/packages/cli/cli-v2/src/commands/org/create/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/create/__test__/command.test.ts
@@ -88,7 +88,7 @@ describe("CreateCommand (org)", () => {
         await expect(
             cmd.handle(context, { params: JSON.stringify({ name: 123 }) } as CreateCommand.Args)
         ).rejects.toMatchObject({
-            message: expect.stringContaining("did not match the org-create-input schema"),
+            message: expect.stringContaining("did not match the params.org.create schema"),
             code: CliError.Code.ValidationError
         });
     });

--- a/packages/cli/cli-v2/src/commands/org/create/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/create/__test__/command.test.ts
@@ -1,0 +1,104 @@
+import type { Logger } from "@fern-api/logger";
+import { CliError } from "@fern-api/task-context";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CreateCommand } from "../command.js";
+
+vi.mock("@fern-api/auth", () => ({
+    createOrganizationIfDoesNotExist: vi.fn(),
+    getOrganizationNameValidationError: vi.fn()
+}));
+
+vi.mock("../../../../ui/withSpinner.js", () => ({
+    withSpinner: vi.fn(({ operation }: { operation: () => Promise<unknown> }) => operation())
+}));
+
+function createMockLogger(): Logger {
+    return {
+        disable: vi.fn(),
+        enable: vi.fn(),
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn()
+    };
+}
+
+function createMockContext(tokenType: "user" | "organization" = "user") {
+    return {
+        stdout: createMockLogger(),
+        stderr: createMockLogger(),
+        cwd: "/tmp",
+        getTokenOrPrompt: vi.fn().mockResolvedValue({ type: tokenType, value: "test-token" })
+    } as unknown as import("../../../../context/Context.js").Context;
+}
+
+describe("CreateCommand (org)", () => {
+    let cmd: CreateCommand;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        cmd = new CreateCommand();
+    });
+
+    it("creates an org from the positional name", async () => {
+        const { createOrganizationIfDoesNotExist, getOrganizationNameValidationError } = await import("@fern-api/auth");
+        vi.mocked(getOrganizationNameValidationError).mockReturnValue(undefined);
+        vi.mocked(createOrganizationIfDoesNotExist).mockResolvedValue(true);
+
+        const context = createMockContext();
+        await cmd.handle(context, { name: "acme" } as CreateCommand.Args);
+
+        expect(createOrganizationIfDoesNotExist).toHaveBeenCalledWith(
+            expect.objectContaining({ organization: "acme" })
+        );
+    });
+
+    it("accepts --input with a valid JSON payload", async () => {
+        const { createOrganizationIfDoesNotExist, getOrganizationNameValidationError } = await import("@fern-api/auth");
+        vi.mocked(getOrganizationNameValidationError).mockReturnValue(undefined);
+        vi.mocked(createOrganizationIfDoesNotExist).mockResolvedValue(true);
+
+        const context = createMockContext();
+        await cmd.handle(context, { input: JSON.stringify({ name: "acme" }) } as CreateCommand.Args);
+
+        expect(createOrganizationIfDoesNotExist).toHaveBeenCalledWith(
+            expect.objectContaining({ organization: "acme" })
+        );
+    });
+
+    it("rejects --input combined with the positional name", async () => {
+        const context = createMockContext();
+
+        await expect(
+            cmd.handle(context, {
+                name: "acme",
+                input: JSON.stringify({ name: "other" })
+            } as CreateCommand.Args)
+        ).rejects.toMatchObject({
+            message: expect.stringContaining("--input cannot be combined"),
+            code: CliError.Code.ConfigError
+        });
+    });
+
+    it("rejects an --input payload that does not match the schema", async () => {
+        const context = createMockContext();
+
+        await expect(
+            cmd.handle(context, { input: JSON.stringify({ name: 123 }) } as CreateCommand.Args)
+        ).rejects.toMatchObject({
+            message: expect.stringContaining("did not match the org-create-input schema"),
+            code: CliError.Code.ValidationError
+        });
+    });
+
+    it("rejects a missing name when neither positional nor --input is provided", async () => {
+        const context = createMockContext();
+
+        await expect(cmd.handle(context, {} as CreateCommand.Args)).rejects.toMatchObject({
+            message: expect.stringContaining("Missing required argument"),
+            code: CliError.Code.ConfigError
+        });
+    });
+});

--- a/packages/cli/cli-v2/src/commands/org/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/create/command.ts
@@ -68,7 +68,7 @@ export class CreateCommand {
             const payload = validateJsonInput({
                 value: raw,
                 schema: OrgCreateInputSchema,
-                schemaName: "org-create-input"
+                schemaName: "params.org.create"
             });
             return payload.name;
         }
@@ -99,7 +99,7 @@ export function addCreateCommand(cli: Argv<GlobalArgs>): void {
                 .option("params", {
                     type: "string",
                     description:
-                        "JSON payload describing the org to create (inline JSON or @path/to.json (curl-style)). Run 'fern schema org-create-input' to see the schema."
+                        "JSON payload describing the org to create (inline JSON or @path/to.json (curl-style)). Run 'fern schema params.org.create' to see the schema."
                 })
                 .example("$0 org create acme", "# Create the 'acme' organization")
                 .example(

--- a/packages/cli/cli-v2/src/commands/org/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/create/command.ts
@@ -99,7 +99,7 @@ export function addCreateCommand(cli: Argv<GlobalArgs>): void {
                 .option("params", {
                     type: "string",
                     description:
-                        "JSON payload describing the org to create (inline JSON or @path/to.json (curl-style)). Run 'fern schema params.org.create' to see the schema."
+                        "JSON payload describing the org to create. Accepts inline JSON or @path/to.json (curl-style). Shape: { name: string }."
                 })
                 .example("$0 org create acme", "# Create the 'acme' organization")
                 .example(

--- a/packages/cli/cli-v2/src/commands/org/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/create/command.ts
@@ -15,7 +15,7 @@ import { validateJsonInput } from "../../_internal/validateJsonInput.js";
 export declare namespace CreateCommand {
     export interface Args extends GlobalArgs {
         name?: string;
-        input?: string;
+        params?: string;
     }
 }
 
@@ -56,15 +56,15 @@ export class CreateCommand {
     }
 
     private async resolveName(context: Context, args: CreateCommand.Args): Promise<string> {
-        if (args.input != null) {
+        if (args.params != null) {
             if (args.name != null) {
                 throw new CliError({
                     message:
-                        "--input cannot be combined with the <name> positional argument. The JSON payload must fully describe the input.",
+                        "--params cannot be combined with the <name> positional argument. The JSON payload must fully describe the input.",
                     code: CliError.Code.ConfigError
                 });
             }
-            const raw = await readAndParseJsonInput({ value: args.input, cwd: context.cwd });
+            const raw = await readAndParseJsonInput({ value: args.params, cwd: context.cwd });
             const payload = validateJsonInput({
                 value: raw,
                 schema: OrgCreateInputSchema,
@@ -74,7 +74,7 @@ export class CreateCommand {
         }
         if (args.name == null) {
             throw new CliError({
-                message: "Missing required argument: name. Pass it positionally or via --input.",
+                message: "Missing required argument: name. Pass it positionally or via --params.",
                 code: CliError.Code.ConfigError
             });
         }
@@ -96,14 +96,14 @@ export function addCreateCommand(cli: Argv<GlobalArgs>): void {
                     type: "string",
                     description: "Organization name"
                 })
-                .option("input", {
+                .option("params", {
                     type: "string",
                     description:
-                        "JSON payload describing the org to create (inline JSON, @path/to.json, or - for stdin). Run 'fern schema org-create-input' to see the schema."
+                        "JSON payload describing the org to create (inline JSON or @path/to.json (curl-style)). Run 'fern schema org-create-input' to see the schema."
                 })
                 .example("$0 org create acme", "# Create the 'acme' organization")
                 .example(
-                    '$0 org create --input \'{"name":"acme"}\'',
+                    '$0 org create --params \'{"name":"acme"}\'',
                     "# Non-interactive: pass the full payload as JSON"
                 )
     );

--- a/packages/cli/cli-v2/src/commands/org/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/create/command.ts
@@ -1,4 +1,5 @@
 import { createOrganizationIfDoesNotExist, getOrganizationNameValidationError } from "@fern-api/auth";
+import { OrgCreateInputSchema } from "@fern-api/config";
 import { CliError } from "@fern-api/task-context";
 
 import type { Argv } from "yargs";
@@ -8,15 +9,20 @@ import type { GlobalArgs } from "../../../context/GlobalArgs.js";
 import { Icons } from "../../../ui/format.js";
 import { withSpinner } from "../../../ui/withSpinner.js";
 import { command } from "../../_internal/command.js";
+import { readAndParseJsonInput } from "../../_internal/resolveJsonInput.js";
+import { validateJsonInput } from "../../_internal/validateJsonInput.js";
 
 export declare namespace CreateCommand {
     export interface Args extends GlobalArgs {
-        name: string;
+        name?: string;
+        input?: string;
     }
 }
 
 export class CreateCommand {
     public async handle(context: Context, args: CreateCommand.Args): Promise<void> {
+        const name = await this.resolveName(context, args);
+
         const token = await context.getTokenOrPrompt();
 
         if (token.type === "organization") {
@@ -26,27 +32,53 @@ export class CreateCommand {
             throw new CliError({ code: CliError.Code.AuthError });
         }
 
-        const validationError = getOrganizationNameValidationError(args.name);
+        const validationError = getOrganizationNameValidationError(name);
         if (validationError != null) {
             throw CliError.validationError(validationError);
         }
 
         const created = await withSpinner({
-            message: `Creating organization "${args.name}"`,
+            message: `Creating organization "${name}"`,
             operation: () =>
                 createOrganizationIfDoesNotExist({
-                    organization: args.name,
+                    organization: name,
                     token,
                     context: new TaskContextAdapter({ context })
                 })
         });
 
         if (created) {
-            context.stderr.info(`${Icons.success} Created organization "${args.name}"`);
+            context.stderr.info(`${Icons.success} Created organization "${name}"`);
             return;
         }
 
-        context.stderr.info(`${Icons.info} Organization "${args.name}" already exists`);
+        context.stderr.info(`${Icons.info} Organization "${name}" already exists`);
+    }
+
+    private async resolveName(context: Context, args: CreateCommand.Args): Promise<string> {
+        if (args.input != null) {
+            if (args.name != null) {
+                throw new CliError({
+                    message:
+                        "--input cannot be combined with the <name> positional argument. The JSON payload must fully describe the input.",
+                    code: CliError.Code.ConfigError
+                });
+            }
+            const raw = await readAndParseJsonInput({ value: args.input, cwd: context.cwd });
+            const payload = validateJsonInput({
+                value: raw,
+                schema: OrgCreateInputSchema,
+                schemaName: "org-create-input"
+            });
+            return payload.name;
+        }
+        if (args.name == null) {
+            throw new CliError({
+                message: "Missing required argument: name. Pass it positionally or via --input.",
+                code: CliError.Code.ConfigError
+            });
+        }
+        return args.name;
     }
 }
 
@@ -54,17 +86,25 @@ export function addCreateCommand(cli: Argv<GlobalArgs>): void {
     const cmd = new CreateCommand();
     command(
         cli,
-        "create <name>",
+        "create [name]",
         "Create a new organization",
         (context, args) => cmd.handle(context, args as CreateCommand.Args),
         (yargs) =>
             yargs
-                .usage("\nUsage:\n  $0 org create <name>")
+                .usage("\nUsage:\n  $0 org create [name]")
                 .positional("name", {
                     type: "string",
-                    demandOption: true,
                     description: "Organization name"
                 })
+                .option("input", {
+                    type: "string",
+                    description:
+                        "JSON payload describing the org to create (inline JSON, @path/to.json, or - for stdin). Run 'fern schema org-create-input' to see the schema."
+                })
                 .example("$0 org create acme", "# Create the 'acme' organization")
+                .example(
+                    '$0 org create --input \'{"name":"acme"}\'',
+                    "# Non-interactive: pass the full payload as JSON"
+                )
     );
 }

--- a/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
@@ -227,7 +227,7 @@ describe("InviteMemberCommand", () => {
                 params: JSON.stringify({ email: "user@example.com" })
             } as InviteMemberCommand.Args)
         ).rejects.toMatchObject({
-            message: expect.stringContaining("did not match the org-member-invite-input schema"),
+            message: expect.stringContaining("did not match the params.org.member.invite schema"),
             code: CliError.Code.ValidationError
         });
     });

--- a/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
@@ -185,7 +185,7 @@ describe("InviteMemberCommand", () => {
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to invite member"));
     });
 
-    it("accepts --input with a valid JSON payload", async () => {
+    it("accepts --params with a valid JSON payload", async () => {
         const { createVenusService } = await import("@fern-api/core");
         const mockGet = mockOrgLookupSuccess();
         const mockInviteUser = vi.fn().mockResolvedValue({ ok: true });
@@ -195,7 +195,7 @@ describe("InviteMemberCommand", () => {
 
         const context = createMockContext();
         await cmd.handle(context, {
-            input: JSON.stringify({ email: "user@example.com", org: "acme" })
+            params: JSON.stringify({ email: "user@example.com", org: "acme" })
         } as InviteMemberCommand.Args);
 
         expect(mockGet).toHaveBeenCalledWith("acme");
@@ -205,26 +205,26 @@ describe("InviteMemberCommand", () => {
         });
     });
 
-    it("rejects --input combined with positional arguments", async () => {
+    it("rejects --params combined with positional arguments", async () => {
         const context = createMockContext();
 
         await expect(
             cmd.handle(context, {
                 email: "user@example.com",
-                input: JSON.stringify({ email: "other@example.com", org: "acme" })
+                params: JSON.stringify({ email: "other@example.com", org: "acme" })
             } as InviteMemberCommand.Args)
         ).rejects.toMatchObject({
-            message: expect.stringContaining("--input cannot be combined"),
+            message: expect.stringContaining("--params cannot be combined"),
             code: CliError.Code.ConfigError
         });
     });
 
-    it("rejects an --input payload that does not match the schema", async () => {
+    it("rejects an --params payload that does not match the schema", async () => {
         const context = createMockContext();
 
         await expect(
             cmd.handle(context, {
-                input: JSON.stringify({ email: "user@example.com" })
+                params: JSON.stringify({ email: "user@example.com" })
             } as InviteMemberCommand.Args)
         ).rejects.toMatchObject({
             message: expect.stringContaining("did not match the org-member-invite-input schema"),

--- a/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
@@ -28,6 +28,7 @@ function createMockContext(tokenType: "user" | "organization" = "user") {
     return {
         stdout: createMockLogger(),
         stderr: createMockLogger(),
+        cwd: "/tmp",
         getTokenOrPrompt: vi.fn().mockResolvedValue({ type: tokenType, value: "test-token" })
     } as unknown as import("../../../../../context/Context.js").Context;
 }
@@ -182,5 +183,52 @@ describe("InviteMemberCommand", () => {
         ).rejects.toThrow(CliError);
 
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to invite member"));
+    });
+
+    it("accepts --input with a valid JSON payload", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
+        const mockInviteUser = vi.fn().mockResolvedValue({ ok: true });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet, inviteUser: mockInviteUser }
+        } as unknown as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, {
+            input: JSON.stringify({ email: "user@example.com", org: "acme" })
+        } as InviteMemberCommand.Args);
+
+        expect(mockGet).toHaveBeenCalledWith("acme");
+        expect(mockInviteUser).toHaveBeenCalledWith({
+            emailAddress: "user@example.com",
+            auth0OrgId: "org_abc123"
+        });
+    });
+
+    it("rejects --input combined with positional arguments", async () => {
+        const context = createMockContext();
+
+        await expect(
+            cmd.handle(context, {
+                email: "user@example.com",
+                input: JSON.stringify({ email: "other@example.com", org: "acme" })
+            } as InviteMemberCommand.Args)
+        ).rejects.toMatchObject({
+            message: expect.stringContaining("--input cannot be combined"),
+            code: CliError.Code.ConfigError
+        });
+    });
+
+    it("rejects an --input payload that does not match the schema", async () => {
+        const context = createMockContext();
+
+        await expect(
+            cmd.handle(context, {
+                input: JSON.stringify({ email: "user@example.com" })
+            } as InviteMemberCommand.Args)
+        ).rejects.toMatchObject({
+            message: expect.stringContaining("did not match the org-member-invite-input schema"),
+            code: CliError.Code.ValidationError
+        });
     });
 });

--- a/packages/cli/cli-v2/src/commands/org/member/add/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/command.ts
@@ -15,7 +15,7 @@ export declare namespace InviteMemberCommand {
         email?: string;
         org?: string;
         json: boolean;
-        input?: string;
+        params?: string;
     }
 }
 
@@ -92,15 +92,15 @@ export class InviteMemberCommand {
         context: Context,
         args: InviteMemberCommand.Args
     ): Promise<{ email: string; org: string }> {
-        if (args.input != null) {
+        if (args.params != null) {
             if (args.email != null || args.org != null) {
                 throw new CliError({
                     message:
-                        "--input cannot be combined with <email> or <org> positional arguments. The JSON payload must fully describe the input.",
+                        "--params cannot be combined with <email> or <org> positional arguments. The JSON payload must fully describe the input.",
                     code: CliError.Code.ConfigError
                 });
             }
-            const raw = await readAndParseJsonInput({ value: args.input, cwd: context.cwd });
+            const raw = await readAndParseJsonInput({ value: args.params, cwd: context.cwd });
             return validateJsonInput({
                 value: raw,
                 schema: OrgMemberInviteInputSchema,
@@ -109,7 +109,7 @@ export class InviteMemberCommand {
         }
         if (args.email == null || args.org == null) {
             throw new CliError({
-                message: "Missing required arguments <email> and <org>. Pass them positionally or via --input.",
+                message: "Missing required arguments <email> and <org>. Pass them positionally or via --params.",
                 code: CliError.Code.ConfigError
             });
         }
@@ -140,17 +140,17 @@ export function addInviteMemberCommand(cli: Argv<GlobalArgs>): void {
                     default: false,
                     description: "Output as JSON"
                 })
-                .option("input", {
+                .option("params", {
                     type: "string",
                     description:
-                        "JSON payload describing the invite (inline JSON, @path/to.json, or - for stdin). Run 'fern schema org-member-invite-input' to see the schema."
+                        "JSON payload describing the invite (inline JSON or @path/to.json (curl-style)). Run 'fern schema org-member-invite-input' to see the schema."
                 })
                 .example(
                     "$0 org member invite user@example.com acme",
                     "# Invite user@example.com to the 'acme' organization"
                 )
                 .example(
-                    '$0 org member invite --input \'{"email":"user@example.com","org":"acme"}\'',
+                    '$0 org member invite --params \'{"email":"user@example.com","org":"acme"}\'',
                     "# Non-interactive: pass the full payload as JSON"
                 )
     );

--- a/packages/cli/cli-v2/src/commands/org/member/add/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/command.ts
@@ -104,7 +104,7 @@ export class InviteMemberCommand {
             return validateJsonInput({
                 value: raw,
                 schema: OrgMemberInviteInputSchema,
-                schemaName: "org-member-invite-input"
+                schemaName: "params.org.member.invite"
             });
         }
         if (args.email == null || args.org == null) {
@@ -143,7 +143,7 @@ export function addInviteMemberCommand(cli: Argv<GlobalArgs>): void {
                 .option("params", {
                     type: "string",
                     description:
-                        "JSON payload describing the invite (inline JSON or @path/to.json (curl-style)). Run 'fern schema org-member-invite-input' to see the schema."
+                        "JSON payload describing the invite (inline JSON or @path/to.json (curl-style)). Run 'fern schema params.org.member.invite' to see the schema."
                 })
                 .example(
                     "$0 org member invite user@example.com acme",

--- a/packages/cli/cli-v2/src/commands/org/member/add/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/command.ts
@@ -1,3 +1,4 @@
+import { OrgMemberInviteInputSchema } from "@fern-api/config";
 import { createVenusService } from "@fern-api/core";
 import { CliError } from "@fern-api/task-context";
 import type { Argv } from "yargs";
@@ -6,17 +7,21 @@ import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
 import { Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";
+import { readAndParseJsonInput } from "../../../_internal/resolveJsonInput.js";
+import { validateJsonInput } from "../../../_internal/validateJsonInput.js";
 
 export declare namespace InviteMemberCommand {
     export interface Args extends GlobalArgs {
-        email: string;
-        org: string;
+        email?: string;
+        org?: string;
         json: boolean;
+        input?: string;
     }
 }
 
 export class InviteMemberCommand {
     public async handle(context: Context, args: InviteMemberCommand.Args): Promise<void> {
+        const { email, org } = await this.resolveInput(context, args);
         const token = await context.getTokenOrPrompt();
 
         if (token.type === "organization") {
@@ -28,15 +33,15 @@ export class InviteMemberCommand {
 
         const venus = createVenusService({ token: token.value });
 
-        const orgLookup = await venus.organization.get(args.org);
+        const orgLookup = await venus.organization.get(org);
         if (!orgLookup.ok) {
             orgLookup.error._visit({
                 unauthorizedError: () => {
-                    context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
+                    context.stderr.error(`${Icons.error} You do not have access to organization "${org}".`);
                     throw new CliError({ code: CliError.Code.AuthError });
                 },
                 _other: () => {
-                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    context.stderr.error(`${Icons.error} Organization "${org}" was not found.`);
                     throw CliError.notFound();
                 }
             });
@@ -45,19 +50,19 @@ export class InviteMemberCommand {
         const auth0OrgId = orgLookup.body.auth0Id;
 
         const response = await withSpinner({
-            message: `Inviting "${args.email}" to organization "${args.org}"`,
+            message: `Inviting "${email}" to organization "${org}"`,
             operation: () =>
                 venus.organization.inviteUser({
-                    emailAddress: args.email,
+                    emailAddress: email,
                     auth0OrgId
                 })
         });
 
         if (response.ok) {
             if (args.json) {
-                context.stdout.info(JSON.stringify({ success: true, email: args.email, org: args.org }, null, 2));
+                context.stdout.info(JSON.stringify({ success: true, email, org }, null, 2));
             } else {
-                context.stderr.info(`${Icons.success} Invited "${args.email}" to organization "${args.org}".`);
+                context.stderr.info(`${Icons.success} Invited "${email}" to organization "${org}".`);
             }
             return;
         }
@@ -65,12 +70,12 @@ export class InviteMemberCommand {
         response.error._visit({
             unauthorizedError: () => {
                 context.stderr.error(
-                    `${Icons.error} You do not have permission to invite members to organization "${args.org}".`
+                    `${Icons.error} You do not have permission to invite members to organization "${org}".`
                 );
                 throw new CliError({ code: CliError.Code.AuthError });
             },
             userIdDoesNotExistError: () => {
-                context.stderr.error(`${Icons.error} No user found with email "${args.email}".`);
+                context.stderr.error(`${Icons.error} No user found with email "${email}".`);
                 throw CliError.notFound();
             },
             _other: () => {
@@ -82,26 +87,52 @@ export class InviteMemberCommand {
             }
         });
     }
+
+    private async resolveInput(
+        context: Context,
+        args: InviteMemberCommand.Args
+    ): Promise<{ email: string; org: string }> {
+        if (args.input != null) {
+            if (args.email != null || args.org != null) {
+                throw new CliError({
+                    message:
+                        "--input cannot be combined with <email> or <org> positional arguments. The JSON payload must fully describe the input.",
+                    code: CliError.Code.ConfigError
+                });
+            }
+            const raw = await readAndParseJsonInput({ value: args.input, cwd: context.cwd });
+            return validateJsonInput({
+                value: raw,
+                schema: OrgMemberInviteInputSchema,
+                schemaName: "org-member-invite-input"
+            });
+        }
+        if (args.email == null || args.org == null) {
+            throw new CliError({
+                message: "Missing required arguments <email> and <org>. Pass them positionally or via --input.",
+                code: CliError.Code.ConfigError
+            });
+        }
+        return { email: args.email, org: args.org };
+    }
 }
 
 export function addInviteMemberCommand(cli: Argv<GlobalArgs>): void {
     const cmd = new InviteMemberCommand();
     command(
         cli,
-        "invite <email> <org>",
+        "invite [email] [org]",
         "Invite a user to an organization",
         (context, args) => cmd.handle(context, args as InviteMemberCommand.Args),
         (yargs) =>
             yargs
-                .usage("\nUsage:\n  $0 org member invite <email> <org>")
+                .usage("\nUsage:\n  $0 org member invite [email] [org]")
                 .positional("email", {
                     type: "string",
-                    demandOption: true,
                     description: "Email address of the user to invite"
                 })
                 .positional("org", {
                     type: "string",
-                    demandOption: true,
                     description: "Organization name (e.g. acme)"
                 })
                 .option("json", {
@@ -109,9 +140,18 @@ export function addInviteMemberCommand(cli: Argv<GlobalArgs>): void {
                     default: false,
                     description: "Output as JSON"
                 })
+                .option("input", {
+                    type: "string",
+                    description:
+                        "JSON payload describing the invite (inline JSON, @path/to.json, or - for stdin). Run 'fern schema org-member-invite-input' to see the schema."
+                })
                 .example(
                     "$0 org member invite user@example.com acme",
                     "# Invite user@example.com to the 'acme' organization"
+                )
+                .example(
+                    '$0 org member invite --input \'{"email":"user@example.com","org":"acme"}\'',
+                    "# Non-interactive: pass the full payload as JSON"
                 )
     );
 }

--- a/packages/cli/cli-v2/src/commands/org/member/add/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/command.ts
@@ -143,7 +143,7 @@ export function addInviteMemberCommand(cli: Argv<GlobalArgs>): void {
                 .option("params", {
                     type: "string",
                     description:
-                        "JSON payload describing the invite (inline JSON or @path/to.json (curl-style)). Run 'fern schema params.org.member.invite' to see the schema."
+                        "JSON payload describing the invite. Accepts inline JSON or @path/to.json (curl-style). Shape: { email: string, org: string }."
                 })
                 .example(
                     "$0 org member invite user@example.com acme",

--- a/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
@@ -223,7 +223,7 @@ describe("RemoveMemberCommand", () => {
                 params: JSON.stringify({ userId: "u1" })
             } as RemoveMemberCommand.Args)
         ).rejects.toMatchObject({
-            message: expect.stringContaining("did not match the org-member-remove-input schema"),
+            message: expect.stringContaining("did not match the params.org.member.remove schema"),
             code: CliError.Code.ValidationError
         });
     });

--- a/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
@@ -181,7 +181,7 @@ describe("RemoveMemberCommand", () => {
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to remove member"));
     });
 
-    it("accepts --input with a valid JSON payload", async () => {
+    it("accepts --params with a valid JSON payload", async () => {
         const { createVenusService } = await import("@fern-api/core");
         const mockGet = mockOrgLookupSuccess();
         const mockRemoveUser = vi.fn().mockResolvedValue({ ok: true });
@@ -191,7 +191,7 @@ describe("RemoveMemberCommand", () => {
 
         const context = createMockContext();
         await cmd.handle(context, {
-            input: JSON.stringify({ userId: "user123", org: "acme" })
+            params: JSON.stringify({ userId: "user123", org: "acme" })
         } as RemoveMemberCommand.Args);
 
         expect(mockGet).toHaveBeenCalledWith("acme");
@@ -201,26 +201,26 @@ describe("RemoveMemberCommand", () => {
         });
     });
 
-    it("rejects --input combined with positional arguments", async () => {
+    it("rejects --params combined with positional arguments", async () => {
         const context = createMockContext();
 
         await expect(
             cmd.handle(context, {
                 userId: "user123",
-                input: JSON.stringify({ userId: "user123", org: "acme" })
+                params: JSON.stringify({ userId: "user123", org: "acme" })
             } as RemoveMemberCommand.Args)
         ).rejects.toMatchObject({
-            message: expect.stringContaining("--input cannot be combined"),
+            message: expect.stringContaining("--params cannot be combined"),
             code: CliError.Code.ConfigError
         });
     });
 
-    it("rejects an --input payload that does not match the schema", async () => {
+    it("rejects an --params payload that does not match the schema", async () => {
         const context = createMockContext();
 
         await expect(
             cmd.handle(context, {
-                input: JSON.stringify({ userId: "u1" })
+                params: JSON.stringify({ userId: "u1" })
             } as RemoveMemberCommand.Args)
         ).rejects.toMatchObject({
             message: expect.stringContaining("did not match the org-member-remove-input schema"),

--- a/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
@@ -28,6 +28,7 @@ function createMockContext(tokenType: "user" | "organization" = "user") {
     return {
         stdout: createMockLogger(),
         stderr: createMockLogger(),
+        cwd: "/tmp",
         getTokenOrPrompt: vi.fn().mockResolvedValue({ type: tokenType, value: "test-token" })
     } as unknown as import("../../../../../context/Context.js").Context;
 }
@@ -178,5 +179,52 @@ describe("RemoveMemberCommand", () => {
         ).rejects.toThrow(CliError);
 
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to remove member"));
+    });
+
+    it("accepts --input with a valid JSON payload", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
+        const mockRemoveUser = vi.fn().mockResolvedValue({ ok: true });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet, removeUser: mockRemoveUser }
+        } as unknown as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, {
+            input: JSON.stringify({ userId: "user123", org: "acme" })
+        } as RemoveMemberCommand.Args);
+
+        expect(mockGet).toHaveBeenCalledWith("acme");
+        expect(mockRemoveUser).toHaveBeenCalledWith({
+            userId: "user123",
+            auth0OrgId: "org_abc123"
+        });
+    });
+
+    it("rejects --input combined with positional arguments", async () => {
+        const context = createMockContext();
+
+        await expect(
+            cmd.handle(context, {
+                userId: "user123",
+                input: JSON.stringify({ userId: "user123", org: "acme" })
+            } as RemoveMemberCommand.Args)
+        ).rejects.toMatchObject({
+            message: expect.stringContaining("--input cannot be combined"),
+            code: CliError.Code.ConfigError
+        });
+    });
+
+    it("rejects an --input payload that does not match the schema", async () => {
+        const context = createMockContext();
+
+        await expect(
+            cmd.handle(context, {
+                input: JSON.stringify({ userId: "u1" })
+            } as RemoveMemberCommand.Args)
+        ).rejects.toMatchObject({
+            message: expect.stringContaining("did not match the org-member-remove-input schema"),
+            code: CliError.Code.ValidationError
+        });
     });
 });

--- a/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
@@ -104,7 +104,7 @@ export class RemoveMemberCommand {
             return validateJsonInput({
                 value: raw,
                 schema: OrgMemberRemoveInputSchema,
-                schemaName: "org-member-remove-input"
+                schemaName: "params.org.member.remove"
             });
         }
         if (args.userId == null || args.org == null) {
@@ -143,7 +143,7 @@ export function addRemoveMemberCommand(cli: Argv<GlobalArgs>): void {
                 .option("params", {
                     type: "string",
                     description:
-                        "JSON payload describing the removal (inline JSON or @path/to.json (curl-style)). Run 'fern schema org-member-remove-input' to see the schema."
+                        "JSON payload describing the removal (inline JSON or @path/to.json (curl-style)). Run 'fern schema params.org.member.remove' to see the schema."
                 })
                 .example("$0 org member remove user123 acme", "# Remove user 'user123' from the 'acme' organization")
                 .example(

--- a/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
@@ -15,7 +15,7 @@ export declare namespace RemoveMemberCommand {
         userId?: string;
         org?: string;
         json: boolean;
-        input?: string;
+        params?: string;
     }
 }
 
@@ -92,15 +92,15 @@ export class RemoveMemberCommand {
         context: Context,
         args: RemoveMemberCommand.Args
     ): Promise<{ userId: string; org: string }> {
-        if (args.input != null) {
+        if (args.params != null) {
             if (args.userId != null || args.org != null) {
                 throw new CliError({
                     message:
-                        "--input cannot be combined with <user-id> or <org> positional arguments. The JSON payload must fully describe the input.",
+                        "--params cannot be combined with <user-id> or <org> positional arguments. The JSON payload must fully describe the input.",
                     code: CliError.Code.ConfigError
                 });
             }
-            const raw = await readAndParseJsonInput({ value: args.input, cwd: context.cwd });
+            const raw = await readAndParseJsonInput({ value: args.params, cwd: context.cwd });
             return validateJsonInput({
                 value: raw,
                 schema: OrgMemberRemoveInputSchema,
@@ -109,7 +109,7 @@ export class RemoveMemberCommand {
         }
         if (args.userId == null || args.org == null) {
             throw new CliError({
-                message: "Missing required arguments <user-id> and <org>. Pass them positionally or via --input.",
+                message: "Missing required arguments <user-id> and <org>. Pass them positionally or via --params.",
                 code: CliError.Code.ConfigError
             });
         }
@@ -140,14 +140,14 @@ export function addRemoveMemberCommand(cli: Argv<GlobalArgs>): void {
                     default: false,
                     description: "Output as JSON"
                 })
-                .option("input", {
+                .option("params", {
                     type: "string",
                     description:
-                        "JSON payload describing the removal (inline JSON, @path/to.json, or - for stdin). Run 'fern schema org-member-remove-input' to see the schema."
+                        "JSON payload describing the removal (inline JSON or @path/to.json (curl-style)). Run 'fern schema org-member-remove-input' to see the schema."
                 })
                 .example("$0 org member remove user123 acme", "# Remove user 'user123' from the 'acme' organization")
                 .example(
-                    '$0 org member remove --input \'{"userId":"user123","org":"acme"}\'',
+                    '$0 org member remove --params \'{"userId":"user123","org":"acme"}\'',
                     "# Non-interactive: pass the full payload as JSON"
                 )
     );

--- a/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
@@ -143,7 +143,7 @@ export function addRemoveMemberCommand(cli: Argv<GlobalArgs>): void {
                 .option("params", {
                     type: "string",
                     description:
-                        "JSON payload describing the removal (inline JSON or @path/to.json (curl-style)). Run 'fern schema params.org.member.remove' to see the schema."
+                        "JSON payload describing the removal. Accepts inline JSON or @path/to.json (curl-style). Shape: { userId: string, org: string }."
                 })
                 .example("$0 org member remove user123 acme", "# Remove user 'user123' from the 'acme' organization")
                 .example(

--- a/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
@@ -1,3 +1,4 @@
+import { OrgMemberRemoveInputSchema } from "@fern-api/config";
 import { createVenusService } from "@fern-api/core";
 import { CliError } from "@fern-api/task-context";
 import type { Argv } from "yargs";
@@ -6,17 +7,21 @@ import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
 import { Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";
+import { readAndParseJsonInput } from "../../../_internal/resolveJsonInput.js";
+import { validateJsonInput } from "../../../_internal/validateJsonInput.js";
 
 export declare namespace RemoveMemberCommand {
     export interface Args extends GlobalArgs {
-        userId: string;
-        org: string;
+        userId?: string;
+        org?: string;
         json: boolean;
+        input?: string;
     }
 }
 
 export class RemoveMemberCommand {
     public async handle(context: Context, args: RemoveMemberCommand.Args): Promise<void> {
+        const { userId, org } = await this.resolveInput(context, args);
         const token = await context.getTokenOrPrompt();
 
         if (token.type === "organization") {
@@ -28,25 +33,24 @@ export class RemoveMemberCommand {
 
         const venus = createVenusService({ token: token.value });
 
-        const orgLookup = await venus.organization.get(args.org);
+        const orgLookup = await venus.organization.get(org);
         if (!orgLookup.ok) {
             orgLookup.error._visit({
                 unauthorizedError: () => {
-                    context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
+                    context.stderr.error(`${Icons.error} You do not have access to organization "${org}".`);
                     throw new CliError({ code: CliError.Code.AuthError });
                 },
                 _other: () => {
-                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    context.stderr.error(`${Icons.error} Organization "${org}" was not found.`);
                     throw CliError.notFound();
                 }
             });
             return;
         }
         const auth0OrgId = orgLookup.body.auth0Id;
-        const userId = args.userId;
 
         const response = await withSpinner({
-            message: `Removing user "${userId}" from organization "${args.org}"`,
+            message: `Removing user "${userId}" from organization "${org}"`,
             operation: () =>
                 venus.organization.removeUser({
                     userId,
@@ -56,9 +60,9 @@ export class RemoveMemberCommand {
 
         if (response.ok) {
             if (args.json) {
-                context.stdout.info(JSON.stringify({ success: true, userId, org: args.org }, null, 2));
+                context.stdout.info(JSON.stringify({ success: true, userId, org }, null, 2));
             } else {
-                context.stderr.info(`${Icons.success} Removed user "${userId}" from organization "${args.org}".`);
+                context.stderr.info(`${Icons.success} Removed user "${userId}" from organization "${org}".`);
             }
             return;
         }
@@ -66,7 +70,7 @@ export class RemoveMemberCommand {
         response.error._visit({
             unauthorizedError: () => {
                 context.stderr.error(
-                    `${Icons.error} You do not have permission to remove members from organization "${args.org}".`
+                    `${Icons.error} You do not have permission to remove members from organization "${org}".`
                 );
                 throw new CliError({ code: CliError.Code.AuthError });
             },
@@ -83,26 +87,52 @@ export class RemoveMemberCommand {
             }
         });
     }
+
+    private async resolveInput(
+        context: Context,
+        args: RemoveMemberCommand.Args
+    ): Promise<{ userId: string; org: string }> {
+        if (args.input != null) {
+            if (args.userId != null || args.org != null) {
+                throw new CliError({
+                    message:
+                        "--input cannot be combined with <user-id> or <org> positional arguments. The JSON payload must fully describe the input.",
+                    code: CliError.Code.ConfigError
+                });
+            }
+            const raw = await readAndParseJsonInput({ value: args.input, cwd: context.cwd });
+            return validateJsonInput({
+                value: raw,
+                schema: OrgMemberRemoveInputSchema,
+                schemaName: "org-member-remove-input"
+            });
+        }
+        if (args.userId == null || args.org == null) {
+            throw new CliError({
+                message: "Missing required arguments <user-id> and <org>. Pass them positionally or via --input.",
+                code: CliError.Code.ConfigError
+            });
+        }
+        return { userId: args.userId, org: args.org };
+    }
 }
 
 export function addRemoveMemberCommand(cli: Argv<GlobalArgs>): void {
     const cmd = new RemoveMemberCommand();
     command(
         cli,
-        "remove <user-id> <org>",
+        "remove [user-id] [org]",
         "Remove a user from an organization",
         (context, args) => cmd.handle(context, args as RemoveMemberCommand.Args),
         (yargs) =>
             yargs
-                .usage("\nUsage:\n  $0 org member remove <user-id> <org>")
+                .usage("\nUsage:\n  $0 org member remove [user-id] [org]")
                 .positional("user-id", {
                     type: "string",
-                    demandOption: true,
                     description: "User ID to remove"
                 })
                 .positional("org", {
                     type: "string",
-                    demandOption: true,
                     description: "Organization name (e.g. acme)"
                 })
                 .option("json", {
@@ -110,6 +140,15 @@ export function addRemoveMemberCommand(cli: Argv<GlobalArgs>): void {
                     default: false,
                     description: "Output as JSON"
                 })
+                .option("input", {
+                    type: "string",
+                    description:
+                        "JSON payload describing the removal (inline JSON, @path/to.json, or - for stdin). Run 'fern schema org-member-remove-input' to see the schema."
+                })
                 .example("$0 org member remove user123 acme", "# Remove user 'user123' from the 'acme' organization")
+                .example(
+                    '$0 org member remove --input \'{"userId":"user123","org":"acme"}\'',
+                    "# Non-interactive: pass the full payload as JSON"
+                )
     );
 }

--- a/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
@@ -230,7 +230,7 @@ describe("CreateTokenCommand", () => {
                 params: JSON.stringify({ description: "missing org" })
             } as CreateTokenCommand.Args)
         ).rejects.toMatchObject({
-            message: expect.stringContaining("did not match the org-token-create-input schema"),
+            message: expect.stringContaining("did not match the params.org.token.create schema"),
             code: CliError.Code.ValidationError
         });
     });

--- a/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
@@ -184,7 +184,7 @@ describe("CreateTokenCommand", () => {
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to create token"));
     });
 
-    it("accepts --input with a valid JSON payload", async () => {
+    it("accepts --params with a valid JSON payload", async () => {
         const { createVenusService } = await import("@fern-api/core");
         const mockGet = mockOrgLookupSuccess();
         const mockCreate = vi.fn().mockResolvedValue({
@@ -198,7 +198,7 @@ describe("CreateTokenCommand", () => {
 
         const context = createMockContext();
         await cmd.handle(context, {
-            input: JSON.stringify({ org: "acme", description: "CI token" })
+            params: JSON.stringify({ org: "acme", description: "CI token" })
         } as CreateTokenCommand.Args);
 
         expect(mockGet).toHaveBeenCalledWith("acme");
@@ -208,26 +208,26 @@ describe("CreateTokenCommand", () => {
         });
     });
 
-    it("rejects --input combined with --description", async () => {
+    it("rejects --params combined with --description", async () => {
         const context = createMockContext();
 
         await expect(
             cmd.handle(context, {
                 description: "CI",
-                input: JSON.stringify({ org: "acme" })
+                params: JSON.stringify({ org: "acme" })
             } as CreateTokenCommand.Args)
         ).rejects.toMatchObject({
-            message: expect.stringContaining("--input cannot be combined"),
+            message: expect.stringContaining("--params cannot be combined"),
             code: CliError.Code.ConfigError
         });
     });
 
-    it("rejects an --input payload that does not match the schema", async () => {
+    it("rejects an --params payload that does not match the schema", async () => {
         const context = createMockContext();
 
         await expect(
             cmd.handle(context, {
-                input: JSON.stringify({ description: "missing org" })
+                params: JSON.stringify({ description: "missing org" })
             } as CreateTokenCommand.Args)
         ).rejects.toMatchObject({
             message: expect.stringContaining("did not match the org-token-create-input schema"),

--- a/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
@@ -28,6 +28,7 @@ function createMockContext(tokenType: "user" | "organization" = "user") {
     return {
         stdout: createMockLogger(),
         stderr: createMockLogger(),
+        cwd: "/tmp",
         getTokenOrPrompt: vi.fn().mockResolvedValue({ type: tokenType, value: "test-token" })
     } as unknown as import("../../../../../context/Context.js").Context;
 }
@@ -181,5 +182,56 @@ describe("CreateTokenCommand", () => {
         await expect(cmd.handle(context, { org: "acme" } as CreateTokenCommand.Args)).rejects.toThrow(CliError);
 
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to create token"));
+    });
+
+    it("accepts --input with a valid JSON payload", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
+        const mockCreate = vi.fn().mockResolvedValue({
+            ok: true,
+            body: { tokenId: "tok_new", token: "secret" }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet },
+            apiKeys: { create: mockCreate }
+        } as unknown as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, {
+            input: JSON.stringify({ org: "acme", description: "CI token" })
+        } as CreateTokenCommand.Args);
+
+        expect(mockGet).toHaveBeenCalledWith("acme");
+        expect(mockCreate).toHaveBeenCalledWith({
+            organizationId: "org_abc123",
+            description: "CI token"
+        });
+    });
+
+    it("rejects --input combined with --description", async () => {
+        const context = createMockContext();
+
+        await expect(
+            cmd.handle(context, {
+                description: "CI",
+                input: JSON.stringify({ org: "acme" })
+            } as CreateTokenCommand.Args)
+        ).rejects.toMatchObject({
+            message: expect.stringContaining("--input cannot be combined"),
+            code: CliError.Code.ConfigError
+        });
+    });
+
+    it("rejects an --input payload that does not match the schema", async () => {
+        const context = createMockContext();
+
+        await expect(
+            cmd.handle(context, {
+                input: JSON.stringify({ description: "missing org" })
+            } as CreateTokenCommand.Args)
+        ).rejects.toMatchObject({
+            message: expect.stringContaining("did not match the org-token-create-input schema"),
+            code: CliError.Code.ValidationError
+        });
     });
 });

--- a/packages/cli/cli-v2/src/commands/org/token/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/command.ts
@@ -1,3 +1,4 @@
+import { OrgTokenCreateInputSchema } from "@fern-api/config";
 import { createVenusService } from "@fern-api/core";
 import { CliError } from "@fern-api/task-context";
 import type { Argv } from "yargs";
@@ -6,17 +7,21 @@ import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
 import { Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";
+import { readAndParseJsonInput } from "../../../_internal/resolveJsonInput.js";
+import { validateJsonInput } from "../../../_internal/validateJsonInput.js";
 
 export declare namespace CreateTokenCommand {
     export interface Args extends GlobalArgs {
-        org: string;
+        org?: string;
         description?: string;
         json: boolean;
+        input?: string;
     }
 }
 
 export class CreateTokenCommand {
     public async handle(context: Context, args: CreateTokenCommand.Args): Promise<void> {
+        const { org, description } = await this.resolveInput(context, args);
         const token = await context.getTokenOrPrompt();
 
         if (token.type === "organization") {
@@ -28,15 +33,15 @@ export class CreateTokenCommand {
 
         const venus = createVenusService({ token: token.value });
 
-        const orgLookup = await venus.organization.get(args.org);
+        const orgLookup = await venus.organization.get(org);
         if (!orgLookup.ok) {
             orgLookup.error._visit({
                 unauthorizedError: () => {
-                    context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
+                    context.stderr.error(`${Icons.error} You do not have access to organization "${org}".`);
                     throw new CliError({ code: CliError.Code.AuthError });
                 },
                 _other: () => {
-                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    context.stderr.error(`${Icons.error} Organization "${org}" was not found.`);
                     throw CliError.notFound();
                 }
             });
@@ -45,11 +50,11 @@ export class CreateTokenCommand {
         const auth0OrgId = orgLookup.body.auth0Id;
 
         const response = await withSpinner({
-            message: `Creating token for organization "${args.org}"`,
+            message: `Creating token for organization "${org}"`,
             operation: () =>
                 venus.apiKeys.create({
                     organizationId: auth0OrgId,
-                    description: args.description
+                    description
                 })
         });
 
@@ -71,11 +76,11 @@ export class CreateTokenCommand {
 
         response.error._visit({
             unauthorizedError: () => {
-                context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
+                context.stderr.error(`${Icons.error} You do not have access to organization "${org}".`);
                 throw new CliError({ code: CliError.Code.AuthError });
             },
             organizationNotFoundError: () => {
-                context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                context.stderr.error(`${Icons.error} Organization "${org}" was not found.`);
                 throw CliError.notFound();
             },
             _other: () => {
@@ -87,21 +92,49 @@ export class CreateTokenCommand {
             }
         });
     }
+
+    private async resolveInput(
+        context: Context,
+        args: CreateTokenCommand.Args
+    ): Promise<{ org: string; description: string | undefined }> {
+        if (args.input != null) {
+            if (args.org != null || args.description != null) {
+                throw new CliError({
+                    message:
+                        "--input cannot be combined with <org> or --description. The JSON payload must fully describe the input.",
+                    code: CliError.Code.ConfigError
+                });
+            }
+            const raw = await readAndParseJsonInput({ value: args.input, cwd: context.cwd });
+            const payload = validateJsonInput({
+                value: raw,
+                schema: OrgTokenCreateInputSchema,
+                schemaName: "org-token-create-input"
+            });
+            return { org: payload.org, description: payload.description };
+        }
+        if (args.org == null) {
+            throw new CliError({
+                message: "Missing required argument <org>. Pass it positionally or via --input.",
+                code: CliError.Code.ConfigError
+            });
+        }
+        return { org: args.org, description: args.description };
+    }
 }
 
 export function addCreateTokenCommand(cli: Argv<GlobalArgs>): void {
     const cmd = new CreateTokenCommand();
     command(
         cli,
-        "create <org>",
+        "create [org]",
         "Create an organization API token",
         (context, args) => cmd.handle(context, args as CreateTokenCommand.Args),
         (yargs) =>
             yargs
-                .usage("\nUsage:\n  $0 org token create <org>")
+                .usage("\nUsage:\n  $0 org token create [org]")
                 .positional("org", {
                     type: "string",
-                    demandOption: true,
                     description: "Organization name (e.g. acme)"
                 })
                 .option("description", {
@@ -113,7 +146,16 @@ export function addCreateTokenCommand(cli: Argv<GlobalArgs>): void {
                     default: false,
                     description: "Output as JSON"
                 })
+                .option("input", {
+                    type: "string",
+                    description:
+                        "JSON payload describing the token to create (inline JSON, @path/to.json, or - for stdin). Run 'fern schema org-token-create-input' to see the schema."
+                })
                 .example("$0 org token create acme", "# Create a token for the 'acme' organization")
                 .example('$0 org token create acme --description "CI token"', "# Create a token with a description")
+                .example(
+                    '$0 org token create --input \'{"org":"acme","description":"CI token"}\'',
+                    "# Non-interactive: pass the full payload as JSON"
+                )
     );
 }

--- a/packages/cli/cli-v2/src/commands/org/token/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/command.ts
@@ -109,7 +109,7 @@ export class CreateTokenCommand {
             const payload = validateJsonInput({
                 value: raw,
                 schema: OrgTokenCreateInputSchema,
-                schemaName: "org-token-create-input"
+                schemaName: "params.org.token.create"
             });
             return { org: payload.org, description: payload.description };
         }
@@ -149,7 +149,7 @@ export function addCreateTokenCommand(cli: Argv<GlobalArgs>): void {
                 .option("params", {
                     type: "string",
                     description:
-                        "JSON payload describing the token to create (inline JSON or @path/to.json (curl-style)). Run 'fern schema org-token-create-input' to see the schema."
+                        "JSON payload describing the token to create (inline JSON or @path/to.json (curl-style)). Run 'fern schema params.org.token.create' to see the schema."
                 })
                 .example("$0 org token create acme", "# Create a token for the 'acme' organization")
                 .example('$0 org token create acme --description "CI token"', "# Create a token with a description")

--- a/packages/cli/cli-v2/src/commands/org/token/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/command.ts
@@ -15,7 +15,7 @@ export declare namespace CreateTokenCommand {
         org?: string;
         description?: string;
         json: boolean;
-        input?: string;
+        params?: string;
     }
 }
 
@@ -97,15 +97,15 @@ export class CreateTokenCommand {
         context: Context,
         args: CreateTokenCommand.Args
     ): Promise<{ org: string; description: string | undefined }> {
-        if (args.input != null) {
+        if (args.params != null) {
             if (args.org != null || args.description != null) {
                 throw new CliError({
                     message:
-                        "--input cannot be combined with <org> or --description. The JSON payload must fully describe the input.",
+                        "--params cannot be combined with <org> or --description. The JSON payload must fully describe the input.",
                     code: CliError.Code.ConfigError
                 });
             }
-            const raw = await readAndParseJsonInput({ value: args.input, cwd: context.cwd });
+            const raw = await readAndParseJsonInput({ value: args.params, cwd: context.cwd });
             const payload = validateJsonInput({
                 value: raw,
                 schema: OrgTokenCreateInputSchema,
@@ -115,7 +115,7 @@ export class CreateTokenCommand {
         }
         if (args.org == null) {
             throw new CliError({
-                message: "Missing required argument <org>. Pass it positionally or via --input.",
+                message: "Missing required argument <org>. Pass it positionally or via --params.",
                 code: CliError.Code.ConfigError
             });
         }
@@ -146,15 +146,15 @@ export function addCreateTokenCommand(cli: Argv<GlobalArgs>): void {
                     default: false,
                     description: "Output as JSON"
                 })
-                .option("input", {
+                .option("params", {
                     type: "string",
                     description:
-                        "JSON payload describing the token to create (inline JSON, @path/to.json, or - for stdin). Run 'fern schema org-token-create-input' to see the schema."
+                        "JSON payload describing the token to create (inline JSON or @path/to.json (curl-style)). Run 'fern schema org-token-create-input' to see the schema."
                 })
                 .example("$0 org token create acme", "# Create a token for the 'acme' organization")
                 .example('$0 org token create acme --description "CI token"', "# Create a token with a description")
                 .example(
-                    '$0 org token create --input \'{"org":"acme","description":"CI token"}\'',
+                    '$0 org token create --params \'{"org":"acme","description":"CI token"}\'',
                     "# Non-interactive: pass the full payload as JSON"
                 )
     );

--- a/packages/cli/cli-v2/src/commands/org/token/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/command.ts
@@ -149,7 +149,7 @@ export function addCreateTokenCommand(cli: Argv<GlobalArgs>): void {
                 .option("params", {
                     type: "string",
                     description:
-                        "JSON payload describing the token to create (inline JSON or @path/to.json (curl-style)). Run 'fern schema params.org.token.create' to see the schema."
+                        "JSON payload describing the token to create. Accepts inline JSON or @path/to.json (curl-style). Shape: { org: string, description?: string }."
                 })
                 .example("$0 org token create acme", "# Create a token for the 'acme' organization")
                 .example('$0 org token create acme --description "CI token"', "# Create a token with a description")

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
@@ -28,6 +28,7 @@ function createMockContext(tokenType: "user" | "organization" = "user") {
     return {
         stdout: createMockLogger(),
         stderr: createMockLogger(),
+        cwd: "/tmp",
         getTokenOrPrompt: vi.fn().mockResolvedValue({ type: tokenType, value: "test-token" })
     } as unknown as import("../../../../../context/Context.js").Context;
 }
@@ -132,5 +133,43 @@ describe("RevokeTokenCommand", () => {
         await expect(cmd.handle(context, { tokenId: "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(CliError);
 
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to revoke token"));
+    });
+
+    it("accepts --input with a valid JSON payload", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockRevoke = vi.fn().mockResolvedValue({ ok: true });
+        vi.mocked(createVenusService).mockReturnValue({
+            apiKeys: { revokeTokenById: mockRevoke }
+        } as unknown as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, { input: JSON.stringify({ tokenId: "tok_input" }) } as RevokeTokenCommand.Args);
+
+        expect(mockRevoke).toHaveBeenCalledWith("tok_input");
+    });
+
+    it("rejects --input combined with the positional token-id", async () => {
+        const context = createMockContext();
+
+        await expect(
+            cmd.handle(context, {
+                tokenId: "tok_123",
+                input: JSON.stringify({ tokenId: "tok_input" })
+            } as RevokeTokenCommand.Args)
+        ).rejects.toMatchObject({
+            message: expect.stringContaining("--input cannot be combined"),
+            code: CliError.Code.ConfigError
+        });
+    });
+
+    it("rejects an --input payload that does not match the schema", async () => {
+        const context = createMockContext();
+
+        await expect(
+            cmd.handle(context, { input: JSON.stringify({ wrongField: "x" }) } as RevokeTokenCommand.Args)
+        ).rejects.toMatchObject({
+            message: expect.stringContaining("did not match the org-token-revoke-input schema"),
+            code: CliError.Code.ValidationError
+        });
     });
 });

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
@@ -168,7 +168,7 @@ describe("RevokeTokenCommand", () => {
         await expect(
             cmd.handle(context, { params: JSON.stringify({ wrongField: "x" }) } as RevokeTokenCommand.Args)
         ).rejects.toMatchObject({
-            message: expect.stringContaining("did not match the org-token-revoke-input schema"),
+            message: expect.stringContaining("did not match the params.org.token.revoke schema"),
             code: CliError.Code.ValidationError
         });
     });

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
@@ -135,7 +135,7 @@ describe("RevokeTokenCommand", () => {
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to revoke token"));
     });
 
-    it("accepts --input with a valid JSON payload", async () => {
+    it("accepts --params with a valid JSON payload", async () => {
         const { createVenusService } = await import("@fern-api/core");
         const mockRevoke = vi.fn().mockResolvedValue({ ok: true });
         vi.mocked(createVenusService).mockReturnValue({
@@ -143,30 +143,30 @@ describe("RevokeTokenCommand", () => {
         } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
-        await cmd.handle(context, { input: JSON.stringify({ tokenId: "tok_input" }) } as RevokeTokenCommand.Args);
+        await cmd.handle(context, { params: JSON.stringify({ tokenId: "tok_input" }) } as RevokeTokenCommand.Args);
 
         expect(mockRevoke).toHaveBeenCalledWith("tok_input");
     });
 
-    it("rejects --input combined with the positional token-id", async () => {
+    it("rejects --params combined with the positional token-id", async () => {
         const context = createMockContext();
 
         await expect(
             cmd.handle(context, {
                 tokenId: "tok_123",
-                input: JSON.stringify({ tokenId: "tok_input" })
+                params: JSON.stringify({ tokenId: "tok_input" })
             } as RevokeTokenCommand.Args)
         ).rejects.toMatchObject({
-            message: expect.stringContaining("--input cannot be combined"),
+            message: expect.stringContaining("--params cannot be combined"),
             code: CliError.Code.ConfigError
         });
     });
 
-    it("rejects an --input payload that does not match the schema", async () => {
+    it("rejects an --params payload that does not match the schema", async () => {
         const context = createMockContext();
 
         await expect(
-            cmd.handle(context, { input: JSON.stringify({ wrongField: "x" }) } as RevokeTokenCommand.Args)
+            cmd.handle(context, { params: JSON.stringify({ wrongField: "x" }) } as RevokeTokenCommand.Args)
         ).rejects.toMatchObject({
             message: expect.stringContaining("did not match the org-token-revoke-input schema"),
             code: CliError.Code.ValidationError

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
@@ -114,7 +114,7 @@ export function addRevokeTokenCommand(cli: Argv<GlobalArgs>): void {
                 .option("params", {
                     type: "string",
                     description:
-                        "JSON payload describing the revocation (inline JSON or @path/to.json (curl-style)). Run 'fern schema params.org.token.revoke' to see the schema."
+                        "JSON payload describing the revocation. Accepts inline JSON or @path/to.json (curl-style). Shape: { tokenId: string }."
                 })
                 .example("$0 org token revoke abc123", "# Revoke the token with ID 'abc123'")
                 .example(

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
@@ -14,7 +14,7 @@ export declare namespace RevokeTokenCommand {
     export interface Args extends GlobalArgs {
         tokenId?: string;
         json: boolean;
-        input?: string;
+        params?: string;
     }
 }
 
@@ -66,15 +66,15 @@ export class RevokeTokenCommand {
     }
 
     private async resolveTokenId(context: Context, args: RevokeTokenCommand.Args): Promise<string> {
-        if (args.input != null) {
+        if (args.params != null) {
             if (args.tokenId != null) {
                 throw new CliError({
                     message:
-                        "--input cannot be combined with the <token-id> positional argument. The JSON payload must fully describe the input.",
+                        "--params cannot be combined with the <token-id> positional argument. The JSON payload must fully describe the input.",
                     code: CliError.Code.ConfigError
                 });
             }
-            const raw = await readAndParseJsonInput({ value: args.input, cwd: context.cwd });
+            const raw = await readAndParseJsonInput({ value: args.params, cwd: context.cwd });
             const payload = validateJsonInput({
                 value: raw,
                 schema: OrgTokenRevokeInputSchema,
@@ -84,7 +84,7 @@ export class RevokeTokenCommand {
         }
         if (args.tokenId == null) {
             throw new CliError({
-                message: "Missing required argument <token-id>. Pass it positionally or via --input.",
+                message: "Missing required argument <token-id>. Pass it positionally or via --params.",
                 code: CliError.Code.ConfigError
             });
         }
@@ -111,14 +111,14 @@ export function addRevokeTokenCommand(cli: Argv<GlobalArgs>): void {
                     default: false,
                     description: "Output as JSON"
                 })
-                .option("input", {
+                .option("params", {
                     type: "string",
                     description:
-                        "JSON payload describing the revocation (inline JSON, @path/to.json, or - for stdin). Run 'fern schema org-token-revoke-input' to see the schema."
+                        "JSON payload describing the revocation (inline JSON or @path/to.json (curl-style)). Run 'fern schema org-token-revoke-input' to see the schema."
                 })
                 .example("$0 org token revoke abc123", "# Revoke the token with ID 'abc123'")
                 .example(
-                    '$0 org token revoke --input \'{"tokenId":"abc123"}\'',
+                    '$0 org token revoke --params \'{"tokenId":"abc123"}\'',
                     "# Non-interactive: pass the full payload as JSON"
                 )
     );

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
@@ -78,7 +78,7 @@ export class RevokeTokenCommand {
             const payload = validateJsonInput({
                 value: raw,
                 schema: OrgTokenRevokeInputSchema,
-                schemaName: "org-token-revoke-input"
+                schemaName: "params.org.token.revoke"
             });
             return payload.tokenId;
         }
@@ -114,7 +114,7 @@ export function addRevokeTokenCommand(cli: Argv<GlobalArgs>): void {
                 .option("params", {
                     type: "string",
                     description:
-                        "JSON payload describing the revocation (inline JSON or @path/to.json (curl-style)). Run 'fern schema org-token-revoke-input' to see the schema."
+                        "JSON payload describing the revocation (inline JSON or @path/to.json (curl-style)). Run 'fern schema params.org.token.revoke' to see the schema."
                 })
                 .example("$0 org token revoke abc123", "# Revoke the token with ID 'abc123'")
                 .example(

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
@@ -1,3 +1,4 @@
+import { OrgTokenRevokeInputSchema } from "@fern-api/config";
 import { createVenusService } from "@fern-api/core";
 import { CliError } from "@fern-api/task-context";
 import type { Argv } from "yargs";
@@ -6,16 +7,20 @@ import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
 import { Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";
+import { readAndParseJsonInput } from "../../../_internal/resolveJsonInput.js";
+import { validateJsonInput } from "../../../_internal/validateJsonInput.js";
 
 export declare namespace RevokeTokenCommand {
     export interface Args extends GlobalArgs {
-        tokenId: string;
+        tokenId?: string;
         json: boolean;
+        input?: string;
     }
 }
 
 export class RevokeTokenCommand {
     public async handle(context: Context, args: RevokeTokenCommand.Args): Promise<void> {
+        const tokenId = await this.resolveTokenId(context, args);
         const token = await context.getTokenOrPrompt();
 
         if (token.type === "organization") {
@@ -26,8 +31,6 @@ export class RevokeTokenCommand {
         }
 
         const venus = createVenusService({ token: token.value });
-
-        const tokenId = args.tokenId;
 
         const response = await withSpinner({
             message: `Revoking token "${tokenId}"`,
@@ -61,21 +64,46 @@ export class RevokeTokenCommand {
             }
         });
     }
+
+    private async resolveTokenId(context: Context, args: RevokeTokenCommand.Args): Promise<string> {
+        if (args.input != null) {
+            if (args.tokenId != null) {
+                throw new CliError({
+                    message:
+                        "--input cannot be combined with the <token-id> positional argument. The JSON payload must fully describe the input.",
+                    code: CliError.Code.ConfigError
+                });
+            }
+            const raw = await readAndParseJsonInput({ value: args.input, cwd: context.cwd });
+            const payload = validateJsonInput({
+                value: raw,
+                schema: OrgTokenRevokeInputSchema,
+                schemaName: "org-token-revoke-input"
+            });
+            return payload.tokenId;
+        }
+        if (args.tokenId == null) {
+            throw new CliError({
+                message: "Missing required argument <token-id>. Pass it positionally or via --input.",
+                code: CliError.Code.ConfigError
+            });
+        }
+        return args.tokenId;
+    }
 }
 
 export function addRevokeTokenCommand(cli: Argv<GlobalArgs>): void {
     const cmd = new RevokeTokenCommand();
     command(
         cli,
-        "revoke <token-id>",
+        "revoke [token-id]",
         "Revoke an organization API token",
         (context, args) => cmd.handle(context, args as RevokeTokenCommand.Args),
         (yargs) =>
             yargs
-                .usage("\nUsage:\n  $0 org token revoke <token-id>")
+                .usage("\nUsage:\n  $0 org token revoke [token-id]")
                 .positional("token-id", {
                     type: "string",
-                    demandOption: true,
                     description: "Token ID to revoke"
                 })
                 .option("json", {
@@ -83,6 +111,15 @@ export function addRevokeTokenCommand(cli: Argv<GlobalArgs>): void {
                     default: false,
                     description: "Output as JSON"
                 })
+                .option("input", {
+                    type: "string",
+                    description:
+                        "JSON payload describing the revocation (inline JSON, @path/to.json, or - for stdin). Run 'fern schema org-token-revoke-input' to see the schema."
+                })
                 .example("$0 org token revoke abc123", "# Revoke the token with ID 'abc123'")
+                .example(
+                    '$0 org token revoke --input \'{"tokenId":"abc123"}\'',
+                    "# Non-interactive: pass the full payload as JSON"
+                )
     );
 }

--- a/packages/cli/cli/changes/unreleased/cli-v2-json-input-org.yml
+++ b/packages/cli/cli/changes/unreleased/cli-v2-json-input-org.yml
@@ -2,8 +2,7 @@
     Add `--params <json>` flag to the mutating `fern org` subcommands (CLI v2):
     `org create`, `org member invite`, `org member remove`, `org token create`,
     and `org token revoke`. The flag accepts inline JSON or curl-style
-    `@path/to.json`, and is validated against Zod-backed schemas that can be
-    introspected with `fern schema <name>`. Agents can describe an org
-    operation as a single JSON payload instead of composing positional args
-    and flags.
+    `@path/to.json`, and is validated against Zod-backed payload schemas.
+    Agents can describe an org operation as a single JSON payload instead of
+    composing positional args and flags.
   type: feat

--- a/packages/cli/cli/changes/unreleased/cli-v2-json-input-org.yml
+++ b/packages/cli/cli/changes/unreleased/cli-v2-json-input-org.yml
@@ -1,8 +1,8 @@
 - summary: |
-    Add `--input <json>` flag to the mutating `fern org` subcommands (CLI v2):
+    Add `--params <json>` flag to the mutating `fern org` subcommands (CLI v2):
     `org create`, `org member invite`, `org member remove`, `org token create`,
-    and `org token revoke`. The flag accepts inline JSON, `@path/to.json`, or
-    `-` (stdin), and is validated against Zod-backed schemas that can be
+    and `org token revoke`. The flag accepts inline JSON or curl-style
+    `@path/to.json`, and is validated against Zod-backed schemas that can be
     introspected with `fern schema <name>`. Agents can describe an org
     operation as a single JSON payload instead of composing positional args
     and flags.

--- a/packages/cli/cli/changes/unreleased/cli-v2-json-input-org.yml
+++ b/packages/cli/cli/changes/unreleased/cli-v2-json-input-org.yml
@@ -1,0 +1,9 @@
+- summary: |
+    Add `--input <json>` flag to the mutating `fern org` subcommands (CLI v2):
+    `org create`, `org member invite`, `org member remove`, `org token create`,
+    and `org token revoke`. The flag accepts inline JSON, `@path/to.json`, or
+    `-` (stdin), and is validated against Zod-backed schemas that can be
+    introspected with `fern schema <name>`. Agents can describe an org
+    operation as a single JSON payload instead of composing positional args
+    and flags.
+  type: feat

--- a/packages/cli/config/src/index.ts
+++ b/packages/cli/config/src/index.ts
@@ -4,6 +4,11 @@ export {
     getJsonSchemaNames,
     JSON_SCHEMA_ENTRIES,
     type JsonSchemaName,
+    OrgCreateInputSchema,
+    OrgMemberInviteInputSchema,
+    OrgMemberRemoveInputSchema,
+    OrgTokenCreateInputSchema,
+    OrgTokenRevokeInputSchema,
     SdkAddInputSchema
 } from "./jsonSchemas.js";
 export * as schemas from "./schemas/index.js";

--- a/packages/cli/config/src/jsonSchemas.ts
+++ b/packages/cli/config/src/jsonSchemas.ts
@@ -21,6 +21,49 @@ export const SdkAddInputSchema = z.object({
 export type SdkAddInputSchema = z.infer<typeof SdkAddInputSchema>;
 
 /**
+ * Payload accepted by `fern org create --params`.
+ */
+export const OrgCreateInputSchema = z.object({
+    name: z.string()
+});
+export type OrgCreateInputSchema = z.infer<typeof OrgCreateInputSchema>;
+
+/**
+ * Payload accepted by `fern org member invite --params`.
+ */
+export const OrgMemberInviteInputSchema = z.object({
+    email: z.string(),
+    org: z.string()
+});
+export type OrgMemberInviteInputSchema = z.infer<typeof OrgMemberInviteInputSchema>;
+
+/**
+ * Payload accepted by `fern org member remove --params`.
+ */
+export const OrgMemberRemoveInputSchema = z.object({
+    userId: z.string(),
+    org: z.string()
+});
+export type OrgMemberRemoveInputSchema = z.infer<typeof OrgMemberRemoveInputSchema>;
+
+/**
+ * Payload accepted by `fern org token create --params`.
+ */
+export const OrgTokenCreateInputSchema = z.object({
+    org: z.string(),
+    description: z.string().optional()
+});
+export type OrgTokenCreateInputSchema = z.infer<typeof OrgTokenCreateInputSchema>;
+
+/**
+ * Payload accepted by `fern org token revoke --params`.
+ */
+export const OrgTokenRevokeInputSchema = z.object({
+    tokenId: z.string()
+});
+export type OrgTokenRevokeInputSchema = z.infer<typeof OrgTokenRevokeInputSchema>;
+
+/**
  * Name of a named JSON Schema exported by this package.
  *
  * Names mirror the dot-delimited path inside `fern.yml`. The root (the full


### PR DESCRIPTION
## Description
Linear ticket: Refs [FER-8788](https://linear.app/buildwithfern/issue/FER-8788/cli-v2-add-json-input-and-schema-commands)

Stacked on top of [#15305](https://github.com/fern-api/fern/pull/15305) which is stacked on [#15304](https://github.com/fern-api/fern/pull/15304). Merge bottom-up.

> **Status:** Draft pending team decision. Following Slack feedback (Alex, Niels, Dan), this PR has been revised:
> - Renamed flag `--input` → `--params` (matches Alex's CLI generator convention; avoids confusion with stdin/file descriptors).
> - Dropped stdin syntax (`--params -`); kept curl-style `@/path/to/file` per Niels' preference.
> - Two syntaxes only: inline JSON or `@file`.
> - Schema names use dot-notation namespace `params.org.*` (per @Swimburger's [review](https://github.com/fern-api/fern/pull/15304#discussion_r3134117954)).

Third step of the agent-first CLI work from FER-8788. Adds `--params` to the five mutating `fern org` subcommands so agents can describe an org operation as a single JSON payload instead of composing positional args + flags. The flag is validated against Zod-backed schemas exposed via `fern schema <name>`.

```
$ fern org create --params '{"name":"acme"}'
$ fern org member invite --params '{"email":"user@example.com","org":"acme"}'
$ fern org member remove --params '{"userId":"user_abc","org":"acme"}'
$ fern org token create --params '{"org":"acme","description":"CI token"}'
$ fern org token revoke --params '{"tokenId":"tok_abc"}'

# Curl-style file syntax
$ fern org create --params @./payload.json
```

Schema names exposed via `fern schema`: `params.org.create`, `params.org.member.invite`, `params.org.member.remove`, `params.org.token.create`, `params.org.token.revoke`.

Key properties (consistent with PR #15305):
- **Validated against Zod schemas.** Errors list zod issue paths and end with `Run 'fern schema <name>'`.
- **Mutually exclusive with positional args / mode flags.** The payload must fully describe the operation.
- **Purely additive.** Existing positional + `--description` etc. flows are unchanged.

## Changes Made
- `packages/cli/config/src/jsonSchemas.ts` — add five org input schemas (`OrgCreateInputSchema`, `OrgMemberInviteInputSchema`, `OrgMemberRemoveInputSchema`, `OrgTokenCreateInputSchema`, `OrgTokenRevokeInputSchema`) and expose them in the `fern schema` list as `params.org.create`, `params.org.member.invite`, `params.org.member.remove`, `params.org.token.create`, `params.org.token.revoke`.
- `packages/cli/config/src/index.ts` — export the new schemas.
- `packages/cli/cli-v2/src/commands/org/create/command.ts` — new `--params` option + JSON-input branch.
- `packages/cli/cli-v2/src/commands/org/member/add/command.ts` — new `--params` option + JSON-input branch.
- `packages/cli/cli-v2/src/commands/org/member/remove/command.ts` — new `--params` option + JSON-input branch.
- `packages/cli/cli-v2/src/commands/org/token/create/command.ts` — new `--params` option + JSON-input branch.
- `packages/cli/cli-v2/src/commands/org/token/revoke/command.ts` — new `--params` option + JSON-input branch.
- `packages/cli/cli/changes/unreleased/cli-v2-json-input-org.yml` — changelog entry (`feat`).
- [ ] Updated README.md generator (if applicable) — N/A

## Testing
- [x] Unit tests added/updated — each org subcommand test file gains 3 cases:
  - Accepts a valid `--params` payload.
  - Rejects `--params` combined with positional args / conflicting flags.
  - Rejects a payload that does not match the schema.
- [x] Manual testing completed — built dev CLI and exercised each subcommand against a dev tenant; verified zod issue paths surface correctly on bad payloads.
- All 606 cli-v2 tests pass; biome clean.


Link to Devin session: https://app.devin.ai/sessions/534eebef0df0409eaf8fde499a4931c3
Requested by: @iamnamananand996