### PR TITLE
fix(ci): use job-level concurrency in publish-cli to prevent release cancellation

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -23,14 +23,6 @@ permissions:
   contents: read # Required for checkout
   id-token: write # Required for OIDC
 
-# Serialize publish runs so queued runs wait for the in-flight publish to finish
-# instead of being cancelled. Without this, a newer release push can race with an
-# in-flight publish and cause a version (e.g. whose changelog was already written
-# to docs) to be skipped on NPM.
-concurrency:
-  group: publish-cli
-  cancel-in-progress: false
-
 env:
   DO_NOT_TRACK: "1"
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -62,6 +54,9 @@ jobs:
   dev:
     needs: [detect-release-bump]
     if: ${{ inputs.version == null && github.repository == 'fern-api/fern' && needs.detect-release-bump.outputs.is_release_bump == 'false' }}
+    concurrency:
+      group: publish-cli-dev
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     env:
       AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
@@ -125,6 +120,9 @@ jobs:
   prod:
     needs: [live-test, detect-release-bump]
     if: ${{ inputs.version == null && needs.detect-release-bump.outputs.is_release_bump == 'true' }}
+    concurrency:
+      group: publish-cli-release
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     env:
       AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
@@ -178,6 +176,9 @@ jobs:
   manual:
     runs-on: ubuntu-latest
     if: ${{ inputs.version != null }}
+    concurrency:
+      group: publish-cli-release
+      cancel-in-progress: false
     env:
       AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
       AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}

--- a/.github/workflows/release-software.yml
+++ b/.github/workflows/release-software.yml
@@ -37,7 +37,12 @@ on:
           - swift
           - typescript
 
-# Prevent concurrent release runs to avoid git conflicts
+# Prevent concurrent release runs to avoid git conflicts.
+# NOTE: cancel-in-progress: false protects the running job, but GitHub still
+# cancels any *pending* run when a newer one arrives (only 1 pending slot per
+# group). This is acceptable because the workflow checks out latest main and
+# processes ALL unreleased change files, so a cancelled pending run's changes
+# are picked up by the run that replaces it.
 concurrency:
   group: release-software
   cancel-in-progress: false

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -14,9 +14,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# Cancel previous workflows on previous push
-# On main: runs queue (no cancellation) so every merge gets tested
-# On PRs: previous runs are cancelled when new commits are pushed
+# On PRs: previous runs are cancelled when new commits are pushed.
+# On main: the running job is protected, but a pending run can still be
+# cancelled if a third push arrives (GitHub allows only 1 pending per group).
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -10,9 +10,11 @@ permissions:
   pull-requests: write
   contents: write
 
+# Idempotent: always checks out latest main and regenerates all changelogs,
+# so cancelling a pending run in favor of a newer one is safe.
 concurrency:
   group: write-changelogs-to-docs
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   DO_NOT_TRACK: "1"


### PR DESCRIPTION
## Description

Fixes the issue where CLI release publish runs were getting cancelled by subsequent pushes to main, and hardens concurrency settings across other workflows.

**Root cause:** GitHub Actions concurrency groups allow at most 1 running + 1 pending run. `cancel-in-progress: false` protects the *running* job, but when a third run arrives, the *pending* run is always cancelled.

This is what happened to [run #5884](https://github.com/fern-api/fern/actions/runs/24910302381) for CLI release 4.94.2:

| Time (UTC) | Commit | Event |
|---|---|---|
| 20:22:41 | `570413b` fix(python) | Triggers publish-cli → **starts running** |
| 20:26:47 | `6e9391d` CLI release 4.94.2 | Triggers publish-cli → **queued** behind running job |
| 20:27:03 | `45bd36b` Python release 5.6.1 | Triggers publish-cli → **cancels the queued CLI release**, takes pending slot |

## Changes Made

### `publish-cli.yml` (behavioral fix)
- Removed the workflow-level `concurrency` block
- Added **job-level** concurrency with separate groups:
  - `publish-cli-release` for `prod` and `manual` jobs (`cancel-in-progress: false`) — release publishes serialize and are never cancelled by dev publishes
  - `publish-cli-dev` for `dev` job (`cancel-in-progress: true`) — dev publishes can safely cancel previous dev publishes

### `write-changelogs-to-docs.yml` (behavioral fix)
- Switched to `cancel-in-progress: true` — this workflow is idempotent (always checks out latest main and regenerates all changelogs), so cancelling a pending run in favor of a newer one is safe and avoids wasted CI time.

### `release-software.yml` (comment only)
- Added documentation explaining why `cancel-in-progress: false` is acceptable here: the workflow checks out latest main and processes ALL unreleased change files, so a cancelled pending run's changes are picked up by the replacing run.

### `seed.yml` (comment only)
- Updated misleading comment that said "runs queue (no cancellation)" — pending runs CAN be cancelled with 3+ rapid pushes to main.

### Other workflows audited (no changes needed)
- `update-seed.yml` — self-correcting, processes latest main state
- `test-remote-vs-local-generation-parity.yml` — comments already acknowledge pending cancellation behavior
- `docs-bundle-smoke-test.yml` — rarely triggered, low risk

## Testing
- [x] Manual review of GitHub Actions concurrency semantics ([docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs))
- Workflow YAML validated

Link to Devin session: https://app.devin.ai/sessions/9152162270754785866ab85a6aae2ca9
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
