### PR TITLE
feat(typescript): use auth placeholder values in SDK snippets

### DIFF
--- a/generators/typescript/model/type-generator/package.json
+++ b/generators/typescript/model/type-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/union-generator": "workspace:*",

--- a/generators/typescript/model/type-generator/src/__test__/GeneratedUndiscriminatedUnionTypeImpl.test.ts
+++ b/generators/typescript/model/type-generator/src/__test__/GeneratedUndiscriminatedUnionTypeImpl.test.ts
@@ -124,7 +124,7 @@ function createGenerator(opts: {
 }): GeneratedUndiscriminatedUnionTypeImpl<any> {
     return new GeneratedUndiscriminatedUnionTypeImpl({
         typeName: opts.typeName,
-        shape: { members: opts.members },
+        shape: { members: opts.members, baseProperties: undefined },
         examples: opts.examples ?? [],
         docs: opts.docs,
         fernFilepath: createFernFilepath(),

--- a/generators/typescript/model/type-generator/src/__test__/GeneratedUnionTypeImpl.test.ts
+++ b/generators/typescript/model/type-generator/src/__test__/GeneratedUnionTypeImpl.test.ts
@@ -99,6 +99,7 @@ function createUnionDeclaration(opts: {
         types: opts.types,
         baseProperties: opts.baseProperties ?? [],
         extends: opts.extends ?? [],
+        default: undefined,
         discriminatorContext: undefined
     };
 }

--- a/generators/typescript/model/type-generator/src/__test__/TypeGenerator.test.ts
+++ b/generators/typescript/model/type-generator/src/__test__/TypeGenerator.test.ts
@@ -105,6 +105,7 @@ describe("TypeGenerator", () => {
                 extends: [],
                 types: [],
                 baseProperties: [],
+                default: undefined,
                 discriminatorContext: undefined
             });
             const result = generator.generateType(createBaseArgs(shape));
@@ -119,7 +120,8 @@ describe("TypeGenerator", () => {
                         type: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
                         docs: undefined
                     }
-                ]
+                ],
+                baseProperties: undefined
             });
             const result = generator.generateType(createBaseArgs(shape));
             expect(result.type).toBe("undiscriminatedUnion");

--- a/generators/typescript/model/type-generator/src/__test__/UnionSubfolderTypes.test.ts
+++ b/generators/typescript/model/type-generator/src/__test__/UnionSubfolderTypes.test.ts
@@ -29,6 +29,7 @@ function createUnionDeclaration(opts?: {
         extends: [],
         types: opts?.types ?? [],
         baseProperties: [],
+        default: undefined,
         discriminatorContext: undefined
     };
 }

--- a/generators/typescript/model/type-reference-converters/package.json
+++ b/generators/typescript/model/type-reference-converters/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/model/type-reference-example-generator/package.json
+++ b/generators/typescript/model/type-reference-example-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/model/type-schema-generator/package.json
+++ b/generators/typescript/model/type-schema-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/model/type-schema-generator/src/__test__/TypeSchemaGenerator.test.ts
+++ b/generators/typescript/model/type-schema-generator/src/__test__/TypeSchemaGenerator.test.ts
@@ -353,6 +353,7 @@ describe("TypeSchemaGenerator", () => {
             extends: [],
             types: [],
             baseProperties: [],
+            default: undefined,
             discriminatorContext: undefined
         });
         const schema = generator.generateTypeSchema({
@@ -374,7 +375,8 @@ describe("TypeSchemaGenerator", () => {
         });
 
         const shape = FernIr.Type.undiscriminatedUnion({
-            members: []
+            members: [],
+            baseProperties: undefined
         });
         const schema = generator.generateTypeSchema({
             typeName: "Value",
@@ -427,6 +429,7 @@ describe("TypeSchemaGenerator", () => {
             extends: [],
             types: [],
             baseProperties: [],
+            default: undefined,
             discriminatorContext: undefined
         });
         const schema = generator.generateTypeSchema({
@@ -786,7 +789,7 @@ describe("GeneratedUndiscriminatedUnionTypeSchemaImpl", () => {
     }) {
         return new GeneratedUndiscriminatedUnionTypeSchemaImpl({
             typeName: opts.typeName,
-            shape: { members: opts.members },
+            shape: { members: opts.members, baseProperties: undefined },
             getGeneratedType: createMockGeneratedUndiscriminatedUnionType,
             getReferenceToGeneratedType: () => ts.factory.createTypeReferenceNode(opts.typeName),
             getReferenceToGeneratedTypeSchema: () => createMockReference(`${opts.typeName}Schema`),
@@ -892,6 +895,7 @@ describe("GeneratedUnionTypeSchemaImpl", () => {
                 extends: [],
                 types: opts.types ?? [],
                 baseProperties: opts.baseProperties ?? [],
+                default: undefined,
                 discriminatorContext: undefined
             },
             getGeneratedType: createMockGeneratedUnionType,

--- a/generators/typescript/model/union-generator/package.json
+++ b/generators/typescript/model/union-generator/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/model/union-schema-generator/package.json
+++ b/generators/typescript/model/union-schema-generator/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/changes/unreleased/feat-auth-placeholder-snippets.yml
+++ b/generators/typescript/sdk/changes/unreleased/feat-auth-placeholder-snippets.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Use auth scheme placeholder values in SDK client snippets when configured via
+    `placeholder` field on auth schemes.
+  type: feat

--- a/generators/typescript/sdk/cli/package.json
+++ b/generators/typescript/sdk/cli/package.json
@@ -39,7 +39,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-api/typescript-ast": "workspace:*",
     "@fern-api/typescript-base": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/abstract-generator-cli": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/client-class-generator/package.json
+++ b/generators/typescript/sdk/client-class-generator/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/resolvers": "workspace:*",

--- a/generators/typescript/sdk/client-class-generator/src/GeneratedSdkClientClassImpl.ts
+++ b/generators/typescript/sdk/client-class-generator/src/GeneratedSdkClientClassImpl.ts
@@ -404,6 +404,7 @@ export class GeneratedSdkClientClassImpl implements GeneratedSdkClientClass {
                         name: header.name,
                         prefix: undefined,
                         headerEnvVar: header.env,
+                        headerPlaceholder: undefined,
                         valueType: header.valueType,
                         docs: header.docs
                     })

--- a/generators/typescript/sdk/client-class-generator/src/__test__/BaseClientTypeGenerator.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/BaseClientTypeGenerator.test.ts
@@ -238,6 +238,7 @@ describe("BaseClientTypeGenerator", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     })
                 ]
@@ -260,6 +261,7 @@ describe("BaseClientTypeGenerator", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     })
                 ]
@@ -284,9 +286,11 @@ describe("BaseClientTypeGenerator", () => {
                         username: casingsGenerator.generateName("username"),
                         usernameEnvVar: undefined,
                         usernameOmit: undefined,
+                        usernamePlaceholder: undefined,
                         password: casingsGenerator.generateName("password"),
                         passwordEnvVar: undefined,
                         passwordOmit: undefined,
+                        passwordPlaceholder: undefined,
                         docs: undefined
                     })
                 ]
@@ -309,6 +313,7 @@ describe("BaseClientTypeGenerator", () => {
                         name: createNameAndWireValue("X-API-Key"),
                         prefix: undefined,
                         headerEnvVar: undefined,
+                        headerPlaceholder: undefined,
                         valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
                         docs: undefined
                     })
@@ -509,6 +514,7 @@ describe("BaseClientTypeGenerator", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     }),
                     FernIr.AuthScheme.header({
@@ -516,6 +522,7 @@ describe("BaseClientTypeGenerator", () => {
                         name: createNameAndWireValue("X-API-Key"),
                         prefix: undefined,
                         headerEnvVar: undefined,
+                        headerPlaceholder: undefined,
                         valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
                         docs: undefined
                     })
@@ -541,6 +548,7 @@ describe("BaseClientTypeGenerator", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     }),
                     FernIr.AuthScheme.basic({
@@ -548,9 +556,11 @@ describe("BaseClientTypeGenerator", () => {
                         username: casingsGenerator.generateName("username"),
                         usernameEnvVar: undefined,
                         usernameOmit: undefined,
+                        usernamePlaceholder: undefined,
                         password: casingsGenerator.generateName("password"),
                         passwordEnvVar: undefined,
                         passwordOmit: undefined,
+                        passwordPlaceholder: undefined,
                         docs: undefined
                     })
                 ],
@@ -679,6 +689,7 @@ describe("BaseClientTypeGenerator", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     })
                 ],
@@ -708,9 +719,11 @@ describe("BaseClientTypeGenerator", () => {
                         username: casingsGenerator.generateName("username"),
                         usernameEnvVar: undefined,
                         usernameOmit: undefined,
+                        usernamePlaceholder: undefined,
                         password: casingsGenerator.generateName("password"),
                         passwordEnvVar: undefined,
                         passwordOmit: undefined,
+                        passwordPlaceholder: undefined,
                         docs: undefined
                     })
                 ],
@@ -734,6 +747,7 @@ describe("BaseClientTypeGenerator", () => {
                         name: createNameAndWireValue("X-API-Key"),
                         prefix: undefined,
                         headerEnvVar: undefined,
+                        headerPlaceholder: undefined,
                         valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
                         docs: undefined
                     })
@@ -862,6 +876,7 @@ describe("BaseClientTypeGenerator", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     }),
                     FernIr.AuthScheme.header({
@@ -869,6 +884,7 @@ describe("BaseClientTypeGenerator", () => {
                         name: createNameAndWireValue("X-API-Key"),
                         prefix: undefined,
                         headerEnvVar: undefined,
+                        headerPlaceholder: undefined,
                         valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
                         docs: undefined
                     })
@@ -899,6 +915,7 @@ describe("BaseClientTypeGenerator", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     }),
                     FernIr.AuthScheme.basic({
@@ -906,9 +923,11 @@ describe("BaseClientTypeGenerator", () => {
                         username: casingsGenerator.generateName("username"),
                         usernameEnvVar: undefined,
                         usernameOmit: undefined,
+                        usernamePlaceholder: undefined,
                         password: casingsGenerator.generateName("password"),
                         passwordEnvVar: undefined,
                         passwordOmit: undefined,
+                        passwordPlaceholder: undefined,
                         docs: undefined
                     })
                 ],
@@ -964,6 +983,7 @@ describe("BaseClientTypeGenerator", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     })
                 ]
@@ -1109,6 +1129,7 @@ describe("BaseClientTypeGenerator", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     }),
                     FernIr.AuthScheme.basic({
@@ -1116,9 +1137,11 @@ describe("BaseClientTypeGenerator", () => {
                         username: casingsGenerator.generateName("username"),
                         usernameEnvVar: undefined,
                         usernameOmit: undefined,
+                        usernamePlaceholder: undefined,
                         password: casingsGenerator.generateName("password"),
                         passwordEnvVar: undefined,
                         passwordOmit: undefined,
+                        passwordPlaceholder: undefined,
                         docs: undefined
                     }),
                     FernIr.AuthScheme.header({
@@ -1126,6 +1149,7 @@ describe("BaseClientTypeGenerator", () => {
                         name: createNameAndWireValue("X-API-Key"),
                         prefix: undefined,
                         headerEnvVar: undefined,
+                        headerPlaceholder: undefined,
                         valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
                         docs: undefined
                     }),
@@ -1169,6 +1193,7 @@ describe("BaseClientTypeGenerator", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     }),
                     FernIr.AuthScheme.header({
@@ -1176,6 +1201,7 @@ describe("BaseClientTypeGenerator", () => {
                         name: createNameAndWireValue("X-API-Key"),
                         prefix: undefined,
                         headerEnvVar: undefined,
+                        headerPlaceholder: undefined,
                         valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
                         docs: undefined
                     }),

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
@@ -291,6 +291,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     })
                 ],
@@ -327,9 +328,11 @@ describe("GeneratedSdkClientClassImpl", () => {
                         username: casingsGenerator.generateName("username"),
                         usernameEnvVar: undefined,
                         usernameOmit: undefined,
+                        usernamePlaceholder: undefined,
                         password: casingsGenerator.generateName("password"),
                         passwordEnvVar: undefined,
                         passwordOmit: undefined,
+                        passwordPlaceholder: undefined,
                         docs: undefined
                     })
                 ],
@@ -358,6 +361,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     }),
                     FernIr.AuthScheme.header({
@@ -365,6 +369,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                         name: createNameAndWireValue("X-API-Key"),
                         prefix: undefined,
                         headerEnvVar: undefined,
+                        headerPlaceholder: undefined,
                         valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
                         docs: undefined
                     })
@@ -467,6 +472,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     })
                 ],
@@ -504,6 +510,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     })
                 ],
@@ -540,6 +547,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     })
                 ],
@@ -759,6 +767,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     }),
                     FernIr.AuthScheme.header({
@@ -766,6 +775,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                         name: createNameAndWireValue("X-API-Key"),
                         prefix: undefined,
                         headerEnvVar: undefined,
+                        headerPlaceholder: undefined,
                         valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
                         docs: undefined
                     })
@@ -832,6 +842,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                         name: createNameAndWireValue("X-API-Key"),
                         prefix: undefined,
                         headerEnvVar: undefined,
+                        headerPlaceholder: undefined,
                         valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
                         docs: undefined
                     })
@@ -1021,6 +1032,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                         key: "bearer",
                         token: casingsGenerator.generateName("token"),
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     })
                 ],

--- a/generators/typescript/sdk/client-class-generator/src/__test__/appendPropertyToFormData.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/appendPropertyToFormData.test.ts
@@ -418,7 +418,8 @@ describe("appendPropertyToFormData", () => {
                         { type: LIST_STRING_TYPE, docs: undefined },
                         { type: SET_STRING_TYPE, docs: undefined },
                         { type: STRING_TYPE, docs: undefined }
-                    ]
+                    ],
+                    baseProperties: undefined
                 })
             );
             const property = createBodyProperty("mixed", unionType);
@@ -428,7 +429,8 @@ describe("appendPropertyToFormData", () => {
                         { type: LIST_STRING_TYPE, docs: undefined },
                         { type: SET_STRING_TYPE, docs: undefined },
                         { type: STRING_TYPE, docs: undefined }
-                    ]
+                    ],
+                    baseProperties: undefined
                 })
             });
             const stmt = appendPropertyToFormData({
@@ -497,7 +499,8 @@ describe("appendPropertyToFormData", () => {
                     members: [
                         { type: SET_STRING_TYPE, docs: undefined },
                         { type: STRING_TYPE, docs: undefined }
-                    ]
+                    ],
+                    baseProperties: undefined
                 })
             );
             const property = createBodyProperty("setOrString", unionType);
@@ -506,7 +509,8 @@ describe("appendPropertyToFormData", () => {
                     members: [
                         { type: SET_STRING_TYPE, docs: undefined },
                         { type: STRING_TYPE, docs: undefined }
-                    ]
+                    ],
+                    baseProperties: undefined
                 })
             });
             const stmt = appendPropertyToFormData({
@@ -531,7 +535,8 @@ describe("appendPropertyToFormData", () => {
                     members: [
                         { type: LIST_STRING_TYPE, docs: undefined },
                         { type: STRING_TYPE, docs: undefined }
-                    ]
+                    ],
+                    baseProperties: undefined
                 })
             );
             const property = createBodyProperty("listOrString", unionType);
@@ -540,7 +545,8 @@ describe("appendPropertyToFormData", () => {
                     members: [
                         { type: LIST_STRING_TYPE, docs: undefined },
                         { type: STRING_TYPE, docs: undefined }
-                    ]
+                    ],
+                    baseProperties: undefined
                 })
             });
             const stmt = appendPropertyToFormData({
@@ -566,7 +572,8 @@ describe("appendPropertyToFormData", () => {
                     members: [
                         { type: LIST_STRING_TYPE, docs: undefined },
                         { type: SET_STRING_TYPE, docs: undefined }
-                    ]
+                    ],
+                    baseProperties: undefined
                 })
             );
             const property = createBodyProperty("allIterable", unionType);
@@ -575,7 +582,8 @@ describe("appendPropertyToFormData", () => {
                     members: [
                         { type: LIST_STRING_TYPE, docs: undefined },
                         { type: SET_STRING_TYPE, docs: undefined }
-                    ]
+                    ],
+                    baseProperties: undefined
                 })
             });
             const stmt = appendPropertyToFormData({
@@ -672,6 +680,7 @@ describe("appendPropertyToFormData", () => {
                     extends: [],
                     baseProperties: [],
                     types: [],
+                    default: undefined,
                     discriminatorContext: undefined
                 })
             );
@@ -682,6 +691,7 @@ describe("appendPropertyToFormData", () => {
                     extends: [],
                     baseProperties: [],
                     types: [],
+                    default: undefined,
                     discriminatorContext: undefined
                 })
             });

--- a/generators/typescript/sdk/client-class-generator/src/auth-provider/BasicAuthProviderInstance.ts
+++ b/generators/typescript/sdk/client-class-generator/src/auth-provider/BasicAuthProviderInstance.ts
@@ -33,7 +33,8 @@ export class BasicAuthProviderInstance implements AuthProviderInstance {
                 ts.factory.createPropertyAssignment(
                     getPropertyKey(context.case.camelSafe(this.authScheme.username)),
                     ts.factory.createStringLiteral(
-                        `YOUR_${context.case.screamingSnakeUnsafe(this.authScheme.username)}`
+                        this.authScheme.usernamePlaceholder ??
+                            `YOUR_${context.case.screamingSnakeUnsafe(this.authScheme.username)}`
                     )
                 )
             );
@@ -43,7 +44,8 @@ export class BasicAuthProviderInstance implements AuthProviderInstance {
                 ts.factory.createPropertyAssignment(
                     getPropertyKey(context.case.camelSafe(this.authScheme.password)),
                     ts.factory.createStringLiteral(
-                        `YOUR_${context.case.screamingSnakeUnsafe(this.authScheme.password)}`
+                        this.authScheme.passwordPlaceholder ??
+                            `YOUR_${context.case.screamingSnakeUnsafe(this.authScheme.password)}`
                     )
                 )
             );

--- a/generators/typescript/sdk/client-class-generator/src/auth-provider/BearerAuthProviderInstance.ts
+++ b/generators/typescript/sdk/client-class-generator/src/auth-provider/BearerAuthProviderInstance.ts
@@ -25,7 +25,10 @@ export class BearerAuthProviderInstance implements AuthProviderInstance {
         return [
             ts.factory.createPropertyAssignment(
                 getPropertyKey(tokenKey),
-                ts.factory.createStringLiteral(`YOUR_${context.case.screamingSnakeUnsafe(this.authScheme.token)}`)
+                ts.factory.createStringLiteral(
+                    this.authScheme.tokenPlaceholder ??
+                        `YOUR_${context.case.screamingSnakeUnsafe(this.authScheme.token)}`
+                )
             )
         ];
     }

--- a/generators/typescript/sdk/client-class-generator/src/auth-provider/HeaderAuthProviderInstance.ts
+++ b/generators/typescript/sdk/client-class-generator/src/auth-provider/HeaderAuthProviderInstance.ts
@@ -23,7 +23,10 @@ export class HeaderAuthProviderInstance implements AuthProviderInstance {
         return [
             ts.factory.createPropertyAssignment(
                 getPropertyKey(context.case.camelSafe(this.authScheme.name)),
-                ts.factory.createStringLiteral(`YOUR_${context.case.screamingSnakeUnsafe(this.authScheme.name)}`)
+                ts.factory.createStringLiteral(
+                    this.authScheme.headerPlaceholder ??
+                        `YOUR_${context.case.screamingSnakeUnsafe(this.authScheme.name)}`
+                )
             )
         ];
     }

--- a/generators/typescript/sdk/endpoint-error-union-generator/package.json
+++ b/generators/typescript/sdk/endpoint-error-union-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/resolvers": "workspace:*",

--- a/generators/typescript/sdk/environments-generator/package.json
+++ b/generators/typescript/sdk/environments-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/sdk/generator/package.json
+++ b/generators/typescript/sdk/generator/package.json
@@ -39,7 +39,7 @@
     "@fern-api/typescript-ast": "workspace:*",
     "@fern-fern/generator-cli-sdk": "^0.5.0",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/endpoint-error-union-generator": "workspace:*",

--- a/generators/typescript/sdk/generator/src/__test__/ReadmeSnippetBuilder.test.ts
+++ b/generators/typescript/sdk/generator/src/__test__/ReadmeSnippetBuilder.test.ts
@@ -1099,6 +1099,7 @@ describe("ReadmeSnippetBuilder", () => {
                             screamingSnakeCase: { unsafeName: "TOKEN", safeName: "TOKEN" }
                         },
                         tokenEnvVar: undefined,
+                        tokenPlaceholder: undefined,
                         docs: undefined
                     })
                 ]

--- a/generators/typescript/sdk/request-wrapper-generator/package.json
+++ b/generators/typescript/sdk/request-wrapper-generator/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
+++ b/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/sdk-error-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-generator/package.json
@@ -32,7 +32,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/abstract-error-class-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/sdk-error-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-schema-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
@@ -32,7 +32,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/test-utils/package.json
+++ b/generators/typescript/sdk/test-utils/package.json
@@ -35,11 +35,11 @@
     "ts-morph": "catalog:"
   },
   "peerDependencies": {
-    "@fern-fern/ir-sdk": "66.0.0"
+    "@fern-fern/ir-sdk": "66.3.0"
   },
   "devDependencies": {
     "@fern-api/configs": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/generators/typescript/sdk/test-utils/src/ir-factories.ts
+++ b/generators/typescript/sdk/test-utils/src/ir-factories.ts
@@ -8,12 +8,14 @@ import { casingsGenerator, createNameAndWireValue } from "./casings.js";
 export function createBearerAuthScheme(opts?: {
     tokenName?: string;
     tokenEnvVar?: string;
+    tokenPlaceholder?: string;
     docs?: string;
 }): FernIr.BearerAuthScheme {
     return {
         docs: opts?.docs,
         token: casingsGenerator.generateName(opts?.tokenName ?? "token"),
         tokenEnvVar: opts?.tokenEnvVar,
+        tokenPlaceholder: opts?.tokenPlaceholder,
         key: "Bearer"
     };
 }
@@ -26,6 +28,8 @@ export function createBasicAuthScheme(opts?: {
     password?: string;
     usernameEnvVar?: string;
     passwordEnvVar?: string;
+    usernamePlaceholder?: string;
+    passwordPlaceholder?: string;
     docs?: string;
 }): FernIr.BasicAuthScheme {
     return {
@@ -33,9 +37,11 @@ export function createBasicAuthScheme(opts?: {
         username: casingsGenerator.generateName(opts?.username ?? "username"),
         usernameEnvVar: opts?.usernameEnvVar,
         usernameOmit: undefined,
+        usernamePlaceholder: opts?.usernamePlaceholder,
         password: casingsGenerator.generateName(opts?.password ?? "password"),
         passwordEnvVar: opts?.passwordEnvVar,
         passwordOmit: undefined,
+        passwordPlaceholder: opts?.passwordPlaceholder,
         key: "BasicAuth"
     };
 }
@@ -47,6 +53,7 @@ export function createHeaderAuthScheme(opts?: {
     name?: string;
     wireValue?: string;
     headerEnvVar?: string;
+    headerPlaceholder?: string;
     docs?: string;
     prefix?: string;
     key?: string;
@@ -57,6 +64,7 @@ export function createHeaderAuthScheme(opts?: {
         valueType: FernIr.TypeReference.primitive({ v1: "STRING", v2: undefined }),
         prefix: opts?.prefix,
         headerEnvVar: opts?.headerEnvVar,
+        headerPlaceholder: opts?.headerPlaceholder,
         key: opts?.key ?? "ApiKey"
     };
 }

--- a/generators/typescript/sdk/websocket-type-schema-generator/package.json
+++ b/generators/typescript/sdk/websocket-type-schema-generator/package.json
@@ -32,7 +32,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/utils/abstract-generator-cli/package.json
+++ b/generators/typescript/utils/abstract-generator-cli/package.json
@@ -37,7 +37,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "tmp-promise": "catalog:"

--- a/generators/typescript/utils/commons/package.json
+++ b/generators/typescript/utils/commons/package.json
@@ -38,7 +38,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
     "@fern-api/typescript-base": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "decompress": "catalog:",
     "esutils": "catalog:",
     "eta": "^4.5.1",

--- a/generators/typescript/utils/contexts/package.json
+++ b/generators/typescript/utils/contexts/package.json
@@ -35,7 +35,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/commons": "workspace:*",
     "ts-morph": "catalog:"
   },

--- a/generators/typescript/utils/resolvers/package.json
+++ b/generators/typescript/utils/resolvers/package.json
@@ -31,7 +31,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "66.3.0",
     "@fern-typescript/commons": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2609,8 +2609,8 @@ importers:
         specifier: workspace:*
         version: link:../../../base
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2649,8 +2649,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2686,8 +2686,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2723,8 +2723,8 @@ importers:
         specifier: workspace:*
         version: link:../../../base
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -2769,8 +2769,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2800,8 +2800,8 @@ importers:
         specifier: workspace:*
         version: link:../../../base
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -2855,8 +2855,8 @@ importers:
         specifier: workspace:*
         version: link:../../../typescript-v2/base
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/abstract-generator-cli':
         specifier: workspace:*
         version: link:../../utils/abstract-generator-cli
@@ -2885,8 +2885,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2934,8 +2934,8 @@ importers:
         specifier: workspace:*
         version: link:../../../base
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2977,8 +2977,8 @@ importers:
         specifier: workspace:*
         version: link:../../../base
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3032,8 +3032,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3157,8 +3157,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3197,8 +3197,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3240,8 +3240,8 @@ importers:
   generators/typescript/sdk/sdk-error-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/abstract-error-class-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-error-class-generator
@@ -3280,8 +3280,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3317,8 +3317,8 @@ importers:
   generators/typescript/sdk/sdk-inlined-request-body-schema-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3370,8 +3370,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17
@@ -3385,8 +3385,8 @@ importers:
   generators/typescript/sdk/websocket-type-schema-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3468,8 +3468,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../commons
@@ -3539,8 +3539,8 @@ importers:
         specifier: workspace:*
         version: link:../../../typescript-v2/base
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       decompress:
         specifier: 'catalog:'
         version: 4.2.1
@@ -3618,8 +3618,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../commons
@@ -3643,8 +3643,8 @@ importers:
   generators/typescript/utils/resolvers:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 66.3.0
+        version: 66.3.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../commons
@@ -9441,6 +9441,10 @@ packages:
 
   '@fern-fern/ir-sdk@66.1.0':
     resolution: {integrity: sha512-Gq/sxhxFtXIFnsDorSnmkBO9QTAgrM51GDuxx4uGXyUARwoKhGOhSx+AM+6kMVVUHcUHoZ8FDG7sGIOOryDjvQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@fern-fern/ir-sdk@66.3.0':
+    resolution: {integrity: sha512-BKtpmuyK98GagBSZ5CMe3oAkkwG5l3MId+/VyyyGbUV+HRrqIS+htIBlGmsNBW6fzuKK6hgOGn+Kyb2N4+Mejg==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/ir-v53-sdk@1.0.1':
@@ -16576,6 +16580,8 @@ snapshots:
   '@fern-fern/ir-sdk@66.0.0': {}
 
   '@fern-fern/ir-sdk@66.1.0': {}
+
+  '@fern-fern/ir-sdk@66.3.0': {}
 
   '@fern-fern/ir-v53-sdk@1.0.1': {}
 


### PR DESCRIPTION
## Description

Use auth scheme `placeholder` fields (added in #15348) in the legacy TypeScript SDK generator when generating client class snippet auth examples. When a placeholder is configured, it is used instead of the auto-generated `YOUR_<SCREAMING_SNAKE>` fallback.

## Changes Made

- **BearerAuthProviderInstance.ts**: Use `tokenPlaceholder ?? fallback` in `getSnippetProperties()`
- **BasicAuthProviderInstance.ts**: Use `usernamePlaceholder ?? fallback` and `passwordPlaceholder ?? fallback` in `getSnippetProperties()`
- **HeaderAuthProviderInstance.ts**: Use `headerPlaceholder ?? fallback` in `getSnippetProperties()`
- **GeneratedSdkClientClassImpl.ts**: Added `headerPlaceholder` to synthetic auth header construction
- Bumped `@fern-fern/ir-sdk` from `66.0.0` → `66.3.0` across all TypeScript generator packages to access the new placeholder fields
- Fixed test files to include new IR fields (`tokenPlaceholder`, `usernamePlaceholder`, `passwordPlaceholder`, `headerPlaceholder`, `baseProperties`, `default`) required by the IR SDK bump
- Added changelog entry

## Testing

- [x] `pnpm format` passes
- [x] `pnpm compile` passes for all TypeScript generator packages (40/40 tasks)
- [x] `pnpm seed test --generator ts-sdk --fixture basic-auth-environment-variables --skip-scripts` passes (1/1)

Link to Devin session: https://app.devin.ai/sessions/cca0a3e3ca9b4729b353189866427910
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
