### PR TITLE
fix(generator-cli): bundle autoversion workspace deps so dist/api.js has no phantom deps

### DIFF
--- a/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.16.yml
+++ b/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.16.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.16, which bundles the autoversion
+    pipeline's private workspace deps (@fern-api/logging-execa,
+    @fern-api/task-context, @fern-api/cli-ai) into the published dist/api.js
+    so consumers no longer hit ERR_MODULE_NOT_FOUND on
+    logging-execa/src/createLoggingExecutable.js under Vite/Vitest.
+  type: chore

--- a/generators/typescript/sdk/changes/unreleased/bump-generator-cli-0.9.16.yml
+++ b/generators/typescript/sdk/changes/unreleased/bump-generator-cli-0.9.16.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.16, which bundles the autoversion
+    pipeline's private workspace deps (@fern-api/logging-execa,
+    @fern-api/task-context, @fern-api/cli-ai) into the published dist/api.js
+    so consumers no longer hit ERR_MODULE_NOT_FOUND on
+    logging-execa/src/createLoggingExecutable.js under Vite/Vitest.
+  type: chore

--- a/packages/generator-cli/build.mjs
+++ b/packages/generator-cli/build.mjs
@@ -39,12 +39,23 @@ async function main() {
         external: ["@boundaryml/baml"]
     });
 
-    // API: bundle private workspace deps (@fern-api/github, @fern-api/fs-utils),
-    // keep published deps external so npm manages them for consumers
+    // API: bundle private workspace deps so consumers of the published
+    // package don't need them on disk (they aren't listed as npm deps), keep
+    // published deps external so npm manages them for consumers. Keep
+    // @boundaryml/baml external so esbuild does not bundle its platform-
+    // specific native .node files; baml is a direct dep of generator-cli
+    // below and resolved from node_modules at runtime.
     await tsup.build({
         ...commonConfig,
         entry: ["src/api.ts"],
-        noExternal: ["@fern-api/github", "@fern-api/fs-utils", "@fern-api/core-utils"],
+        noExternal: [
+            "@fern-api/github",
+            "@fern-api/fs-utils",
+            "@fern-api/core-utils",
+            "@fern-api/logging-execa",
+            "@fern-api/task-context",
+            "@fern-api/cli-ai"
+        ],
         external: ["@fern-api/replay", "@octokit/rest", "es-toolkit", "tmp-promise", "@boundaryml/baml"],
         clean: false
     });

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,24 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Bundle the private workspace deps used by the autoversion pipeline
+        (`@fern-api/logging-execa`, `@fern-api/task-context`, `@fern-api/cli-ai`)
+        into the published `dist/api.js`. They were added to generator-cli as
+        `workspace:*` deps for autoversion, but `build.mjs` only force-bundled
+        `@fern-api/github`, `@fern-api/fs-utils`, and `@fern-api/core-utils`,
+        so tsup externalized the new ones. The workspace filter in `build.mjs`
+        strips `workspace:*` entries from the published `package.json`, so
+        consumers received an `api.js` doing `require("@fern-api/logging-execa")`
+        (etc.) with no matching entry in `dependencies`. pnpm `install` papered
+        over this via hoisting, but Vite/Vitest's ESM resolution in consumer
+        packages (e.g. `@fern-api/openapi-generator`) surfaced the phantom dep
+        as `ERR_MODULE_NOT_FOUND` on `logging-execa/src/createLoggingExecutable.js`.
+      type: fix
+  createdAt: "2026-04-23"
+  version: 0.9.16
+
+- changelogEntry:
+    - summary: |
         Fix autoversion placeholder leak on NO_CHANGE runs and auto-wire
         `GithubStep` PR body from the `AutoVersionStep` result (FER-10028,
         FER-10029).


### PR DESCRIPTION
## Description
Linear ticket: Refs FER-9980

Fix a phantom dependency in the published `@fern-api/generator-cli` bundle that broke Vitest module resolution in consumer packages (e.g. `@fern-api/openapi-generator`) once generator-cli's autoversion pipeline shipped.

## Root cause
[PR #15287](https://github.com/fern-api/fern/pull/15287) added three new `workspace:*` deps to `packages/generator-cli/package.json` so the autoversion pipeline could call them: `@fern-api/logging-execa`, `@fern-api/task-context`, `@fern-api/cli-ai`. But `build.mjs` only force-bundled the older workspace deps:

```js
noExternal: ["@fern-api/github", "@fern-api/fs-utils", "@fern-api/core-utils"],
```

so tsup externalized the three new ones. Meanwhile `build.mjs` writes the published `package.json` with a filter that strips `workspace:*` entries (they aren't real npm packages):

```js
Object.entries(packageJson.dependencies).filter(([, v]) => !String(v).startsWith("workspace:"))
```

The net effect is that from `0.9.13` onward the published `dist/api.js` contains `require("@fern-api/logging-execa")` with **no matching entry** in `dependencies`. Confirmed on the npm tarball:

```
$ grep -oE 'require\("@fern-api/[^"]+"\)' node_modules/.pnpm/@fern-api+generator-cli@0.9.13/…/dist/api.js | sort -u
require("@fern-api/logging-execa")
require("@fern-api/replay")

$ cat node_modules/.pnpm/@fern-api+generator-cli@0.9.13/…/package.json
{ "dependencies": { "@boundaryml/baml": "...", "@fern-api/replay": "...", "@octokit/rest": "...", "es-toolkit": "...", "semver": "...", "tmp-promise": "..." } }
```

pnpm `install` papered over this via hoisting (the workspace copy of `logging-execa` is visible from `node_modules/.pnpm/node_modules/@fern-api/logging-execa`), but Vite/Vitest's ESM resolution — which bypasses pnpm's virtual store resolution — surfaces the phantom dep as:

```
Error: Cannot find module '.../packages/commons/logging-execa/src/createLoggingExecutable.js' imported from .../packages/commons/logging-execa/src/index.ts
  code: 'ERR_MODULE_NOT_FOUND'
```

in the first consumer PR that re-pinned the catalog to `0.9.13`/`0.9.14`/`0.9.15` (see #15297, where `@fern-api/openapi-generator` tests started failing under Vitest with no code changes in that package).

## Changes
- `packages/generator-cli/build.mjs`: add `@fern-api/logging-execa`, `@fern-api/task-context`, `@fern-api/cli-ai` to the API build's `noExternal` so tsup bundles them into `dist/api.js`. `@boundaryml/baml` stays external (still resolved from `node_modules` at runtime so esbuild does not try to bundle its platform-specific `.node` bindings — same reason as #15287).
- `packages/generator-cli/versions.yml`: new `0.9.16` `fix` entry.
- `generators/{typescript,python}/sdk/changes/unreleased/bump-generator-cli-0.9.16.yml`: `chore` bumps so the TS + Python SDK generators pick up `0.9.16`.

## Testing
- [x] Rebuilt locally with `pnpm turbo run dist:cli --filter @fern-api/generator-cli`. The resulting `dist/api.js` now only requires external npm deps:
  ```
  $ grep -oE 'require\("@fern-api/[^"]+"\)' packages/generator-cli/dist/dist/api.js | sort -u
  require("@fern-api/replay")
  ```
- [x] `pnpm turbo run test --filter @fern-api/generator-cli`: 38 test files / 367 tests passed, 1 skipped.

## Follow-up
Once `0.9.16` is live on npm, I'll rebase #15297 on top of this so the catalog pin bumps straight from `0.9.11` → `0.9.16` and the `@fern-api/openapi-generator` Vitest failures there go away.


Link to Devin session: https://app.devin.ai/sessions/6683cff4f28846199889da8f8a4bcc43
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
