### PR TITLE
feat(go): use auth placeholder values in README snippets

### DIFF
--- a/generators/go-v2/base/package.json
+++ b/generators/go-v2/base/package.json
@@ -43,7 +43,7 @@
     "@fern-api/go-ast": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@types/node": "catalog:",
     "dedent": "catalog:",
     "typescript": "catalog:",

--- a/generators/go-v2/model/package.json
+++ b/generators/go-v2/model/package.json
@@ -45,7 +45,7 @@
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/go-ast": "workspace:*",
     "@fern-api/go-base": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/generators/go-v2/sdk/package.json
+++ b/generators/go-v2/sdk/package.json
@@ -42,6 +42,7 @@
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
+    "@fern-api/dynamic-ir-sdk": "66.1.0",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/go-ast": "workspace:*",
     "@fern-api/go-base": "workspace:*",
@@ -50,11 +51,10 @@
     "@fern-api/mock-utils": "workspace:*",
     "@fern-fern/generator-cli-sdk": "^0.1.5",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@types/node": "catalog:",
     "dedent": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:",
-    "@fern-api/dynamic-ir-sdk": "66.1.0"
+    "vitest": "catalog:"
   }
 }

--- a/generators/go-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/go-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -318,24 +318,10 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     }
 
     private getOAuthClientIdPlaceholder(): string {
-        if (this.context.ir.auth != null) {
-            for (const scheme of this.context.ir.auth.schemes) {
-                if (scheme.type === "basic" && scheme.usernamePlaceholder != null) {
-                    return scheme.usernamePlaceholder;
-                }
-            }
-        }
         return "YOUR_CLIENT_ID";
     }
 
     private getOAuthClientSecretPlaceholder(): string {
-        if (this.context.ir.auth != null) {
-            for (const scheme of this.context.ir.auth.schemes) {
-                if (scheme.type === "basic" && scheme.passwordPlaceholder != null) {
-                    return scheme.passwordPlaceholder;
-                }
-            }
-        }
         return "YOUR_CLIENT_SECRET";
     }
 

--- a/generators/go-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/go-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -303,7 +303,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         `);
     }
 
-    private getTokenPlaceholder({ defaultValue = "YOUR_API_KEY" }: { defaultValue?: string } = {}): string {
+    private getTokenPlaceholder({ defaultValue = "<YOUR_API_KEY>" }: { defaultValue?: string } = {}): string {
         if (this.context.ir.auth != null) {
             for (const scheme of this.context.ir.auth.schemes) {
                 if (scheme.type === "bearer" && scheme.tokenPlaceholder != null) {
@@ -318,11 +318,11 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
     }
 
     private getOAuthClientIdPlaceholder(): string {
-        return "YOUR_CLIENT_ID";
+        return "<YOUR_CLIENT_ID>";
     }
 
     private getOAuthClientSecretPlaceholder(): string {
-        return "YOUR_CLIENT_SECRET";
+        return "<YOUR_CLIENT_SECRET>";
     }
 
     private hasOAuthScheme(): boolean {
@@ -344,7 +344,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
 
             // Option 2: Use a pre-fetched token directly
             ${ReadmeSnippetBuilder.CLIENT_VARIABLE_NAME} := ${this.rootPackageClientName}.NewClient(
-                option.WithToken("${this.getTokenPlaceholder({ defaultValue: "YOUR_ACCESS_TOKEN" })}"),
+                option.WithToken("${this.getTokenPlaceholder({ defaultValue: "<YOUR_ACCESS_TOKEN>" })}"),
             )
         `);
     }

--- a/generators/go-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/go-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -303,7 +303,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         `);
     }
 
-    private getTokenPlaceholder(): string {
+    private getTokenPlaceholder({ defaultValue = "YOUR_API_KEY" }: { defaultValue?: string } = {}): string {
         if (this.context.ir.auth != null) {
             for (const scheme of this.context.ir.auth.schemes) {
                 if (scheme.type === "bearer" && scheme.tokenPlaceholder != null) {
@@ -314,7 +314,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
                 }
             }
         }
-        return "YOUR_API_KEY";
+        return defaultValue;
     }
 
     private getOAuthClientIdPlaceholder(): string {
@@ -344,7 +344,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
 
             // Option 2: Use a pre-fetched token directly
             ${ReadmeSnippetBuilder.CLIENT_VARIABLE_NAME} := ${this.rootPackageClientName}.NewClient(
-                option.WithToken("${this.getTokenPlaceholder()}"),
+                option.WithToken("${this.getTokenPlaceholder({ defaultValue: "YOUR_ACCESS_TOKEN" })}"),
             )
         `);
     }

--- a/generators/go-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/go-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -179,7 +179,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         return this.writeCode(dedent`
             // Specify default options applied on every request.
             ${ReadmeSnippetBuilder.CLIENT_VARIABLE_NAME} := ${this.rootPackageClientName}.NewClient(
-                option.WithToken("<YOUR_API_KEY>"),
+                option.WithToken("${this.getTokenPlaceholder()}"),
                 option.WithHTTPClient(
                     &http.Client{
                         Timeout: 5 * time.Second,
@@ -190,7 +190,7 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
             // Specify options for an individual request.
             response, err := ${this.getMethodCall(endpoint)}(
                 ...,
-                option.WithToken("<YOUR_API_KEY>"),
+                option.WithToken("${this.getTokenPlaceholder()}"),
             )
         `);
     }
@@ -303,6 +303,42 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         `);
     }
 
+    private getTokenPlaceholder(): string {
+        if (this.context.ir.auth != null) {
+            for (const scheme of this.context.ir.auth.schemes) {
+                if (scheme.type === "bearer" && scheme.tokenPlaceholder != null) {
+                    return scheme.tokenPlaceholder;
+                }
+                if (scheme.type === "header" && scheme.headerPlaceholder != null) {
+                    return scheme.headerPlaceholder;
+                }
+            }
+        }
+        return "YOUR_API_KEY";
+    }
+
+    private getOAuthClientIdPlaceholder(): string {
+        if (this.context.ir.auth != null) {
+            for (const scheme of this.context.ir.auth.schemes) {
+                if (scheme.type === "basic" && scheme.usernamePlaceholder != null) {
+                    return scheme.usernamePlaceholder;
+                }
+            }
+        }
+        return "YOUR_CLIENT_ID";
+    }
+
+    private getOAuthClientSecretPlaceholder(): string {
+        if (this.context.ir.auth != null) {
+            for (const scheme of this.context.ir.auth.schemes) {
+                if (scheme.type === "basic" && scheme.passwordPlaceholder != null) {
+                    return scheme.passwordPlaceholder;
+                }
+            }
+        }
+        return "YOUR_CLIENT_SECRET";
+    }
+
     private hasOAuthScheme(): boolean {
         if (this.context.ir.auth == null) {
             return false;
@@ -315,14 +351,14 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
             // Option 1: Use client credentials (SDK will handle token fetching and refresh)
             ${ReadmeSnippetBuilder.CLIENT_VARIABLE_NAME} := ${this.rootPackageClientName}.NewClient(
                 option.WithClientCredentials(
-                    "<YOUR_CLIENT_ID>",
-                    "<YOUR_CLIENT_SECRET>",
+                    "${this.getOAuthClientIdPlaceholder()}",
+                    "${this.getOAuthClientSecretPlaceholder()}",
                 ),
             )
 
             // Option 2: Use a pre-fetched token directly
             ${ReadmeSnippetBuilder.CLIENT_VARIABLE_NAME} := ${this.rootPackageClientName}.NewClient(
-                option.WithToken("<YOUR_ACCESS_TOKEN>"),
+                option.WithToken("${this.getTokenPlaceholder()}"),
             )
         `);
     }

--- a/generators/go-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/go-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -26,7 +26,9 @@ export class WireTestSetupGenerator {
     }
 
     public static getWiremockConfigContent(ir: FernIr.IntermediateRepresentation) {
-        return new WireMock().convertToWireMock(ir);
+        // ir-sdk versions may differ between go-sdk (66.3.0) and mock-utils (66.0.0);
+        // 66.3.0 is a strict superset (adds optional fields only), so this is safe.
+        return new WireMock().convertToWireMock(ir as Parameters<WireMock["convertToWireMock"]>[0]);
     }
 
     private generateWireMockConfigFile(): void {

--- a/generators/go/sdk/changes/unreleased/feat-auth-placeholder-snippets.yml
+++ b/generators/go/sdk/changes/unreleased/feat-auth-placeholder-snippets.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Use auth scheme placeholder values in README snippets when configured via
+    `placeholder` field on auth schemes.
+  type: feat

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions-openapi/code-samples-open-api.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions-openapi/code-samples-open-api.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "BearerAuth",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions-openapi/multiple-request-bodies.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions-openapi/multiple-request-bodies.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearerAuth",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions-openapi/names.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions-openapi/names.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "BearerAuth",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/accept-header.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/accept-header.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/any-auth.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/any-auth.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": "MY_TOKEN",
+                "tokenPlaceholder": null,
                 "key": "Bearer",
                 "docs": null
             },
@@ -34,6 +35,7 @@
                 },
                 "prefix": null,
                 "headerEnvVar": "MY_API_KEY",
+                "headerPlaceholder": null,
                 "key": "ApiKey",
                 "docs": null
             },
@@ -217,9 +219,11 @@
                 "username": "username",
                 "usernameEnvVar": "MY_USERNAME",
                 "usernameOmit": null,
+                "usernamePlaceholder": null,
                 "password": "password",
                 "passwordEnvVar": "MY_PASSWORD",
                 "passwordOmit": null,
+                "passwordPlaceholder": null,
                 "key": "Basic",
                 "docs": null
             },

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/basic-auth-environment-variables.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/basic-auth-environment-variables.json
@@ -13,9 +13,11 @@
                 "username": "username",
                 "usernameEnvVar": "USERNAME",
                 "usernameOmit": null,
+                "usernamePlaceholder": null,
                 "password": "accessToken",
                 "passwordEnvVar": "PASSWORD",
                 "passwordOmit": null,
+                "passwordPlaceholder": null,
                 "key": "Basic",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/basic-auth-pw-omitted.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/basic-auth-pw-omitted.json
@@ -13,9 +13,11 @@
                 "username": "username",
                 "usernameEnvVar": null,
                 "usernameOmit": null,
+                "usernamePlaceholder": null,
                 "password": "password",
                 "passwordEnvVar": null,
                 "passwordOmit": true,
+                "passwordPlaceholder": null,
                 "key": "Basic",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/basic-auth.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/basic-auth.json
@@ -13,9 +13,11 @@
                 "username": "username",
                 "usernameEnvVar": null,
                 "usernameOmit": null,
+                "usernamePlaceholder": null,
                 "password": "password",
                 "passwordEnvVar": null,
                 "passwordOmit": null,
+                "passwordPlaceholder": null,
                 "key": "basic",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/bearer-token-environment-variable.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/bearer-token-environment-variable.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "apiKey",
                 "tokenEnvVar": "COURIER_API_KEY",
+                "tokenPlaceholder": null,
                 "key": "Bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/client-side-params.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/client-side-params.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/endpoint-security-auth.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/endpoint-security-auth.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": "MY_TOKEN",
+                "tokenPlaceholder": null,
                 "key": "Bearer",
                 "docs": null
             },
@@ -34,6 +35,7 @@
                 },
                 "prefix": null,
                 "headerEnvVar": "MY_API_KEY",
+                "headerPlaceholder": null,
                 "key": "ApiKey",
                 "docs": null
             },
@@ -217,9 +219,11 @@
                 "username": "username",
                 "usernameEnvVar": "MY_USERNAME",
                 "usernameOmit": null,
+                "usernamePlaceholder": null,
                 "password": "password",
                 "passwordEnvVar": "MY_PASSWORD",
                 "passwordOmit": null,
+                "passwordPlaceholder": null,
                 "key": "Basic",
                 "docs": null
             },

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/examples.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/examples.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/exhaustive.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/exhaustive.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/go-content-type.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/go-content-type.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/go-deterministic-ordering.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/go-deterministic-ordering.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/go-undiscriminated-union-wire-tests.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/go-undiscriminated-union-wire-tests.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/header-auth-environment-variable.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/header-auth-environment-variable.json
@@ -27,6 +27,7 @@
                 },
                 "prefix": "test_prefix",
                 "headerEnvVar": "HEADER_TOKEN_ENV_VAR",
+                "headerPlaceholder": null,
                 "key": "Header",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/header-auth.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/header-auth.json
@@ -27,6 +27,7 @@
                 },
                 "prefix": "test_prefix",
                 "headerEnvVar": null,
+                "headerPlaceholder": null,
                 "key": "Header",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/idempotency-headers.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/idempotency-headers.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/imdb.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/imdb.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/java-builder-extension.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/java-builder-extension.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/java-custom-package-prefix.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/java-custom-package-prefix.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/multi-url-environment-no-default.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/multi-url-environment-no-default.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/multi-url-environment-reference.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/multi-url-environment-reference.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "BearerAuth",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/multi-url-environment.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/multi-url-environment.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/multiple-request-bodies.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/multiple-request-bodies.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "BearerAuthScheme",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/no-environment.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/no-environment.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/pagination-custom.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/pagination-custom.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/pagination-uri-path.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/pagination-uri-path.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/pagination.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/pagination.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/simple-api.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/simple-api.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/single-url-environment-default.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/single-url-environment-default.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/single-url-environment-no-default.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/single-url-environment-no-default.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/ts-express-casing.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/ts-express-casing.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/websocket-bearer-auth.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/websocket-bearer-auth.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "apiKey",
                 "tokenEnvVar": "SEED_API_KEY",
+                "tokenPlaceholder": null,
                 "key": "Bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/websocket-multi-url.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/websocket-multi-url.json
@@ -12,6 +12,7 @@
                 "_type": "bearer",
                 "token": "token",
                 "tokenEnvVar": null,
+                "tokenPlaceholder": null,
                 "key": "bearer",
                 "docs": null
             }

--- a/packages/commons/mock-utils/package.json
+++ b/packages/commons/mock-utils/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/ir-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "^66.0.0"
+    "@fern-fern/ir-sdk": "^66.3.0"
   },
   "devDependencies": {
     "@fern-api/configs": "workspace:*",

--- a/packages/commons/mock-utils/package.json
+++ b/packages/commons/mock-utils/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/ir-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "^66.3.0"
+    "@fern-fern/ir-sdk": "66.0.0"
   },
   "devDependencies": {
     "@fern-api/configs": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7738,8 +7738,8 @@ importers:
         specifier: workspace:*
         version: link:../ir-utils
       '@fern-fern/ir-sdk':
-        specifier: ^66.3.0
-        version: 66.3.0
+        specifier: 66.0.0
+        version: 66.0.0
     devDependencies:
       '@fern-api/configs':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -661,10 +661,10 @@ importers:
         version: 0.0.1(stylelint@14.16.1)
       stylelint-config-standard-scss:
         specifier: 'catalog:'
-        version: 5.0.0(postcss@8.5.9)(stylelint@14.16.1)
+        version: 5.0.0(postcss@8.5.10)(stylelint@14.16.1)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
@@ -1066,8 +1066,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17
@@ -1157,8 +1157,8 @@ importers:
         specifier: workspace:*
         version: link:../base
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17
@@ -1208,8 +1208,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17
@@ -4540,7 +4540,7 @@ importers:
         version: 3.0.3
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -4922,7 +4922,7 @@ importers:
         version: 7.7.4
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -6924,7 +6924,7 @@ importers:
         version: 0.27.7
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -7738,8 +7738,8 @@ importers:
         specifier: workspace:*
         version: link:../ir-utils
       '@fern-fern/ir-sdk':
-        specifier: ^66.0.0
-        version: 66.0.0
+        specifier: ^66.3.0
+        version: 66.3.0
     devDependencies:
       '@fern-api/configs':
         specifier: workspace:*
@@ -7824,7 +7824,7 @@ importers:
         version: 0.3.0(esbuild@0.27.7)
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -7922,7 +7922,7 @@ importers:
         version: 9.6.1
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -8140,7 +8140,7 @@ importers:
         version: 3.0.3
       tsup:
         specifier: 'catalog:'
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -9439,12 +9439,12 @@ packages:
     resolution: {integrity: sha512-uo1+fMnJOw5ApWVmKzb5wcLggjS4te3N8QorMClttA6DcBpgn0x1HbSl823oSyFvdqNV9U7GjmeQ+kzX1lWJUg==}
     engines: {node: '>=18.0.0'}
 
-  '@fern-fern/ir-sdk@66.3.0':
-    resolution: {integrity: sha512-BKtpmuyK98GagBSZ5CMe3oAkkwG5l3MId+/VyyyGbUV+HRrqIS+htIBlGmsNBW6fzuKK6hgOGn+Kyb2N4+Mejg==}
-    engines: {node: '>=18.0.0'}
-
   '@fern-fern/ir-sdk@66.2.0':
     resolution: {integrity: sha512-xTDCg4mecJyOIfhVeWmZ5rquDxkBChEWO31mjWZrwo1tOQhsnFUb8gj5rLW5E0G525TfLGr/MKi3kbzq7E1uNw==}
+    engines: {node: '>=18.0.0'}
+
+  '@fern-fern/ir-sdk@66.3.0':
+    resolution: {integrity: sha512-BKtpmuyK98GagBSZ5CMe3oAkkwG5l3MId+/VyyyGbUV+HRrqIS+htIBlGmsNBW6fzuKK6hgOGn+Kyb2N4+Mejg==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/ir-v53-sdk@1.0.1':
@@ -10478,8 +10478,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.60.1':
     resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
     cpu: [arm64]
     os: [android]
 
@@ -10488,8 +10498,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.60.1':
     resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
     cpu: [x64]
     os: [darwin]
 
@@ -10498,13 +10518,29 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@rollup/rollup-freebsd-x64@4.60.1':
     resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
     cpu: [x64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -10515,8 +10551,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -10527,8 +10575,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
@@ -10539,8 +10599,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -10551,8 +10623,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -10563,8 +10647,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -10575,8 +10671,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -10586,8 +10694,18 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
   '@rollup/rollup-openharmony-arm64@4.60.1':
     resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
     cpu: [arm64]
     os: [openharmony]
 
@@ -10596,8 +10714,18 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
   '@rollup/rollup-win32-ia32-msvc@4.60.1':
     resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
     cpu: [ia32]
     os: [win32]
 
@@ -10606,8 +10734,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
 
@@ -13831,6 +13969,10 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.9:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
@@ -14156,6 +14298,11 @@ packages:
 
   rollup@4.60.1:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -14594,6 +14741,10 @@ packages:
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -16579,9 +16730,9 @@ snapshots:
 
   '@fern-fern/ir-sdk@66.0.0': {}
 
-  '@fern-fern/ir-sdk@66.3.0': {}
-
   '@fern-fern/ir-sdk@66.2.0': {}
+
+  '@fern-fern/ir-sdk@66.3.0': {}
 
   '@fern-fern/ir-v53-sdk@1.0.1': {}
 
@@ -17632,76 +17783,151 @@ snapshots:
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
   '@rollup/rollup-android-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.60.1':
     optional: true
 
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
   '@rollup/rollup-darwin-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
     optional: true
 
   '@rollup/rollup-freebsd-arm64@4.60.1':
     optional: true
 
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
   '@rollup/rollup-freebsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
     optional: true
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     optional: true
 
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
   '@rollup/rollup-linux-arm64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
     optional: true
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     optional: true
 
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
   '@rollup/rollup-linux-loong64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
     optional: true
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     optional: true
 
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
     optional: true
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     optional: true
 
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
   '@rollup/rollup-linux-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     optional: true
 
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
   '@rollup/rollup-openbsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
     optional: true
 
   '@rollup/rollup-openharmony-arm64@4.60.1':
     optional: true
 
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
   '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.60.1':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
   '@rollup/rollup-win32-x64-gnu@4.60.1':
     optional: true
 
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
   '@rollup/rollup-win32-x64-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
   '@scarf/scarf@1.4.0': {}
@@ -21402,12 +21628,12 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.9
+      postcss: 8.5.10
       tsx: 4.21.0
       yaml: 2.8.3
 
@@ -21423,9 +21649,9 @@ snapshots:
     dependencies:
       postcss: 8.5.9
 
-  postcss-scss@4.0.9(postcss@8.5.9):
+  postcss-scss@4.0.9(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.9
+      postcss: 8.5.10
 
   postcss-selector-parser@6.1.2:
     dependencies:
@@ -21438,6 +21664,12 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.8
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.9:
     dependencies:
@@ -21911,6 +22143,37 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
   run-async@3.0.0: {}
 
   run-parallel@1.2.0:
@@ -22247,9 +22510,9 @@ snapshots:
     dependencies:
       stylelint: 14.16.1
 
-  stylelint-config-recommended-scss@7.0.0(postcss@8.5.9)(stylelint@14.16.1):
+  stylelint-config-recommended-scss@7.0.0(postcss@8.5.10)(stylelint@14.16.1):
     dependencies:
-      postcss-scss: 4.0.9(postcss@8.5.9)
+      postcss-scss: 4.0.9(postcss@8.5.10)
       stylelint: 14.16.1
       stylelint-config-recommended: 8.0.0(stylelint@14.16.1)
       stylelint-scss: 4.7.0(stylelint@14.16.1)
@@ -22260,10 +22523,10 @@ snapshots:
     dependencies:
       stylelint: 14.16.1
 
-  stylelint-config-standard-scss@5.0.0(postcss@8.5.9)(stylelint@14.16.1):
+  stylelint-config-standard-scss@5.0.0(postcss@8.5.10)(stylelint@14.16.1):
     dependencies:
       stylelint: 14.16.1
-      stylelint-config-recommended-scss: 7.0.0(postcss@8.5.9)(stylelint@14.16.1)
+      stylelint-config-recommended-scss: 7.0.0(postcss@8.5.10)(stylelint@14.16.1)
       stylelint-config-standard: 26.0.0(stylelint@14.16.1)
     transitivePeerDependencies:
       - postcss
@@ -22513,6 +22776,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinyrainbow@3.1.0: {}
 
   title@3.5.3:
@@ -22616,7 +22884,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -22627,7 +22895,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.7.6
@@ -22636,7 +22904,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.9
+      postcss: 8.5.10
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -22852,9 +23120,9 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.9
-      rollup: 4.60.1
-      tinyglobby: 0.2.15
+      postcss: 8.5.10
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 22.19.17
       fsevents: 2.3.3

--- a/seed/go-sdk/basic-auth-environment-variables/README.md
+++ b/seed/go-sdk/basic-auth-environment-variables/README.md
@@ -95,7 +95,7 @@ specified on the client so that they're applied on every request, or for an indi
 ```go
 // Specify default options applied on every request.
 client := client.NewClient(
-    option.WithToken("<YOUR_API_KEY>"),
+    option.WithToken("YOUR_API_KEY"),
     option.WithHTTPClient(
         &http.Client{
             Timeout: 5 * time.Second,
@@ -106,7 +106,7 @@ client := client.NewClient(
 // Specify options for an individual request.
 response, err := client.BasicAuth.PostWithBasicAuth(
     ...,
-    option.WithToken("<YOUR_API_KEY>"),
+    option.WithToken("YOUR_API_KEY"),
 )
 ```
 

--- a/seed/go-sdk/basic-auth-environment-variables/README.md
+++ b/seed/go-sdk/basic-auth-environment-variables/README.md
@@ -95,7 +95,7 @@ specified on the client so that they're applied on every request, or for an indi
 ```go
 // Specify default options applied on every request.
 client := client.NewClient(
-    option.WithToken("YOUR_API_KEY"),
+    option.WithToken("<YOUR_API_KEY>"),
     option.WithHTTPClient(
         &http.Client{
             Timeout: 5 * time.Second,
@@ -106,7 +106,7 @@ client := client.NewClient(
 // Specify options for an individual request.
 response, err := client.BasicAuth.PostWithBasicAuth(
     ...,
-    option.WithToken("YOUR_API_KEY"),
+    option.WithToken("<YOUR_API_KEY>"),
 )
 ```
 


### PR DESCRIPTION
## Description

Update the Go v2 generator to use the new IR auth `placeholder` fields (from #15348) when generating README snippet and client generator auth examples. Instead of hardcoded strings like `<YOUR_API_KEY>`, the generator now reads placeholder values from the IR auth scheme definitions.

## Changes Made

- **`ReadmeSnippetBuilder.ts`**: Added `getTokenPlaceholder()` method that reads `tokenPlaceholder` (bearer) and `headerPlaceholder` (header) from `this.context.ir.auth.schemes`, falling back to configurable defaults with angle brackets (e.g., `<YOUR_API_KEY>`). Updated `renderRequestOptionsSnippet()` and `renderOAuthSnippet()` to use dynamic placeholders instead of hardcoded values.
- **`getOAuthClientIdPlaceholder()` / `getOAuthClientSecretPlaceholder()`**: Return hardcoded defaults (`<YOUR_CLIENT_ID>`, `<YOUR_CLIENT_SECRET>`) since `OAuthClientCredentials` IR type has no placeholder fields.
- **OAuth "Option 2" snippet**: Preserves `<YOUR_ACCESS_TOKEN>` as the default for the pre-fetched token option (not the generic `<YOUR_API_KEY>`).
- **`WireTestSetupGenerator.ts`**: Added precise type assertion to handle ir-sdk version mismatch between go-sdk (66.3.0) and mock-utils (66.0.0).
- **IR generator test snapshots**: Updated 37 snapshot files with new `tokenPlaceholder: null` fields added in #15348.
- **Bumped `@fern-fern/ir-sdk`**: 66.0.0 → 66.3.0 in go-v2 packages (base, model, sdk) to access placeholder fields.
- **Changelog**: Added `generators/go/sdk/changes/unreleased/feat-auth-placeholder-snippets.yml`.

No changes needed in `ClientGenerator.ts` (no hardcoded placeholders) or dynamic snippets (`EndpointSnippetGenerator.ts` receives pre-resolved `AuthValues`).

## Testing

- [x] `pnpm format` — passes
- [x] `pnpm compile` — passes (go-sdk, mock-utils, python-sdk, php-sdk all compile)
- [x] `pnpm seed test --generator go-sdk --fixture basic-auth-environment-variables --skip-scripts` — passes (no diff in seed output)
- [x] IR generator test snapshots updated via `test:update`
- [x] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/2e283b9947f8422b9c5738579cb8ebaa
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
