### PR TITLE
feat(php): use auth placeholder values in README snippets

### DIFF
--- a/api-yml.schema.json
+++ b/api-yml.schema.json
@@ -857,6 +857,16 @@
               "type": "null"
             }
           ]
+        },
+        "placeholder": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -891,6 +901,16 @@
           "oneOf": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "placeholder": {
+          "oneOf": [
+            {
+              "type": "string"
             },
             {
               "type": "null"

--- a/fern/apis/fern-definition/definition/auth.yml
+++ b/fern/apis/fern-definition/definition/auth.yml
@@ -67,6 +67,9 @@ types:
       omit:
         type: optional<boolean>
         docs: If true, the auth variable will be omitted from the SDK.
+      placeholder:
+        type: optional<string>
+        docs: The placeholder value to use in code snippets (e.g., "YOUR_API_KEY").
 
   HeaderAuthSchemeSchema:
     extends:
@@ -79,6 +82,9 @@ types:
         type: optional<string>
         docs: Defaults to string
       prefix: optional<string>
+      placeholder:
+        type: optional<string>
+        docs: The placeholder value to use in code snippets (e.g., "YOUR_API_KEY").
 
   BasicAuthSchemeSchema:
     extends:

--- a/generators-yml.schema.json
+++ b/generators-yml.schema.json
@@ -531,6 +531,16 @@
               "type": "null"
             }
           ]
+        },
+        "placeholder": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -565,6 +575,16 @@
           "oneOf": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "placeholder": {
+          "oneOf": [
+            {
+              "type": "string"
             },
             {
               "type": "null"

--- a/generators/php/sdk/changes/unreleased/feat-auth-placeholder-snippets.yml
+++ b/generators/php/sdk/changes/unreleased/feat-auth-placeholder-snippets.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Use auth scheme placeholder values in README snippets when configured via
+    `placeholder` field on auth schemes.
+  type: feat

--- a/generators/php/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/php/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -1,10 +1,21 @@
 import { AbstractReadmeSnippetBuilder, CaseConverter, GeneratorError } from "@fern-api/base-generator";
+import { assertNever } from "@fern-api/core-utils";
 import { php } from "@fern-api/php-codegen";
 
 import { FernGeneratorCli } from "@fern-fern/generator-cli-sdk";
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
+
+// Auth placeholder fields (e.g. tokenPlaceholder, headerPlaceholder) are available
+// in IR v66.2.0+ at runtime but not in our pinned TypeScript types.
+function hasStringField<K extends string>(obj: object, key: K): obj is Record<K, string> {
+    if (key in obj) {
+        const record = obj as Record<string, unknown>;
+        return typeof record[key] === "string";
+    }
+    return false;
+}
 
 interface EndpointWithFilepath {
     endpoint: FernIr.HttpEndpoint;
@@ -181,9 +192,10 @@ ${this.context.getClientVariableName()} = new ${this.context.getRootClientClassN
                 namespace: this.context.getRootNamespace()
             });
 
+            const tokenPlaceholder = this.getAuthTokenPlaceholder();
             const clientInstantiation = php.instantiateClass({
                 classReference: clientClassReference,
-                arguments_: [php.codeblock((w) => w.write("'<token>'")), optionsArray],
+                arguments_: [php.codeblock((w) => w.write(`'${tokenPlaceholder}'`)), optionsArray],
                 multiline: true
             });
 
@@ -407,7 +419,7 @@ use ${this.context.getRootNamespace()}\\${this.context.getRootClientClassName()}
 use ${this.context.getRootNamespace()}\\${this.context.getEnvironmentsClassReference().name};
 
 ${this.context.getClientVariableName()} = new ${this.context.getRootClientClassName()}(
-    token: '<YOUR_TOKEN>',
+    token: '${this.getAuthTokenPlaceholder()}',
     options: [
         'baseUrl' => ${this.context.getEnvironmentsClassReference().name}::Staging->value
     ]
@@ -479,7 +491,7 @@ use ${this.context.getRootNamespace()}\\${this.context.getRootClientClassName()}
 use ${this.context.getRootNamespace()}\\${this.context.getEnvironmentsClassReference().name};
 
 ${this.context.getClientVariableName()} = new ${this.context.getRootClientClassName()}(
-    token: '<YOUR_TOKEN>',
+    token: '${this.getAuthTokenPlaceholder()}',
     environment: ${this.context.getEnvironmentsClassReference().name}::Staging()
 );
 \`\`\`
@@ -488,13 +500,38 @@ You can also create a custom environment with your own URLs:
 
 \`\`\`php
 ${this.context.getClientVariableName()} = new ${this.context.getRootClientClassName()}(
-    token: '<YOUR_TOKEN>',
+    token: '${this.getAuthTokenPlaceholder()}',
     environment: ${this.context.getEnvironmentsClassReference().name}::custom(
         ${customEnvParams}
     )
 );
 \`\`\`
 `);
+    }
+
+    private getAuthTokenPlaceholder(): string {
+        for (const scheme of this.context.ir.auth.schemes) {
+            switch (scheme.type) {
+                case "bearer":
+                    if (hasStringField(scheme, "tokenPlaceholder")) {
+                        return scheme.tokenPlaceholder;
+                    }
+                    break;
+                case "basic":
+                    break;
+                case "header":
+                    if (hasStringField(scheme, "headerPlaceholder")) {
+                        return scheme.headerPlaceholder;
+                    }
+                    break;
+                case "oauth":
+                case "inferred":
+                    break;
+                default:
+                    assertNever(scheme);
+            }
+        }
+        return "<YOUR_TOKEN>";
     }
 
     private writeCode(s: string): string {

--- a/generators/php/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/php/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -192,7 +192,7 @@ ${this.context.getClientVariableName()} = new ${this.context.getRootClientClassN
                 namespace: this.context.getRootNamespace()
             });
 
-            const tokenPlaceholder = this.getAuthTokenPlaceholder();
+            const tokenPlaceholder = this.escapePhpSingleQuote(this.getAuthTokenPlaceholder());
             const clientInstantiation = php.instantiateClass({
                 classReference: clientClassReference,
                 arguments_: [php.codeblock((w) => w.write(`'${tokenPlaceholder}'`)), optionsArray],
@@ -419,7 +419,7 @@ use ${this.context.getRootNamespace()}\\${this.context.getRootClientClassName()}
 use ${this.context.getRootNamespace()}\\${this.context.getEnvironmentsClassReference().name};
 
 ${this.context.getClientVariableName()} = new ${this.context.getRootClientClassName()}(
-    token: '${this.getAuthTokenPlaceholder()}',
+    token: '${this.escapePhpSingleQuote(this.getAuthTokenPlaceholder())}',
     options: [
         'baseUrl' => ${this.context.getEnvironmentsClassReference().name}::Staging->value
     ]
@@ -491,7 +491,7 @@ use ${this.context.getRootNamespace()}\\${this.context.getRootClientClassName()}
 use ${this.context.getRootNamespace()}\\${this.context.getEnvironmentsClassReference().name};
 
 ${this.context.getClientVariableName()} = new ${this.context.getRootClientClassName()}(
-    token: '${this.getAuthTokenPlaceholder()}',
+    token: '${this.escapePhpSingleQuote(this.getAuthTokenPlaceholder())}',
     environment: ${this.context.getEnvironmentsClassReference().name}::Staging()
 );
 \`\`\`
@@ -500,7 +500,7 @@ You can also create a custom environment with your own URLs:
 
 \`\`\`php
 ${this.context.getClientVariableName()} = new ${this.context.getRootClientClassName()}(
-    token: '${this.getAuthTokenPlaceholder()}',
+    token: '${this.escapePhpSingleQuote(this.getAuthTokenPlaceholder())}',
     environment: ${this.context.getEnvironmentsClassReference().name}::custom(
         ${customEnvParams}
     )
@@ -532,6 +532,10 @@ ${this.context.getClientVariableName()} = new ${this.context.getRootClientClassN
             }
         }
         return "<YOUR_TOKEN>";
+    }
+
+    private escapePhpSingleQuote(value: string): string {
+        return value.replace(/'/g, "\\'");
     }
 
     private writeCode(s: string): string {

--- a/generators/php/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/php/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -535,7 +535,7 @@ ${this.context.getClientVariableName()} = new ${this.context.getRootClientClassN
     }
 
     private escapePhpSingleQuote(value: string): string {
-        return value.replace(/'/g, "\\'");
+        return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
     }
 
     private writeCode(s: string): string {

--- a/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -30,7 +30,9 @@ export class WireTestSetupGenerator {
     }
 
     public static getWiremockConfigContent(ir: FernIr.IntermediateRepresentation) {
-        return new WireMock().convertToWireMock(ir);
+        // ir-sdk versions may differ between php-sdk (66.0.0) and mock-utils (66.3.0);
+        // 66.3.0 is a strict superset (adds optional fields only), so this is safe.
+        return new WireMock().convertToWireMock(ir as Parameters<WireMock["convertToWireMock"]>[0]);
     }
 
     /**

--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -32,8 +32,9 @@ export class WireTestSetupGenerator {
     }
 
     public static getWiremockConfigContent(ir: FernIr.IntermediateRepresentation) {
-        // @ts-expect-error ir-sdk 66.3.0 IR is structurally compatible with 66.0.0 expected by mock-utils
-        return new WireMock().convertToWireMock(ir);
+        // ir-sdk versions may differ between python-sdk and mock-utils;
+        // 66.3.0 is a strict superset (adds optional fields only), so this is safe.
+        return new WireMock().convertToWireMock(ir as Parameters<WireMock["convertToWireMock"]>[0]);
     }
 
     /**

--- a/generators/ruby-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/ruby-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -29,8 +29,9 @@ export class WireTestSetupGenerator {
     }
 
     public static getWiremockConfigContent(ir: FernIr.IntermediateRepresentation) {
-        // @ts-expect-error ir-sdk 66.2.0 (this package) vs 66.0.0 (mock-utils) have nominally incompatible visitor types
-        return new WireMock().convertToWireMock(ir);
+        // ir-sdk versions may differ between ruby-v2-sdk and mock-utils;
+        // 66.3.0 is a strict superset (adds optional fields only), so this is safe.
+        return new WireMock().convertToWireMock(ir as Parameters<WireMock["convertToWireMock"]>[0]);
     }
 
     /**

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/bearer-token-environment-variable.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/bearer-token-environment-variable.json
@@ -12,7 +12,7 @@
                 "_type": "bearer",
                 "token": "apiKey",
                 "tokenEnvVar": "COURIER_API_KEY",
-                "tokenPlaceholder": null,
+                "tokenPlaceholder": "YOUR_API_KEY",
                 "key": "Bearer",
                 "docs": null
             }

--- a/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/header-auth-environment-variable.json
+++ b/packages/cli/generation/ir-generator-tests/src/ir/__test__/test-definitions/header-auth-environment-variable.json
@@ -27,7 +27,7 @@
                 },
                 "prefix": "test_prefix",
                 "headerEnvVar": "HEADER_TOKEN_ENV_VAR",
-                "headerPlaceholder": null,
+                "headerPlaceholder": "YOUR_HEADER_VALUE",
                 "key": "Header",
                 "docs": null
             }

--- a/packages/cli/workspace/lazy-fern-workspace/src/api-yml.schema.json
+++ b/packages/cli/workspace/lazy-fern-workspace/src/api-yml.schema.json
@@ -857,6 +857,16 @@
               "type": "null"
             }
           ]
+        },
+        "placeholder": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -891,6 +901,16 @@
           "oneOf": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "placeholder": {
+          "oneOf": [
+            {
+              "type": "string"
             },
             {
               "type": "null"

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/README.md
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/README.md
@@ -41,7 +41,7 @@ Instantiate and use the client with the following:
 ```csharp
 using SeedBearerTokenEnvironmentVariable;
 
-var client = new SeedBearerTokenEnvironmentVariableClient("API_KEY");
+var client = new SeedBearerTokenEnvironmentVariableClient("YOUR_API_KEY");
 await client.Service.GetWithBearerTokenAsync();
 ```
 

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/Snippets/Example0.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/Snippets/Example0.cs
@@ -4,7 +4,7 @@ public partial class Examples
 {
     public async Task Example0() {
         var client = new SeedBearerTokenEnvironmentVariableClient(
-            apiKey: "<token>",
+            apiKey: "YOUR_API_KEY",
             clientOptions: new ClientOptions {
                 BaseUrl = "https://api.fern.com"
             }

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/snippet.json
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/snippet.json
@@ -10,7 +10,7 @@
             },
             "snippet": {
                 "type": "csharp",
-                "client": "using SeedBearerTokenEnvironmentVariable;\n\nvar client = new SeedBearerTokenEnvironmentVariableClient(\"API_KEY\");\nawait client.Service.GetWithBearerTokenAsync();\n"
+                "client": "using SeedBearerTokenEnvironmentVariable;\n\nvar client = new SeedBearerTokenEnvironmentVariableClient(\"YOUR_API_KEY\");\nawait client.Service.GetWithBearerTokenAsync();\n"
             }
         }
     ]

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable.Test/Unit/MockServer/BaseMockServerTest.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable.Test/Unit/MockServer/BaseMockServerTest.cs
@@ -24,7 +24,7 @@ public class BaseMockServerTest
 
         // Initialize the Client
         Client = new SeedBearerTokenEnvironmentVariableClient(
-            "API_KEY",
+            "YOUR_API_KEY",
             clientOptions: new ClientOptions { BaseUrl = Server.Urls[0], MaxRetries = 0 }
         );
     }

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/README.md
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/README.md
@@ -42,7 +42,7 @@ Instantiate and use the client with the following:
 using SeedBearerTokenEnvironmentVariable;
 
 var client = new SeedBearerTokenEnvironmentVariableClient(
-    clientOptions: new ClientOptions { ApiKey = "API_KEY" }
+    clientOptions: new ClientOptions { ApiKey = "YOUR_API_KEY" }
 );
 await client.Service.GetWithBearerTokenAsync();
 ```

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/Snippets/Example0.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/Snippets/Example0.cs
@@ -5,7 +5,7 @@ public partial class Examples
     public async Task Example0() {
         var client = new SeedBearerTokenEnvironmentVariableClient(
             clientOptions: new ClientOptions {
-                ApiKey = "<token>",
+                ApiKey = "YOUR_API_KEY",
                 BaseUrl = "https://api.fern.com"
             }
         );

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/snippet.json
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/snippet.json
@@ -10,7 +10,7 @@
             },
             "snippet": {
                 "type": "csharp",
-                "client": "using SeedBearerTokenEnvironmentVariable;\n\nvar client = new SeedBearerTokenEnvironmentVariableClient(\n    clientOptions: new ClientOptions { ApiKey = \"API_KEY\" }\n);\nawait client.Service.GetWithBearerTokenAsync();\n"
+                "client": "using SeedBearerTokenEnvironmentVariable;\n\nvar client = new SeedBearerTokenEnvironmentVariableClient(\n    clientOptions: new ClientOptions { ApiKey = \"YOUR_API_KEY\" }\n);\nawait client.Service.GetWithBearerTokenAsync();\n"
             }
         }
     ]

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable.Test/Unit/MockServer/BaseMockServerTest.cs
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable.Test/Unit/MockServer/BaseMockServerTest.cs
@@ -26,7 +26,7 @@ public class BaseMockServerTest
         Client = new SeedBearerTokenEnvironmentVariableClient(
             clientOptions: new ClientOptions
             {
-                ApiKey = "API_KEY",
+                ApiKey = "YOUR_API_KEY",
                 BaseUrl = Server.Urls[0],
                 MaxRetries = 0,
             }

--- a/seed/php-sdk/bearer-token-environment-variable/README.md
+++ b/seed/php-sdk/bearer-token-environment-variable/README.md
@@ -39,7 +39,7 @@ namespace Example;
 use Seed\SeedClient;
 
 $client = new SeedClient(
-    apiKey: '<token>',
+    apiKey: 'YOUR_API_KEY',
 );
 $client->service->getWithBearerToken();
 

--- a/seed/php-sdk/bearer-token-environment-variable/src/dynamic-snippets/example0/snippet.php
+++ b/seed/php-sdk/bearer-token-environment-variable/src/dynamic-snippets/example0/snippet.php
@@ -5,7 +5,7 @@ namespace Example;
 use Seed\SeedClient;
 
 $client = new SeedClient(
-    apiKey: '<token>',
+    apiKey: 'YOUR_API_KEY',
     options: [
         'baseUrl' => 'https://api.fern.com',
     ],

--- a/seed/php-sdk/header-auth-environment-variable/README.md
+++ b/seed/php-sdk/header-auth-environment-variable/README.md
@@ -39,7 +39,7 @@ namespace Example;
 use Seed\SeedClient;
 
 $client = new SeedClient(
-    headerTokenAuth: '<value>',
+    headerTokenAuth: 'YOUR_HEADER_VALUE',
 );
 $client->service->getWithBearerToken();
 

--- a/seed/php-sdk/header-auth-environment-variable/src/dynamic-snippets/example0/snippet.php
+++ b/seed/php-sdk/header-auth-environment-variable/src/dynamic-snippets/example0/snippet.php
@@ -5,7 +5,7 @@ namespace Example;
 use Seed\SeedClient;
 
 $client = new SeedClient(
-    headerTokenAuth: '<value>',
+    headerTokenAuth: 'YOUR_HEADER_VALUE',
     options: [
         'baseUrl' => 'https://api.fern.com',
     ],

--- a/seed/swift-sdk/header-auth-environment-variable/README.md
+++ b/seed/swift-sdk/header-auth-environment-variable/README.md
@@ -51,7 +51,7 @@ import Foundation
 import HeaderTokenEnvironmentVariable
 
 private func main() async throws {
-    let client = HeaderTokenEnvironmentVariableClient(headerTokenAuth: "<value>")
+    let client = HeaderTokenEnvironmentVariableClient(headerTokenAuth: "YOUR_HEADER_VALUE")
 
     _ = try await client.service.getWithBearerToken()
 }

--- a/seed/swift-sdk/header-auth-environment-variable/Snippets/Example0.swift
+++ b/seed/swift-sdk/header-auth-environment-variable/Snippets/Example0.swift
@@ -4,7 +4,7 @@ import HeaderTokenEnvironmentVariable
 private func main() async throws {
     let client = HeaderTokenEnvironmentVariableClient(
         baseURL: "https://api.fern.com",
-        headerTokenAuth: "<value>"
+        headerTokenAuth: "YOUR_HEADER_VALUE"
     )
 
     _ = try await client.service.getWithBearerToken()

--- a/seed/swift-sdk/header-auth-environment-variable/Tests/Core/ClientErrorTests.swift
+++ b/seed/swift-sdk/header-auth-environment-variable/Tests/Core/ClientErrorTests.swift
@@ -15,7 +15,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -46,7 +46,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -77,7 +77,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -110,7 +110,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -141,7 +141,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -174,7 +174,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -205,7 +205,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 

--- a/seed/swift-sdk/header-auth-environment-variable/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/header-auth-environment-variable/Tests/Core/ClientRetryTests.swift
@@ -16,7 +16,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -41,7 +41,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -66,7 +66,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -90,7 +90,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -113,7 +113,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -137,7 +137,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -161,7 +161,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -189,7 +189,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -228,7 +228,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -263,7 +263,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -310,7 +310,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -330,7 +330,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 
@@ -354,7 +354,7 @@ import Testing
 
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
 

--- a/seed/swift-sdk/header-auth-environment-variable/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/header-auth-environment-variable/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -14,7 +14,7 @@ import HeaderTokenEnvironmentVariable
         )
         let client = HeaderTokenEnvironmentVariableClient(
             baseURL: "https://api.fern.com",
-            headerTokenAuth: "<value>",
+            headerTokenAuth: "YOUR_HEADER_VALUE",
             urlSession: stub.urlSession
         )
         let expectedResponse = "string"

--- a/seed/swift-sdk/header-auth-environment-variable/reference.md
+++ b/seed/swift-sdk/header-auth-environment-variable/reference.md
@@ -31,7 +31,7 @@ import Foundation
 import HeaderTokenEnvironmentVariable
 
 private func main() async throws {
-    let client = HeaderTokenEnvironmentVariableClient(headerTokenAuth: "<value>")
+    let client = HeaderTokenEnvironmentVariableClient(headerTokenAuth: "YOUR_HEADER_VALUE")
 
     _ = try await client.service.getWithBearerToken()
 }

--- a/test-definitions/fern/apis/bearer-token-environment-variable/definition/api.yml
+++ b/test-definitions/fern/apis/bearer-token-environment-variable/definition/api.yml
@@ -6,6 +6,7 @@ auth-schemes:
     token:
       name: apiKey
       env: COURIER_API_KEY
+      placeholder: YOUR_API_KEY
 headers:
   X-API-Version:
     name: version

--- a/test-definitions/fern/apis/header-auth-environment-variable/definition/api.yml
+++ b/test-definitions/fern/apis/header-auth-environment-variable/definition/api.yml
@@ -7,3 +7,4 @@ auth-schemes:
     type: string
     prefix: test_prefix
     env: HEADER_TOKEN_ENV_VAR
+    placeholder: YOUR_HEADER_VALUE


### PR DESCRIPTION
## Description

Use the new IR auth `placeholder` fields (from PR #15348) in the PHP SDK generator when generating README snippet auth examples. When a placeholder is configured on an auth scheme, the generator now uses it instead of the default hardcoded values.

Also adds `placeholder` to the Fern definition schema for `AuthVariable` and `HeaderAuthSchemeSchema`, regenerates the JSON schema, and updates test fixtures to demonstrate the feature with seed output changes.

## Changes Made

### PHP Generator
- Added `hasStringField()` type guard for safe runtime access to optional IR fields without bumping `@fern-fern/ir-sdk`
- Added `getAuthTokenPlaceholder()` method that iterates auth schemes and returns the first available placeholder
- Updated 4 hardcoded placeholder strings: 3 environment snippets (`<YOUR_TOKEN>`) and 1 pagination snippet (`<token>`)
- Exhaustive switch with `assertNever` on the auth scheme union

### Fern Definition & Schema
- Added `placeholder` field to `AuthVariable` and `HeaderAuthSchemeSchema` in `fern/apis/fern-definition/definition/auth.yml`
- Regenerated `api-yml.schema.json` to include placeholder validation

### Test Fixtures
- Added `placeholder: YOUR_API_KEY` to `bearer-token-environment-variable` test definition
- Added `placeholder: YOUR_HEADER_VALUE` to `header-auth-environment-variable` test definition
- Updated seed outputs for `php-sdk`, `csharp-sdk`, and `swift-sdk` showing the placeholder values in generated code

### Pre-existing Fixes
- Fixed IR version mismatch `@ts-expect-error` in `WireTestSetupGenerator.ts` across python-v2, ruby-v2, go-v2, and rust generators

## Testing
- [x] `pnpm compile --filter @fern-api/php-sdk` — compiles cleanly
- [x] `pnpm seed test --generator php-sdk --fixture bearer-token-environment-variable --skip-scripts` — passes with expected output changes
- [x] `pnpm seed test --generator php-sdk --fixture header-auth-environment-variable --skip-scripts` — passes with expected output changes
- [x] `pnpm seed test --generator csharp-sdk --fixture bearer-token-environment-variable --skip-scripts` — passes
- [x] `pnpm seed test --generator swift-sdk --fixture header-auth-environment-variable --skip-scripts` — passes
- [x] CI passing

Link to Devin session: https://app.devin.ai/sessions/408b3bcaefbf459eb9beae5a15109b50
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
