### PR TITLE
fix(cli): populate SDK version in automations-generate step summary

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-automations-generate-version-display.yml
+++ b/packages/cli/cli/changes/unreleased/fix-automations-generate-version-display.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix `fern automations generate` step summary not displaying SDK versions.
+    The version column now falls back to the locally-resolved version when
+    Fiddle does not echo it back (e.g. GitHub PR/push modes without a
+    registry publish).
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
@@ -122,7 +122,7 @@ export class RemoteTaskHandler {
             if (this.#actualVersion == null) {
                 const tagMatch = newLog.message.match(/Tagging release (v?\d+\.\d+\.\d+(?:-[\w.]+)?)/);
                 if (tagMatch) {
-                    this.#actualVersion = tagMatch[1];
+                    this.#actualVersion = tagMatch[1]?.replace(/^v/, "");
                 }
             }
         }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
@@ -118,9 +118,9 @@ export class RemoteTaskHandler {
         for (const newLog of remoteTask.logs.slice(this.lengthOfLastLogs)) {
             this.context.logger.log(convertLogLevel(newLog.level), newLog.message);
 
-            // extract version from log messages as fallback (e.g., "Tagging release 0.0.9")
+            // extract version from log messages as fallback (e.g., "Tagging release 0.0.9" or "Tagging release v0.2.0")
             if (this.#actualVersion == null) {
-                const tagMatch = newLog.message.match(/Tagging release (\d+\.\d+\.\d+)/);
+                const tagMatch = newLog.message.match(/Tagging release (v?\d+\.\d+\.\d+(?:-[\w.]+)?)/);
                 if (tagMatch) {
                     this.#actualVersion = tagMatch[1];
                 }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -376,8 +376,11 @@ export async function runRemoteGenerationForGenerator({
     }
 
     // Fall back to the locally-resolved version when Fiddle doesn't echo it back
-    // (e.g. GitHub PR / push modes where no registry publish or release tag occurs).
-    if (result != null && result.actualVersion == null && resolvedVersion != null) {
+    // (e.g. GitHub push modes where no registry publish or release tag occurs).
+    // Skip the fallback when the version is AUTO — Fiddle determines the real version
+    // via AI-based semantic analysis, and resolvedVersion would be the literal "AUTO" string.
+    const isAutoVersioning = resolvedVersion?.toUpperCase() === "AUTO";
+    if (result != null && result.actualVersion == null && resolvedVersion != null && !isAutoVersioning) {
         return { ...result, actualVersion: resolvedVersion };
     }
     return result;

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -375,6 +375,11 @@ export async function runRemoteGenerationForGenerator({
         }
     }
 
+    // Fall back to the locally-resolved version when Fiddle doesn't echo it back
+    // (e.g. GitHub PR / push modes where no registry publish or release tag occurs).
+    if (result != null && result.actualVersion == null && resolvedVersion != null) {
+        return { ...result, actualVersion: resolvedVersion };
+    }
     return result;
 }
 


### PR DESCRIPTION
## Description

Fix `fern automations generate` step summary not displaying SDK versions in the table.

## Changes Made

**Root cause:** The step summary version column relies on two extraction paths in `RemoteTaskHandler`:
1. Registry package coordinates (`remoteTask.packages[0].coordinate`) — only populated for registry publishers
2. Log parsing via `"Tagging release X.Y.Z"` — only emitted for `commitAndRelease` mode

For GitHub-only output modes (push, PR) without registry publish, neither source provides the version, so the table shows "—".

**Fixes (3 changes across 2 files):**

1. **Improved version regex** (`RemoteTaskHandler.ts`): Updated the log-parsing regex from `/Tagging release (\d+\.\d+\.\d+)/` to `/Tagging release (v?\d+\.\d+\.\d+(?:-[\w.]+)?)/` so it captures v-prefixed versions (Go generators) and pre-release suffixes.

2. **Added version fallback** (`runRemoteGenerationForGenerator.ts`): When Fiddle doesn't echo back the version (push mode, PR mode without release tag), fall back to the locally-resolved version that was sent to Fiddle.

3. **Excluded AUTO from fallback** (`runRemoteGenerationForGenerator.ts`): When `--version AUTO` is used, the resolved version is the literal string `"AUTO"`. The fallback is skipped in this case since the real version is determined server-side by Fiddle's AI-based semantic versioning — showing "AUTO" in the table would be incorrect.

- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Lint checks pass (`pnpm run check`)
- [x] Format checks pass (`pnpm format`)
- [x] Pre-commit hooks pass
- [x] Verified data flow: `resolvedVersion` → Fiddle → `actualVersion` extraction → `recordSuccess` → `versionCell`

Link to Devin session: https://app.devin.ai/sessions/762ac0c471f142378dde5683a304c00c
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
