### PR TITLE
chore(deps): bump @fern-api/dynamic-ir-sdk to 66.1.0

### DIFF
--- a/generators/browser-compatible-base/package.json
+++ b/generators/browser-compatible-base/package.json
@@ -35,7 +35,7 @@
     "@fern-api/casings-generator": "workspace:*",
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "65.5.0",
+    "@fern-api/dynamic-ir-sdk": "66.1.0",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/ir-sdk": "workspace:*",
     "@fern-api/logger": "workspace:*",

--- a/generators/csharp/codegen/package.json
+++ b/generators/csharp/codegen/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "65.5.0",
+    "@fern-api/dynamic-ir-sdk": "66.1.0",
     "@fern-fern/ir-sdk": "66.0.0",
     "domhandler": "catalog:",
     "htmlparser2": "catalog:",

--- a/generators/csharp/dynamic-snippets/package.json
+++ b/generators/csharp/dynamic-snippets/package.json
@@ -36,7 +36,7 @@
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/csharp-codegen": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "65.5.0",
+    "@fern-api/dynamic-ir-sdk": "66.1.0",
     "@fern-api/path-utils": "workspace:*",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",

--- a/generators/go-v2/dynamic-snippets/package.json
+++ b/generators/go-v2/dynamic-snippets/package.json
@@ -35,7 +35,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "65.5.0",
+    "@fern-api/dynamic-ir-sdk": "66.1.0",
     "@fern-api/go-ast": "workspace:*",
     "@fern-api/go-formatter": "workspace:*",
     "@fern-api/path-utils": "workspace:*",

--- a/generators/go-v2/sdk/package.json
+++ b/generators/go-v2/sdk/package.json
@@ -55,6 +55,6 @@
     "dedent": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "@fern-api/dynamic-ir-sdk": "65.5.0"
+    "@fern-api/dynamic-ir-sdk": "66.1.0"
   }
 }

--- a/generators/java-v2/dynamic-snippets/package.json
+++ b/generators/java-v2/dynamic-snippets/package.json
@@ -35,7 +35,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "65.5.0",
+    "@fern-api/dynamic-ir-sdk": "66.1.0",
     "@fern-api/java-ast": "workspace:*",
     "@fern-api/path-utils": "workspace:*",
     "@types/lodash-es": "catalog:",

--- a/generators/php/dynamic-snippets/package.json
+++ b/generators/php/dynamic-snippets/package.json
@@ -35,7 +35,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "65.5.0",
+    "@fern-api/dynamic-ir-sdk": "66.1.0",
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/php-codegen": "workspace:*",
     "@types/lodash-es": "catalog:",

--- a/generators/php/sdk/package.json
+++ b/generators/php/sdk/package.json
@@ -47,7 +47,7 @@
     "@fern-api/mock-utils": "workspace:*",
     "@fern-api/php-base": "workspace:*",
     "@fern-api/php-codegen": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "65.5.0",
+    "@fern-api/dynamic-ir-sdk": "66.1.0",
     "@fern-api/php-dynamic-snippets": "workspace:*",
     "@fern-api/php-model": "workspace:*",
     "@fern-fern/generator-cli-sdk": "^0.1.5",

--- a/generators/python-v2/dynamic-snippets/package.json
+++ b/generators/python-v2/dynamic-snippets/package.json
@@ -35,7 +35,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "65.5.0",
+    "@fern-api/dynamic-ir-sdk": "66.1.0",
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/python-ast": "workspace:*",
     "@fern-api/python-browser-compatible-base": "workspace:*",

--- a/generators/ruby-v2/dynamic-snippets/package.json
+++ b/generators/ruby-v2/dynamic-snippets/package.json
@@ -35,7 +35,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "65.5.0",
+    "@fern-api/dynamic-ir-sdk": "66.1.0",
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/ruby-ast": "workspace:*",
     "@types/lodash-es": "catalog:",

--- a/generators/rust/dynamic-snippets/package.json
+++ b/generators/rust/dynamic-snippets/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@fern-api/configs": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "65.5.0",
+    "@fern-api/dynamic-ir-sdk": "66.1.0",
     "@fern-api/path-utils": "workspace:*",
     "@types/node": "catalog:",
     "typescript": "catalog:",

--- a/generators/rust/sdk/package.json
+++ b/generators/rust/sdk/package.json
@@ -45,7 +45,7 @@
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "65.5.0",
+    "@fern-api/dynamic-ir-sdk": "66.1.0",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/mock-utils": "workspace:*",

--- a/generators/swift/dynamic-snippets/package.json
+++ b/generators/swift/dynamic-snippets/package.json
@@ -35,7 +35,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "65.5.0",
+    "@fern-api/dynamic-ir-sdk": "66.1.0",
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/swift-codegen": "workspace:*",
     "@types/lodash-es": "catalog:",

--- a/generators/typescript-v2/dynamic-snippets/package.json
+++ b/generators/typescript-v2/dynamic-snippets/package.json
@@ -35,7 +35,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "65.5.0",
+    "@fern-api/dynamic-ir-sdk": "66.1.0",
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/typescript-ast": "workspace:*",
     "@fern-api/typescript-browser-compatible-base": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -751,8 +751,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 65.5.0
-        version: 65.5.0
+        specifier: 66.1.0
+        version: 66.1.0
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../../packages/cli/fern-definition/schema
@@ -833,8 +833,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 65.5.0
-        version: 65.5.0
+        specifier: 66.1.0
+        version: 66.1.0
       '@fern-fern/ir-sdk':
         specifier: 66.0.0
         version: 66.0.0
@@ -876,8 +876,8 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@fern-api/dynamic-ir-sdk':
-        specifier: 65.5.0
-        version: 65.5.0
+        specifier: 66.1.0
+        version: 66.1.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -1093,8 +1093,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 65.5.0
-        version: 65.5.0
+        specifier: 66.1.0
+        version: 66.1.0
       '@fern-api/go-ast':
         specifier: workspace:*
         version: link:../ast
@@ -1181,8 +1181,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 65.5.0
-        version: 65.5.0
+        specifier: 66.1.0
+        version: 66.1.0
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/fs-utils
@@ -1293,8 +1293,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 65.5.0
-        version: 65.5.0
+        specifier: 66.1.0
+        version: 66.1.0
       '@fern-api/java-ast':
         specifier: workspace:*
         version: link:../ast
@@ -1501,8 +1501,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 65.5.0
-        version: 65.5.0
+        specifier: 66.1.0
+        version: 66.1.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -1573,8 +1573,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 65.5.0
-        version: 65.5.0
+        specifier: 66.1.0
+        version: 66.1.0
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/fs-utils
@@ -1721,8 +1721,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 65.5.0
-        version: 65.5.0
+        specifier: 66.1.0
+        version: 66.1.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -1956,8 +1956,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 65.5.0
-        version: 65.5.0
+        specifier: 66.1.0
+        version: 66.1.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -2157,8 +2157,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/configs
       '@fern-api/dynamic-ir-sdk':
-        specifier: 65.5.0
-        version: 65.5.0
+        specifier: 66.1.0
+        version: 66.1.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -2230,8 +2230,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 65.5.0
-        version: 65.5.0
+        specifier: 66.1.0
+        version: 66.1.0
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/fs-utils
@@ -2351,8 +2351,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 65.5.0
-        version: 65.5.0
+        specifier: 66.1.0
+        version: 66.1.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -2557,8 +2557,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 65.5.0
-        version: 65.5.0
+        specifier: 66.1.0
+        version: 66.1.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -9366,8 +9366,8 @@ packages:
   '@fern-api/dynamic-ir-sdk@62.6.0':
     resolution: {integrity: sha512-l7I5/pZ6REsNyt4mC3ws+SqlEQ1UBy1hlQOrYL3fxKjsSlRKsZS5uOSQuzIkAHpbpYKNvYattc0LhONhySYoQA==}
 
-  '@fern-api/dynamic-ir-sdk@65.5.0':
-    resolution: {integrity: sha512-D7dBfdbWfH/ESdOFC8Fm/gHDfgswMbeeBDjCi+3Z5rK6XuAvNZa6oFrryYNoTB2uGV5Kgp+VqEigrtGHVZN4Cw==}
+  '@fern-api/dynamic-ir-sdk@66.1.0':
+    resolution: {integrity: sha512-ILT96PcT+HV1pVGVNg3cs6xnb/JRdKCJ1Tk1AO+sTxQFRRHoIwqr1KUfEQVW9iuvBsbgiApRZHfw42e5r/uMlA==}
     engines: {node: '>=18.0.0'}
 
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28':
@@ -16442,7 +16442,7 @@ snapshots:
 
   '@fern-api/dynamic-ir-sdk@62.6.0': {}
 
-  '@fern-api/dynamic-ir-sdk@65.5.0': {}
+  '@fern-api/dynamic-ir-sdk@66.1.0': {}
 
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28': {}
 


### PR DESCRIPTION
## Description
Linear ticket: Closes 

Bumps `@fern-api/dynamic-ir-sdk` from `65.5.0` to `66.1.0` across all generator packages and updates `pnpm-lock.yaml` accordingly.

## Changes Made
- Updated `"@fern-api/dynamic-ir-sdk"` from `"65.5.0"` to `"66.1.0"` in 14 generator `package.json` files under `generators/`.
- Refreshed `pnpm-lock.yaml` via `pnpm install --no-frozen-lockfile` to pick up the new dependency version.
- [ ] Updated README.md generator (if applicable)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed (ran `pnpm install --no-frozen-lockfile`; lockfile updated cleanly; verified diff is restricted to `package.json` files and `pnpm-lock.yaml`).


Link to Devin session: https://app.devin.ai/sessions/98a3654d3a2745078f307e9438adfc94
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
