### PR TITLE
feat(cli): expose `claude-code` under docs.yml `page-actions` config

### DIFF
--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -3939,6 +3939,7 @@
         "chatgpt",
         "claude",
         "cursor",
+        "claude-code",
         "vscode"
       ]
     },
@@ -4042,6 +4043,16 @@
           ]
         },
         "cursor": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "claude-code": {
           "oneOf": [
             {
               "type": "boolean"

--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -4042,7 +4042,7 @@
             }
           ]
         },
-        "cursor": {
+        "claude-code": {
           "oneOf": [
             {
               "type": "boolean"
@@ -4052,7 +4052,7 @@
             }
           ]
         },
-        "claude-code": {
+        "cursor": {
           "oneOf": [
             {
               "type": "boolean"

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -380,12 +380,6 @@ types:
           When enabled, displays an "Open in Claude" button that allows users to send the page content to Claude for further exploration and Q&A.
 
           @default: false
-      cursor:
-        type: optional<boolean>
-        docs: |
-          When enabled, displays an "Open in Cursor" button that allows users to open the page content in Cursor IDE with AI-powered code assistance.
-
-          @default: false
       claude-code:
         type: optional<boolean>
         docs: |
@@ -394,6 +388,12 @@ types:
           renders on docs sites that have Ask AI enabled; set to `false` to hide it on those sites.
 
           @default: true
+      cursor:
+        type: optional<boolean>
+        docs: |
+          When enabled, displays an "Open in Cursor" button that allows users to open the page content in Cursor IDE with AI-powered code assistance.
+
+          @default: false
       vscode:
         type: optional<boolean>
         docs: |

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -344,6 +344,8 @@ types:
       - chatgpt
       - claude
       - cursor
+      - value: claude-code
+        name: claude_code
       - vscode
 
   PageActionOptions:
@@ -384,6 +386,14 @@ types:
           When enabled, displays an "Open in Cursor" button that allows users to open the page content in Cursor IDE with AI-powered code assistance.
 
           @default: false
+      claude-code:
+        type: optional<boolean>
+        docs: |
+          Controls the "Connect to Claude Code" button, which copies a `claude mcp add` command to the
+          clipboard so users can register this docs site's MCP server with Claude Code. The button only
+          renders on docs sites that have Ask AI enabled; set to `false` to hide it on those sites.
+
+          @default: true
       vscode:
         type: optional<boolean>
         docs: |

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -371,15 +371,17 @@ types:
       chatgpt:
         type: optional<boolean>
         docs: |
-          When enabled, displays an "Open in ChatGPT" button that allows users to send the page content to ChatGPT for further exploration and Q&A.
+          Controls the "Open in ChatGPT" button, which sends the page content to ChatGPT for further
+          exploration and Q&A. Set to `false` to hide it.
 
-          @default: false
+          @default: true
       claude:
         type: optional<boolean>
         docs: |
-          When enabled, displays an "Open in Claude" button that allows users to send the page content to Claude for further exploration and Q&A.
+          Controls the "Open in Claude" button, which sends the page content to Claude for further
+          exploration and Q&A. Set to `false` to hide it.
 
-          @default: false
+          @default: true
       claude-code:
         type: optional<boolean>
         docs: |
@@ -391,9 +393,11 @@ types:
       cursor:
         type: optional<boolean>
         docs: |
-          When enabled, displays an "Open in Cursor" button that allows users to open the page content in Cursor IDE with AI-powered code assistance.
+          Controls the "Connect to Cursor" button, which installs this docs site's MCP server in
+          Cursor via a deeplink. The button only renders on docs sites that have Ask AI enabled; set
+          to `false` to hide it on those sites.
 
-          @default: false
+          @default: true
       vscode:
         type: optional<boolean>
         docs: |

--- a/packages/cli/cli/changes/unreleased/docs-yml-claude-code-page-action.yml
+++ b/packages/cli/cli/changes/unreleased/docs-yml-claude-code-page-action.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Expose `claude-code` under `page-actions` in `docs.yml` so docs sites can toggle the
+    "Connect to Claude Code" button (e.g. `page-actions.options.claude-code: false` or
+    `page-actions.default: claude-code`).
+  type: feat

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -384,6 +384,7 @@ function convertPageActions(
             openAi: pageActions.options?.chatgpt ?? true,
             claude: pageActions.options?.claude ?? true,
             cursor: pageActions.options?.cursor ?? true,
+            claudeCode: pageActions.options?.claudeCode ?? true,
             vscode: pageActions.options?.vscode ?? false,
             custom: (pageActions.options?.custom ?? []).map((action) =>
                 convertCustomPageAction(action, absoluteFilepathToDocsConfig)
@@ -408,6 +409,8 @@ function convertPageActionOption(
             return "claude";
         case "cursor":
             return "cursor";
+        case "claude-code":
+            return "claudeCode";
         case "vscode":
             return "vscode";
         default:

--- a/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
@@ -34,6 +34,7 @@ export interface ParsedPageActionsConfig {
         openAi: boolean;
         claude: boolean;
         cursor: boolean;
+        claudeCode: boolean;
         vscode: boolean;
         custom: ParsedCustomPageAction[];
     };

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/PageActionOption.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/PageActionOption.ts
@@ -7,6 +7,7 @@ export const PageActionOption = {
     Chatgpt: "chatgpt",
     Claude: "claude",
     Cursor: "cursor",
+    ClaudeCode: "claude-code",
     Vscode: "vscode",
 } as const;
 export type PageActionOption = (typeof PageActionOption)[keyof typeof PageActionOption];

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/PageActionOptions.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/PageActionOptions.ts
@@ -40,6 +40,14 @@ export interface PageActionOptions {
      */
     cursor?: boolean;
     /**
+     * Controls the "Connect to Claude Code" button, which copies a `claude mcp add` command to the
+     * clipboard so users can register this docs site's MCP server with Claude Code. The button only
+     * renders on docs sites that have Ask AI enabled; set to `false` to hide it on those sites.
+     *
+     * @default: true
+     */
+    claudeCode?: boolean;
+    /**
      * When enabled, displays an "Open in VS Code" button that allows users to open the page content in Visual Studio Code for editing and development.
      *
      * @default: false

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/PageActionOptions.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/PageActionOptions.ts
@@ -22,23 +22,19 @@ export interface PageActionOptions {
      */
     askAi?: boolean;
     /**
-     * When enabled, displays an "Open in ChatGPT" button that allows users to send the page content to ChatGPT for further exploration and Q&A.
+     * Controls the "Open in ChatGPT" button, which sends the page content to ChatGPT for further
+     * exploration and Q&A. Set to `false` to hide it.
      *
-     * @default: false
+     * @default: true
      */
     chatgpt?: boolean;
     /**
-     * When enabled, displays an "Open in Claude" button that allows users to send the page content to Claude for further exploration and Q&A.
+     * Controls the "Open in Claude" button, which sends the page content to Claude for further
+     * exploration and Q&A. Set to `false` to hide it.
      *
-     * @default: false
+     * @default: true
      */
     claude?: boolean;
-    /**
-     * When enabled, displays an "Open in Cursor" button that allows users to open the page content in Cursor IDE with AI-powered code assistance.
-     *
-     * @default: false
-     */
-    cursor?: boolean;
     /**
      * Controls the "Connect to Claude Code" button, which copies a `claude mcp add` command to the
      * clipboard so users can register this docs site's MCP server with Claude Code. The button only
@@ -47,6 +43,14 @@ export interface PageActionOptions {
      * @default: true
      */
     claudeCode?: boolean;
+    /**
+     * Controls the "Connect to Cursor" button, which installs this docs site's MCP server in
+     * Cursor via a deeplink. The button only renders on docs sites that have Ask AI enabled; set
+     * to `false` to hide it on those sites.
+     *
+     * @default: true
+     */
+    cursor?: boolean;
     /**
      * When enabled, displays an "Open in VS Code" button that allows users to open the page content in Visual Studio Code for editing and development.
      *

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/PageActionOption.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/PageActionOption.ts
@@ -7,8 +7,25 @@ import type * as serializers from "../../../index.js";
 export const PageActionOption: core.serialization.Schema<
     serializers.PageActionOption.Raw,
     FernDocsConfig.PageActionOption
-> = core.serialization.enum_(["copy-page", "view-as-markdown", "ask-ai", "chatgpt", "claude", "cursor", "vscode"]);
+> = core.serialization.enum_([
+    "copy-page",
+    "view-as-markdown",
+    "ask-ai",
+    "chatgpt",
+    "claude",
+    "cursor",
+    "claude-code",
+    "vscode",
+]);
 
 export declare namespace PageActionOption {
-    export type Raw = "copy-page" | "view-as-markdown" | "ask-ai" | "chatgpt" | "claude" | "cursor" | "vscode";
+    export type Raw =
+        | "copy-page"
+        | "view-as-markdown"
+        | "ask-ai"
+        | "chatgpt"
+        | "claude"
+        | "cursor"
+        | "claude-code"
+        | "vscode";
 }

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/PageActionOptions.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/PageActionOptions.ts
@@ -15,6 +15,7 @@ export const PageActionOptions: core.serialization.ObjectSchema<
     chatgpt: core.serialization.boolean().optional(),
     claude: core.serialization.boolean().optional(),
     cursor: core.serialization.boolean().optional(),
+    claudeCode: core.serialization.property("claude-code", core.serialization.boolean().optional()),
     vscode: core.serialization.boolean().optional(),
     custom: core.serialization.list(CustomPageAction).optional(),
 });
@@ -27,6 +28,7 @@ export declare namespace PageActionOptions {
         chatgpt?: boolean | null;
         claude?: boolean | null;
         cursor?: boolean | null;
+        "claude-code"?: boolean | null;
         vscode?: boolean | null;
         custom?: CustomPageAction.Raw[] | null;
     }

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/PageActionOptions.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/PageActionOptions.ts
@@ -14,8 +14,8 @@ export const PageActionOptions: core.serialization.ObjectSchema<
     askAi: core.serialization.property("ask-ai", core.serialization.boolean().optional()),
     chatgpt: core.serialization.boolean().optional(),
     claude: core.serialization.boolean().optional(),
-    cursor: core.serialization.boolean().optional(),
     claudeCode: core.serialization.property("claude-code", core.serialization.boolean().optional()),
+    cursor: core.serialization.boolean().optional(),
     vscode: core.serialization.boolean().optional(),
     custom: core.serialization.list(CustomPageAction).optional(),
 });
@@ -27,8 +27,8 @@ export declare namespace PageActionOptions {
         "ask-ai"?: boolean | null;
         chatgpt?: boolean | null;
         claude?: boolean | null;
-        cursor?: boolean | null;
         "claude-code"?: boolean | null;
+        cursor?: boolean | null;
         vscode?: boolean | null;
         custom?: CustomPageAction.Raw[] | null;
     }

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -2138,6 +2138,7 @@ export class DocsDefinitionResolver {
                 openAi: this.parsedDocsConfig.pageActions.options.openAi,
                 claude: this.parsedDocsConfig.pageActions.options.claude,
                 cursor: this.parsedDocsConfig.pageActions.options.cursor,
+                claudeCode: this.parsedDocsConfig.pageActions.options.claudeCode,
                 vscode: this.parsedDocsConfig.pageActions.options.vscode,
                 custom: this.parsedDocsConfig.pageActions.options.custom.map((customAction) => ({
                     title: customAction.title,

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -3939,6 +3939,7 @@
         "chatgpt",
         "claude",
         "cursor",
+        "claude-code",
         "vscode"
       ]
     },
@@ -4042,6 +4043,16 @@
           ]
         },
         "cursor": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "claude-code": {
           "oneOf": [
             {
               "type": "boolean"

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -4042,7 +4042,7 @@
             }
           ]
         },
-        "cursor": {
+        "claude-code": {
           "oneOf": [
             {
               "type": "boolean"
@@ -4052,7 +4052,7 @@
             }
           ]
         },
-        "claude-code": {
+        "cursor": {
           "oneOf": [
             {
               "type": "boolean"


### PR DESCRIPTION
## Description
Linear ticket: Refs FER-9336
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Adds `claude-code` to the `page-actions` config in `docs.yml` so docs sites can explicitly control the "Connect to Claude Code" button. This also fixes the docs.yml documentation to reflect the actual default behavior for the AI-related page actions that are currently enabled unless explicitly set to `false`.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Add `claude-code` to the docs.yml API definition, parser, resolver, and generated schemas/types
- Allow docs sites to use `page-actions.options.claude-code` and `page-actions.default: claude-code`
- Update docs.yml docs for `chatgpt`, `claude`, `cursor`, and `claude-code` to match their real default behavior

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed