### PR TITLE
fix(python): respect use_typeddict_requests in dynamic snippets

### DIFF
--- a/generators/python-v2/dynamic-snippets/src/__test__/DynamicSnippetsGenerator.test.ts
+++ b/generators/python-v2/dynamic-snippets/src/__test__/DynamicSnippetsGenerator.test.ts
@@ -10,3 +10,14 @@ describe("snippets", () => {
             buildDynamicSnippetsGenerator({ irFilepath, config: buildGeneratorConfig() })
     });
 });
+
+describe("snippets (use_typeddict_requests)", () => {
+    const runner = new DynamicSnippetsTestRunner();
+    runner.runTests({
+        buildGenerator: ({ irFilepath }) =>
+            buildDynamicSnippetsGenerator({
+                irFilepath,
+                config: buildGeneratorConfig({ customConfig: { use_typeddict_requests: true } })
+            })
+    });
+});

--- a/generators/python-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/python-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -1,5 +1,597 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`snippets (use_typeddict_requests) > examples > 'GET /metadata (allow-multiple)' 1`] = `
+"from acme import Acme
+
+client = Acme(
+    token="<YOUR_API_KEY>",
+)
+
+client.service.get_metadata(
+    shallow=False,
+    tag=[
+        "development",
+        "public"
+    ],
+    x_api_version="0.0.1",
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > examples > 'GET /metadata (simple)' 1`] = `
+"from acme import Acme
+
+client = Acme(
+    token="<YOUR_API_KEY>",
+)
+
+client.service.get_metadata(
+    shallow=False,
+    tag=[
+        "development"
+    ],
+    x_api_version="0.0.1",
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > examples > 'POST /big-entity (simple)' 1`] = `
+"from acme import Acme
+
+client = Acme(
+    token="<YOUR_API_KEY>",
+)
+
+client.service.create_big_entity(
+    cast_member={
+        "id": "john.doe",
+        "name": "John Doe"
+    },
+    extended_movie={
+        "cast": [
+            "John Travolta",
+            "Samuel L. Jackson",
+            "Uma Thurman",
+            "Bruce Willis"
+        ],
+        "id": "movie-sda231x",
+        "title": "Pulp Fiction",
+        "from": "Quentin Tarantino",
+        "rating": 8.5,
+        "type": "movie",
+        "tag": "tag-12efs9dv",
+        "metadata": {
+            "academyAward": True,
+            "releaseDate": "2023-12-08",
+            "ratings": {"rottenTomatoes": 97, "imdb": 7.6}
+        },
+        "revenue": 1000000
+    },
+    event_info={
+        "type": "metadata",
+        "id": "event-12345",
+        "data": {
+            "key1": "val1",
+            "key2": "val2"
+        },
+        "json_string": "abc"
+    },
+    migration={
+        "name": "Migration 31 Aug",
+        "status": "RUNNING"
+    },
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > examples > 'POST /movie (invalid request body)' 1`] = `
+"[
+  {
+    "severity": "CRITICAL",
+    "path": [
+      "pathParameters"
+    ],
+    "message": "Expected string, got number"
+  },
+  {
+    "severity": "CRITICAL",
+    "path": [
+      "requestBody"
+    ],
+    "message": "Expected string, got number"
+  }
+]"
+`;
+
+exports[`snippets (use_typeddict_requests) > examples > 'POST /movie (simple)' 1`] = `
+"from acme import Acme
+
+client = Acme(
+    token="<YOUR_API_KEY>",
+)
+
+client.service.create_movie(
+    id="movie-c06a4ad7",
+    prequel="movie-cv9b914f",
+    title="The Boy and the Heron",
+    from="Hayao Miyazaki",
+    rating=8,
+    tag="development",
+    metadata={
+        "actors": ["Christian Bale", "Florence Pugh", "Willem Dafoe"],
+        "releaseDate": "2023-12-08",
+        "ratings": {"rottenTomatoes": 97, "imdb": 7.6}
+    },
+    revenue=1000000,
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > exhaustive > 'GET /object/get-and-return-with-optio…' 1`] = `
+"from acme import Acme
+import datetime
+import uuid
+
+client = Acme(
+    token="<YOUR_API_KEY>",
+)
+
+client.endpoints.object.get_and_return_with_optional_field(
+    string="string",
+    integer=1,
+    long=1000000,
+    double=1.1,
+    bool=True,
+    datetime=datetime.datetime.fromisoformat("2024-01-15T09:30:00+00:00"),
+    date=datetime.date.fromisoformat("2023-01-15"),
+    uuid=uuid.UUID("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"),
+    base64="SGVsbG8gd29ybGQh",
+    list=[
+        "list",
+        "list"
+    ],
+    set=[
+        "set"
+    ],
+    map={
+        1: "map"
+    },
+    bigint="1000000",
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > exhaustive > 'POST /container/list-of-objects (inva…' 1`] = `
+"[
+  {
+    "severity": "CRITICAL",
+    "path": [
+      "pathParameters[0]",
+      "string"
+    ],
+    "message": "Expected string, got boolean"
+  },
+  {
+    "severity": "CRITICAL",
+    "path": [
+      "pathParameters[1]",
+      "invalid"
+    ],
+    "message": "\\"invalid\\" is not a recognized parameter for this endpoint"
+  },
+  {
+    "severity": "CRITICAL",
+    "path": [
+      "pathParameters[2]",
+      "string"
+    ],
+    "message": "Expected string, got number"
+  },
+  {
+    "severity": "CRITICAL",
+    "path": [
+      "requestBody[0]",
+      "string"
+    ],
+    "message": "Expected string, got boolean"
+  },
+  {
+    "severity": "CRITICAL",
+    "path": [
+      "requestBody[1]",
+      "invalid"
+    ],
+    "message": "\\"invalid\\" is not a recognized parameter for this endpoint"
+  },
+  {
+    "severity": "CRITICAL",
+    "path": [
+      "requestBody[2]",
+      "string"
+    ],
+    "message": "Expected string, got number"
+  }
+]"
+`;
+
+exports[`snippets (use_typeddict_requests) > exhaustive > 'POST /container/list-of-objects (simp…' 1`] = `
+"from acme import Acme
+
+client = Acme(
+    token="<YOUR_API_KEY>",
+)
+
+client.endpoints.container.get_and_return_list_of_objects(
+    request=[
+        {
+            "string": "one"
+        },
+        {
+            "string": "two"
+        },
+        {
+            "string": "three"
+        }
+    ],
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > exhaustive > 'POST /container/list-of-primitives (s…' 1`] = `
+"from acme import Acme
+
+client = Acme(
+    token="<YOUR_API_KEY>",
+)
+
+client.endpoints.container.get_and_return_list_of_primitives(
+    request=[
+        "one",
+        "two",
+        "three"
+    ],
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > exhaustive > 'POST /container/map-prim-to-union (mi…' 1`] = `
+"from acme import Acme
+
+client = Acme(
+    token="<YOUR_API_KEY>",
+)
+
+client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
+    request={
+        "test": 0,
+        "test2": True,
+        "test3": "Test",
+        "test4": [
+            "1",
+            "1",
+            "1",
+            "1"
+        ]
+    },
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > file-upload > 'POST /' 1`] = `
+"from acme import Acme
+
+client = Acme()
+
+client.service.post(
+    file="Hello, world!",
+    file_list=["First", "Second"],
+    maybe_file="example_maybe_file",
+    maybe_file_list=["example_maybe_file_list"],
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > file-upload > 'POST /just-file' 1`] = `
+"from acme import Acme
+
+client = Acme()
+
+client.service.just_file(
+    file="Hello, world!",
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > file-upload > 'POST /just-file-with-query-params' 1`] = `
+"from acme import Acme
+
+client = Acme()
+
+client.service.just_file_with_query_params(
+    integer=42,
+    maybe_string="exists",
+    file="Hello, world!",
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > imdb > 'GET /movies/{movieId} (simple)' 1`] = `
+"from acme import Acme
+
+client = Acme(
+    token="<YOUR_API_KEY>",
+)
+
+client.imdb.get_movie(
+    movie_id="movie_xyz",
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > imdb > 'POST /movies/create-movie (simple)' 1`] = `
+"from acme import Acme
+
+client = Acme(
+    token="<YOUR_API_KEY>",
+)
+
+client.imdb.create_movie(
+    title="The Matrix",
+    rating=8.2,
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > multi-url-environment > 'Custom environment' 1`] = `
+"from acme import Acme
+from acme.environment import AcmeEnvironment
+
+client = Acme(
+    environment=AcmeEnvironment(
+        ec2="https://custom.ec2.aws.com",
+        s3="https://custom.s3.aws.com",
+    ),
+    token="<YOUR_API_KEY>",
+)
+
+client.s3.get_presigned_url(
+    s3key="xyz",
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > multi-url-environment > 'Invalid multi url environment' 1`] = `
+"[
+  {
+    "severity": "CRITICAL",
+    "path": [],
+    "message": "The provided environments are invalid; got: [ec2], expected: [ec2, s3]"
+  }
+]"
+`;
+
+exports[`snippets (use_typeddict_requests) > multi-url-environment > 'Production environment' 1`] = `
+"from acme import Acme
+from acme.environment import AcmeEnvironment
+
+client = Acme(
+    environment=AcmeEnvironment.PRODUCTION,
+    token="<YOUR_API_KEY>",
+)
+
+client.s3.get_presigned_url(
+    s3key="xyz",
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > multi-url-environment > 'Staging environment' 1`] = `
+"from acme import Acme
+from acme.environment import AcmeEnvironment
+
+client = Acme(
+    environment=AcmeEnvironment.STAGING,
+    token="<YOUR_API_KEY>",
+)
+
+client.s3.get_presigned_url(
+    s3key="xyz",
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > multi-url-environment > 'Unrecognized environment' 1`] = `
+"[
+  {
+    "severity": "WARNING",
+    "path": [],
+    "message": "Environment \\"Unrecognized\\" was not found"
+  }
+]"
+`;
+
+exports[`snippets (use_typeddict_requests) > nullable > 'Body properties' 1`] = `
+"from acme import Acme
+import datetime
+
+client = Acme(
+    base_url="https://api.example.com",
+)
+
+client.nullable.create_user(
+    username="john.doe",
+    tags=[
+        "admin"
+    ],
+    metadata={
+        "created_at": datetime.datetime.fromisoformat("1980-01-01T00:00:00+00:00"),
+        "updated_at": datetime.datetime.fromisoformat("1980-01-01T00:00:00+00:00"),
+        "avatar": None,
+        "activated": None
+    },
+    avatar=None,
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > nullable > 'Invalid null value' 1`] = `
+"[
+  {
+    "severity": "CRITICAL",
+    "path": [
+      "requestBody"
+    ],
+    "message": "Expected non-null value, but got null"
+  }
+]"
+`;
+
+exports[`snippets (use_typeddict_requests) > nullable > 'Query parameters' 1`] = `
+"from acme import Acme
+
+client = Acme(
+    base_url="https://api.example.com",
+)
+
+client.nullable.get_users(
+    usernames=[
+        "john.doe",
+        "jane.doe"
+    ],
+    tags=[
+        None
+    ],
+    extra=None,
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > read-write-only > 'Body properties' 1`] = `
+"from acme import Acme
+
+client = Acme(
+    base_url="https://api.example.com",
+)
+
+client.create_user(
+    password="password",
+    profile={
+        "name": "name",
+        "verification": {
+            "verified": "string"
+        },
+        "ssn": "ssn"
+    },
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > read-write-only > 'Readonly value in request' 1`] = `
+"from acme import Acme
+
+client = Acme(
+    base_url="https://api.example.com",
+)
+
+client.create_user(
+    id="id",
+    password="password",
+    profile={
+        "name": "name",
+        "verification": {
+            "verified": "string"
+        },
+        "ssn": "ssn"
+    },
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > required-headers > 'GET /plants (simple)' 1`] = `
+"from acme import Acme
+
+client = Acme(
+    token="<YOUR_API_KEY>",
+    tenant_id="my-tenant-id",
+)
+
+client.plantstore.list()
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > required-headers > 'POST /plants (simple)' 1`] = `
+"from acme import Acme
+
+client = Acme(
+    token="<YOUR_API_KEY>",
+    tenant_id="my-tenant-id",
+)
+
+client.plantstore.create(
+    name="Fern",
+    price=12.99,
+)
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > single-url-environment-default > 'Production environment' 1`] = `
+"from acme import Acme
+from acme.environment import AcmeEnvironment
+
+client = Acme(
+    environment=AcmeEnvironment.PRODUCTION,
+    token="<YOUR_API_KEY>",
+)
+
+client.dummy.get_dummy()
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > single-url-environment-default > 'Staging environment' 1`] = `
+"from acme import Acme
+from acme.environment import AcmeEnvironment
+
+client = Acme(
+    environment=AcmeEnvironment.STAGING,
+    token="<YOUR_API_KEY>",
+)
+
+client.dummy.get_dummy()
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > single-url-environment-default > 'custom baseURL' 1`] = `
+"from acme import Acme
+
+client = Acme(
+    base_url="http://localhost:8080",
+    token="<YOUR_API_KEY>",
+)
+
+client.dummy.get_dummy()
+"
+`;
+
+exports[`snippets (use_typeddict_requests) > single-url-environment-default > 'invalid baseURL and environment' 1`] = `
+"[
+  {
+    "severity": "CRITICAL",
+    "path": [],
+    "message": "Cannot specify both baseUrl and environment options"
+  }
+]"
+`;
+
+exports[`snippets (use_typeddict_requests) > single-url-environment-default > 'invalid environment' 1`] = `
+"[
+  {
+    "severity": "WARNING",
+    "path": [],
+    "message": "Environment \\"Unrecognized\\" was not found"
+  }
+]"
+`;
+
 exports[`snippets > examples > 'GET /metadata (allow-multiple)' 1`] = `
 "from acme import Acme
 

--- a/generators/python-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/python-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -211,6 +211,8 @@ export class DynamicTypeLiteralMapper {
         discriminatedUnion: FernIr.dynamic.DiscriminatedUnionType;
         value: unknown;
     }): python.TypeInstantiation {
+        // biome-ignore lint/correctness/useHookAtTopLevel: not a React hook
+        const typedDictRequests = this.context.useTypedDictRequests();
         const discriminatedUnionTypeInstance = this.context.resolveDiscriminatedUnionTypeInstance({
             discriminatedUnion,
             value
@@ -225,6 +227,13 @@ export class DynamicTypeLiteralMapper {
         });
         if (unionProperties == null) {
             return python.TypeInstantiation.nop();
+        }
+        if (typedDictRequests) {
+            const discriminantEntry: python.NamedValue = {
+                name: discriminatedUnion.discriminant.wireValue,
+                value: python.TypeInstantiation.str(discriminatedUnionTypeInstance.discriminantValue.wireValue)
+            };
+            return python.TypeInstantiation.typedDict([discriminantEntry, ...unionProperties], { multiline: true });
         }
         const variantClassReference = this.context.getDiscriminatedUnionVariantClassReference({
             unionDeclaration: discriminatedUnion.declaration,
@@ -401,7 +410,12 @@ export class DynamicTypeLiteralMapper {
         object_: FernIr.dynamic.ObjectType;
         value: unknown;
     }): python.TypeInstantiation {
+        // biome-ignore lint/correctness/useHookAtTopLevel: not a React hook
+        const typedDictRequests = this.context.useTypedDictRequests();
         const entries = this.convertObjectEntries({ object_, value });
+        if (typedDictRequests) {
+            return python.TypeInstantiation.typedDict(entries, { multiline: true });
+        }
         const classReference = this.context.getTypeClassReference(object_.declaration);
         return python.TypeInstantiation.reference(
             python.instantiateClass({
@@ -600,6 +614,8 @@ export class DynamicTypeLiteralMapper {
         typeId: string;
         seen: Set<string>;
     }): python.TypeInstantiation {
+        // biome-ignore lint/correctness/useHookAtTopLevel: not a React hook
+        const typedDictRequests = this.context.useTypedDictRequests();
         const newSeen = new Set(seen);
         newSeen.add(typeId);
 
@@ -640,6 +656,9 @@ export class DynamicTypeLiteralMapper {
                             value: defaultValue
                         });
                     }
+                }
+                if (typedDictRequests) {
+                    return python.TypeInstantiation.typedDict(entries, { multiline: true });
                 }
                 const classReference = this.context.getTypeClassReference(named.declaration);
                 return python.TypeInstantiation.reference(

--- a/generators/python-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/python-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -230,7 +230,7 @@ export class DynamicTypeLiteralMapper {
         }
         if (typedDictRequests) {
             const discriminantEntry: python.NamedValue = {
-                name: discriminatedUnion.discriminant.wireValue,
+                name: this.context.getPropertyName(discriminatedUnion.discriminant.name),
                 value: python.TypeInstantiation.str(discriminatedUnionTypeInstance.discriminantValue.wireValue)
             };
             return python.TypeInstantiation.typedDict([discriminantEntry, ...unionProperties], { multiline: true });

--- a/generators/python/sdk/changes/unreleased/fix-dynamic-snippets-typeddict.yml
+++ b/generators/python/sdk/changes/unreleased/fix-dynamic-snippets-typeddict.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix `@fern-api/python-dynamic-snippets` to respect the `use_typeddict_requests`
+    configuration option. When enabled, dynamic snippets now generate dict literals
+    instead of Pydantic model constructors for object and discriminated union types.
+  type: fix

--- a/packages/cli/cli/changes/unreleased/fix-python-dynamic-snippets-typeddict.yml
+++ b/packages/cli/cli/changes/unreleased/fix-python-dynamic-snippets-typeddict.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix Python dynamic snippet generation to respect the `use_typeddict_requests`
+    configuration option. When enabled, dynamic snippets now generate dict literals
+    instead of Pydantic model constructors for object and discriminated union types.
+  type: fix

--- a/seed/python-sdk/literal/use_typeddict_requests/reference.md
+++ b/seed/python-sdk/literal/use_typeddict_requests/reference.md
@@ -90,7 +90,6 @@ client.headers.send(
 
 ```python
 from seed import SeedLiteral
-from seed.inlined import ATopLevelLiteral, ANestedLiteral
 
 client = SeedLiteral(
     base_url="https://yourhost.com/path/to/api",
@@ -98,11 +97,11 @@ client = SeedLiteral(
 
 client.inlined.send(
     temperature=10.1,
-    object_with_literal=ATopLevelLiteral(
-        nested_literal=ANestedLiteral(
-            my_literal="How super cool",
-        ),
-    ),
+    object_with_literal={
+        "nested_literal": {
+            "my_literal": "How super cool"
+        }
+    },
     query="What is the weather today",
 )
 
@@ -397,7 +396,6 @@ client.query.send(
 
 ```python
 from seed import SeedLiteral
-from seed.reference import ContainerObject, NestedObjectWithLiterals
 
 client = SeedLiteral(
     base_url="https://yourhost.com/path/to/api",
@@ -405,15 +403,15 @@ client = SeedLiteral(
 
 client.reference.send(
     query="What is the weather today",
-    container_object=ContainerObject(
-        nested_objects=[
-            NestedObjectWithLiterals(
-                literal1="literal1",
-                literal2="literal2",
-                str_prop="strProp",
-            )
-        ],
-    ),
+    container_object={
+        "nested_objects": [
+            {
+                "literal1": "literal1",
+                "literal2": "literal2",
+                "str_prop": "strProp"
+            }
+        ]
+    },
 )
 
 ```

--- a/seed/python-sdk/nullable/use-typeddict-requests/README.md
+++ b/seed/python-sdk/nullable/use-typeddict-requests/README.md
@@ -35,7 +35,6 @@ Instantiate and use the client with the following:
 
 ```python
 from seed import SeedNullable
-from seed.nullable import Metadata, Status_Active
 import datetime
 
 client = SeedNullable(
@@ -48,16 +47,18 @@ client.nullable.create_user(
         "tags",
         "tags"
     ],
-    metadata=Metadata(
-        created_at=datetime.datetime.fromisoformat("2024-01-15T09:30:00+00:00"),
-        updated_at=datetime.datetime.fromisoformat("2024-01-15T09:30:00+00:00"),
-        avatar="avatar",
-        activated=True,
-        status=Status_Active(),
-        values={
-            "values": "values"
+    metadata={
+        "created_at": datetime.datetime.fromisoformat("2024-01-15T09:30:00+00:00"),
+        "updated_at": datetime.datetime.fromisoformat("2024-01-15T09:30:00+00:00"),
+        "avatar": "avatar",
+        "activated": True,
+        "status": {
+            "type": "active"
         },
-    ),
+        "values": {
+            "values": "values"
+        }
+    },
     avatar="avatar",
 )
 ```
@@ -68,7 +69,6 @@ The SDK also exports an `async` client so that you can make non-blocking calls t
 
 ```python
 import asyncio
-from seed.nullable import Metadata, Status_Active
 import datetime
 
 from seed import AsyncSeedNullable
@@ -85,16 +85,18 @@ async def main() -> None:
             "tags",
             "tags"
         ],
-        metadata=Metadata(
-            created_at=datetime.datetime.fromisoformat("2024-01-15T09:30:00+00:00"),
-            updated_at=datetime.datetime.fromisoformat("2024-01-15T09:30:00+00:00"),
-            avatar="avatar",
-            activated=True,
-            status=Status_Active(),
-            values={
-                "values": "values"
+        metadata={
+            "created_at": datetime.datetime.fromisoformat("2024-01-15T09:30:00+00:00"),
+            "updated_at": datetime.datetime.fromisoformat("2024-01-15T09:30:00+00:00"),
+            "avatar": "avatar",
+            "activated": True,
+            "status": {
+                "type": "active"
             },
-        ),
+            "values": {
+                "values": "values"
+            }
+        },
         avatar="avatar",
     )
 

--- a/seed/python-sdk/nullable/use-typeddict-requests/reference.md
+++ b/seed/python-sdk/nullable/use-typeddict-requests/reference.md
@@ -113,7 +113,6 @@ client.nullable.get_users(
 
 ```python
 from seed import SeedNullable
-from seed.nullable import Metadata, Status_Active
 import datetime
 
 client = SeedNullable(
@@ -126,16 +125,18 @@ client.nullable.create_user(
         "tags",
         "tags"
     ],
-    metadata=Metadata(
-        created_at=datetime.datetime.fromisoformat("2024-01-15T09:30:00+00:00"),
-        updated_at=datetime.datetime.fromisoformat("2024-01-15T09:30:00+00:00"),
-        avatar="avatar",
-        activated=True,
-        status=Status_Active(),
-        values={
-            "values": "values"
+    metadata={
+        "created_at": datetime.datetime.fromisoformat("2024-01-15T09:30:00+00:00"),
+        "updated_at": datetime.datetime.fromisoformat("2024-01-15T09:30:00+00:00"),
+        "avatar": "avatar",
+        "activated": True,
+        "status": {
+            "type": "active"
         },
-    ),
+        "values": {
+            "values": "values"
+        }
+    },
     avatar="avatar",
 )
 


### PR DESCRIPTION
## Description

Fixes `@fern-api/python-dynamic-snippets` ignoring the `use_typeddict_requests` configuration option. When enabled, dynamic snippets now generate dict literals instead of Pydantic model constructors.

## Changes Made

- Updated `DynamicTypeLiteralMapper.convertObject` to emit `TypeInstantiation.typedDict(...)` (dict literal) when `use_typeddict_requests` is true, instead of always using `instantiateClass(...)` (Pydantic constructor)
- Updated `DynamicTypeLiteralMapper.convertDiscriminatedUnion` to emit a typedDict with the discriminant field included inline when `use_typeddict_requests` is true
- Updated `DynamicTypeLiteralMapper.synthesizeDefaultNamed` (object case) with the same TypedDict treatment for synthesized default values
- Added a full `use_typeddict_requests` test suite that mirrors all existing dynamic snippet fixtures
- Updated seed snapshots for `literal:use_typeddict_requests`, `nullable:use-typeddict-requests` (README.md, reference.md now show dict syntax)
- [x] Updated README.md generator (if applicable)

**Before** (with `use_typeddict_requests: true`):
```python
from seed.nullable import Metadata, Status_Active

client.nullable.create_user(
    metadata=Metadata(
        created_at=datetime.datetime.fromisoformat("2024-01-15T09:30:00+00:00"),
        status=Status_Active(),
        values={"values": "values"},
    ),
)
```

**After** (with `use_typeddict_requests: true`):
```python
client.nullable.create_user(
    metadata={
        "created_at": datetime.datetime.fromisoformat("2024-01-15T09:30:00+00:00"),
        "status": {"type": "active"},
        "values": {"values": "values"}
    },
)
```

## Testing

- [x] Unit tests added/updated — 32 new snapshot tests for `use_typeddict_requests` covering all existing dynamic snippet fixtures
- [x] All 64 tests pass (32 original + 32 new)
- [x] Biome lint/format checks pass
- [x] Seed tests pass for `file-upload:use_typeddict_requests`, `literal:use_typeddict_requests`, `nullable:use-typeddict-requests`, `mixed-file-directory:exclude_types_from_init_exports`, `examples:no-custom-config`, `exhaustive:no-custom-config`
- [x] Manual testing completed (seed snapshot updates verified)

Link to Devin session: https://app.devin.ai/sessions/30f520007e564aaa9becb864dc479daa
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
