### PR TITLE
fix(seed): add `set -euo pipefail` to runScript generated scripts

### DIFF
--- a/packages/seed/src/__test__/runScript.test.ts
+++ b/packages/seed/src/__test__/runScript.test.ts
@@ -1,0 +1,33 @@
+import os from "os";
+import { describe, expect, it } from "vitest";
+
+import { runScript } from "../runScript.js";
+
+describe("runScript", () => {
+    it("should return nonzero exit code when an early command fails", async () => {
+        const result = await runScript({
+            commands: ["exit 1", "echo success"],
+            workingDir: os.tmpdir(),
+            doNotPipeOutput: true
+        });
+        expect(result.exitCode).not.toBe(0);
+    });
+
+    it("should return zero exit code when all commands succeed", async () => {
+        const result = await runScript({
+            commands: ["echo first", "echo second"],
+            workingDir: os.tmpdir(),
+            doNotPipeOutput: true
+        });
+        expect(result.exitCode).toBe(0);
+    });
+
+    it("should abort on undefined variable with set -u", async () => {
+        const result = await runScript({
+            commands: ['echo "$UNDEFINED_VAR_THAT_DOES_NOT_EXIST"'],
+            workingDir: os.tmpdir(),
+            doNotPipeOutput: true
+        });
+        expect(result.exitCode).not.toBe(0);
+    });
+});

--- a/packages/seed/src/runScript.ts
+++ b/packages/seed/src/runScript.ts
@@ -17,9 +17,10 @@ export async function runScript({
     env?: Record<string, string>;
 }): Promise<loggingExeca.ReturnValue> {
     const scriptFile = await tmp.file();
-    await writeFile(scriptFile.path, [`cd ${workingDir}`, ...commands].join("\n"));
+    await writeFile(scriptFile.path, ["set -euo pipefail", `cd ${workingDir}`, ...commands].join("\n"));
     return await loggingExeca(logger, "bash", [scriptFile.path], {
         doNotPipeOutput,
+        reject: false,
         env: {
             ...process.env,
             ...env


### PR DESCRIPTION
## Description

`runScript` writes shell commands to a temp file and runs it via `bash`. Without `set -e`, if an early command fails (e.g. `./gradlew :sdk:distTar` exits 1), bash continues to the next command. The final exit code is just the last command's — so a later command like `docker build` can succeed against stale artifacts, and the caller sees exit 0 despite a broken build.

## Changes Made

- Prepend `set -euo pipefail` to the generated script in `runScript.ts`, so any failing command aborts the whole sequence
- Add `reject: false` to the `loggingExeca` call so `runScript` returns the result with the real nonzero exit code (instead of throwing), which is what callers (`ContainerTestRunner`, `LocalTestRunner`) expect when they check `exitCode !== 0`
- Add unit tests for `runScript` covering:
  - Early command failure returns nonzero exit code
  - All commands succeeding returns exit code 0
  - Undefined variable aborts the script (`set -u`)

## Testing

- [x] Unit tests added
- [x] Manual testing completed (`pnpm turbo run test --filter @fern-api/seed-cli` — all 209 tests pass)
- [x] Lint/format check passes (`pnpm run check`)

Link to Devin session: https://app.devin.ai/sessions/e903eff5219f45b093c5973cb337228f
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
