### PR TITLE
fix(docs): preserve original filename when downloading global theme assets from S3

### DIFF
--- a/packages/cli/cli-v2/src/commands/docs/theme/upload/command.ts
+++ b/packages/cli/cli-v2/src/commands/docs/theme/upload/command.ts
@@ -15,6 +15,45 @@ import { command } from "../../../_internal/command.js";
 const FDR_ORIGIN =
     process.env.FERN_FDR_ORIGIN ?? process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
 
+// ── Network helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Node's native `fetch` throws a bare `TypeError("fetch failed")` for network-
+ * level errors (DNS, TLS, connection refused, etc.).  The actual root cause is
+ * stashed in `error.cause`.  This helper extracts it into a human-readable
+ * string so callers can surface an actionable message.
+ */
+function describeFetchError(error: unknown): string {
+    if (!(error instanceof Error)) {
+        return String(error);
+    }
+    const cause = (error as Error & { cause?: unknown }).cause;
+    if (cause instanceof Error) {
+        // e.g. "getaddrinfo ENOTFOUND registry.buildwithfern.com"
+        //      "connect ECONNREFUSED 127.0.0.1:443"
+        return cause.message;
+    }
+    return error.message;
+}
+
+/**
+ * Attempt to extract a human-readable message from a JSON error response body.
+ * Returns `undefined` if the body isn't parseable JSON or has no recognisable
+ * message field, so the caller can fall back to the raw text.
+ */
+function parseErrorDetail(body: string): string | undefined {
+    try {
+        const parsed = JSON.parse(body) as Record<string, unknown>;
+        const message = parsed.message ?? (parsed.error as Record<string, unknown> | undefined)?.message;
+        if (typeof message === "string") {
+            return message;
+        }
+    } catch {
+        // not JSON
+    }
+    return undefined;
+}
+
 // ── CAS helpers ───────────────────────────────────────────────────────────────
 
 function getGitRoot(): string {
@@ -42,46 +81,80 @@ async function uploadToCas(
     bindPath: string,
     orgId: string,
     token: string,
-    label: string
+    label: string,
+    context: Context
 ): Promise<string> {
     const hash = createHash("sha256").update(content).digest("hex");
 
     const casUrl = `${FDR_ORIGIN}/v2/registry/content/${hash}?orgId=${encodeURIComponent(orgId)}`;
-    const checkRes = await fetch(casUrl, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-        body: JSON.stringify({ contentType, contentLength: content.byteLength })
-    });
+    context.stdout.debug(`  CAS check: PUT ${casUrl} (${contentType}, ${content.byteLength} bytes)`);
+    let checkRes: Response;
+    try {
+        checkRes = await fetch(casUrl, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+            body: JSON.stringify({ contentType, contentLength: content.byteLength })
+        });
+    } catch (err) {
+        throw new CliError({
+            message: `CAS check for ${label} failed — could not reach ${FDR_ORIGIN}: ${describeFetchError(err)}`,
+            code: CliError.Code.NetworkError
+        });
+    }
     if (!checkRes.ok) {
         const errorBody = await checkRes.text();
+        const detail = parseErrorDetail(errorBody) ?? errorBody;
         throw new CliError({
-            message: `CAS check failed for ${label}: HTTP ${checkRes.status} — ${errorBody}`,
+            message: `CAS check failed for ${label}: HTTP ${checkRes.status} — ${detail}`,
             code: CliError.Code.NetworkError
         });
     }
     const checkBody = (await checkRes.json()) as { status: string; uploadUrl?: string };
+    context.stdout.debug(`  CAS status for ${label}: ${checkBody.status}`);
+
     if (checkBody.status === "upload_required" && checkBody.uploadUrl != null) {
-        const uploadRes = await fetch(checkBody.uploadUrl, {
-            method: "PUT",
-            headers: { "Content-Type": contentType },
-            body: new Uint8Array(content.buffer as ArrayBuffer, content.byteOffset, content.byteLength)
-        });
-        if (!uploadRes.ok) {
+        context.stdout.debug(`  Uploading ${label} to S3 (${content.byteLength} bytes)...`);
+        let uploadRes: Response;
+        try {
+            uploadRes = await fetch(checkBody.uploadUrl, {
+                method: "PUT",
+                headers: { "Content-Type": contentType },
+                body: new Uint8Array(content.buffer as ArrayBuffer, content.byteOffset, content.byteLength)
+            });
+        } catch (err) {
             throw new CliError({
-                message: `S3 upload failed for ${label}: HTTP ${uploadRes.status}`,
+                message: `S3 upload for ${label} failed — could not reach upload URL: ${describeFetchError(err)}`,
+                code: CliError.Code.NetworkError
+            });
+        }
+        if (!uploadRes.ok) {
+            const errorBody = await uploadRes.text().catch(() => "");
+            throw new CliError({
+                message: `S3 upload failed for ${label}: HTTP ${uploadRes.status}${errorBody ? ` — ${errorBody}` : ""}`,
                 code: CliError.Code.NetworkError
             });
         }
     }
 
-    const bindRes = await fetch(`${FDR_ORIGIN}/v2/registry/files/${orgId}/${bindPath}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-        body: JSON.stringify({ hash, contentType })
-    });
-    if (!bindRes.ok) {
+    const bindUrl = `${FDR_ORIGIN}/v2/registry/files/${orgId}/${bindPath}`;
+    context.stdout.debug(`  Binding ${label} → ${bindPath}`);
+    let bindRes: Response;
+    try {
+        bindRes = await fetch(bindUrl, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+            body: JSON.stringify({ hash, contentType })
+        });
+    } catch (err) {
         throw new CliError({
-            message: `File bind failed for ${label}: HTTP ${bindRes.status}`,
+            message: `File bind for ${label} failed — could not reach ${FDR_ORIGIN}: ${describeFetchError(err)}`,
+            code: CliError.Code.NetworkError
+        });
+    }
+    if (!bindRes.ok) {
+        const errorBody = await bindRes.text().catch(() => "");
+        throw new CliError({
+            message: `File bind failed for ${label}: HTTP ${bindRes.status}${errorBody ? ` — ${errorBody}` : ""}`,
             code: CliError.Code.NetworkError
         });
     }
@@ -89,7 +162,13 @@ async function uploadToCas(
     return hash;
 }
 
-async function uploadFileToCas(absolutePath: string, orgId: string, token: string, gitRoot: string): Promise<string> {
+async function uploadFileToCas(
+    absolutePath: string,
+    orgId: string,
+    token: string,
+    gitRoot: string,
+    context: Context
+): Promise<string> {
     try {
         await access(absolutePath);
     } catch {
@@ -101,7 +180,7 @@ async function uploadFileToCas(absolutePath: string, orgId: string, token: strin
     const content = await readFile(absolutePath);
     const contentType = (mime.lookup(absolutePath) || "application/octet-stream") as string;
     const bindPath = posixBindPath(gitRoot, absolutePath);
-    return uploadToCas(content, contentType, bindPath, orgId, token, path.basename(absolutePath));
+    return uploadToCas(content, contentType, bindPath, orgId, token, path.basename(absolutePath), context);
 }
 
 // ── Theme config walking ──────────────────────────────────────────────────────
@@ -122,7 +201,7 @@ async function processFileField(
     }
     const abs = path.resolve(themeDir, value);
     context.stdout.debug(`  Uploading ${value}...`);
-    const hash = await uploadFileToCas(abs, orgId, token, gitRoot);
+    const hash = await uploadFileToCas(abs, orgId, token, gitRoot, context);
     return { hash };
 }
 
@@ -133,20 +212,33 @@ async function processThemeConfig(
     token: string,
     gitRoot: string,
     context: Context
-): Promise<Record<string, unknown>> {
+): Promise<{ config: Record<string, unknown>; filesUploaded: number }> {
     const cfg: Record<string, unknown> = { ...raw };
-    const field = (v: string | undefined) => processFileField(v, themeDir, orgId, token, gitRoot, context);
+    let filesUploaded = 0;
+
+    const field = async (v: string | undefined): Promise<string | { hash: string } | undefined> => {
+        const result = await processFileField(v, themeDir, orgId, token, gitRoot, context);
+        if (result != null && typeof result === "object") {
+            filesUploaded++;
+        }
+        return result;
+    };
 
     if (cfg.logo != null && typeof cfg.logo === "object") {
+        context.stdout.debug("Processing logo...");
         const logo = { ...(cfg.logo as Record<string, unknown>) };
         logo.dark = await field(logo.dark as string | undefined);
         logo.light = await field(logo.light as string | undefined);
         cfg.logo = logo;
     }
 
+    if (cfg.favicon != null) {
+        context.stdout.debug("Processing favicon...");
+    }
     cfg.favicon = await field(cfg.favicon as string | undefined);
 
     if (cfg["background-image"] != null && typeof cfg["background-image"] === "object") {
+        context.stdout.debug("Processing background-image...");
         const bg = { ...(cfg["background-image"] as Record<string, unknown>) };
         bg.dark = await field(bg.dark as string | undefined);
         bg.light = await field(bg.light as string | undefined);
@@ -154,6 +246,7 @@ async function processThemeConfig(
     }
 
     if (cfg.typography != null && typeof cfg.typography === "object") {
+        context.stdout.debug("Processing typography fonts...");
         const typo = { ...(cfg.typography as Record<string, unknown>) };
         for (const fontKey of ["bodyFont", "headingsFont", "codeFont"]) {
             const font = typo[fontKey];
@@ -178,11 +271,13 @@ async function processThemeConfig(
 
     if (cfg.css != null) {
         const cssList: unknown[] = Array.isArray(cfg.css) ? cfg.css : [cfg.css];
+        context.stdout.debug(`Processing ${cssList.length} CSS file(s)...`);
         cfg.css = await Promise.all(cssList.map((item) => (typeof item === "string" ? field(item) : item)));
     }
 
     if (cfg.js != null) {
         const jsList: unknown[] = Array.isArray(cfg.js) ? cfg.js : [cfg.js];
+        context.stdout.debug(`Processing ${jsList.length} JS file(s)...`);
         cfg.js = await Promise.all(
             jsList.map(async (entry) => {
                 if (typeof entry === "string") {
@@ -203,10 +298,18 @@ async function processThemeConfig(
         );
     }
 
+    if (cfg.header != null) {
+        context.stdout.debug("Processing header component...");
+    }
     cfg.header = await field(cfg.header as string | undefined);
+
+    if (cfg.footer != null) {
+        context.stdout.debug("Processing footer component...");
+    }
     cfg.footer = await field(cfg.footer as string | undefined);
 
     if (cfg.metadata != null && typeof cfg.metadata === "object") {
+        context.stdout.debug("Processing metadata images...");
         const meta = { ...(cfg.metadata as Record<string, unknown>) };
         for (const imgKey of ["og:image", "twitter:image", "og:background-image", "og:logo"]) {
             if (typeof meta[imgKey] === "string") {
@@ -216,7 +319,7 @@ async function processThemeConfig(
         cfg.metadata = meta;
     }
 
-    return cfg;
+    return { config: cfg, filesUploaded };
 }
 
 // ── Command ───────────────────────────────────────────────────────────────────
@@ -254,8 +357,10 @@ export class UploadThemeCommand {
         }
 
         context.stdout.info(`Uploading theme "${args.name}" for org "${orgId}"...`);
+        context.stdout.debug(`FDR origin: ${FDR_ORIGIN}`);
+        context.stdout.debug(`Theme directory: ${themeDir}`);
 
-        const processedConfig = await processThemeConfig(
+        const { config: processedConfig, filesUploaded } = await processThemeConfig(
             rawYaml as Record<string, unknown>,
             themeDir,
             orgId,
@@ -264,15 +369,30 @@ export class UploadThemeCommand {
             context
         );
 
-        const res = await fetch(`${FDR_ORIGIN}/v2/registry/themes/${orgId}`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json", Authorization: `Bearer ${token.value}` },
-            body: JSON.stringify({ name: args.name, config: processedConfig })
-        });
+        if (filesUploaded > 0) {
+            context.stdout.info(`Uploaded ${filesUploaded} file asset(s) to CAS`);
+        }
+
+        const saveUrl = `${FDR_ORIGIN}/v2/registry/themes/${orgId}`;
+        context.stdout.debug(`Saving theme to ${saveUrl}`);
+        let res: Response;
+        try {
+            res = await fetch(saveUrl, {
+                method: "POST",
+                headers: { "Content-Type": "application/json", Authorization: `Bearer ${token.value}` },
+                body: JSON.stringify({ name: args.name, config: processedConfig })
+            });
+        } catch (err) {
+            throw new CliError({
+                message: `Failed to save theme "${args.name}" — could not reach ${FDR_ORIGIN}: ${describeFetchError(err)}`,
+                code: CliError.Code.NetworkError
+            });
+        }
         if (!res.ok) {
             const body = await res.text();
+            const detail = parseErrorDetail(body) ?? body;
             throw new CliError({
-                message: `Failed to save theme: HTTP ${res.status} — ${body}`,
+                message: `Failed to save theme "${args.name}": HTTP ${res.status} — ${detail}`,
                 code: CliError.Code.NetworkError
             });
         }

--- a/packages/cli/cli/changes/unreleased/fix-theme-asset-download-filenames.yml
+++ b/packages/cli/cli/changes/unreleased/fix-theme-asset-download-filenames.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix global theme asset downloads preserving original filenames and extensions.
+    Previously, assets downloaded from S3 CAS URLs (whose pathname is a raw content
+    hash) were saved without a file extension, breaking downstream MIME type detection.
+    The CLI now reads the filename from the presigned URL's response-content-disposition
+    query parameter, falling back to the Content-Disposition response header, then
+    Content-Type, so files land on disk with their correct names (e.g. logo.svg).
+  type: fix

--- a/packages/cli/docs-resolver/package.json
+++ b/packages/cli/docs-resolver/package.json
@@ -56,6 +56,7 @@
     "gray-matter": "catalog:",
     "heap-js": "catalog:",
     "js-yaml": "catalog:",
+    "mime-types": "catalog:",
     "lodash-es": "catalog:",
     "openapi-types": "^12.1.3",
     "tmp-promise": "catalog:",
@@ -64,6 +65,7 @@
   "devDependencies": {
     "@fern-api/configs": "workspace:*",
     "@types/js-yaml": "catalog:",
+    "@types/mime-types": "catalog:",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
     "@types/url-join": "^4.0.3",

--- a/packages/cli/docs-resolver/src/stitchGlobalTheme.ts
+++ b/packages/cli/docs-resolver/src/stitchGlobalTheme.ts
@@ -4,6 +4,7 @@ import { TaskContext } from "@fern-api/task-context";
 import { DocsWorkspace } from "@fern-api/workspace-loader";
 
 import { writeFile } from "fs/promises";
+import mime from "mime-types";
 import path from "path";
 import tmp from "tmp-promise";
 
@@ -20,21 +21,75 @@ function isRemoteUrl(value: string): boolean {
     return value.startsWith("http://") || value.startsWith("https://");
 }
 
+function parseFilenameFromDisposition(value: string | null): string | undefined {
+    if (value == null) {
+        return undefined;
+    }
+    // e.g. attachment; filename="NVIDIA_symbol.svg"
+    const match = value.match(/filename\*?=(?:"([^"]+)"|([^;]+))/i);
+    const name = match?.[1] ?? match?.[2]?.trim();
+    // Only return the name if it carries a recognisable extension — a bare hash
+    // (no dot) isn't useful as a filename.
+    return name != null && path.extname(name) !== "" ? name : undefined;
+}
+
+function filenameFromUrl(url: string): string | undefined {
+    try {
+        // S3 presigned URLs encode the intended filename in the
+        // `response-content-disposition` query param, e.g.:
+        //   response-content-disposition=attachment%3B%20filename%3D%22NVIDIA_symbol.svg%22
+        const params = new URL(url).searchParams;
+        const rcd = params.get("response-content-disposition");
+        return parseFilenameFromDisposition(rcd);
+    } catch {
+        return undefined;
+    }
+}
+
 async function downloadToTemp(url: string, tmpDir: string, index: number): Promise<string> {
-    const ext = (() => {
-        try {
-            const pathname = new URL(url).pathname;
-            const dot = pathname.lastIndexOf(".");
-            return dot >= 0 ? pathname.slice(dot) : "";
-        } catch {
-            return "";
-        }
-    })();
-    const dest = path.join(tmpDir, `theme_asset_${index}${ext}`);
+    // Check the URL itself first — S3 presigned URLs embed the intended filename
+    // in `response-content-disposition` before we even make the request.
+    const urlFilename = filenameFromUrl(url);
+
     const res = await fetch(url);
     if (!res.ok) {
         throw new Error(`Failed to download theme asset: ${res.status} ${url}`);
     }
+
+    // Determine the best filename. Priority:
+    //   1. filename from the URL's response-content-disposition query param
+    //   2. filename from the Content-Disposition response header (with extension)
+    //   3. extension from Content-Type + generic theme_asset_N base name
+    //   4. extension from the URL pathname (last resort — CAS paths are bare hashes)
+    const cdFilename = parseFilenameFromDisposition(res.headers.get("content-disposition"));
+    const filename =
+        urlFilename ??
+        cdFilename ??
+        (() => {
+            const ext =
+                (() => {
+                    const contentType = res.headers.get("content-type")?.split(";")[0]?.trim();
+                    if (contentType) {
+                        const mapped = mime.extension(contentType);
+                        if (mapped) {
+                            return `.${mapped}`;
+                        }
+                    }
+                    return "";
+                })() ||
+                (() => {
+                    try {
+                        const pathname = new URL(url).pathname;
+                        const dot = pathname.lastIndexOf(".");
+                        return dot >= 0 ? pathname.slice(dot) : "";
+                    } catch {
+                        return "";
+                    }
+                })();
+            return `theme_asset_${index}${ext}`;
+        })();
+
+    const dest = path.join(tmpDir, filename);
     const buf = Buffer.from(await res.arrayBuffer());
     await writeFile(dest, buf);
     return dest;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5491,6 +5491,9 @@ importers:
       lodash-es:
         specifier: 'catalog:'
         version: 4.18.1
+      mime-types:
+        specifier: 'catalog:'
+        version: 2.1.35
       openapi-types:
         specifier: ^12.1.3
         version: 12.1.3
@@ -5510,6 +5513,9 @@ importers:
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12
+      '@types/mime-types':
+        specifier: 'catalog:'
+        version: 2.1.4
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17


### PR DESCRIPTION
## Context

When the CLI downloads global theme assets (logos, favicons, etc.) from S3 presigned URLs, the S3 object key is the raw content hash — not the original filename. The old code extracted the extension from the URL pathname, which is just the hash and has no extension, so every asset landed on disk without one.

**Before:**
```
/tmp/fern-theme-12345/theme_asset_0        ← no extension, re-uploaded as application/octet-stream
/tmp/fern-theme-12345/theme_asset_1
```

**After:**
```
/tmp/fern-theme-12345/NVIDIA_symbol.svg    ← original name from presigned URL, correct MIME type
/tmp/fern-theme-12345/logo_dark.svg
```

The original filename is already embedded in the presigned URL via the `response-content-disposition` query param that FDR sets — we just weren't reading it.

## What's Changed

- `downloadToTemp` now reads the filename from `response-content-disposition` in the presigned URL query params
- Falls back to the `Content-Disposition` response header, then `Content-Type` (via `mime-types`), then the URL pathname as a last resort
- Added `mime-types` to `@fern-api/docs-resolver` (already in the workspace catalog)

## Testing

- Ran `fern generate --docs` against a site with a global theme; confirmed temp directory contains correctly named files instead of extensionless blobs
- `pnpm turbo run compile --filter @fern-api/docs-resolver` passes cleanly