### PR TITLE
fix(cli): surface real error when org-existence check fails

### DIFF
--- a/packages/cli/auth/src/orgs/createOrganizationIfDoesNotExist.ts
+++ b/packages/cli/auth/src/orgs/createOrganizationIfDoesNotExist.ts
@@ -18,7 +18,50 @@ export async function createOrganizationIfDoesNotExist({
     if (getOrganizationResponse.ok) {
         return false;
     }
-    // if failed response, assume organization does not exist
+
+    // Only treat HTTP 404 as "organization does not exist". Any other failure
+    // (unauthorized, 5xx, timeout) means we can't tell — surfacing the real
+    // error is better than attempting a create that will fail with a
+    // misleading OrganizationAlreadyExistsError when the org already exists.
+    let organizationIsMissing = false;
+    getOrganizationResponse.error._visit({
+        unauthorizedError: () => {
+            context.failAndThrow(
+                `You do not have access to organization "${organization}". ` +
+                    `Run 'fern auth login' as a user with access, or contact an admin.`
+            );
+        },
+        _other: (fetcherError) => {
+            if (fetcherError.reason === "status-code" && fetcherError.statusCode === 404) {
+                organizationIsMissing = true;
+                return;
+            }
+            let detail: string;
+            switch (fetcherError.reason) {
+                case "status-code":
+                case "non-json":
+                case "body-is-null":
+                    detail = `status ${fetcherError.statusCode}`;
+                    break;
+                case "timeout":
+                    detail = "request timed out";
+                    break;
+                case "unknown":
+                    detail = fetcherError.errorMessage;
+                    break;
+            }
+            context.failAndThrow(
+                `Failed to check whether organization "${organization}" exists (${detail}). ` +
+                    `Please retry, and contact support@buildwithfern.com if the issue persists.`,
+                fetcherError
+            );
+        }
+    });
+
+    if (!organizationIsMissing) {
+        // Any non-404 error path already called failAndThrow above.
+        return false;
+    }
 
     const validationError = getOrganizationNameValidationError(organization);
     if (validationError != null) {

--- a/packages/cli/cli/changes/unreleased/fix-org-exists-check.yml
+++ b/packages/cli/cli/changes/unreleased/fix-org-exists-check.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix `fern token` (and other commands that auto-create organizations)
+    returning a misleading `OrganizationAlreadyExistsError` when the
+    org-existence check against venus fails for reasons other than 404.
+    The CLI now only attempts to create an organization on a confirmed 404,
+    and surfaces the real error (unauthorized, 5xx, timeout, etc.) for any
+    other failure mode.
+  type: fix


### PR DESCRIPTION
## Summary

`fern token` and other commands that auto-create organizations were treating any non-ok response from `venus.organization.get` as "org does not exist" and blindly calling `create`. When venus returned 500 (or 401/403, or a timeout), the subsequent create attempt failed with a misleading `OrganizationAlreadyExistsError`, masking the real cause.

This PR narrows the response error using the generated SDK's `Fetcher.Error` discriminated union. A create is only attempted on a confirmed HTTP **404**. All other variants (`status-code` ≠ 404, `non-json`, `body-is-null`, `timeout`, `unknown`) now hard-fail with a specific status or reason via `context.failAndThrow`.

## Companion PR

[fern-api/venus#444](https://github.com/fern-api/venus/pull/444) fixes the underlying 500 that exposed this CLI bug: Auth0 omits `email` for SAML/SSO-provisioned org members, which raised `KeyError` in venus's `get_users_for_org` mapping.

With the venus fix, `fern token` works normally. Without it, this PR still produces a clear error (`status 500`) instead of `OrganizationAlreadyExistsError`.

## Test plan

- [x] `pnpm turbo run compile --filter @fern-api/auth` — passes; exhaustive narrowing verified across all 5 `Fetcher.Error` variants.
- [x] `pnpm lint:biome` / `pnpm format` — clean, no changes.
- [x] Public signature of `createOrganizationIfDoesNotExist` unchanged — all 7 callers across `cli`, `cli-v2`, and `init` continue to compile.
- [ ] Manual: run `fern token --org <some-org-user-lacks-access-to>` → expect "You do not have access to organization" instead of `OrganizationAlreadyExistsError`.

## Changelog

Added `packages/cli/cli/changes/unreleased/fix-org-exists-check.yml` (type: `fix`) per the CLI changelog policy.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
