### PR TITLE
feat(python): add config-driven retryStatusCodes with legacy/recommended modes

### DIFF
--- a/generators/python-v2/sdk/build.mjs
+++ b/generators/python-v2/sdk/build.mjs
@@ -1,3 +1,7 @@
 import { buildGenerator, getDirname } from "@fern-api/configs/build-utils.mjs";
 
-await buildGenerator(getDirname(import.meta.url));
+await buildGenerator(getDirname(import.meta.url), {
+    tsupOptions: {
+        external: ["@boundaryml/baml"]
+    }
+});

--- a/generators/python-v2/sdk/build.mjs
+++ b/generators/python-v2/sdk/build.mjs
@@ -1,7 +1,3 @@
 import { buildGenerator, getDirname } from "@fern-api/configs/build-utils.mjs";
 
-await buildGenerator(getDirname(import.meta.url), {
-    tsupOptions: {
-        external: ["@boundaryml/baml"]
-    }
-});
+await buildGenerator(getDirname(import.meta.url));

--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -124,7 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -124,7 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -122,7 +122,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -122,12 +122,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -123,7 +123,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    return response.status_code >= 500 or response.status_code in [429, 408, 409]
+    return {{RETRY_STATUS_CHECK}}
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -123,7 +123,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    return {{RETRY_STATUS_CHECK}}
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]  # {{RETRY_STATUS_CHECK}}
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -123,8 +123,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return {{RETRY_STATUS_CHECK}}
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/generators/python/core_utilities/shared/http_client.py
+++ b/generators/python/core_utilities/shared/http_client.py
@@ -123,7 +123,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    return {{RETRY_STATUS_CHECK}}
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/generators/python/sdk/changes/unreleased/fix-retry-status-codes.yml
+++ b/generators/python/sdk/changes/unreleased/fix-retry-status-codes.yml
@@ -1,5 +1,6 @@
 - summary: |
-    Stop retrying on 500 Internal Server Error. Previously all 5xx errors were
-    retried, but 500 is typically not transient and retrying can cause idempotency
-    issues. 501-599 continue to be retried, along with 408, 409, and 429.
-  type: fix
+    Add `retryStatusCodes` config with `"legacy"` and `"recommended"` modes. Legacy (default)
+    preserves current behavior (408, 409, 429, >= 500). Recommended retries only transient
+    codes (408, 409, 429, 502, 503, 504), avoiding idempotency issues with 500. A 6.0.0
+    migration auto-pins legacy for upgrading users.
+  type: feat

--- a/generators/python/sdk/changes/unreleased/fix-retry-status-codes.yml
+++ b/generators/python/sdk/changes/unreleased/fix-retry-status-codes.yml
@@ -1,5 +1,5 @@
 - summary: |
-    Only retry requests on 408, 409, 429, and 5xx status codes except 500 Internal
-    Server Error. Previously all 5xx errors were retried, but 500 is typically
-    not transient and retrying can cause idempotency issues.
+    Stop retrying on 500 Internal Server Error. Previously all 5xx errors were
+    retried, but 500 is typically not transient and retrying can cause idempotency
+    issues. 501-599 continue to be retried, along with 408, 409, and 429.
   type: fix

--- a/generators/python/sdk/changes/unreleased/fix-retry-status-codes.yml
+++ b/generators/python/sdk/changes/unreleased/fix-retry-status-codes.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Only retry requests on 408, 409, 429, and 5xx status codes except 500 Internal
+    Server Error. Previously all 5xx errors were retried, but 500 is typically
+    not transient and retrying can cause idempotency issues.
+  type: fix

--- a/generators/python/sdk/features.yml
+++ b/generators/python/sdk/features.yml
@@ -36,12 +36,21 @@ features:
       as the request is deemed retryable and the number of retry attempts has not grown larger than the configured
       retry limit (default: 2).
 
-      A request is deemed retryable when any of the following HTTP status codes is returned:
+      Which status codes are retried depends on the `retryStatusCodes` generator configuration:
 
+      **`legacy`** (current default): retries on
       - [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
       - [409](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409) (Conflict)
       - [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
-      - [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#server_error_responses) (All server errors except [500](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) Internal Server Error)
+      - [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#server_error_responses) (All server errors, including 500)
+
+      **`recommended`**: retries on
+      - [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+      - [409](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409) (Conflict)
+      - [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
+      - [502](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502) (Bad Gateway)
+      - [503](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/503) (Service Unavailable)
+      - [504](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504) (Gateway Timeout)
 
       Use the `max_retries` request option to configure this behavior.
 

--- a/generators/python/sdk/features.yml
+++ b/generators/python/sdk/features.yml
@@ -39,8 +39,9 @@ features:
       A request is deemed retryable when any of the following HTTP status codes is returned:
 
       - [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
+      - [409](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409) (Conflict)
       - [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
-      - [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+      - 5XX (All server errors except [500](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) Internal Server Error)
 
       Use the `max_retries` request option to configure this behavior.
 

--- a/generators/python/sdk/features.yml
+++ b/generators/python/sdk/features.yml
@@ -41,7 +41,7 @@ features:
       - [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
       - [409](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409) (Conflict)
       - [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
-      - 5XX (All server errors except [500](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) Internal Server Error)
+      - [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#server_error_responses) (All server errors except [500](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) Internal Server Error)
 
       Use the `max_retries` request option to configure this behavior.
 

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -159,8 +159,7 @@ class CoreUtilities:
         )
         retry_replacements = (
             {
-                "retryable_400s = [429, 408, 409]\n    return response.status_code >= 500 or response.status_code in retryable_400s":
-                "return response.status_code in [408, 409, 429, 502, 503, 504]",
+                "retryable_400s = [429, 408, 409]\n    return response.status_code >= 500 or response.status_code in retryable_400s": "return response.status_code in [408, 409, 429, 502, 503, 504]",
             }
             if self._retry_status_codes == "recommended"
             else None

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -48,6 +48,7 @@ class CoreUtilities:
         self._import_paths = custom_config.import_paths
         self._datetime_milliseconds = custom_config.datetime_milliseconds
         self._default_max_retries = custom_config.default_max_retries
+        self._retry_status_codes = custom_config.retry_status_codes
 
     def copy_to_project(self, *, project: Project) -> None:
         datetime_replacements = (
@@ -156,6 +157,13 @@ class CoreUtilities:
             if not self._exclude_types_from_init_exports
             else set(),
         )
+        retry_replacements = (
+            {
+                "return response.status_code >= 500 or response.status_code in retryable_400s": "return response.status_code in [408, 409, 429, 502, 503, 504]",
+            }
+            if self._retry_status_codes == "recommended"
+            else None
+        )
         self._copy_file_to_project(
             project=project,
             relative_filepath_on_disk="http_client.py",
@@ -164,6 +172,7 @@ class CoreUtilities:
                 file=Filepath.FilepathPart(module_name="http_client"),
             ),
             exports={"HttpClient", "AsyncHttpClient"} if not self._exclude_types_from_init_exports else set(),
+            string_replacements=retry_replacements,
         )
 
         self._copy_file_to_project(

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -159,7 +159,8 @@ class CoreUtilities:
         )
         retry_replacements = (
             {
-                'RETRY_STATUS_CODES = "legacy"': 'RETRY_STATUS_CODES = "recommended"',
+                "retryable_400s = [429, 408, 409]\n    return response.status_code >= 500 or response.status_code in retryable_400s":
+                "return response.status_code in [408, 409, 429, 502, 503, 504]",
             }
             if self._retry_status_codes == "recommended"
             else None

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -159,7 +159,7 @@ class CoreUtilities:
         )
         retry_replacements = (
             {
-                "return response.status_code >= 500 or response.status_code in retryable_400s": "return response.status_code in [408, 409, 429, 502, 503, 504]",
+                'RETRY_STATUS_CODES = "legacy"': 'RETRY_STATUS_CODES = "recommended"',
             }
             if self._retry_status_codes == "recommended"
             else None

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -157,10 +157,12 @@ class CoreUtilities:
             if not self._exclude_types_from_init_exports
             else set(),
         )
-        retry_status_check = (
-            "response.status_code in [408, 409, 429, 502, 503, 504]"
+        retry_replacements = (
+            {
+                "return response.status_code >= 500 or response.status_code in [429, 408, 409]": "return response.status_code in [408, 409, 429, 502, 503, 504]",
+            }
             if self._retry_status_codes == "recommended"
-            else "response.status_code >= 500 or response.status_code in [429, 408, 409]"
+            else None
         )
         self._copy_file_to_project(
             project=project,
@@ -170,7 +172,7 @@ class CoreUtilities:
                 file=Filepath.FilepathPart(module_name="http_client"),
             ),
             exports={"HttpClient", "AsyncHttpClient"} if not self._exclude_types_from_init_exports else set(),
-            string_replacements={"{{RETRY_STATUS_CHECK}}": retry_status_check},
+            string_replacements=retry_replacements,
         )
 
         self._copy_file_to_project(

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -157,12 +157,10 @@ class CoreUtilities:
             if not self._exclude_types_from_init_exports
             else set(),
         )
-        retry_replacements = (
-            {
-                "retryable_400s = [429, 408, 409]\n    return response.status_code >= 500 or response.status_code in retryable_400s": "return response.status_code in [408, 409, 429, 502, 503, 504]",
-            }
+        retry_status_check = (
+            "response.status_code in [408, 409, 429, 502, 503, 504]"
             if self._retry_status_codes == "recommended"
-            else None
+            else "response.status_code >= 500 or response.status_code in [429, 408, 409]"
         )
         self._copy_file_to_project(
             project=project,
@@ -172,7 +170,7 @@ class CoreUtilities:
                 file=Filepath.FilepathPart(module_name="http_client"),
             ),
             exports={"HttpClient", "AsyncHttpClient"} if not self._exclude_types_from_init_exports else set(),
-            string_replacements=retry_replacements,
+            string_replacements={"{{RETRY_STATUS_CHECK}}": retry_status_check},
         )
 
         self._copy_file_to_project(

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -170,7 +170,9 @@ class CoreUtilities:
                 file=Filepath.FilepathPart(module_name="http_client"),
             ),
             exports={"HttpClient", "AsyncHttpClient"} if not self._exclude_types_from_init_exports else set(),
-            string_replacements={"{{RETRY_STATUS_CHECK}}": retry_status_check},
+            string_replacements={
+                "return response.status_code >= 500 or response.status_code in [429, 408, 409]  # {{RETRY_STATUS_CHECK}}": f"return {retry_status_check}",
+            },
         )
 
         self._copy_file_to_project(

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -157,12 +157,10 @@ class CoreUtilities:
             if not self._exclude_types_from_init_exports
             else set(),
         )
-        retry_replacements = (
-            {
-                "return response.status_code >= 500 or response.status_code in [429, 408, 409]": "return response.status_code in [408, 409, 429, 502, 503, 504]",
-            }
+        retry_status_check = (
+            "response.status_code in [408, 409, 429, 502, 503, 504]"
             if self._retry_status_codes == "recommended"
-            else None
+            else "response.status_code >= 500 or response.status_code in [429, 408, 409]"
         )
         self._copy_file_to_project(
             project=project,
@@ -172,7 +170,7 @@ class CoreUtilities:
                 file=Filepath.FilepathPart(module_name="http_client"),
             ),
             exports={"HttpClient", "AsyncHttpClient"} if not self._exclude_types_from_init_exports else set(),
-            string_replacements=retry_replacements,
+            string_replacements={"{{RETRY_STATUS_CHECK}}": retry_status_check},
         )
 
         self._copy_file_to_project(

--- a/generators/python/src/fern_python/generators/sdk/custom_config.py
+++ b/generators/python/src/fern_python/generators/sdk/custom_config.py
@@ -177,6 +177,11 @@ class SDKCustomConfig(pydantic.BaseModel):
     # SDK users can still override this per-request via request_options.
     default_max_retries: int = pydantic.Field(2, ge=0)
 
+    # Controls which HTTP status codes trigger automatic retries.
+    # "legacy" (default): Retries on 408, 409, 429, and all >= 500.
+    # "recommended": Retries only on transient codes: 408, 409, 429, 502, 503, 504.
+    retry_status_codes: Literal["legacy", "recommended"] = "legacy"
+
     # Controls where OpenAPI/IR default values are applied in generated code.
     # Takes precedence over pydantic_config.use_provided_defaults when set.
     #   "none": no defaults applied anywhere
@@ -199,6 +204,8 @@ class SDKCustomConfig(pydantic.BaseModel):
                 obj["omit_fern_headers"] = obj.pop("omitFernHeaders")
             if "maxRetries" in obj and "default_max_retries" not in obj:
                 obj["default_max_retries"] = obj.pop("maxRetries")
+            if "retryStatusCodes" in obj and "retry_status_codes" not in obj:
+                obj["retry_status_codes"] = obj.pop("retryStatusCodes")
 
         obj = super().parse_obj(obj)
 

--- a/generators/python/tests/utils/test_http_client.py
+++ b/generators/python/tests/utils/test_http_client.py
@@ -672,27 +672,21 @@ def _make_response(status_code: int) -> httpx.Response:
 
 @pytest.mark.parametrize(
     "status_code",
-    [408, 409, 429, 501, 502, 503, 504, 599],
+    [408, 409, 429, 500, 501, 502, 503, 504, 599],
 )
 def test_should_retry_retryable_status_codes(status_code: int) -> None:
+    """Legacy mode: retries on 408, 409, 429, and all >= 500."""
     assert _should_retry(_make_response(status_code)) is True
 
 
 @pytest.mark.parametrize(
     "status_code",
-    [200, 201, 301, 400, 401, 403, 404, 500, 600],
+    [200, 201, 301, 400, 401, 403, 404],
 )
 def test_should_not_retry_non_retryable_status_codes(status_code: int) -> None:
     assert _should_retry(_make_response(status_code)) is False
 
 
-def test_should_not_retry_500_internal_server_error() -> None:
-    assert _should_retry(_make_response(500)) is False
-
-
 def test_should_retry_599_upper_boundary() -> None:
+    """Legacy mode retries on >= 500, which includes 599."""
     assert _should_retry(_make_response(599)) is True
-
-
-def test_should_not_retry_600_above_5xx_range() -> None:
-    assert _should_retry(_make_response(600)) is False

--- a/generators/python/tests/utils/test_http_client.py
+++ b/generators/python/tests/utils/test_http_client.py
@@ -8,6 +8,7 @@ from core_utilities.shared.http_client import (
     AsyncHttpClient,
     HttpClient,
     _build_url,
+    _should_retry,
     get_request_body,
     remove_none_from_dict,
 )
@@ -658,3 +659,40 @@ async def test_async_base_max_retries_used_as_default(mock_sleep: AsyncMock) -> 
     assert response.status_code == 200
     # 1 initial + 3 retries = 4 total attempts
     assert mock_client.request.call_count == 4
+
+
+# ---------------------------------------------------------------------------
+# _should_retry unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_response(status_code: int) -> httpx.Response:
+    return httpx.Response(status_code=status_code, content=b"")
+
+
+@pytest.mark.parametrize(
+    "status_code",
+    [408, 409, 429, 501, 502, 503, 504, 599],
+)
+def test_should_retry_retryable_status_codes(status_code: int) -> None:
+    assert _should_retry(_make_response(status_code)) is True
+
+
+@pytest.mark.parametrize(
+    "status_code",
+    [200, 201, 301, 400, 401, 403, 404, 500, 600],
+)
+def test_should_not_retry_non_retryable_status_codes(status_code: int) -> None:
+    assert _should_retry(_make_response(status_code)) is False
+
+
+def test_should_not_retry_500_internal_server_error() -> None:
+    assert _should_retry(_make_response(500)) is False
+
+
+def test_should_retry_599_upper_boundary() -> None:
+    assert _should_retry(_make_response(599)) is True
+
+
+def test_should_not_retry_600_above_5xx_range() -> None:
+    assert _should_retry(_make_response(600)) is False

--- a/packages/generator-migrations/src/__test__/index.test.ts
+++ b/packages/generator-migrations/src/__test__/index.test.ts
@@ -158,7 +158,7 @@ describe("@fern-api/generator-migrations", () => {
             const module = migrations["fernapi/fern-python-sdk"];
             const versions = module?.migrations.map((m) => m.version) ?? [];
 
-            expect(versions).toEqual(["4.0.0", "4.54.4"]);
+            expect(versions).toEqual(["4.0.0", "4.54.4", "6.0.0"]);
         });
     });
 

--- a/packages/generator-migrations/src/generators/python/__test__/migrations.test.ts
+++ b/packages/generator-migrations/src/generators/python/__test__/migrations.test.ts
@@ -676,6 +676,28 @@ describe("Python SDK Migrations", () => {
             });
         });
 
+        it("skips non-SDK generators (fastapi)", () => {
+            const config = createBaseConfig("fernapi/fern-fastapi-server");
+
+            const result = migration_6_0_0.migrateGeneratorConfig({
+                config,
+                context: { logger: mockLogger }
+            });
+
+            expect(result.config).toBeUndefined();
+        });
+
+        it("skips non-SDK generators (pydantic)", () => {
+            const config = createBaseConfig("fernapi/fern-pydantic-model");
+
+            const result = migration_6_0_0.migrateGeneratorConfig({
+                config,
+                context: { logger: mockLogger }
+            });
+
+            expect(result.config).toBeUndefined();
+        });
+
         it("does not modify generators.yml", () => {
             const document = { stringify: () => "original" };
 

--- a/packages/generator-migrations/src/generators/python/__test__/migrations.test.ts
+++ b/packages/generator-migrations/src/generators/python/__test__/migrations.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { migration_4_0_0 } from "../migrations/4.0.0.js";
 import { migration_4_54_4 } from "../migrations/4.54.4.js";
+import { migration_6_0_0 } from "../migrations/6.0.0.js";
 import migrationModule from "../migrations/index.js";
 
 const mockLogger: Logger = {
@@ -460,14 +461,16 @@ describe("Python SDK Migrations", () => {
 
     describe("migration module", () => {
         it("exports all migrations in correct order", () => {
-            expect(migrationModule.migrations).toHaveLength(2);
+            expect(migrationModule.migrations).toHaveLength(3);
             expect(migrationModule.migrations[0]).toBe(migration_4_0_0);
             expect(migrationModule.migrations[1]).toBe(migration_4_54_4);
+            expect(migrationModule.migrations[2]).toBe(migration_6_0_0);
         });
 
         it("all migrations have correct versions", () => {
             expect(migration_4_0_0.version).toBe("4.0.0");
             expect(migration_4_54_4.version).toBe("4.54.4");
+            expect(migration_6_0_0.version).toBe("6.0.0");
         });
 
         it("all migrations are properly structured", () => {
@@ -608,6 +611,80 @@ describe("Python SDK Migrations", () => {
                     docs: ["sphinx"]
                 }
             });
+        });
+    });
+
+    describe("migration_6_0_0", () => {
+        it("sets retryStatusCodes to legacy when not configured", () => {
+            const config = createBaseConfig("fernapi/fern-python-sdk");
+
+            const result = migration_6_0_0.migrateGeneratorConfig({
+                config,
+                context: { logger: mockLogger }
+            });
+
+            expect(result.config).toEqual({
+                retryStatusCodes: "legacy"
+            });
+        });
+
+        it("preserves explicitly set retryStatusCodes to recommended", () => {
+            const config = createBaseConfig("fernapi/fern-python-sdk", {
+                retryStatusCodes: "recommended"
+            });
+
+            const result = migration_6_0_0.migrateGeneratorConfig({
+                config,
+                context: { logger: mockLogger }
+            });
+
+            expect(result.config).toEqual({
+                retryStatusCodes: "recommended"
+            });
+        });
+
+        it("preserves explicitly set retryStatusCodes to legacy", () => {
+            const config = createBaseConfig("fernapi/fern-python-sdk", {
+                retryStatusCodes: "legacy"
+            });
+
+            const result = migration_6_0_0.migrateGeneratorConfig({
+                config,
+                context: { logger: mockLogger }
+            });
+
+            expect(result.config).toEqual({
+                retryStatusCodes: "legacy"
+            });
+        });
+
+        it("preserves other config fields", () => {
+            const config = createBaseConfig("fernapi/fern-python-sdk", {
+                client_class_name: "AcmeClient",
+                timeout_in_seconds: 60
+            });
+
+            const result = migration_6_0_0.migrateGeneratorConfig({
+                config,
+                context: { logger: mockLogger }
+            });
+
+            expect(result.config).toMatchObject({
+                client_class_name: "AcmeClient",
+                timeout_in_seconds: 60,
+                retryStatusCodes: "legacy"
+            });
+        });
+
+        it("does not modify generators.yml", () => {
+            const document = { stringify: () => "original" };
+
+            const result = migration_6_0_0.migrateGeneratorsYml({
+                document: document as never,
+                context: { logger: mockLogger }
+            });
+
+            expect(result).toBe(document);
         });
     });
 });

--- a/packages/generator-migrations/src/generators/python/migrations/6.0.0.ts
+++ b/packages/generator-migrations/src/generators/python/migrations/6.0.0.ts
@@ -1,0 +1,24 @@
+import type { Migration } from "@fern-api/migrations-base";
+import { migrateConfig } from "@fern-api/migrations-base";
+
+// Migration for version 6.0.0
+//
+// Context:
+// Version 6.0.0 changes the default retry status codes from `legacy` to `recommended`.
+// Under `legacy`, all 5xx status codes (including 500) are retried along with 408, 409, and 429.
+// Under `recommended`, only 408, 409, 429, 502, 503, and 504 are retried, avoiding
+// idempotency issues when retrying non-transient errors like 500 Internal Server Error.
+//
+// This migration explicitly sets `retry_status_codes: "legacy"` for users upgrading from
+// pre-6.0.0 versions, preserving their current retry behavior. Users can opt into the
+// new defaults by removing the field or setting `retry_status_codes: "recommended"`.
+export const migration_6_0_0: Migration = {
+    version: "6.0.0",
+
+    migrateGeneratorConfig: ({ config }) =>
+        migrateConfig(config, (draft) => {
+            draft.retry_status_codes ??= "legacy";
+        }),
+
+    migrateGeneratorsYml: ({ document }) => document
+};

--- a/packages/generator-migrations/src/generators/python/migrations/6.0.0.ts
+++ b/packages/generator-migrations/src/generators/python/migrations/6.0.0.ts
@@ -4,20 +4,27 @@ import { migrateConfig } from "@fern-api/migrations-base";
 // Migration for version 6.0.0
 //
 // Context:
-// Version 6.0.0 changes the default retry status codes from `legacy` to `recommended`.
-// Under `legacy`, all 5xx status codes (including 500) are retried along with 408, 409, and 429.
-// Under `recommended`, only 408, 409, 429, 502, 503, and 504 are retried, avoiding
-// idempotency issues when retrying non-transient errors like 500 Internal Server Error.
+// Version 6.0.0 changes the default retry behavior. Previously, all 5xx status codes
+// (>= 500) were retried. The new default only retries transient status codes:
+// 408, 409, 429, 502, 503, 504. This avoids retrying 500 Internal Server Error,
+// which is typically not transient and retrying can cause idempotency issues.
 //
-// This migration explicitly sets `retry_status_codes: "legacy"` for users upgrading from
-// pre-6.0.0 versions, preserving their current retry behavior. Users can opt into the
-// new defaults by removing the field or setting `retry_status_codes: "recommended"`.
+// Changed Default:
+// - retryStatusCodes: "recommended" → "legacy" (when migrating from pre-6.0.0)
+//   In v6, the recommended mode is the default. Setting this to "legacy" restores
+//   the pre-6.0.0 behavior of retrying all >= 500 status codes.
+//
+// Migration Strategy:
+// This migration uses the nullish coalescing assignment operator (??=) to only set
+// the value if it is explicitly undefined. This means:
+// - If a user has explicitly configured this field, that value is preserved
+// - If the field is undefined, it is set to "legacy" for backwards compatibility
 export const migration_6_0_0: Migration = {
     version: "6.0.0",
 
     migrateGeneratorConfig: ({ config }) =>
         migrateConfig(config, (draft) => {
-            draft.retry_status_codes ??= "legacy";
+            draft.retryStatusCodes ??= "legacy";
         }),
 
     migrateGeneratorsYml: ({ document }) => document

--- a/packages/generator-migrations/src/generators/python/migrations/6.0.0.ts
+++ b/packages/generator-migrations/src/generators/python/migrations/6.0.0.ts
@@ -19,13 +19,23 @@ import { migrateConfig } from "@fern-api/migrations-base";
 // the value if it is explicitly undefined. This means:
 // - If a user has explicitly configured this field, that value is preserved
 // - If the field is undefined, it is set to "legacy" for backwards compatibility
+//
+// This migration only applies to the SDK generator (`fernapi/fern-python-sdk`).
+// The `retryStatusCodes` option does not exist on the pydantic-model or fastapi-server
+// generators, so those configurations are passed through unchanged.
 export const migration_6_0_0: Migration = {
     version: "6.0.0",
 
-    migrateGeneratorConfig: ({ config }) =>
-        migrateConfig(config, (draft) => {
+    migrateGeneratorConfig: ({ config }) => {
+        const generatorName = "name" in config ? config.name : undefined;
+        if (generatorName !== "fernapi/fern-python-sdk") {
+            return config;
+        }
+
+        return migrateConfig(config, (draft) => {
             draft.retryStatusCodes ??= "legacy";
-        }),
+        });
+    },
 
     migrateGeneratorsYml: ({ document }) => document
 };

--- a/packages/generator-migrations/src/generators/python/migrations/index.ts
+++ b/packages/generator-migrations/src/generators/python/migrations/index.ts
@@ -2,6 +2,7 @@ import type { MigrationModule } from "@fern-api/migrations-base";
 
 import { migration_4_0_0 } from "./4.0.0.js";
 import { migration_4_54_4 } from "./4.54.4.js";
+import { migration_6_0_0 } from "./6.0.0.js";
 
 /**
  * Migration module for Python SDK generator.
@@ -19,7 +20,7 @@ import { migration_4_54_4 } from "./4.54.4.js";
  * are not included in this migration module.
  */
 const migrationModule: MigrationModule = {
-    migrations: [migration_4_0_0, migration_4_54_4]
+    migrations: [migration_4_0_0, migration_4_54_4, migration_6_0_0]
 };
 
 export default migrationModule;

--- a/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
@@ -77,9 +77,16 @@ export class ContainerTestRunner extends TestRunner {
             doNotPipeOutput: !this.shouldPipeOutput()
         });
         if (containerBuildReturn.exitCode !== 0) {
-            const stderr = containerBuildReturn.stderr?.trim();
-            const stdout = containerBuildReturn.stdout?.trim();
-            const output = stderr || stdout || "(no output captured)";
+            const stderr = containerBuildReturn.stderr?.trim() ?? "";
+            const stdout = containerBuildReturn.stdout?.trim() ?? "";
+            const parts: string[] = [];
+            if (stdout) {
+                parts.push(`STDOUT:\n${stdout}`);
+            }
+            if (stderr) {
+                parts.push(`STDERR:\n${stderr}`);
+            }
+            const output = parts.length > 0 ? parts.join("\n\n") : "(no output captured)";
             throw new Error(
                 `Failed to build the container for ${this.generator.workspaceName}. Exit code: ${containerBuildReturn.exitCode}\n${output}`
             );

--- a/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
@@ -77,7 +77,12 @@ export class ContainerTestRunner extends TestRunner {
             doNotPipeOutput: !this.shouldPipeOutput()
         });
         if (containerBuildReturn.exitCode !== 0) {
-            throw new Error(`Failed to build the container for ${this.generator.workspaceName}.`);
+            const stderr = containerBuildReturn.stderr?.trim();
+            const stdout = containerBuildReturn.stdout?.trim();
+            const output = stderr || stdout || "(no output captured)";
+            throw new Error(
+                `Failed to build the container for ${this.generator.workspaceName}. Exit code: ${containerBuildReturn.exitCode}\n${output}`
+            );
         }
 
         // For turbo-wrapped or other indirect build commands that may have built

--- a/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
@@ -77,19 +77,7 @@ export class ContainerTestRunner extends TestRunner {
             doNotPipeOutput: !this.shouldPipeOutput()
         });
         if (containerBuildReturn.exitCode !== 0) {
-            const stderr = containerBuildReturn.stderr?.trim() ?? "";
-            const stdout = containerBuildReturn.stdout?.trim() ?? "";
-            const parts: string[] = [];
-            if (stdout) {
-                parts.push(`STDOUT:\n${stdout}`);
-            }
-            if (stderr) {
-                parts.push(`STDERR:\n${stderr}`);
-            }
-            const output = parts.length > 0 ? parts.join("\n\n") : "(no output captured)";
-            throw new Error(
-                `Failed to build the container for ${this.generator.workspaceName}. Exit code: ${containerBuildReturn.exitCode}\n${output}`
-            );
+            throw new Error(`Failed to build the container for ${this.generator.workspaceName}.`);
         }
 
         // For turbo-wrapped or other indirect build commands that may have built

--- a/seed/python-sdk/accept-header/src/seed/core/http_client.py
+++ b/seed/python-sdk/accept-header/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/accept-header/src/seed/core/http_client.py
+++ b/seed/python-sdk/accept-header/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/accept-header/src/seed/core/http_client.py
+++ b/seed/python-sdk/accept-header/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/accept-header/src/seed/core/http_client.py
+++ b/seed/python-sdk/accept-header/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/accept-header/src/seed/core/http_client.py
+++ b/seed/python-sdk/accept-header/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias-extends/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/alias/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/alias/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/alias/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/alias/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/alias/src/seed/core/http_client.py
+++ b/seed/python-sdk/alias/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/allof-inline/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/allof/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/allof/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/allof/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/allof/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/allof/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/allof/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/any-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/any-auth/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/any-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/any-auth/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/any-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/any-auth/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/any-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/any-auth/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/any-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/any-auth/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/http_client.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/http_client.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/http_client.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/http_client.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/api-wide-base-path/src/seed/core/http_client.py
+++ b/seed/python-sdk/api-wide-base-path/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/audiences/src/seed/core/http_client.py
+++ b/seed/python-sdk/audiences/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/audiences/src/seed/core/http_client.py
+++ b/seed/python-sdk/audiences/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/audiences/src/seed/core/http_client.py
+++ b/seed/python-sdk/audiences/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/audiences/src/seed/core/http_client.py
+++ b/seed/python-sdk/audiences/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/audiences/src/seed/core/http_client.py
+++ b/seed/python-sdk/audiences/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth-environment-variables/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/basic-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/basic-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/basic-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/basic-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/basic-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/basic-auth/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_client.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_client.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_client.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_client.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_client.py
+++ b/seed/python-sdk/bearer-token-environment-variable/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/bytes-download/src/seed/core/http_client.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/bytes-download/src/seed/core/http_client.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/bytes-download/src/seed/core/http_client.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/bytes-download/src/seed/core/http_client.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/bytes-download/src/seed/core/http_client.py
+++ b/seed/python-sdk/bytes-download/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/bytes-upload/src/seed/core/http_client.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/bytes-upload/src/seed/core/http_client.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/bytes-upload/src/seed/core/http_client.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/bytes-upload/src/seed/core/http_client.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/bytes-upload/src/seed/core/http_client.py
+++ b/seed/python-sdk/bytes-upload/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/client-side-params/src/seed/core/http_client.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/client-side-params/src/seed/core/http_client.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/client-side-params/src/seed/core/http_client.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/client-side-params/src/seed/core/http_client.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/client-side-params/src/seed/core/http_client.py
+++ b/seed/python-sdk/client-side-params/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/content-type/src/seed/core/http_client.py
+++ b/seed/python-sdk/content-type/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/content-type/src/seed/core/http_client.py
+++ b/seed/python-sdk/content-type/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/content-type/src/seed/core/http_client.py
+++ b/seed/python-sdk/content-type/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/content-type/src/seed/core/http_client.py
+++ b/seed/python-sdk/content-type/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/content-type/src/seed/core/http_client.py
+++ b/seed/python-sdk/content-type/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/http_client.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/http_client.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/http_client.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/http_client.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/cross-package-type-names/src/seed/core/http_client.py
+++ b/seed/python-sdk/cross-package-type-names/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/dollar-string-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/dollar-string-examples/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/empty-clients/src/seed/core/http_client.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/empty-clients/src/seed/core/http_client.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/empty-clients/src/seed/core/http_client.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/empty-clients/src/seed/core/http_client.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/empty-clients/src/seed/core/http_client.py
+++ b/seed/python-sdk/empty-clients/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/enum/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/real-enum-forward-compat/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/enum/real-enum/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/enum/real-enum/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/enum/real-enum/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/enum/real-enum/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/enum/real-enum/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/real-enum/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/enum/strenum/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/enum/strenum/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/enum/strenum/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/enum/strenum/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/enum/strenum/src/seed/core/http_client.py
+++ b/seed/python-sdk/enum/strenum/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/error-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/error-property/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/error-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/error-property/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/error-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/error-property/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/error-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/error-property/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/error-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/error-property/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/errors/src/seed/core/http_client.py
+++ b/seed/python-sdk/errors/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/errors/src/seed/core/http_client.py
+++ b/seed/python-sdk/errors/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/errors/src/seed/core/http_client.py
+++ b/seed/python-sdk/errors/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/errors/src/seed/core/http_client.py
+++ b/seed/python-sdk/errors/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/errors/src/seed/core/http_client.py
+++ b/seed/python-sdk/errors/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/examples/client-filename/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/client-filename/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/client-filename/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/client-filename/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/examples/client-filename/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/client-filename/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/legacy-wire-tests/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/examples/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/omit-fern-headers/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/examples/readme/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/readme/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/readme/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/examples/readme/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/examples/readme/src/seed/core/http_client.py
+++ b/seed/python-sdk/examples/readme/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/additional_init_exports/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/custom-transport/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/eager-imports/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/extra_dependencies/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/five-second-timeout/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/import-paths/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/improved_imports/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/infinite-timeout/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/inline-path-params/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/inline_request_params/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/http_client.py
+++ b/seed/python-sdk/exhaustive/package-path/src/seed/matryoshka/doll/structure/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v1/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/pyproject_extras/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/union-utils/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_client.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/extends/src/seed/core/http_client.py
+++ b/seed/python-sdk/extends/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/extends/src/seed/core/http_client.py
+++ b/seed/python-sdk/extends/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/extends/src/seed/core/http_client.py
+++ b/seed/python-sdk/extends/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/extends/src/seed/core/http_client.py
+++ b/seed/python-sdk/extends/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/extends/src/seed/core/http_client.py
+++ b/seed/python-sdk/extends/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/extra-properties/src/seed/core/http_client.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/extra-properties/src/seed/core/http_client.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/extra-properties/src/seed/core/http_client.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/extra-properties/src/seed/core/http_client.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/extra-properties/src/seed/core/http_client.py
+++ b/seed/python-sdk/extra-properties/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-download/default-chunk-size/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-download/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/file-upload-openapi/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload-openapi/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/folders/src/seed/core/http_client.py
+++ b/seed/python-sdk/folders/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/folders/src/seed/core/http_client.py
+++ b/seed/python-sdk/folders/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/folders/src/seed/core/http_client.py
+++ b/seed/python-sdk/folders/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/folders/src/seed/core/http_client.py
+++ b/seed/python-sdk/folders/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/folders/src/seed/core/http_client.py
+++ b/seed/python-sdk/folders/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_client.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_client.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_client.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_client.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_client.py
+++ b/seed/python-sdk/header-auth-environment-variable/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/header-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/header-auth/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/header-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/header-auth/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/header-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/header-auth/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/header-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/header-auth/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/header-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/header-auth/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/http-head/src/seed/core/http_client.py
+++ b/seed/python-sdk/http-head/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/http-head/src/seed/core/http_client.py
+++ b/seed/python-sdk/http-head/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/http-head/src/seed/core/http_client.py
+++ b/seed/python-sdk/http-head/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/http-head/src/seed/core/http_client.py
+++ b/seed/python-sdk/http-head/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/http-head/src/seed/core/http_client.py
+++ b/seed/python-sdk/http-head/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/idempotency-headers/src/seed/core/http_client.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/idempotency-headers/src/seed/core/http_client.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/idempotency-headers/src/seed/core/http_client.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/idempotency-headers/src/seed/core/http_client.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/idempotency-headers/src/seed/core/http_client.py
+++ b/seed/python-sdk/idempotency-headers/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/imdb/src/seed/core/http_client.py
+++ b/seed/python-sdk/imdb/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/imdb/src/seed/core/http_client.py
+++ b/seed/python-sdk/imdb/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/imdb/src/seed/core/http_client.py
+++ b/seed/python-sdk/imdb/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/imdb/src/seed/core/http_client.py
+++ b/seed/python-sdk/imdb/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/imdb/src/seed/core/http_client.py
+++ b/seed/python-sdk/imdb/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-explicit/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit-reference/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_client.py
+++ b/seed/python-sdk/inferred-auth-implicit/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/license/src/seed/core/http_client.py
+++ b/seed/python-sdk/license/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/license/src/seed/core/http_client.py
+++ b/seed/python-sdk/license/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/license/src/seed/core/http_client.py
+++ b/seed/python-sdk/license/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/license/src/seed/core/http_client.py
+++ b/seed/python-sdk/license/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/license/src/seed/core/http_client.py
+++ b/seed/python-sdk/license/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/literal/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/literal/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/literal/use_typeddict_requests/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/literals-unions/src/seed/core/http_client.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/literals-unions/src/seed/core/http_client.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/literals-unions/src/seed/core/http_client.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/literals-unions/src/seed/core/http_client.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/literals-unions/src/seed/core/http_client.py
+++ b/seed/python-sdk/literals-unions/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/mixed-case/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/mixed-case/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/mixed-case/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/mixed-case/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/mixed-case/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-case/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/multi-line-docs/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/multi-line-docs/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/multi-line-docs/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/multi-line-docs/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/multi-line-docs/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-line-docs/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment-no-default/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment-reference/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/multi-url-environment/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/multi-url-environment/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/multi-url-environment/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/multi-url-environment/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/multi-url-environment/src/seed/core/http_client.py
+++ b/seed/python-sdk/multi-url-environment/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/http_client.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/http_client.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/http_client.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/http_client.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/multiple-request-bodies/src/seed/core/http_client.py
+++ b/seed/python-sdk/multiple-request-bodies/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/no-content-response/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-content-response/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/no-content-response/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-content-response/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/no-content-response/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-content-response/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/no-content-response/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-content-response/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/no-content-response/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-content-response/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/no-environment/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-environment/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/no-environment/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-environment/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/no-environment/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-environment/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/no-environment/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-environment/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/no-environment/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-environment/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/no-retries/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-retries/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/no-retries/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-retries/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/no-retries/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-retries/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/no-retries/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-retries/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/no-retries/src/seed/core/http_client.py
+++ b/seed/python-sdk/no-retries/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/null-type/src/seed/core/http_client.py
+++ b/seed/python-sdk/null-type/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/null-type/src/seed/core/http_client.py
+++ b/seed/python-sdk/null-type/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/null-type/src/seed/core/http_client.py
+++ b/seed/python-sdk/null-type/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/null-type/src/seed/core/http_client.py
+++ b/seed/python-sdk/null-type/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/null-type/src/seed/core/http_client.py
+++ b/seed/python-sdk/null-type/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/nullable-allof-extends/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-allof-extends/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/nullable-optional/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/nullable-optional/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/nullable-optional/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/nullable-optional/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/nullable-optional/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-optional/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/nullable-request-body/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/nullable-request-body/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/nullable-request-body/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/nullable-request-body/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/nullable-request-body/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable-request-body/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_client.py
+++ b/seed/python-sdk/nullable/use-typeddict-requests/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-custom/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-default/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-openapi/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-reference/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/oauth-client-credentials/src/seed/core/http_client.py
+++ b/seed/python-sdk/oauth-client-credentials/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/object/src/seed/core/http_client.py
+++ b/seed/python-sdk/object/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/object/src/seed/core/http_client.py
+++ b/seed/python-sdk/object/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/object/src/seed/core/http_client.py
+++ b/seed/python-sdk/object/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/object/src/seed/core/http_client.py
+++ b/seed/python-sdk/object/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/object/src/seed/core/http_client.py
+++ b/seed/python-sdk/object/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/objects-with-imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/objects-with-imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/objects-with-imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/objects-with-imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/objects-with-imports/src/seed/core/http_client.py
+++ b/seed/python-sdk/objects-with-imports/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/openapi-request-body-ref/src/seed/core/http_client.py
+++ b/seed/python-sdk/openapi-request-body-ref/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/optional/src/seed/core/http_client.py
+++ b/seed/python-sdk/optional/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/optional/src/seed/core/http_client.py
+++ b/seed/python-sdk/optional/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/optional/src/seed/core/http_client.py
+++ b/seed/python-sdk/optional/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/optional/src/seed/core/http_client.py
+++ b/seed/python-sdk/optional/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/optional/src/seed/core/http_client.py
+++ b/seed/python-sdk/optional/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/package-yml/src/seed/core/http_client.py
+++ b/seed/python-sdk/package-yml/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/package-yml/src/seed/core/http_client.py
+++ b/seed/python-sdk/package-yml/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/package-yml/src/seed/core/http_client.py
+++ b/seed/python-sdk/package-yml/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/package-yml/src/seed/core/http_client.py
+++ b/seed/python-sdk/package-yml/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/package-yml/src/seed/core/http_client.py
+++ b/seed/python-sdk/package-yml/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/pagination-custom/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/pagination-custom/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/pagination-custom/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/pagination-custom/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/pagination-custom/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination-custom/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/pagination-uri-path/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination-uri-path/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/pagination-uri-path/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination-uri-path/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/pagination-uri-path/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination-uri-path/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/pagination-uri-path/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination-uri-path/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/pagination-uri-path/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination-uri-path/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_client.py
+++ b/seed/python-sdk/pagination/page-index-semantics/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/path-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/path-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/path-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/path-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/path-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/path-parameters/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/plain-text/src/seed/core/http_client.py
+++ b/seed/python-sdk/plain-text/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/plain-text/src/seed/core/http_client.py
+++ b/seed/python-sdk/plain-text/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/plain-text/src/seed/core/http_client.py
+++ b/seed/python-sdk/plain-text/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/plain-text/src/seed/core/http_client.py
+++ b/seed/python-sdk/plain-text/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/plain-text/src/seed/core/http_client.py
+++ b/seed/python-sdk/plain-text/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/property-access/src/seed/core/http_client.py
+++ b/seed/python-sdk/property-access/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/property-access/src/seed/core/http_client.py
+++ b/seed/python-sdk/property-access/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/property-access/src/seed/core/http_client.py
+++ b/seed/python-sdk/property-access/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/property-access/src/seed/core/http_client.py
+++ b/seed/python-sdk/property-access/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/property-access/src/seed/core/http_client.py
+++ b/seed/python-sdk/property-access/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/public-object/src/seed/core/http_client.py
+++ b/seed/python-sdk/public-object/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/public-object/src/seed/core/http_client.py
+++ b/seed/python-sdk/public-object/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/public-object/src/seed/core/http_client.py
+++ b/seed/python-sdk/public-object/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/public-object/src/seed/core/http_client.py
+++ b/seed/python-sdk/public-object/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/public-object/src/seed/core/http_client.py
+++ b/seed/python-sdk/public-object/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/python-backslash-escape/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-backslash-escape/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-reserved-keyword-subpackages/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/query-param-name-conflict/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-param-name-conflict/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/query-param-name-conflict/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-param-name-conflict/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/query-param-name-conflict/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-param-name-conflict/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/query-param-name-conflict/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-param-name-conflict/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/query-param-name-conflict/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-param-name-conflict/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/query-parameters/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/request-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/request-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/request-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/request-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/request-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/request-parameters/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/required-nullable/src/seed/core/http_client.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/required-nullable/src/seed/core/http_client.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/required-nullable/src/seed/core/http_client.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/required-nullable/src/seed/core/http_client.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/required-nullable/src/seed/core/http_client.py
+++ b/seed/python-sdk/required-nullable/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/reserved-keywords/src/seed/core/http_client.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/reserved-keywords/src/seed/core/http_client.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/reserved-keywords/src/seed/core/http_client.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/reserved-keywords/src/seed/core/http_client.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/reserved-keywords/src/seed/core/http_client.py
+++ b/seed/python-sdk/reserved-keywords/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/response-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/response-property/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/response-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/response-property/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/response-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/response-property/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/response-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/response-property/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/response-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/response-property/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/schemaless-request-body-examples/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/server-url-templating/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/simple-api/src/seed/core/http_client.py
+++ b/seed/python-sdk/simple-api/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/simple-api/src/seed/core/http_client.py
+++ b/seed/python-sdk/simple-api/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/simple-api/src/seed/core/http_client.py
+++ b/seed/python-sdk/simple-api/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/simple-api/src/seed/core/http_client.py
+++ b/seed/python-sdk/simple-api/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/simple-api/src/seed/core/http_client.py
+++ b/seed/python-sdk/simple-api/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_client.py
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/single-url-environment-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/single-url-environment-default/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/single-url-environment-no-default/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/streaming-parameter/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/streaming-parameter/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/streaming-parameter/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/streaming-parameter/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/streaming-parameter/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming-parameter/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/trace/src/seed/core/http_client.py
+++ b/seed/python-sdk/trace/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/trace/src/seed/core/http_client.py
+++ b/seed/python-sdk/trace/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/trace/src/seed/core/http_client.py
+++ b/seed/python-sdk/trace/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/trace/src/seed/core/http_client.py
+++ b/seed/python-sdk/trace/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/trace/src/seed/core/http_client.py
+++ b/seed/python-sdk/trace/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_client.py
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/http_client.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/http_client.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/http_client.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/http_client.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/undiscriminated-unions/src/seed/core/http_client.py
+++ b/seed/python-sdk/undiscriminated-unions/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/unions-with-local-date/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions-with-local-date/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/unions/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-naming-v1/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/unions/union-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unions/union-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unions/union-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unions/union-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/unions/union-utils/src/seed/core/http_client.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/unknown/src/seed/core/http_client.py
+++ b/seed/python-sdk/unknown/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unknown/src/seed/core/http_client.py
+++ b/seed/python-sdk/unknown/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unknown/src/seed/core/http_client.py
+++ b/seed/python-sdk/unknown/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/unknown/src/seed/core/http_client.py
+++ b/seed/python-sdk/unknown/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/unknown/src/seed/core/http_client.py
+++ b/seed/python-sdk/unknown/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/url-form-encoded/src/seed/core/http_client.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/url-form-encoded/src/seed/core/http_client.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/url-form-encoded/src/seed/core/http_client.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/url-form-encoded/src/seed/core/http_client.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/url-form-encoded/src/seed/core/http_client.py
+++ b/seed/python-sdk/url-form-encoded/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/validation/no-custom-config/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/no-custom-config/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/with-defaults-parameters/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/validation/with-defaults/src/seed/core/http_client.py
+++ b/seed/python-sdk/validation/with-defaults/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/variables/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/variables/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/variables/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/variables/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/variables/src/seed/core/http_client.py
+++ b/seed/python-sdk/variables/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/version-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/version-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/version-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/version-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/version-no-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/version-no-default/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/version/src/seed/core/http_client.py
+++ b/seed/python-sdk/version/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/version/src/seed/core/http_client.py
+++ b/seed/python-sdk/version/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/version/src/seed/core/http_client.py
+++ b/seed/python-sdk/version/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/version/src/seed/core/http_client.py
+++ b/seed/python-sdk/version/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/version/src/seed/core/http_client.py
+++ b/seed/python-sdk/version/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/webhook-audience/src/seed/core/http_client.py
+++ b/seed/python-sdk/webhook-audience/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/webhook-audience/src/seed/core/http_client.py
+++ b/seed/python-sdk/webhook-audience/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/webhook-audience/src/seed/core/http_client.py
+++ b/seed/python-sdk/webhook-audience/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/webhook-audience/src/seed/core/http_client.py
+++ b/seed/python-sdk/webhook-audience/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/webhook-audience/src/seed/core/http_client.py
+++ b/seed/python-sdk/webhook-audience/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/webhooks/src/seed/core/http_client.py
+++ b/seed/python-sdk/webhooks/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/webhooks/src/seed/core/http_client.py
+++ b/seed/python-sdk/webhooks/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/webhooks/src/seed/core/http_client.py
+++ b/seed/python-sdk/webhooks/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/webhooks/src/seed/core/http_client.py
+++ b/seed/python-sdk/webhooks/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/webhooks/src/seed/core/http_client.py
+++ b/seed/python-sdk/webhooks/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-bearer-auth/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-inferred-auth/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/websocket-multi-url/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-multi-url/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket-multi-url/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-multi-url/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket-multi-url/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-multi-url/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket-multi-url/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-multi-url/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/websocket-multi-url/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket-multi-url/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/websocket/websocket-base/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-base/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_client.py
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/x-fern-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/x-fern-default/src/seed/core/http_client.py
@@ -125,8 +125,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 
 def _should_retry(response: httpx.Response) -> bool:
-    retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in [429, 408, 409]
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/x-fern-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/x-fern-default/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return response.status_code >= 500 or response.status_code in retryable_400s
+    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/x-fern-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/x-fern-default/src/seed/core/http_client.py
@@ -126,7 +126,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
 
 def _should_retry(response: httpx.Response) -> bool:
     retryable_400s = [429, 408, 409]
-    return (response.status_code >= 501 and response.status_code < 600) or response.status_code in retryable_400s
+    return response.status_code >= 500 or response.status_code in retryable_400s
 
 
 _SENSITIVE_HEADERS = frozenset(

--- a/seed/python-sdk/x-fern-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/x-fern-default/src/seed/core/http_client.py
@@ -124,7 +124,12 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
+RETRY_STATUS_CODES = "legacy"
+
+
 def _should_retry(response: httpx.Response) -> bool:
+    if RETRY_STATUS_CODES == "recommended":
+        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 

--- a/seed/python-sdk/x-fern-default/src/seed/core/http_client.py
+++ b/seed/python-sdk/x-fern-default/src/seed/core/http_client.py
@@ -124,12 +124,7 @@ def _retry_timeout_from_retries(retries: int) -> float:
     return _add_symmetric_jitter(backoff)
 
 
-RETRY_STATUS_CODES = "legacy"
-
-
 def _should_retry(response: httpx.Response) -> bool:
-    if RETRY_STATUS_CODES == "recommended":
-        return response.status_code in [408, 409, 429, 502, 503, 504]
     retryable_400s = [429, 408, 409]
     return response.status_code >= 500 or response.status_code in retryable_400s
 


### PR DESCRIPTION
## Description
Linear ticket: Refs FER-6486

Adds a `retryStatusCodes` configuration option to the Python SDK generator with two modes:

- **`legacy`** (default): Preserves existing behavior — retries `429`, `408`, `409`, and all `>= 500`
- **`recommended`**: Only retries `408`, `409`, `429`, `502`, `503`, `504` (excludes `500 Internal Server Error`)

## Templating Approach
Source file (`http_client.py`) uses `{{RETRY_STATUS_CHECK}}` placeholder:
```python
def _should_retry(response: httpx.Response) -> bool:
    return {{RETRY_STATUS_CHECK}}
```
Generator resolves the placeholder via `string_replacements`:
- **Legacy**: `response.status_code >= 500 or response.status_code in [429, 408, 409]`
- **Recommended**: `response.status_code in [408, 409, 429, 502, 503, 504]`

(Python v1 is a native Python generator — no EJS/Eta infrastructure available, so uses `{{PLACEHOLDER}}` + `.replace()` pattern consistent with Java and Rust generators.)

## Changes Made
- Source `http_client.py` uses `{{RETRY_STATUS_CHECK}}` placeholder (resolved by generator)
- Generator computes language-appropriate expression and injects via `string_replacements`
- Added `retryStatusCodes: "legacy" | "recommended"` to `BasePythonCustomConfigSchema.ts`
- Created `6.0.0.ts` migration to auto-pin `legacy` for existing users
- Updated features.yml, changelog, and 180 seed fixtures

## Testing
- [x] `pnpm compile` passes
- [x] Migration tests pass
- [x] CI seed tests

Link to Devin session: https://app.devin.ai/sessions/6d2ebbd3c6a44761b2b3a939eaafd274
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
