### PR TITLE
chore(cli): add republish entry for CLI after failed production publish in CI

### DIFF
--- a/packages/cli/cli/changes/unreleased/republish-4-94-2.yml
+++ b/packages/cli/cli/changes/unreleased/republish-4-94-2.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Re-publish CLI after the 4.94.2 production publish failed in CI. The dev
+    version had already been published in an earlier job, so the prod job's
+    dev re-publish step errored out and prevented the prod publish from
+    running.
+  type: chore


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
