### PR TITLE
use env var names as auth example values in snippets

### DIFF
--- a/packages/cli/generation/ir-generator/src/dynamic-snippets/DynamicSnippetsConverter.ts
+++ b/packages/cli/generation/ir-generator/src/dynamic-snippets/DynamicSnippetsConverter.ts
@@ -786,16 +786,16 @@ export class DynamicSnippetsConverter {
         switch (scheme.type) {
             case "bearer":
                 return DynamicSnippets.AuthValues.bearer({
-                    token: "<token>"
+                    token: scheme.tokenEnvVar ?? "<token>"
                 });
             case "basic":
                 return DynamicSnippets.AuthValues.basic({
-                    username: "<username>",
-                    password: "<password>"
+                    username: scheme.usernameEnvVar ?? "<username>",
+                    password: scheme.passwordEnvVar ?? "<password>"
                 });
             case "header":
                 return DynamicSnippets.AuthValues.header({
-                    value: "<value>"
+                    value: scheme.headerEnvVar ?? "<value>"
                 });
             case "oauth":
                 return DynamicSnippets.AuthValues.oauth({


### PR DESCRIPTION
## Description

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
When a security scheme declares env vars via x-fern-basic (or bearer/header equivalents), use those names as the example placeholder values in the dynamic IR rather than the hardcoded generics (<username>, <password>, <token>, <value>). Falls back to the existing generic placeholders when no env var is declared.
- [ ] Updated README.md generator (if applicable)

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
