### PR TITLE
feat(java): use auth placeholder values in README snippets

### DIFF
--- a/generators/java-v2/base/package.json
+++ b/generators/java-v2/base/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",

--- a/generators/java-v2/base/package.json
+++ b/generators/java-v2/base/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib",
     "compile": "tsc",
@@ -41,7 +43,7 @@
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/java-ast": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
-    "@fern-fern/ir-sdk": "^66.1.0",
+    "@fern-fern/ir-sdk": "^66.3.0",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/generators/java-v2/sdk/package.json
+++ b/generators/java-v2/sdk/package.json
@@ -20,7 +20,9 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",
@@ -49,7 +51,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-fern/generator-cli-sdk": "^0.1.8",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "^66.1.0",
+    "@fern-fern/ir-sdk": "^66.3.0",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
     "lodash-es": "catalog:",

--- a/generators/java-v2/sdk/package.json
+++ b/generators/java-v2/sdk/package.json
@@ -20,9 +20,7 @@
   "main": "lib/index.js",
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib && rm -rf ./dist",
     "compile": "tsc",

--- a/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -910,23 +910,23 @@ ${clientClassName} client = ${clientClassName}.builder()
                     authScheme.token != null ? this.context.caseConverter.camelUnsafe(authScheme.token) : "token";
                 builderParameters.push({
                     name: tokenName,
-                    value: java.TypeLiteral.string("<token>")
+                    value: java.TypeLiteral.string(authScheme.tokenPlaceholder ?? "<token>")
                 });
             } else if (authScheme?.type === "basic") {
                 builderParameters.push({
                     name: "username",
-                    value: java.TypeLiteral.string("<username>")
+                    value: java.TypeLiteral.string(authScheme.usernamePlaceholder ?? "<username>")
                 });
                 builderParameters.push({
                     name: "password",
-                    value: java.TypeLiteral.string("<password>")
+                    value: java.TypeLiteral.string(authScheme.passwordPlaceholder ?? "<password>")
                 });
             } else if (authScheme?.type === "header") {
                 const headerName =
                     authScheme.name != null ? this.context.caseConverter.camelUnsafe(authScheme.name) : "apiKey";
                 builderParameters.push({
                     name: headerName,
-                    value: java.TypeLiteral.string("<api-key>")
+                    value: java.TypeLiteral.string(authScheme.headerPlaceholder ?? "<api-key>")
                 });
             }
         }

--- a/generators/java/sdk/changes/unreleased/feat-auth-placeholder-snippets.yml
+++ b/generators/java/sdk/changes/unreleased/feat-auth-placeholder-snippets.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Use auth scheme placeholder values in README snippets when configured via
+    `placeholder` field on auth schemes.
+  type: feat

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1269,8 +1269,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/logging-execa
       '@fern-fern/ir-sdk':
-        specifier: ^66.1.0
-        version: 66.1.0
+        specifier: ^66.3.0
+        version: 66.3.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17
@@ -1350,8 +1350,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: ^66.1.0
-        version: 66.1.0
+        specifier: ^66.3.0
+        version: 66.3.0
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12
@@ -9439,8 +9439,8 @@ packages:
     resolution: {integrity: sha512-uo1+fMnJOw5ApWVmKzb5wcLggjS4te3N8QorMClttA6DcBpgn0x1HbSl823oSyFvdqNV9U7GjmeQ+kzX1lWJUg==}
     engines: {node: '>=18.0.0'}
 
-  '@fern-fern/ir-sdk@66.1.0':
-    resolution: {integrity: sha512-Gq/sxhxFtXIFnsDorSnmkBO9QTAgrM51GDuxx4uGXyUARwoKhGOhSx+AM+6kMVVUHcUHoZ8FDG7sGIOOryDjvQ==}
+  '@fern-fern/ir-sdk@66.3.0':
+    resolution: {integrity: sha512-BKtpmuyK98GagBSZ5CMe3oAkkwG5l3MId+/VyyyGbUV+HRrqIS+htIBlGmsNBW6fzuKK6hgOGn+Kyb2N4+Mejg==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/ir-v53-sdk@1.0.1':
@@ -16575,7 +16575,7 @@ snapshots:
 
   '@fern-fern/ir-sdk@66.0.0': {}
 
-  '@fern-fern/ir-sdk@66.1.0': {}
+  '@fern-fern/ir-sdk@66.3.0': {}
 
   '@fern-fern/ir-v53-sdk@1.0.1': {}
 

--- a/seed/java-sdk/basic-auth-environment-variables/.fern/metadata.json
+++ b/seed/java-sdk/basic-auth-environment-variables/.fern/metadata.json
@@ -3,9 +3,7 @@
   "generatorName": "fernapi/fern-java-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }


### PR DESCRIPTION
## Description

Use the new IR auth `placeholder` fields (from PR #15348) when generating README snippet auth examples in the Java v2 generator. When a placeholder is configured on an auth scheme, that value is used instead of the hardcoded defaults.

## Changes Made

- Updated `ReadmeSnippetBuilder.addClientBuilderParameters()` to use `tokenPlaceholder`, `usernamePlaceholder`, `passwordPlaceholder`, and `headerPlaceholder` with fallbacks to the original defaults (`<token>`, `<username>`, `<password>`, `<api-key>`)
- Bumped `@fern-fern/ir-sdk` from `^66.1.0` to `^66.3.0` in java-v2 base and sdk packages to pick up the new placeholder fields
- Added changelog entry

## Testing

- [x] `pnpm format` — no formatting issues
- [x] `pnpm turbo run compile --filter @fern-api/java-sdk` — compiles successfully
- [x] `pnpm seed test --generator java-sdk --fixture basic-auth-environment-variables --skip-scripts` — passes

Link to Devin session: https://app.devin.ai/sessions/2b29a5a295724786a9a002db9996a710
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
