### PR TITLE
fix(typescript): align dynamic snippets inlinePathParameters/inlineFileProperties defaults with SDK generator

### DIFF
--- a/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -631,7 +631,7 @@ export class EndpointSnippetGenerator {
     }: {
         filePropertyInfo: FilePropertyInfo;
     }): ts.ObjectField[] {
-        if (this.context.customConfig?.inlineFileProperties) {
+        if (this.context.customConfig?.inlineFileProperties ?? true) {
             return [...filePropertyInfo.fileFields, ...filePropertyInfo.bodyPropertyFields];
         }
         return filePropertyInfo.bodyPropertyFields;

--- a/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -482,8 +482,8 @@ export class EndpointSnippetGenerator {
         const args: ts.TypeLiteral[] = [];
 
         const { inlinePathParameters, inlineFileProperties } = {
-            inlinePathParameters: this.context.customConfig?.inlinePathParameters ?? false,
-            inlineFileProperties: this.context.customConfig?.inlineFileProperties ?? false
+            inlinePathParameters: this.context.customConfig?.inlinePathParameters ?? true,
+            inlineFileProperties: this.context.customConfig?.inlineFileProperties ?? true
         };
 
         this.context.errors.scope(Scope.PathParameters);

--- a/generators/typescript/sdk/changes/unreleased/fix-dynamic-snippets-path-params-default.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-dynamic-snippets-path-params-default.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix dynamic snippets to default `inlinePathParameters` and `inlineFileProperties`
+    to `true`, matching the TypeScript SDK generator's defaults. This fixes a mismatch
+    where docs snippets showed positional string arguments for path parameters instead
+    of the correct object-wrapped syntax.
+  type: fix


### PR DESCRIPTION
## Description
Fixes a mismatch where Fern docs snippets show positional string arguments for path parameters (e.g., `client.customers.getCustomerByExternalId("externalId")`), but the actual generated TypeScript SDK uses object-wrapped params (e.g., `client.customers.getCustomerByExternalId({ externalId: "..." })`). This affects all path-parameter-only endpoints.

## Changes Made
- Changed the default value of `inlinePathParameters` from `false` to `true` in the TypeScript v2 dynamic snippets generator (`EndpointSnippetGenerator.ts`)
- Changed the default value of `inlineFileProperties` from `false` to `true` (same mismatch)
- These now match the actual TypeScript SDK generator defaults in `SdkGeneratorCli.ts` (line 73: `inlinePathParameters: parsed?.inlinePathParameters ?? true`)

### Root Cause
The TypeScript SDK generator (`generators/typescript/sdk/cli/src/SdkGeneratorCli.ts`) defaults both `inlinePathParameters` and `inlineFileProperties` to `true`. However, the dynamic snippets generator (`generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts`) defaulted them to `false`. When customers don't explicitly set these config options (which is the common case), the SDK wraps path parameters in request objects but the docs snippets show them as positional arguments.

### Verification
- Confirmed the actual published SDK (`@paid-ai/paid-node@1.1.0`) uses `GetCustomerByExternalIdRequest { externalId: string }` (object-wrapped)
- Confirmed seed test output: `no-custom-config` variant wraps path params, `no-inline-path-parameters` variant uses positional — both will now match their dynamic snippet output
- All existing dynamic snippet tests pass

## Testing
- [x] Unit tests pass (`pnpm vitest run` in `generators/typescript-v2/dynamic-snippets/`)
- [x] Format check passes (`pnpm format:fix`)
- [x] Manual verification against published `@paid-ai/paid-node` SDK types

Link to Devin session: https://app.devin.ai/sessions/86caf5596cf84036a1ca7a499bbd6954
Requested by: @Ryan-Amirthan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
