### PR TITLE
feat(csharp): use auth placeholder values in snippets

### DIFF
--- a/generators/csharp/base/package.json
+++ b/generators/csharp/base/package.json
@@ -37,7 +37,7 @@
     "@fern-api/csharp-codegen": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
     "eta": "^4.5.1",

--- a/generators/csharp/codegen/package.json
+++ b/generators/csharp/codegen/package.json
@@ -34,7 +34,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/dynamic-ir-sdk": "66.1.0",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "domhandler": "catalog:",
     "htmlparser2": "catalog:",
     "zod": "catalog:"

--- a/generators/csharp/model/package.json
+++ b/generators/csharp/model/package.json
@@ -46,7 +46,7 @@
     "@fern-api/csharp-codegen": "workspace:*",
     "@fern-api/csharp-formatter": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/generators/csharp/sdk/changes/unreleased/feat-auth-placeholder-snippets.yml
+++ b/generators/csharp/sdk/changes/unreleased/feat-auth-placeholder-snippets.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Use auth scheme placeholder values in snippets when configured via
+    `placeholder` field on auth schemes.
+  type: feat

--- a/generators/csharp/sdk/package.json
+++ b/generators/csharp/sdk/package.json
@@ -50,7 +50,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-fern/generator-cli-sdk": "^0.1.5",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@types/node": "catalog:",
     "@types/url-join": "4.0.1",
     "typescript": "catalog:",

--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -785,7 +785,7 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                             reference: scheme.valueType
                         }),
                         environmentVariable: scheme.headerEnvVar,
-                        exampleValue: this.case.screamingSnakeSafe(scheme.name)
+                        exampleValue: scheme.headerPlaceholder ?? this.case.screamingSnakeSafe(scheme.name)
                     }
                 ];
             }
@@ -810,7 +810,7 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                         }),
                         type: this.Primitive.string,
                         environmentVariable: scheme.tokenEnvVar,
-                        exampleValue: this.case.screamingSnakeSafe(scheme.token)
+                        exampleValue: scheme.tokenPlaceholder ?? this.case.screamingSnakeSafe(scheme.token)
                     }
                 ];
             }
@@ -836,7 +836,7 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                         }),
                         type: this.Primitive.string,
                         environmentVariable: scheme.usernameEnvVar,
-                        exampleValue: this.case.screamingSnakeSafe(scheme.username)
+                        exampleValue: scheme.usernamePlaceholder ?? this.case.screamingSnakeSafe(scheme.username)
                     });
                 }
                 if (!passwordOmitted) {
@@ -853,7 +853,7 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                         }),
                         type: this.Primitive.string,
                         environmentVariable: scheme.passwordEnvVar,
-                        exampleValue: this.case.screamingSnakeSafe(scheme.password)
+                        exampleValue: scheme.passwordPlaceholder ?? this.case.screamingSnakeSafe(scheme.password)
                     });
                 }
                 return params;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -803,8 +803,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/logging-execa
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12
@@ -836,8 +836,8 @@ importers:
         specifier: 66.1.0
         version: 66.1.0
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       domhandler:
         specifier: 'catalog:'
         version: 5.0.3
@@ -946,8 +946,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/fs-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17
@@ -994,8 +994,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17
@@ -9443,6 +9443,10 @@ packages:
     resolution: {integrity: sha512-Gq/sxhxFtXIFnsDorSnmkBO9QTAgrM51GDuxx4uGXyUARwoKhGOhSx+AM+6kMVVUHcUHoZ8FDG7sGIOOryDjvQ==}
     engines: {node: '>=18.0.0'}
 
+  '@fern-fern/ir-sdk@66.3.0':
+    resolution: {integrity: sha512-BKtpmuyK98GagBSZ5CMe3oAkkwG5l3MId+/VyyyGbUV+HRrqIS+htIBlGmsNBW6fzuKK6hgOGn+Kyb2N4+Mejg==}
+    engines: {node: '>=18.0.0'}
+
   '@fern-fern/ir-v53-sdk@1.0.1':
     resolution: {integrity: sha512-SVNbkGBVgE/PkgurqqdFEYkmYBGNZzD2Qh8wF9nApp1NH2Wipte5zbzngl78snGTk/e9DN6+mYHfgQPzv6Pi4w==}
     engines: {node: '>=18.0.0'}
@@ -16576,6 +16580,8 @@ snapshots:
   '@fern-fern/ir-sdk@66.0.0': {}
 
   '@fern-fern/ir-sdk@66.1.0': {}
+
+  '@fern-fern/ir-sdk@66.3.0': {}
 
   '@fern-fern/ir-v53-sdk@1.0.1': {}
 

--- a/seed/csharp-sdk/basic-auth-environment-variables/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth-environment-variables/.fern/metadata.json
@@ -4,9 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }


### PR DESCRIPTION
## Description

Use the new IR auth `placeholder` fields (from PR #15348) in the C# SDK generator when generating snippet auth examples. When a placeholder is configured on an auth scheme, the generator now uses it instead of the default SCREAMING_SNAKE_CASE derived name.

## Changes Made
- Updated `RootClientGenerator.ts` to prefer `scheme.headerPlaceholder`, `scheme.tokenPlaceholder`, `scheme.usernamePlaceholder`, and `scheme.passwordPlaceholder` over the default `screamingSnakeSafe` fallback when setting `exampleValue` for auth constructor parameters
- Bumped `@fern-fern/ir-sdk` from 66.0.0 to 66.3.0 across all C# generator packages (base, codegen, model, sdk) to get the new placeholder fields
- Added changelog entry
- No changes needed in `ReadmeSnippetBuilder.ts` (no auth-specific snippet logic)
- No changes needed in `dynamic-snippets/` (receives pre-resolved auth values)

## Testing
- [x] `pnpm format` — no issues
- [x] `pnpm turbo run compile --filter @fern-api/fern-csharp-sdk` — compiles cleanly
- [x] `pnpm seed test --generator csharp-sdk --fixture basic-auth-environment-variables --skip-scripts` — passes (no generated output changes since fixture doesn't set placeholders)

Link to Devin session: https://app.devin.ai/sessions/18168f1345814be19110e3d51cc3b423
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
