### PR TITLE
feat(cli-v2): add GraphQL spec support in fern.yml with docs rendering and SDK warnings

### DIFF
--- a/packages/cli/cli-v2/src/__test__/ApiDefinitionConverter.test.ts
+++ b/packages/cli/cli-v2/src/__test__/ApiDefinitionConverter.test.ts
@@ -8,6 +8,7 @@ import { isAsyncApiSpec } from "../api/config/AsyncApiSpec.js";
 import { isConjureSpec } from "../api/config/ConjureSpec.js";
 import { ApiDefinitionConverter, DEFAULT_API_NAME } from "../api/config/converter/ApiDefinitionConverter.js";
 import { isFernSpec } from "../api/config/FernSpec.js";
+import { isGraphQlSpec } from "../api/config/GraphQlSpec.js";
 import { isOpenApiSpec } from "../api/config/OpenApiSpec.js";
 import { isOpenRpcSpec } from "../api/config/OpenRpcSpec.js";
 import { isProtobufSpec } from "../api/config/ProtobufSpec.js";
@@ -271,6 +272,40 @@ apis:
                 const spec = result.apis["jsonrpc-api"]?.specs[0];
                 expect(spec).toBeDefined();
                 expect(spec != null && isOpenRpcSpec(spec)).toBe(true);
+            }
+        });
+
+        it("converts GraphQL spec with name and origin", async () => {
+            await mkdir(join(testDir, "graphql"), { recursive: true });
+            await writeFile(join(testDir, "graphql/plants.graphql"), "type Query { plants: [String!]! }");
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+apis:
+  graphql-api:
+    specs:
+      - graphql: graphql/plants.graphql
+        name: Plants
+        origin: https://api.example.com/plants/graphql
+`
+            );
+
+            const fernYml = await loadFernYml({ cwd: testDir });
+            const result = await createConverter().convert({ fernYml });
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                const spec = result.apis["graphql-api"]?.specs[0];
+                expect(spec).toBeDefined();
+                if (spec != null && isGraphQlSpec(spec)) {
+                    expect(spec.graphql).toContain("plants.graphql");
+                    expect(spec.name).toBe("Plants");
+                    expect(spec.origin).toBe("https://api.example.com/plants/graphql");
+                } else {
+                    expect.fail("Expected GraphQL spec");
+                }
             }
         });
 

--- a/packages/cli/cli-v2/src/__test__/ApiSpecDetector.test.ts
+++ b/packages/cli/cli-v2/src/__test__/ApiSpecDetector.test.ts
@@ -1,0 +1,153 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { randomUUID } from "crypto";
+import { mkdir, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ApiSpecDetector } from "../api/resolver/ApiSpecDetector.js";
+
+const MINIMAL_OPENAPI = `
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+`;
+
+const MINIMAL_ASYNCAPI = `
+asyncapi: 2.0.0
+info:
+  title: Test
+  version: 1.0.0
+`;
+
+const MINIMAL_GRAPHQL = `type Query { hello: String }`;
+
+describe("ApiSpecDetector", () => {
+    let testDir: AbsoluteFilePath;
+    let detector: ApiSpecDetector;
+
+    beforeEach(async () => {
+        testDir = AbsoluteFilePath.of(join(tmpdir(), `fern-spec-detector-test-${randomUUID()}`));
+        await mkdir(testDir, { recursive: true });
+        detector = new ApiSpecDetector();
+    });
+
+    afterEach(async () => {
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    describe("GraphQL detection by file extension", () => {
+        it("detects .graphql extension", async () => {
+            const filePath = AbsoluteFilePath.of(join(testDir, "schema.graphql"));
+            await writeFile(filePath, MINIMAL_GRAPHQL);
+
+            const result = await detector.detect({
+                absoluteFilePath: filePath,
+                reference: "schema.graphql",
+                content: MINIMAL_GRAPHQL
+            });
+
+            expect(result).toBe("graphql");
+        });
+
+        it("detects .graphqls extension", async () => {
+            const filePath = AbsoluteFilePath.of(join(testDir, "schema.graphqls"));
+            await writeFile(filePath, MINIMAL_GRAPHQL);
+
+            const result = await detector.detect({
+                absoluteFilePath: filePath,
+                reference: "schema.graphqls",
+                content: MINIMAL_GRAPHQL
+            });
+
+            expect(result).toBe("graphql");
+        });
+
+        it("detects .gql extension", async () => {
+            const filePath = AbsoluteFilePath.of(join(testDir, "schema.gql"));
+            await writeFile(filePath, MINIMAL_GRAPHQL);
+
+            const result = await detector.detect({
+                absoluteFilePath: filePath,
+                reference: "schema.gql",
+                content: MINIMAL_GRAPHQL
+            });
+
+            expect(result).toBe("graphql");
+        });
+
+        it("detects GraphQL extension case-insensitively (.GRAPHQL)", async () => {
+            const filePath = AbsoluteFilePath.of(join(testDir, "schema.GRAPHQL"));
+            await writeFile(filePath, MINIMAL_GRAPHQL);
+
+            const result = await detector.detect({
+                absoluteFilePath: filePath,
+                reference: "schema.GRAPHQL",
+                content: MINIMAL_GRAPHQL
+            });
+
+            expect(result).toBe("graphql");
+        });
+
+        it("detects GraphQL when the reference URL has a .graphql extension", async () => {
+            // absoluteFilePath has no graphql extension, but reference (original URL) does
+            const filePath = AbsoluteFilePath.of(join(testDir, "spec.yaml"));
+            await writeFile(filePath, MINIMAL_GRAPHQL);
+
+            const result = await detector.detect({
+                absoluteFilePath: filePath,
+                reference: "https://api.example.com/schema.graphql",
+                content: MINIMAL_GRAPHQL
+            });
+
+            expect(result).toBe("graphql");
+        });
+    });
+
+    describe("OpenAPI detection by content", () => {
+        it("detects openapi spec from content", async () => {
+            const filePath = AbsoluteFilePath.of(join(testDir, "spec.yaml"));
+            await writeFile(filePath, MINIMAL_OPENAPI);
+
+            const result = await detector.detect({
+                absoluteFilePath: filePath,
+                reference: "spec.yaml",
+                content: MINIMAL_OPENAPI
+            });
+
+            expect(result).toBe("openapi");
+        });
+    });
+
+    describe("AsyncAPI detection by content", () => {
+        it("detects asyncapi spec from content", async () => {
+            const filePath = AbsoluteFilePath.of(join(testDir, "spec.yaml"));
+            await writeFile(filePath, MINIMAL_ASYNCAPI);
+
+            const result = await detector.detect({
+                absoluteFilePath: filePath,
+                reference: "spec.yaml",
+                content: MINIMAL_ASYNCAPI
+            });
+
+            expect(result).toBe("asyncapi");
+        });
+    });
+
+    describe("error handling", () => {
+        it("throws when content has no recognizable spec key", async () => {
+            const filePath = AbsoluteFilePath.of(join(testDir, "spec.yaml"));
+            const unknownContent = "foo: bar\nbaz: qux\n";
+            await writeFile(filePath, unknownContent);
+
+            await expect(
+                detector.detect({
+                    absoluteFilePath: filePath,
+                    reference: "spec.yaml",
+                    content: unknownContent
+                })
+            ).rejects.toThrow();
+        });
+    });
+});

--- a/packages/cli/cli-v2/src/__test__/SdkChecker.test.ts
+++ b/packages/cli/cli-v2/src/__test__/SdkChecker.test.ts
@@ -223,6 +223,75 @@ sdks:
         });
     });
 
+    describe("GraphQL spec validation", () => {
+        it("warns when an SDK target references an API with a GraphQL spec", async () => {
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+api:
+  specs:
+    - graphql: schema.graphql
+sdks:
+  targets:
+    typescript:
+      lang: typescript
+      version: "1.0.0"
+      output:
+        path: ./sdks/typescript
+`
+            );
+            await writeFile(join(testDir, "schema.graphql"), "type Query { hello: String }");
+
+            const workspace = await loadTempWorkspace(testDir);
+            const checker = new SdkChecker({
+                context: await createTestContext({ cwd: testDir }),
+                versionChecker: NOOP_VERSION_CHECKER
+            });
+
+            const result = await checker.check({ workspace });
+
+            expect(result.warningCount).toBe(1);
+            expect(result.errorCount).toBe(0);
+            expect(result.violations.some((v) => v.severity === "warning" && v.message.includes("GraphQL"))).toBe(true);
+            expect(
+                result.violations.some((v) => v.message.includes("graphql specs will be skipped for this target"))
+            ).toBe(true);
+        });
+
+        it("does not warn for an SDK target whose API has no GraphQL spec", async () => {
+            await writeFile(
+                join(testDir, "fern.yml"),
+                `
+edition: 2026-01-01
+org: acme
+api:
+  specs:
+    - openapi: openapi.yml
+sdks:
+  targets:
+    typescript:
+      lang: typescript
+      version: "1.0.0"
+      output:
+        path: ./sdks/typescript
+`
+            );
+            await writeMinimalOpenApi(testDir);
+
+            const workspace = await loadTempWorkspace(testDir);
+            const checker = new SdkChecker({
+                context: await createTestContext({ cwd: testDir }),
+                versionChecker: NOOP_VERSION_CHECKER
+            });
+
+            const result = await checker.check({ workspace });
+
+            expect(result.violations.every((v) => !v.message.includes("GraphQL"))).toBe(true);
+        });
+    });
+
     describe("registry unreachable", () => {
         it("warns when registry is unreachable", async () => {
             const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));

--- a/packages/cli/cli-v2/src/api/adapter/LegacyApiSpecAdapter.ts
+++ b/packages/cli/cli-v2/src/api/adapter/LegacyApiSpecAdapter.ts
@@ -6,6 +6,38 @@ import type {
     OpenRPCSpec as V1OpenRPCSpec,
     ProtobufSpec as V1ProtobufSpec
 } from "@fern-api/api-workspace-commons";
+
+/**
+ * Partitions v1 specs into two groups:
+ *
+ * - `filteredSpecs`: IR-generating specs (OpenAPI, AsyncAPI, protobuf-from-openapi).
+ *   Docs-only types (graphql, openrpc) and raw protobuf are excluded.
+ * - `allSpecs`: All specs except protobuf-from-openapi (used by OSSWorkspace for doc rendering).
+ */
+export function partitionV1Specs(v1Specs: Spec[]): {
+    filteredSpecs: (OpenAPISpec | V1ProtobufSpec)[];
+    allSpecs: Spec[];
+} {
+    const filteredSpecs = v1Specs.filter((spec): spec is OpenAPISpec | V1ProtobufSpec => {
+        if (spec.type === "openrpc" || spec.type === "graphql") {
+            return false;
+        }
+        if (spec.type === "protobuf" && !spec.fromOpenAPI) {
+            return false;
+        }
+        return true;
+    });
+
+    const allSpecs = v1Specs.filter((spec) => {
+        if (spec.type === "protobuf" && spec.fromOpenAPI) {
+            return false;
+        }
+        return true;
+    });
+
+    return { filteredSpecs, allSpecs };
+}
+
 import type { schemas } from "@fern-api/config";
 import { generatorsYml } from "@fern-api/configuration";
 import { relativize } from "@fern-api/fs-utils";

--- a/packages/cli/cli-v2/src/api/adapter/LegacyApiSpecAdapter.ts
+++ b/packages/cli/cli-v2/src/api/adapter/LegacyApiSpecAdapter.ts
@@ -2,6 +2,7 @@ import type {
     OpenAPISettings,
     OpenAPISpec,
     Spec,
+    GraphQLSpec as V1GraphQLSpec,
     OpenRPCSpec as V1OpenRPCSpec,
     ProtobufSpec as V1ProtobufSpec
 } from "@fern-api/api-workspace-commons";
@@ -13,6 +14,8 @@ import type { Context } from "../../context/Context.js";
 import type { ApiSpec } from "../config/ApiSpec.js";
 import type { AsyncApiSpec } from "../config/AsyncApiSpec.js";
 import { isAsyncApiSpec } from "../config/AsyncApiSpec.js";
+import type { GraphQlSpec } from "../config/GraphQlSpec.js";
+import { isGraphQlSpec } from "../config/GraphQlSpec.js";
 import type { OpenApiSpec } from "../config/OpenApiSpec.js";
 import { isOpenApiSpec } from "../config/OpenApiSpec.js";
 import type { OpenRpcSpec } from "../config/OpenRpcSpec.js";
@@ -49,6 +52,9 @@ export class LegacyApiSpecAdapter {
         }
         if (isOpenRpcSpec(spec)) {
             return this.adaptOpenRpcSpec(spec);
+        }
+        if (isGraphQlSpec(spec)) {
+            return this.adaptGraphQlSpec(spec);
         }
         throw new CliError({
             message: `Unsupported spec type: ${JSON.stringify(spec)}`,
@@ -111,6 +117,15 @@ export class LegacyApiSpecAdapter {
             absoluteFilepath: spec.openrpc,
             absoluteFilepathToOverrides: spec.overrides,
             namespace: undefined
+        };
+    }
+
+    private adaptGraphQlSpec(spec: GraphQlSpec): V1GraphQLSpec {
+        return {
+            type: "graphql" as const,
+            absoluteFilepath: spec.graphql,
+            absoluteFilepathToOverrides: spec.overrides,
+            namespace: spec.name
         };
     }
 

--- a/packages/cli/cli-v2/src/api/adapter/LegacyOSSWorkspaceAdapter.ts
+++ b/packages/cli/cli-v2/src/api/adapter/LegacyOSSWorkspaceAdapter.ts
@@ -1,4 +1,3 @@
-import type { OpenAPISpec, ProtobufSpec, Spec } from "@fern-api/api-workspace-commons";
 import type { generatorsYml } from "@fern-api/configuration";
 import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
@@ -6,7 +5,7 @@ import type { Context } from "../../context/Context.js";
 import type { ApiDefinition } from "../config/ApiDefinition.js";
 import { isConjureSpec } from "../config/ConjureSpec.js";
 import { isFernSpec } from "../config/FernSpec.js";
-import { LegacyApiSpecAdapter } from "./LegacyApiSpecAdapter.js";
+import { LegacyApiSpecAdapter, partitionV1Specs } from "./LegacyApiSpecAdapter.js";
 
 /**
  * Shared adapter for constructing OSSWorkspace instances from an ApiDefinition.
@@ -43,23 +42,7 @@ export class LegacyOSSWorkspaceAdapter {
         }
 
         const v1Specs = this.specAdapter.convertAll(ossSpecs);
-
-        const filteredSpecs = v1Specs.filter((spec): spec is OpenAPISpec | ProtobufSpec => {
-            if (spec.type === "openrpc" || spec.type === "graphql") {
-                return false;
-            }
-            if (spec.type === "protobuf" && !spec.fromOpenAPI) {
-                return false;
-            }
-            return true;
-        });
-
-        const allSpecs = v1Specs.filter((spec: Spec) => {
-            if (spec.type === "protobuf" && spec.fromOpenAPI) {
-                return false;
-            }
-            return true;
-        });
+        const { filteredSpecs, allSpecs } = partitionV1Specs(v1Specs);
 
         const hasGraphQlSpec = allSpecs.some((spec) => spec.type === "graphql");
 

--- a/packages/cli/cli-v2/src/api/adapter/LegacyOSSWorkspaceAdapter.ts
+++ b/packages/cli/cli-v2/src/api/adapter/LegacyOSSWorkspaceAdapter.ts
@@ -45,7 +45,7 @@ export class LegacyOSSWorkspaceAdapter {
         const v1Specs = this.specAdapter.convertAll(ossSpecs);
 
         const filteredSpecs = v1Specs.filter((spec): spec is OpenAPISpec | ProtobufSpec => {
-            if (spec.type === "openrpc") {
+            if (spec.type === "openrpc" || spec.type === "graphql") {
                 return false;
             }
             if (spec.type === "protobuf" && !spec.fromOpenAPI) {
@@ -61,7 +61,12 @@ export class LegacyOSSWorkspaceAdapter {
             return true;
         });
 
-        if (filteredSpecs.length === 0) {
+        const hasGraphQlSpec = allSpecs.some((spec) => spec.type === "graphql");
+
+        // If there are no IR-generating specs, skip the workspace — unless there
+        // is at least one GraphQL spec, which is docs-only and must still be
+        // surfaced so `fern docs` can render it.
+        if (filteredSpecs.length === 0 && !hasGraphQlSpec) {
             return undefined;
         }
 

--- a/packages/cli/cli-v2/src/api/compiler/ApiDefinitionHasher.ts
+++ b/packages/cli/cli-v2/src/api/compiler/ApiDefinitionHasher.ts
@@ -7,6 +7,7 @@ import type { ApiSpec } from "../config/ApiSpec.js";
 import { isAsyncApiSpec } from "../config/AsyncApiSpec.js";
 import { isConjureSpec } from "../config/ConjureSpec.js";
 import { isFernSpec } from "../config/FernSpec.js";
+import { isGraphQlSpec } from "../config/GraphQlSpec.js";
 import { isOpenApiSpec } from "../config/OpenApiSpec.js";
 import { isOpenRpcSpec } from "../config/OpenRpcSpec.js";
 import { isProtobufSpec } from "../config/ProtobufSpec.js";
@@ -94,6 +95,11 @@ export class ApiDefinitionHasher {
         }
         if (isOpenRpcSpec(spec)) {
             paths.push(spec.openrpc);
+            this.pushOverrides(spec.overrides, paths);
+            return;
+        }
+        if (isGraphQlSpec(spec)) {
+            paths.push(spec.graphql);
             this.pushOverrides(spec.overrides, paths);
             return;
         }

--- a/packages/cli/cli-v2/src/api/config/ApiSpec.ts
+++ b/packages/cli/cli-v2/src/api/config/ApiSpec.ts
@@ -1,6 +1,7 @@
 import type { AsyncApiSpec } from "./AsyncApiSpec.js";
 import type { ConjureSpec } from "./ConjureSpec.js";
 import type { FernSpec } from "./FernSpec.js";
+import type { GraphQlSpec } from "./GraphQlSpec.js";
 import type { OpenApiSpec } from "./OpenApiSpec.js";
 import type { OpenRpcSpec } from "./OpenRpcSpec.js";
 import type { ProtobufSpec } from "./ProtobufSpec.js";
@@ -8,9 +9,9 @@ import type { ProtobufSpec } from "./ProtobufSpec.js";
 /**
  * An individual API specification.
  */
-export type ApiSpec = OpenApiSpec | AsyncApiSpec | ProtobufSpec | FernSpec | ConjureSpec | OpenRpcSpec;
+export type ApiSpec = OpenApiSpec | AsyncApiSpec | ProtobufSpec | FernSpec | ConjureSpec | OpenRpcSpec | GraphQlSpec;
 
 /**
  * The type identifier for each spec format.
  */
-export type ApiSpecType = "openapi" | "asyncapi" | "protobuf" | "fern" | "conjure" | "openrpc";
+export type ApiSpecType = "openapi" | "asyncapi" | "protobuf" | "fern" | "conjure" | "openrpc" | "graphql";

--- a/packages/cli/cli-v2/src/api/config/GraphQlSpec.ts
+++ b/packages/cli/cli-v2/src/api/config/GraphQlSpec.ts
@@ -1,0 +1,28 @@
+import type { AbsoluteFilePath } from "@fern-api/fs-utils";
+import type { ApiSpec } from "./ApiSpec.js";
+
+/**
+ * A GraphQL specification.
+ *
+ * GraphQL specs are only rendered in documentation; they are ignored by SDK generators.
+ */
+export interface GraphQlSpec {
+    /** Path to the GraphQL schema file */
+    graphql: AbsoluteFilePath;
+
+    /** URL origin for the GraphQL endpoint */
+    origin?: string;
+
+    /** Path to the overrides file(s) */
+    overrides?: AbsoluteFilePath | AbsoluteFilePath[];
+
+    /** Name used to group this GraphQL spec in the docs (rendered as a top-level section) */
+    name?: string;
+}
+
+/**
+ * Type guard to check if an ApiSpec is a GraphQlSpec.
+ */
+export function isGraphQlSpec(spec: ApiSpec): spec is GraphQlSpec {
+    return "graphql" in spec;
+}

--- a/packages/cli/cli-v2/src/api/config/converter/ApiDefinitionConverter.ts
+++ b/packages/cli/cli-v2/src/api/config/converter/ApiDefinitionConverter.ts
@@ -9,6 +9,7 @@ import type { ApiSpec } from "../ApiSpec.js";
 import type { AsyncApiSpec } from "../AsyncApiSpec.js";
 import type { ConjureSpec } from "../ConjureSpec.js";
 import type { FernSpec } from "../FernSpec.js";
+import type { GraphQlSpec } from "../GraphQlSpec.js";
 import type { OpenApiSpec } from "../OpenApiSpec.js";
 import type { OpenRpcSpec } from "../OpenRpcSpec.js";
 import type { ProtobufDefinition, ProtobufSpec } from "../ProtobufSpec.js";
@@ -271,6 +272,13 @@ export class ApiDefinitionConverter {
                 sourced: sourced as Sourced<schemas.OpenRpcSpecSchema>
             });
         }
+        if ("graphql" in spec && "graphql" in sourced) {
+            return await this.convertGraphQlSpec({
+                absoluteFernYmlPath,
+                spec: spec as schemas.GraphQlSpecSchema,
+                sourced: sourced as Sourced<schemas.GraphQlSpecSchema>
+            });
+        }
         // Unreachable; this should never happen if the schema validation is correct.
         throw new CliError({
             message: `Unknown spec type: ${JSON.stringify(spec)}`,
@@ -424,6 +432,34 @@ export class ApiDefinitionConverter {
         };
         if (spec.settings != null) {
             result.settings = spec.settings;
+        }
+        return result;
+    }
+
+    private async convertGraphQlSpec({
+        absoluteFernYmlPath,
+        spec,
+        sourced
+    }: {
+        absoluteFernYmlPath: AbsoluteFilePath;
+        spec: schemas.GraphQlSpecSchema;
+        sourced: Sourced<schemas.GraphQlSpecSchema>;
+    }): Promise<GraphQlSpec> {
+        const result: GraphQlSpec = {
+            graphql: await this.resolvePath({ absoluteFernYmlPath, path: spec.graphql, sourced: sourced.graphql })
+        };
+        if (spec.origin != null) {
+            result.origin = spec.origin;
+        }
+        if (spec.overrides != null && !isNullish(sourced.overrides)) {
+            result.overrides = await this.resolvePathOrPaths({
+                absoluteFernYmlPath,
+                paths: spec.overrides,
+                sourced: sourced.overrides
+            });
+        }
+        if (spec.name != null) {
+            result.name = spec.name;
         }
         return result;
     }

--- a/packages/cli/cli-v2/src/api/resolver/ApiSpecDetector.ts
+++ b/packages/cli/cli-v2/src/api/resolver/ApiSpecDetector.ts
@@ -4,9 +4,14 @@ import yaml from "js-yaml";
 import type { ApiSpecType } from "../config/ApiSpec.js";
 
 /**
- * Supported spec types that can be auto-detected from a file.
+ * Supported spec types that can be auto-detected from YAML/JSON content.
  */
 const DETECTABLE_SPEC_TYPES: readonly ApiSpecType[] = ["openapi", "asyncapi"];
+
+/**
+ * File extensions that unambiguously identify a GraphQL schema.
+ */
+const GRAPHQL_EXTENSIONS: readonly string[] = [".graphql", ".graphqls", ".gql"];
 
 export namespace ApiSpecDetector {
     export interface Args {
@@ -24,6 +29,10 @@ export namespace ApiSpecDetector {
  */
 export class ApiSpecDetector {
     public async detect({ absoluteFilePath, reference, content }: ApiSpecDetector.Args): Promise<ApiSpecType> {
+        if (this.hasGraphQlExtension(absoluteFilePath) || this.hasGraphQlExtension(reference)) {
+            return "graphql";
+        }
+
         const parsed = this.parseOrThrow({ content, reference });
         if (typeof parsed !== "object" || parsed == null) {
             throw new CliError({
@@ -44,6 +53,11 @@ export class ApiSpecDetector {
                 `File must contain a top-level "openapi" or "asyncapi" key.`,
             code: CliError.Code.InternalError
         });
+    }
+
+    private hasGraphQlExtension(path: string): boolean {
+        const lower = path.toLowerCase();
+        return GRAPHQL_EXTENSIONS.some((ext) => lower.endsWith(ext));
     }
 
     private parseOrThrow({ content, reference }: { content: string; reference: string }): unknown {

--- a/packages/cli/cli-v2/src/api/resolver/ApiSpecResolver.ts
+++ b/packages/cli/cli-v2/src/api/resolver/ApiSpecResolver.ts
@@ -97,7 +97,10 @@ export class ApiSpecResolver {
     }
 
     private inferExtension({ url, contentType }: { url: string; contentType: string }): string {
-        const urlPath = new URL(url).pathname;
+        const urlPath = new URL(url).pathname.toLowerCase();
+        if (urlPath.endsWith(".graphql") || urlPath.endsWith(".graphqls") || urlPath.endsWith(".gql")) {
+            return ".graphql";
+        }
         if (urlPath.endsWith(".json")) {
             return ".json";
         }
@@ -124,9 +127,11 @@ export class ApiSpecResolver {
                 return { openapi: absoluteFilePath, origin };
             case "asyncapi":
                 return { asyncapi: absoluteFilePath, origin };
+            case "graphql":
+                return { graphql: absoluteFilePath, origin };
             default:
                 throw new CliError({
-                    message: `Unsupported spec type for flags mode: "${specType}". Supported: openapi, asyncapi`,
+                    message: `Unsupported spec type for flags mode: "${specType}". Supported: openapi, asyncapi, graphql`,
                     code: CliError.Code.ConfigError
                 });
         }

--- a/packages/cli/cli-v2/src/api/validator/ApiDefinitionValidator.ts
+++ b/packages/cli/cli-v2/src/api/validator/ApiDefinitionValidator.ts
@@ -133,7 +133,7 @@ export class ApiDefinitionValidator {
         const v1Specs = specAdapter.convertAll(ossSpecs);
 
         const filteredSpecs = v1Specs.filter((spec): spec is OpenAPISpec | ProtobufSpec => {
-            if (spec.type === "openrpc") {
+            if (spec.type === "openrpc" || spec.type === "graphql") {
                 return false;
             }
             if (spec.type === "protobuf" && !spec.fromOpenAPI) {

--- a/packages/cli/cli-v2/src/api/validator/ApiDefinitionValidator.ts
+++ b/packages/cli/cli-v2/src/api/validator/ApiDefinitionValidator.ts
@@ -1,4 +1,4 @@
-import type { FernWorkspace, OpenAPISpec, ProtobufSpec } from "@fern-api/api-workspace-commons";
+import type { FernWorkspace } from "@fern-api/api-workspace-commons";
 import { ValidationViolation, validateFernWorkspace } from "@fern-api/fern-definition-validator";
 import { AbsoluteFilePath, dirname } from "@fern-api/fs-utils";
 import { LazyFernWorkspace, OSSWorkspace } from "@fern-api/lazy-fern-workspace";
@@ -6,7 +6,7 @@ import { validateOSSWorkspace } from "@fern-api/oss-validator";
 import { TaskContextAdapter } from "../../context/adapter/TaskContextAdapter.js";
 import type { Context } from "../../context/Context.js";
 import { Task } from "../../ui/Task.js";
-import { LegacyApiSpecAdapter } from "../adapter/LegacyApiSpecAdapter.js";
+import { LegacyApiSpecAdapter, partitionV1Specs } from "../adapter/LegacyApiSpecAdapter.js";
 import type { ApiDefinition } from "../config/ApiDefinition.js";
 import type { ApiSpec } from "../config/ApiSpec.js";
 import { isConjureSpec } from "../config/ConjureSpec.js";
@@ -131,23 +131,12 @@ export class ApiDefinitionValidator {
 
         const specAdapter = new LegacyApiSpecAdapter({ context: this.context });
         const v1Specs = specAdapter.convertAll(ossSpecs);
+        const { filteredSpecs, allSpecs } = partitionV1Specs(v1Specs);
 
-        const filteredSpecs = v1Specs.filter((spec): spec is OpenAPISpec | ProtobufSpec => {
-            if (spec.type === "openrpc" || spec.type === "graphql") {
-                return false;
-            }
-            if (spec.type === "protobuf" && !spec.fromOpenAPI) {
-                return false;
-            }
-            return true;
-        });
-
-        const allSpecs = v1Specs.filter((spec) => {
-            if (spec.type === "protobuf" && spec.fromOpenAPI) {
-                return false;
-            }
-            return true;
-        });
+        // GraphQL-only APIs have no IR-generating specs; nothing to validate via OSSWorkspace.
+        if (filteredSpecs.length === 0) {
+            return violations;
+        }
 
         const ossWorkspace = new OSSWorkspace({
             specs: filteredSpecs,

--- a/packages/cli/cli-v2/src/commands/docs/publish/command.ts
+++ b/packages/cli/cli-v2/src/commands/docs/publish/command.ts
@@ -82,7 +82,7 @@ export class PublishCommand {
         }
 
         const adapter = new LegacyProjectAdapter({ context });
-        const project = adapter.adapt(workspace);
+        const project = await adapter.adapt(workspace);
 
         const docsWorkspace = project.docsWorkspaces;
         if (docsWorkspace == null) {

--- a/packages/cli/cli-v2/src/docs/adapter/LegacyProjectAdapter.ts
+++ b/packages/cli/cli-v2/src/docs/adapter/LegacyProjectAdapter.ts
@@ -1,5 +1,4 @@
 import { AbstractAPIWorkspace } from "@fern-api/api-workspace-commons";
-import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import type { Project } from "@fern-api/project-loader";
 import { LegacyOSSWorkspaceAdapter } from "../../api/adapter/LegacyOSSWorkspaceAdapter.js";
 import { TaskContextAdapter } from "../../context/adapter/TaskContextAdapter.js";
@@ -65,10 +64,8 @@ export class LegacyProjectAdapter {
                 absoluteFilePath: this.context.cwd
             });
             if (ossWorkspace != null) {
-                if (ossWorkspace instanceof OSSWorkspace) {
-                    // Resolve GraphQL specs into operations/types so docs can render them.
-                    await ossWorkspace.processGraphQLSpecs(taskContext);
-                }
+                // Resolve GraphQL specs into operations/types so docs can render them.
+                await ossWorkspace.processGraphQLSpecs(taskContext);
                 workspaces.push(ossWorkspace);
             }
         }

--- a/packages/cli/cli-v2/src/docs/adapter/LegacyProjectAdapter.ts
+++ b/packages/cli/cli-v2/src/docs/adapter/LegacyProjectAdapter.ts
@@ -1,6 +1,8 @@
 import { AbstractAPIWorkspace } from "@fern-api/api-workspace-commons";
+import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import type { Project } from "@fern-api/project-loader";
 import { LegacyOSSWorkspaceAdapter } from "../../api/adapter/LegacyOSSWorkspaceAdapter.js";
+import { TaskContextAdapter } from "../../context/adapter/TaskContextAdapter.js";
 import type { Context } from "../../context/Context.js";
 import type { Workspace } from "../../workspace/Workspace.js";
 import { LegacyDocsWorkspaceAdapter } from "./LegacyDocsWorkspaceAdapter.js";
@@ -18,8 +20,8 @@ export class LegacyProjectAdapter {
         this.ossAdapter = new LegacyOSSWorkspaceAdapter({ context });
     }
 
-    public adapt(workspace: Workspace): Project {
-        const apiWorkspaces = this.buildApiWorkspaces(workspace);
+    public async adapt(workspace: Workspace): Promise<Project> {
+        const apiWorkspaces = await this.buildApiWorkspaces(workspace);
         const docsWorkspace =
             workspace.docs != null
                 ? this.docsAdapter.adapt({
@@ -52,8 +54,9 @@ export class LegacyProjectAdapter {
     /**
      * Bridges API definitions to legacy AbstractAPIWorkspace instances.
      */
-    private buildApiWorkspaces(workspace: Workspace): AbstractAPIWorkspace<unknown>[] {
+    private async buildApiWorkspaces(workspace: Workspace): Promise<AbstractAPIWorkspace<unknown>[]> {
         const workspaces: AbstractAPIWorkspace<unknown>[] = [];
+        const taskContext = new TaskContextAdapter({ context: this.context });
         for (const [apiName, apiDef] of Object.entries(workspace.apis)) {
             const ossWorkspace = this.ossAdapter.build({
                 definition: apiDef,
@@ -62,6 +65,10 @@ export class LegacyProjectAdapter {
                 absoluteFilePath: this.context.cwd
             });
             if (ossWorkspace != null) {
+                if (ossWorkspace instanceof OSSWorkspace) {
+                    // Resolve GraphQL specs into operations/types so docs can render them.
+                    await ossWorkspace.processGraphQLSpecs(taskContext);
+                }
                 workspaces.push(ossWorkspace);
             }
         }

--- a/packages/cli/cli-v2/src/docs/checker/DocsChecker.ts
+++ b/packages/cli/cli-v2/src/docs/checker/DocsChecker.ts
@@ -83,7 +83,7 @@ export class DocsChecker {
         }
 
         const adapter = new LegacyProjectAdapter({ context: this.context });
-        const project = adapter.adapt(workspace);
+        const project = await adapter.adapt(workspace);
 
         const docsWorkspace = project.docsWorkspaces;
         if (docsWorkspace == null) {

--- a/packages/cli/cli-v2/src/docs/server/LegacyDevServer.ts
+++ b/packages/cli/cli-v2/src/docs/server/LegacyDevServer.ts
@@ -65,7 +65,7 @@ export class LegacyDevServer {
      */
     private async reloadProject(): Promise<Project> {
         const workspace = await this.context.loadWorkspaceOrThrow();
-        return await this.adapter.adapt(workspace);
+        return this.adapter.adapt(workspace);
     }
 
     /**

--- a/packages/cli/cli-v2/src/docs/server/LegacyDevServer.ts
+++ b/packages/cli/cli-v2/src/docs/server/LegacyDevServer.ts
@@ -40,7 +40,7 @@ export class LegacyDevServer {
         logLevel: LogLevel;
     }): Promise<void> {
         const workspace = await this.context.loadWorkspaceOrThrow();
-        const initialProject = this.adapter.adapt(workspace);
+        const initialProject = await this.adapter.adapt(workspace);
         const taskContext = new TaskContextAdapter({ context: this.context, logLevel });
 
         // TODO: Use a spinner here.
@@ -65,7 +65,7 @@ export class LegacyDevServer {
      */
     private async reloadProject(): Promise<Project> {
         const workspace = await this.context.loadWorkspaceOrThrow();
-        return this.adapter.adapt(workspace);
+        return await this.adapter.adapt(workspace);
     }
 
     /**

--- a/packages/cli/cli-v2/src/migrator/__test__/convertApiSpecs.test.ts
+++ b/packages/cli/cli-v2/src/migrator/__test__/convertApiSpecs.test.ts
@@ -87,6 +87,24 @@ describe("convertApiSpecs", () => {
         expect(spec.overrides).toBe("./overrides.yml");
     });
 
+    it("converts V2 schema with graphql spec", () => {
+        const result = convertApiSpecs({
+            specs: [
+                {
+                    graphql: "./schema.graphql",
+                    name: "Plants",
+                    origin: "https://api.example.com/plants/graphql",
+                    overrides: "./overrides.yml"
+                }
+            ]
+        });
+        const spec = result.specs[0] as { graphql: string; name: string; origin: string; overrides: string };
+        expect(spec.graphql).toBe("./schema.graphql");
+        expect(spec.name).toBe("Plants");
+        expect(spec.origin).toBe("https://api.example.com/plants/graphql");
+        expect(spec.overrides).toBe("./overrides.yml");
+    });
+
     it("warns on unknown spec type in V2 schema", () => {
         const result = convertApiSpecs({
             specs: [{ unknownKey: "./something.yml" } as never]

--- a/packages/cli/cli-v2/src/migrator/converters/convertApiSpecs.ts
+++ b/packages/cli/cli-v2/src/migrator/converters/convertApiSpecs.ts
@@ -181,6 +181,13 @@ function adjustSpecPaths(specs: schemas.ApiSpecSchema[], apiName: string): schem
                 overrides: spec.overrides != null ? adjustPathOrPaths(spec.overrides, apiName) : undefined
             };
         }
+        if ("graphql" in spec) {
+            return {
+                ...spec,
+                graphql: adjustPath(spec.graphql, apiName),
+                overrides: spec.overrides != null ? adjustPathOrPaths(spec.overrides, apiName) : undefined
+            };
+        }
         if ("proto" in spec) {
             return {
                 ...spec,
@@ -363,6 +370,25 @@ function convertSpec(spec: generatorsYml.SpecSchema, warnings: MigratorWarning[]
 
         return result;
     }
+    if ("graphql" in spec) {
+        const graphqlSpec = spec as generatorsYml.GraphQlSpecSchema;
+
+        const result: schemas.GraphQlSpecSchema = {
+            graphql: graphqlSpec.graphql
+        };
+
+        if (graphqlSpec.origin != null) {
+            result.origin = graphqlSpec.origin;
+        }
+        if (graphqlSpec.overrides != null) {
+            result.overrides = graphqlSpec.overrides;
+        }
+        if (graphqlSpec.name != null) {
+            result.name = graphqlSpec.name;
+        }
+
+        return result;
+    }
 
     warnings.push({
         type: "unsupported",
@@ -385,6 +411,8 @@ function convertNamespacedSpecs(
                 specs.push({ ...spec, namespace });
             } else if ("asyncapi" in spec) {
                 specs.push({ ...spec, namespace });
+            } else if ("graphql" in spec) {
+                specs.push({ ...spec, name: spec.name ?? namespace });
             } else if ("fern" in spec) {
                 // Fern specs don't have namespace in the schema, add warning.
                 warnings.push({

--- a/packages/cli/cli-v2/src/sdk/checker/SdkChecker.ts
+++ b/packages/cli/cli-v2/src/sdk/checker/SdkChecker.ts
@@ -1,6 +1,7 @@
 import { type ValidationViolation } from "@fern-api/fern-definition-validator";
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import { FernRegistryClient as GeneratorsClient } from "@fern-fern/generators-sdk";
+import { isGraphQlSpec } from "../../api/config/GraphQlSpec.js";
 import type { Context } from "../../context/Context.js";
 import type { Workspace } from "../../workspace/Workspace.js";
 import { getGeneratorIdFromImage } from "../config/converter/getGeneratorIdFromImage.js";
@@ -73,6 +74,7 @@ export class SdkChecker {
         this.validateTargetApiReferences({ workspace, sdks, violations });
         this.validateDefaultGroup({ sdks, fernYmlRelativePath, violations });
         this.validateEmptyVersions({ sdks, violations });
+        this.validateGraphQlSpecs({ workspace, sdks, violations });
         await this.validateVersions({ sdks, violations });
 
         return {
@@ -191,6 +193,40 @@ export class SdkChecker {
                     column: target.sourceLocation.column
                 });
             }
+        }
+    }
+
+    /**
+     * Emits a warning for any target whose referenced API contains a GraphQL spec.
+     * GraphQL SDKs are not supported; the graphql specs will be skipped during generation.
+     */
+    private validateGraphQlSpecs({
+        workspace,
+        sdks,
+        violations
+    }: {
+        workspace: Workspace;
+        sdks: SdkConfig;
+        violations: SdkChecker.ResolvedViolation[];
+    }): void {
+        for (const target of sdks.targets) {
+            const api = workspace.apis[target.api];
+            if (api == null) {
+                continue;
+            }
+            const hasGraphQl = api.specs.some(isGraphQlSpec);
+            if (!hasGraphQl) {
+                continue;
+            }
+            violations.push({
+                severity: "warning",
+                relativeFilepath: target.sourceLocation.relativeFilePath,
+                nodePath: ["sdks", "targets", target.name, "api"],
+                message: `API '${target.api}' contains a GraphQL spec. GraphQL SDKs are not supported and graphql specs will be skipped for this target.`,
+                displayRelativeFilepath: target.sourceLocation.relativeFilePath,
+                line: target.sourceLocation.line,
+                column: target.sourceLocation.column
+            });
         }
     }
 

--- a/packages/cli/cli/changes/unreleased/cli-v2-graphql-spec-support.yml
+++ b/packages/cli/cli/changes/unreleased/cli-v2-graphql-spec-support.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    cli-v2: Add support for GraphQL specs in `fern.yml`. Specs can now be declared
+    with a `graphql` key (plus optional `name`, `origin`, and `overrides`) and are
+    rendered in the docs pipeline. SDK generation targets that reference an API
+    containing a GraphQL spec emit a non-fatal warning and skip the GraphQL spec,
+    since GraphQL SDK generation is not supported.
+  type: feat

--- a/packages/cli/config/src/schemas/ApiSpecSchema.ts
+++ b/packages/cli/config/src/schemas/ApiSpecSchema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { AsyncApiSpecSchema } from "./specs/AsyncApiSpecSchema.js";
 import { ConjureSpecSchema } from "./specs/ConjureSpecSchema.js";
 import { FernSpecSchema } from "./specs/FernSpecSchema.js";
+import { GraphQlSpecSchema } from "./specs/GraphQlSpecSchema.js";
 import { OpenApiSpecSchema } from "./specs/OpenApiSpecSchema.js";
 import { OpenRpcSpecSchema } from "./specs/OpenRpcSpecSchema.js";
 import { ProtobufSpecSchema } from "./specs/ProtobufSpecSchema.js";
@@ -16,7 +17,8 @@ export const ApiSpecSchema = z.union([
     ProtobufSpecSchema,
     FernSpecSchema,
     ConjureSpecSchema,
-    OpenRpcSpecSchema
+    OpenRpcSpecSchema,
+    GraphQlSpecSchema
 ]);
 
 export type ApiSpecSchema = z.infer<typeof ApiSpecSchema>;

--- a/packages/cli/config/src/schemas/index.ts
+++ b/packages/cli/config/src/schemas/index.ts
@@ -66,6 +66,7 @@ export {
     ConjureSpecSchema,
     FernSettingsSchema,
     FernSpecSchema,
+    GraphQlSpecSchema,
     OpenApiSpecSchema,
     OpenRpcSettingsSchema,
     OpenRpcSpecSchema,

--- a/packages/cli/config/src/schemas/specs/GraphQlSpecSchema.ts
+++ b/packages/cli/config/src/schemas/specs/GraphQlSpecSchema.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+/**
+ * Schema for GraphQL spec definition in fern.yml.
+ */
+export const GraphQlSpecSchema = z.object({
+    /** Path to the GraphQL schema file. */
+    graphql: z.string(),
+
+    /** URL origin for the GraphQL endpoint. */
+    origin: z.string().optional(),
+
+    /** Path to overrides file for the GraphQL spec. */
+    overrides: z.union([z.string(), z.array(z.string()).nonempty()]).optional(),
+
+    /** Name used to group this GraphQL spec in the docs (rendered as a top-level section). */
+    name: z.string().optional()
+});
+
+export type GraphQlSpecSchema = z.infer<typeof GraphQlSpecSchema>;

--- a/packages/cli/config/src/schemas/specs/__test__/GraphQlSpecSchema.test.ts
+++ b/packages/cli/config/src/schemas/specs/__test__/GraphQlSpecSchema.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { GraphQlSpecSchema } from "../GraphQlSpecSchema.js";
+
+describe("GraphQlSpecSchema", () => {
+    it("should accept a minimal spec with only graphql", () => {
+        const input = { graphql: "./schema.graphql" };
+        const result = GraphQlSpecSchema.safeParse(input);
+        expect(result.success).toBe(true);
+    });
+
+    it("should accept name, origin, and overrides", () => {
+        const input = {
+            graphql: "./plants.graphql",
+            name: "Plants",
+            origin: "https://api.example.com/plants/graphql",
+            overrides: "./overrides.yml"
+        };
+        const result = GraphQlSpecSchema.safeParse(input);
+        expect(result.success).toBe(true);
+    });
+
+    it("should accept an array of overrides", () => {
+        const input = {
+            graphql: "./schema.graphql",
+            overrides: ["./overrides1.yml", "./overrides2.yml"]
+        };
+        const result = GraphQlSpecSchema.safeParse(input);
+        expect(result.success).toBe(true);
+    });
+
+    it("should reject missing graphql field", () => {
+        const input = { name: "Plants" };
+        const result = GraphQlSpecSchema.safeParse(input);
+        expect(result.success).toBe(false);
+    });
+});

--- a/packages/cli/config/src/schemas/specs/index.ts
+++ b/packages/cli/config/src/schemas/specs/index.ts
@@ -1,6 +1,7 @@
 export { AsyncApiSpecSchema } from "./AsyncApiSpecSchema.js";
 export { ConjureSettingsSchema, ConjureSpecSchema } from "./ConjureSpecSchema.js";
 export { FernSettingsSchema, FernSpecSchema } from "./FernSpecSchema.js";
+export { GraphQlSpecSchema } from "./GraphQlSpecSchema.js";
 export { OpenApiSpecSchema } from "./OpenApiSpecSchema.js";
 export { OpenRpcSettingsSchema, OpenRpcSpecSchema } from "./OpenRpcSpecSchema.js";
 export { ProtobufDefinitionSchema, ProtobufSettingsSchema, ProtobufSpecSchema } from "./ProtobufSpecSchema.js";


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-8555

Adds GraphQL API spec support to cli-v2 / the new `fern.yml` format. Covers the three requirements:

1. **GraphQL as a valid API spec format** — `graphql:` is now a recognized spec type in `fern.yml`
2. **`fern sdk` warns when API contains GraphQL** — `fern sdk check` emits a warning per SDK target referencing a GraphQL-containing API
3. **`fern docs` supports GraphQL** — `fern docs dev`, `fern docs publish`, and `fern docs check` all process GraphQL specs for rendering

Example `fern.yml`:

```yaml
api:
  specs:
    - graphql: plants.schema.graphql
      name: Plants
      origin: https://api.example.com/plants/graphql
    - graphql: storefront.schema.graphql
      name: Storefront
      origin: https://api.example.com/storefront/graphql
```

## Changes Made
- **Spec type & zod schema:** new `GraphQlSpec` config type + `isGraphQlSpec` type guard in `packages/cli/cli-v2/src/api/config/GraphQlSpec.ts`; new `GraphQlSpecSchema` (fields `graphql`, `origin?`, `overrides?`, `name?`) in `packages/cli/config/src/schemas/specs/GraphQlSpecSchema.ts`; both wired into the `ApiSpec` union / `ApiSpecType` and the `ApiSpecSchema` zod union.
- **Converter:** `ApiDefinitionConverter` resolves graphql specs (absolute path + optional origin/overrides/name).
- **Legacy adapters:** `LegacyApiSpecAdapter` converts to `@fern-api/api-workspace-commons` `GraphQLSpec` (type `graphql`, `absoluteFilepath`, `absoluteFilepathToOverrides`, `namespace = name`). `LegacyOSSWorkspaceAdapter` routes graphql specs into `OSSWorkspace.allSpecs` (for docs) but excludes them from `specs` (IR generation), and allows a workspace to be created even when only graphql specs are present.
- **Docs pipeline:** `LegacyProjectAdapter.adapt` invokes `OSSWorkspace.processGraphQLSpecs` after building each OSS workspace so that docs rendering picks up graphql operations/types. All three docs commands (`fern docs dev`, `fern docs publish`, `fern docs check`) go through this path.
- **SDK warning:** `SdkChecker.validateGraphQlSpecs` emits a non-fatal warning on any SDK target whose referenced API contains a GraphQL spec (`GraphQL SDKs are not supported and graphql specs will be skipped for this target.`). `ApiDefinitionValidator` also excludes graphql from the OpenAPI/Protobuf filter used to construct the validation workspace.
- **Bare-file detection:** `ApiSpecDetector` recognizes `.graphql` / `.graphqls` / `.gql` extensions and returns `"graphql"`; `ApiSpecResolver` builds a `GraphQlSpec` for that type and infers the right extension for remote URLs.
- **Migrator:** `convertApiSpecs` converts v1 `generators.yml` graphql entries to the new fern.yml schema, adjusts spec paths for multi-API migration, and maps namespaced graphql specs onto the `name` field.
- **Compile cache:** `ApiDefinitionHasher` includes the graphql file and its overrides in the hashed input set so IR caching stays correct when graphql files change.
- [ ] Updated README.md generator (if applicable) — n/a

## Testing
- [x] Unit tests added/updated
  - `ApiDefinitionConverter` test: converts graphql spec with `name` + `origin`
  - `convertApiSpecs` migrator test: v1 graphql spec → v2 `GraphQlSpecSchema`
  - `GraphQlSpecSchema` zod tests: required fields, optional overrides (string and array), rejection when `graphql` is missing
  - `SdkChecker` tests: warns when SDK target references a GraphQL-spec API; no warning for OpenAPI-only API
  - `ApiSpecDetector` tests: detects `.graphql`, `.graphqls`, `.gql` extensions
- [x] Manual testing completed

### Commands to test locally

```bash
# Build CLI
cd packages/cli/cli-v2 && pnpm dist:cli:dev
alias fern-v2="node packages/cli/cli-v2/dist/dev/cli.cjs"

# Run unit tests
pnpm turbo run test --filter @fern-api/cli-v2 --filter @fern-api/config

# api check — should pass clean for a GraphQL spec
fern-v2 api check

# sdk check — warns per SDK target referencing a GraphQL spec
fern-v2 sdk check

# sdk check strict mode — treats warnings as errors
fern-v2 sdk check --strict
```

Link to Devin session: https://app.devin.ai/sessions/eb0b673ee025469aaaf21667c1713dda
Requested by: @iamnamananand996
