### PR TITLE
feat(rust): add config-driven retryStatusCodes with legacy/recommended modes

### DIFF
--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -451,7 +451,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -451,6 +451,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -654,3 +655,34 @@ impl HttpClient {
     }
 
 {{SSE_METHOD}}}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
+    }
+}

--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -474,7 +474,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        {{RETRY_STATUS_CHECK}}
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -450,6 +450,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -466,6 +471,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -474,7 +474,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -665,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/generators/rust/base/src/project/RustProject.ts
+++ b/generators/rust/base/src/project/RustProject.ts
@@ -63,6 +63,13 @@ export class RustProject extends AbstractProject<AbstractRustGeneratorContext<Ba
                 // Replace template variables
                 fileContents = this.replaceTemplateVariables(fileContents);
 
+                if (def.filename === "http_client.rs" && context.customConfig.retryStatusCodes === "recommended") {
+                    fileContents = fileContents.replace(
+                        "status_code == 408 || status_code == 429 || status_code >= 500",
+                        "status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)"
+                    );
+                }
+
                 const rustFile = new RustFile({
                     filename: def.filename,
                     directory: def.directory,

--- a/generators/rust/base/src/project/RustProject.ts
+++ b/generators/rust/base/src/project/RustProject.ts
@@ -63,13 +63,6 @@ export class RustProject extends AbstractProject<AbstractRustGeneratorContext<Ba
                 // Replace template variables
                 fileContents = this.replaceTemplateVariables(fileContents);
 
-                if (def.filename === "http_client.rs" && context.customConfig.retryStatusCodes === "recommended") {
-                    fileContents = fileContents.replace(
-                        "status_code == 408 || status_code == 429 || status_code >= 500",
-                        "status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)"
-                    );
-                }
-
                 const rustFile = new RustFile({
                     filename: def.filename,
                     directory: def.directory,
@@ -103,6 +96,12 @@ export class RustProject extends AbstractProject<AbstractRustGeneratorContext<Ba
         const tomlSections = this.context.dependencyManager.toTomlSections();
         content = content.replace(/\{\{EXTRA_DEPENDENCIES\}\}/g, tomlSections.dependencies);
         content = content.replace(/\{\{EXTRA_DEV_DEPENDENCIES\}\}/g, tomlSections.devDependencies);
+
+        const retryStatusCheck =
+            this.context.customConfig.retryStatusCodes === "recommended"
+                ? "status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)"
+                : "status_code == 408 || status_code == 429 || status_code >= 500";
+        content = content.replace(/\{\{RETRY_STATUS_CHECK\}\}/g, retryStatusCheck);
 
         if (tomlSections.features) {
             content = content.replace(/\{\{FEATURES\}\}/g, `\n[features]\n${tomlSections.features}`);

--- a/generators/rust/base/src/project/RustProject.ts
+++ b/generators/rust/base/src/project/RustProject.ts
@@ -99,8 +99,8 @@ export class RustProject extends AbstractProject<AbstractRustGeneratorContext<Ba
 
         const retryStatusCheck =
             this.context.customConfig.retryStatusCodes === "recommended"
-                ? "status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)"
-                : "status_code == 408 || status_code == 429 || status_code >= 500";
+                ? "[408, 429, 502, 503, 504].contains(&status_code)"
+                : "[408, 429].contains(&status_code) || status_code >= 500";
         content = content.replace(/\{\{RETRY_STATUS_CHECK\}\}/g, retryStatusCheck);
 
         if (tomlSections.features) {

--- a/generators/rust/codegen/src/custom-config/BaseRustConfigSchema.ts
+++ b/generators/rust/codegen/src/custom-config/BaseRustConfigSchema.ts
@@ -49,6 +49,7 @@ export const BaseRustCustomConfigSchema = z.object({
     // Example: ["sse"] to only include SSE in default features
     defaultFeatures: z.array(z.string()).optional(),
     maxRetries: z.number().int().min(0).optional(),
+    retryStatusCodes: z.optional(z.enum(["legacy", "recommended"])),
 
     // =========================================================================
     // Casing Configuration

--- a/generators/rust/sdk/build.mjs
+++ b/generators/rust/sdk/build.mjs
@@ -3,7 +3,6 @@ import { buildGenerator, getDirname } from '@fern-api/configs/build-utils.mjs';
 await buildGenerator(getDirname(import.meta.url), {
   tsupOptions: {
     noExternal: [/@fern-api\/.*/, /dedent/],
-    external: ["@boundaryml/baml"],
   },
   copy: [
     { from: './features.yml', to: './dist/assets/features.yml' },

--- a/generators/rust/sdk/build.mjs
+++ b/generators/rust/sdk/build.mjs
@@ -3,6 +3,7 @@ import { buildGenerator, getDirname } from '@fern-api/configs/build-utils.mjs';
 await buildGenerator(getDirname(import.meta.url), {
   tsupOptions: {
     noExternal: [/@fern-api\/.*/, /dedent/],
+    external: ["@boundaryml/baml"],
   },
   copy: [
     { from: './features.yml', to: './dist/assets/features.yml' },

--- a/generators/rust/sdk/changes/unreleased/fix-retry-status-codes.yml
+++ b/generators/rust/sdk/changes/unreleased/fix-retry-status-codes.yml
@@ -1,4 +1,5 @@
 - summary: |
-    Add HTTP status code-based retry logic for 408, 429, and all 5xx except
-    500 Internal Server Error. Previously only network errors were retried.
+    Stop retrying on 500 Internal Server Error. Previously only network errors
+    were retried. Now retries on 408, 429, and 501-599 status codes, but not 500
+    which is typically not transient and retrying can cause idempotency issues.
   type: fix

--- a/generators/rust/sdk/changes/unreleased/fix-retry-status-codes.yml
+++ b/generators/rust/sdk/changes/unreleased/fix-retry-status-codes.yml
@@ -1,5 +1,6 @@
 - summary: |
-    Stop retrying on 500 Internal Server Error. Previously only network errors
-    were retried. Now retries on 408, 429, and 501-599 status codes, but not 500
-    which is typically not transient and retrying can cause idempotency issues.
-  type: fix
+    Add `retryStatusCodes` configuration option (`legacy` | `recommended`). The default
+    `legacy` mode preserves existing behavior (retries 408, 429, and all >= 500). The
+    `recommended` mode only retries 408, 429, 502, 503, 504 (excludes 500 Internal
+    Server Error to avoid retrying non-idempotent failures).
+  type: feat

--- a/generators/rust/sdk/changes/unreleased/fix-retry-status-codes.yml
+++ b/generators/rust/sdk/changes/unreleased/fix-retry-status-codes.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Add HTTP status code-based retry logic for 408, 429, and all 5xx except
+    500 Internal Server Error. Previously only network errors were retried.
+  type: fix

--- a/generators/rust/sdk/features.yml
+++ b/generators/rust/sdk/features.yml
@@ -26,7 +26,7 @@ features:
 
       - [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
       - [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
-      - [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) (Internal Server Errors)
+      - 5XX (All server errors except [500](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) Internal Server Error)
 
       Use the `max_retries` method to configure this behavior.
 

--- a/generators/rust/sdk/features.yml
+++ b/generators/rust/sdk/features.yml
@@ -26,7 +26,7 @@ features:
 
       - [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
       - [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
-      - 5XX (All server errors except [500](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) Internal Server Error)
+      - [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#server_error_responses) (All server errors except [500](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) Internal Server Error)
 
       Use the `max_retries` method to configure this behavior.
 

--- a/generators/rust/sdk/features.yml
+++ b/generators/rust/sdk/features.yml
@@ -26,7 +26,12 @@ features:
 
       - [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) (Timeout)
       - [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) (Too Many Requests)
-      - [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#server_error_responses) (All server errors except [500](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500) Internal Server Error)
+      - [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#server_error_responses) (Internal Server Error)
+
+      The `retryStatusCodes` configuration controls which [5XX](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#server_error_responses) status codes are retried:
+
+      - `legacy` (default): Retries `408`, `429`, and all `>= 500`
+      - `recommended`: Retries `408`, `429`, `502`, `503`, `504` only (excludes `500 Internal Server Error` to avoid retrying non-idempotent failures)
 
       Use the `max_retries` method to configure this behavior.
 

--- a/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
@@ -451,7 +451,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
@@ -451,6 +451,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -654,3 +655,34 @@ impl HttpClient {
     }
 
 {{SSE_METHOD}}}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
+    }
+}

--- a/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
@@ -474,7 +474,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        {{RETRY_STATUS_CHECK}}
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
@@ -450,6 +450,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -466,6 +471,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
@@ -474,7 +474,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -665,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/packages/generator-migrations/src/__test__/index.test.ts
+++ b/packages/generator-migrations/src/__test__/index.test.ts
@@ -162,6 +162,34 @@ describe("@fern-api/generator-migrations", () => {
         });
     });
 
+    describe("Rust SDK migrations", () => {
+        it("includes Rust SDK migration entries", () => {
+            expect(migrations["fernapi/fern-rust-sdk"]).toBeDefined();
+            expect(migrations["fernapi/fern-rust-sdk"]?.migrations).toBeDefined();
+            expect(Array.isArray(migrations["fernapi/fern-rust-sdk"]?.migrations)).toBe(true);
+        });
+
+        it("Rust SDK migrations have correct structure", () => {
+            const module = migrations["fernapi/fern-rust-sdk"];
+
+            expect(module).toBeDefined();
+            expect(module?.migrations.length).toBeGreaterThan(0);
+
+            for (const migration of module?.migrations ?? []) {
+                expect(migration).toHaveProperty("version");
+                expect(migration).toHaveProperty("migrateGeneratorConfig");
+                expect(migration).toHaveProperty("migrateGeneratorsYml");
+            }
+        });
+
+        it("Rust SDK migrations are in semver order", () => {
+            const module = migrations["fernapi/fern-rust-sdk"];
+            const versions = module?.migrations.map((m) => m.version) ?? [];
+
+            expect(versions).toEqual(["1.0.0"]);
+        });
+    });
+
     describe("generator name lookup", () => {
         it("returns undefined for generators without migrations", () => {
             expect(migrations["fernapi/fern-go-sdk"]).toBeUndefined();

--- a/packages/generator-migrations/src/generators/rust/migrations/1.0.0.ts
+++ b/packages/generator-migrations/src/generators/rust/migrations/1.0.0.ts
@@ -1,0 +1,25 @@
+import type { Migration } from "@fern-api/migrations-base";
+import { migrateConfig } from "@fern-api/migrations-base";
+
+// Migration for version 1.0.0
+//
+// Context:
+// Version 1.0.0 changes the default retry behavior to only retry on transient
+// 5xx status codes (408, 429, 502, 503, 504), excluding 500 Internal Server Error.
+//
+// Changed Defaults:
+// - retryStatusCodes: undefined (legacy behavior: 408, 429, >= 500) → "recommended" (408, 429, 502, 503, 504)
+//
+// Migration Strategy:
+// This migration pins existing users to "legacy" so their retry behavior
+// does not change on upgrade. New users get "recommended" by default.
+export const migration_1_0_0: Migration = {
+    version: "1.0.0",
+
+    migrateGeneratorConfig: ({ config }) =>
+        migrateConfig(config, (draft) => {
+            draft.retryStatusCodes ??= "legacy";
+        }),
+
+    migrateGeneratorsYml: ({ document }) => document
+};

--- a/packages/generator-migrations/src/generators/rust/migrations/index.ts
+++ b/packages/generator-migrations/src/generators/rust/migrations/index.ts
@@ -1,0 +1,8 @@
+import type { MigrationModule } from "@fern-api/migrations-base";
+import { migration_1_0_0 } from "./1.0.0.js";
+
+const rustSdkMigrations: MigrationModule = {
+    migrations: [migration_1_0_0]
+};
+
+export default rustSdkMigrations;

--- a/packages/generator-migrations/src/index.ts
+++ b/packages/generator-migrations/src/index.ts
@@ -11,6 +11,7 @@ import csharpSdkMigrations from "./generators/csharp/migrations/index.js";
 import javaSdkMigrations from "./generators/java/migrations/index.js";
 import javaModelMigrations from "./generators/java-model/migrations/index.js";
 import pythonSdkMigrations from "./generators/python/migrations/index.js";
+import rustSdkMigrations from "./generators/rust/migrations/index.js";
 import typescriptSdkMigrations from "./generators/typescript/migrations/index.js";
 
 /**
@@ -36,6 +37,9 @@ export const migrations: Record<string, MigrationModule> = {
     "fernapi/fern-python-sdk": pythonSdkMigrations,
     "fernapi/fern-fastapi-server": pythonSdkMigrations,
     "fernapi/fern-pydantic-model": pythonSdkMigrations,
+
+    // Rust SDK
+    "fernapi/fern-rust-sdk": rustSdkMigrations,
 
     // TypeScript SDK - all variants share the same migrations
     "fernapi/fern-typescript": typescriptSdkMigrations,

--- a/seed/rust-sdk/accept-header/src/core/http_client.rs
+++ b/seed/rust-sdk/accept-header/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/accept-header/src/core/http_client.rs
+++ b/seed/rust-sdk/accept-header/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/accept-header/src/core/http_client.rs
+++ b/seed/rust-sdk/accept-header/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/accept-header/src/core/http_client.rs
+++ b/seed/rust-sdk/accept-header/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/accept-header/src/core/http_client.rs
+++ b/seed/rust-sdk/accept-header/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/alias-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/alias-extends/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/alias-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/alias-extends/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/alias-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/alias-extends/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/alias-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/alias-extends/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/alias-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/alias-extends/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/alias/src/core/http_client.rs
+++ b/seed/rust-sdk/alias/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/alias/src/core/http_client.rs
+++ b/seed/rust-sdk/alias/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/alias/src/core/http_client.rs
+++ b/seed/rust-sdk/alias/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/alias/src/core/http_client.rs
+++ b/seed/rust-sdk/alias/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/alias/src/core/http_client.rs
+++ b/seed/rust-sdk/alias/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/allof-inline/src/core/http_client.rs
+++ b/seed/rust-sdk/allof-inline/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/allof-inline/src/core/http_client.rs
+++ b/seed/rust-sdk/allof-inline/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/allof-inline/src/core/http_client.rs
+++ b/seed/rust-sdk/allof-inline/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/allof-inline/src/core/http_client.rs
+++ b/seed/rust-sdk/allof-inline/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/allof-inline/src/core/http_client.rs
+++ b/seed/rust-sdk/allof-inline/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/allof/src/core/http_client.rs
+++ b/seed/rust-sdk/allof/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/allof/src/core/http_client.rs
+++ b/seed/rust-sdk/allof/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/allof/src/core/http_client.rs
+++ b/seed/rust-sdk/allof/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/allof/src/core/http_client.rs
+++ b/seed/rust-sdk/allof/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/allof/src/core/http_client.rs
+++ b/seed/rust-sdk/allof/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/any-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/any-auth/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/any-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/any-auth/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/any-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/any-auth/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/any-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/any-auth/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/any-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/any-auth/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
+++ b/seed/rust-sdk/api-wide-base-path/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/audiences/src/core/http_client.rs
+++ b/seed/rust-sdk/audiences/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/audiences/src/core/http_client.rs
+++ b/seed/rust-sdk/audiences/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/audiences/src/core/http_client.rs
+++ b/seed/rust-sdk/audiences/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/audiences/src/core/http_client.rs
+++ b/seed/rust-sdk/audiences/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/audiences/src/core/http_client.rs
+++ b/seed/rust-sdk/audiences/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-environment-variables/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/basic-auth-pw-omitted/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-pw-omitted/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/basic-auth-pw-omitted/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-pw-omitted/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/basic-auth-pw-omitted/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-pw-omitted/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/basic-auth-pw-omitted/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-pw-omitted/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/basic-auth-pw-omitted/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth-pw-omitted/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/basic-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/basic-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/basic-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/basic-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/basic-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/basic-auth/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/bearer-token-environment-variable/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/bytes-download/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-download/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/bytes-download/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-download/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/bytes-download/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-download/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/bytes-download/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-download/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/bytes-download/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-download/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/bytes-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/http_client.rs
@@ -492,6 +492,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -515,7 +516,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -704,18 +705,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/bytes-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/http_client.rs
@@ -492,7 +492,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/bytes-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/http_client.rs
@@ -491,6 +491,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -507,6 +512,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/bytes-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/http_client.rs
@@ -492,6 +492,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -691,5 +692,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/bytes-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/bytes-upload/src/core/http_client.rs
@@ -516,7 +516,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-advanced/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/circular-references-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-extends/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/circular-references-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-extends/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/circular-references-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-extends/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/circular-references-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-extends/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/circular-references-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references-extends/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/circular-references/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/circular-references/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/circular-references/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/circular-references/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/circular-references/src/core/http_client.rs
+++ b/seed/rust-sdk/circular-references/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/client-side-params/src/core/http_client.rs
+++ b/seed/rust-sdk/client-side-params/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/client-side-params/src/core/http_client.rs
+++ b/seed/rust-sdk/client-side-params/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/client-side-params/src/core/http_client.rs
+++ b/seed/rust-sdk/client-side-params/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/client-side-params/src/core/http_client.rs
+++ b/seed/rust-sdk/client-side-params/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/client-side-params/src/core/http_client.rs
+++ b/seed/rust-sdk/client-side-params/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/content-type/src/core/http_client.rs
+++ b/seed/rust-sdk/content-type/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/content-type/src/core/http_client.rs
+++ b/seed/rust-sdk/content-type/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/content-type/src/core/http_client.rs
+++ b/seed/rust-sdk/content-type/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/content-type/src/core/http_client.rs
+++ b/seed/rust-sdk/content-type/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/content-type/src/core/http_client.rs
+++ b/seed/rust-sdk/content-type/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
+++ b/seed/rust-sdk/cross-package-type-names/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/dollar-string-examples/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/empty-clients/src/core/http_client.rs
+++ b/seed/rust-sdk/empty-clients/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/empty-clients/src/core/http_client.rs
+++ b/seed/rust-sdk/empty-clients/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/empty-clients/src/core/http_client.rs
+++ b/seed/rust-sdk/empty-clients/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/empty-clients/src/core/http_client.rs
+++ b/seed/rust-sdk/empty-clients/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/empty-clients/src/core/http_client.rs
+++ b/seed/rust-sdk/empty-clients/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/endpoint-security-auth/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/enum/src/core/http_client.rs
+++ b/seed/rust-sdk/enum/src/core/http_client.rs
@@ -522,6 +522,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -774,5 +775,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/enum/src/core/http_client.rs
+++ b/seed/rust-sdk/enum/src/core/http_client.rs
@@ -521,6 +521,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -537,6 +542,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/enum/src/core/http_client.rs
+++ b/seed/rust-sdk/enum/src/core/http_client.rs
@@ -522,7 +522,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/enum/src/core/http_client.rs
+++ b/seed/rust-sdk/enum/src/core/http_client.rs
@@ -522,6 +522,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -545,7 +546,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -787,18 +788,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/enum/src/core/http_client.rs
+++ b/seed/rust-sdk/enum/src/core/http_client.rs
@@ -546,7 +546,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/error-property/src/core/http_client.rs
+++ b/seed/rust-sdk/error-property/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/error-property/src/core/http_client.rs
+++ b/seed/rust-sdk/error-property/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/error-property/src/core/http_client.rs
+++ b/seed/rust-sdk/error-property/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/error-property/src/core/http_client.rs
+++ b/seed/rust-sdk/error-property/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/error-property/src/core/http_client.rs
+++ b/seed/rust-sdk/error-property/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/errors/src/core/http_client.rs
+++ b/seed/rust-sdk/errors/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/errors/src/core/http_client.rs
+++ b/seed/rust-sdk/errors/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/errors/src/core/http_client.rs
+++ b/seed/rust-sdk/errors/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/errors/src/core/http_client.rs
+++ b/seed/rust-sdk/errors/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/errors/src/core/http_client.rs
+++ b/seed/rust-sdk/errors/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
@@ -454,6 +454,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -706,5 +707,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
@@ -453,6 +453,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -469,6 +474,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
@@ -454,7 +454,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
@@ -454,6 +454,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -477,7 +478,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -719,18 +720,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/no-custom-config/src/core/http_client.rs
@@ -478,7 +478,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
@@ -454,6 +454,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -706,5 +707,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
@@ -453,6 +453,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -469,6 +474,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
@@ -454,7 +454,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
@@ -454,6 +454,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -477,7 +478,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -719,18 +720,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
+++ b/seed/rust-sdk/examples/readme-config/src/core/http_client.rs
@@ -478,7 +478,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/exhaustive/src/core/http_client.rs
+++ b/seed/rust-sdk/exhaustive/src/core/http_client.rs
@@ -494,6 +494,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -746,5 +747,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/exhaustive/src/core/http_client.rs
+++ b/seed/rust-sdk/exhaustive/src/core/http_client.rs
@@ -494,6 +494,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -517,7 +518,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -759,18 +760,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/exhaustive/src/core/http_client.rs
+++ b/seed/rust-sdk/exhaustive/src/core/http_client.rs
@@ -494,7 +494,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/exhaustive/src/core/http_client.rs
+++ b/seed/rust-sdk/exhaustive/src/core/http_client.rs
@@ -493,6 +493,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -509,6 +514,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/exhaustive/src/core/http_client.rs
+++ b/seed/rust-sdk/exhaustive/src/core/http_client.rs
@@ -518,7 +518,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/extends/src/core/http_client.rs
+++ b/seed/rust-sdk/extends/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/extends/src/core/http_client.rs
+++ b/seed/rust-sdk/extends/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/extends/src/core/http_client.rs
+++ b/seed/rust-sdk/extends/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/extends/src/core/http_client.rs
+++ b/seed/rust-sdk/extends/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/extends/src/core/http_client.rs
+++ b/seed/rust-sdk/extends/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/extra-properties/src/core/http_client.rs
+++ b/seed/rust-sdk/extra-properties/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/extra-properties/src/core/http_client.rs
+++ b/seed/rust-sdk/extra-properties/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/extra-properties/src/core/http_client.rs
+++ b/seed/rust-sdk/extra-properties/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/extra-properties/src/core/http_client.rs
+++ b/seed/rust-sdk/extra-properties/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/extra-properties/src/core/http_client.rs
+++ b/seed/rust-sdk/extra-properties/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/file-download/src/core/http_client.rs
+++ b/seed/rust-sdk/file-download/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/file-download/src/core/http_client.rs
+++ b/seed/rust-sdk/file-download/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/file-download/src/core/http_client.rs
+++ b/seed/rust-sdk/file-download/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/file-download/src/core/http_client.rs
+++ b/seed/rust-sdk/file-download/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/file-download/src/core/http_client.rs
+++ b/seed/rust-sdk/file-download/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
@@ -522,6 +522,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -774,5 +775,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
@@ -521,6 +521,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -537,6 +542,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
@@ -522,7 +522,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
@@ -522,6 +522,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -545,7 +546,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -787,18 +788,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload-openapi/src/core/http_client.rs
@@ -546,7 +546,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/file-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload/src/core/http_client.rs
@@ -522,6 +522,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -774,5 +775,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/file-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload/src/core/http_client.rs
@@ -521,6 +521,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -537,6 +542,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/file-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload/src/core/http_client.rs
@@ -522,7 +522,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/file-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload/src/core/http_client.rs
@@ -522,6 +522,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -545,7 +546,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -787,18 +788,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/file-upload/src/core/http_client.rs
+++ b/seed/rust-sdk/file-upload/src/core/http_client.rs
@@ -546,7 +546,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/folders/src/core/http_client.rs
+++ b/seed/rust-sdk/folders/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/folders/src/core/http_client.rs
+++ b/seed/rust-sdk/folders/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/folders/src/core/http_client.rs
+++ b/seed/rust-sdk/folders/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/folders/src/core/http_client.rs
+++ b/seed/rust-sdk/folders/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/folders/src/core/http_client.rs
+++ b/seed/rust-sdk/folders/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth-environment-variable/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/header-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/header-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/header-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/header-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/header-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/header-auth/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/http-head/src/core/http_client.rs
+++ b/seed/rust-sdk/http-head/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/http-head/src/core/http_client.rs
+++ b/seed/rust-sdk/http-head/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/http-head/src/core/http_client.rs
+++ b/seed/rust-sdk/http-head/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/http-head/src/core/http_client.rs
+++ b/seed/rust-sdk/http-head/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/http-head/src/core/http_client.rs
+++ b/seed/rust-sdk/http-head/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
+++ b/seed/rust-sdk/idempotency-headers/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-config/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb-custom-features/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
+++ b/seed/rust-sdk/imdb/imdb/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-explicit/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-api-key/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-no-expiry/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit-reference/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
+++ b/seed/rust-sdk/inferred-auth-implicit/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/license/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/license/basic/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/license/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/license/basic/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/license/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/license/basic/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/license/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/license/basic/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/license/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/license/basic/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
+++ b/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
+++ b/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
+++ b/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
+++ b/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
+++ b/seed/rust-sdk/license/both-license-options/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/custom-license-file/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
+++ b/seed/rust-sdk/license/empty-license-file/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/literal/src/core/http_client.rs
+++ b/seed/rust-sdk/literal/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/literal/src/core/http_client.rs
+++ b/seed/rust-sdk/literal/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/literal/src/core/http_client.rs
+++ b/seed/rust-sdk/literal/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/literal/src/core/http_client.rs
+++ b/seed/rust-sdk/literal/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/literal/src/core/http_client.rs
+++ b/seed/rust-sdk/literal/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/literals-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/literals-unions/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/literals-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/literals-unions/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/literals-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/literals-unions/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/literals-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/literals-unions/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/literals-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/literals-unions/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/mixed-case/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-case/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/mixed-case/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-case/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/mixed-case/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-case/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/mixed-case/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-case/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/mixed-case/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-case/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
+++ b/seed/rust-sdk/mixed-file-directory/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-line-docs/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-no-default/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/multi-url-environment-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-reference/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/multi-url-environment-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-reference/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/multi-url-environment-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-reference/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/multi-url-environment-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-reference/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/multi-url-environment-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment-reference/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
@@ -492,6 +492,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -515,7 +516,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -704,18 +705,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
@@ -492,7 +492,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
@@ -491,6 +491,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -507,6 +512,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
@@ -492,6 +492,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -691,5 +692,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
+++ b/seed/rust-sdk/multiple-request-bodies/src/core/http_client.rs
@@ -516,7 +516,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/no-content-response/src/core/http_client.rs
+++ b/seed/rust-sdk/no-content-response/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/no-content-response/src/core/http_client.rs
+++ b/seed/rust-sdk/no-content-response/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/no-content-response/src/core/http_client.rs
+++ b/seed/rust-sdk/no-content-response/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/no-content-response/src/core/http_client.rs
+++ b/seed/rust-sdk/no-content-response/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/no-content-response/src/core/http_client.rs
+++ b/seed/rust-sdk/no-content-response/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/no-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/no-environment/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/no-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/no-environment/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/no-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/no-environment/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/no-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/no-environment/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/no-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/no-environment/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/no-retries/src/core/http_client.rs
+++ b/seed/rust-sdk/no-retries/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/no-retries/src/core/http_client.rs
+++ b/seed/rust-sdk/no-retries/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/no-retries/src/core/http_client.rs
+++ b/seed/rust-sdk/no-retries/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/no-retries/src/core/http_client.rs
+++ b/seed/rust-sdk/no-retries/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/no-retries/src/core/http_client.rs
+++ b/seed/rust-sdk/no-retries/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/null-type/src/core/http_client.rs
+++ b/seed/rust-sdk/null-type/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/null-type/src/core/http_client.rs
+++ b/seed/rust-sdk/null-type/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/null-type/src/core/http_client.rs
+++ b/seed/rust-sdk/null-type/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/null-type/src/core/http_client.rs
+++ b/seed/rust-sdk/null-type/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/null-type/src/core/http_client.rs
+++ b/seed/rust-sdk/null-type/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-allof-extends/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/nullable-optional/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/nullable-optional/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/nullable-optional/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/nullable-optional/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/nullable-optional/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-optional/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable-request-body/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/nullable/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-custom/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-default/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-environment-variables/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-mandatory-auth/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-nested-root/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-openapi/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-openapi/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/oauth-client-credentials-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-openapi/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/oauth-client-credentials-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-openapi/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-openapi/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-reference/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials-with-variables/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
+++ b/seed/rust-sdk/oauth-client-credentials/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/object/src/core/http_client.rs
+++ b/seed/rust-sdk/object/src/core/http_client.rs
@@ -454,6 +454,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -706,5 +707,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/object/src/core/http_client.rs
+++ b/seed/rust-sdk/object/src/core/http_client.rs
@@ -453,6 +453,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -469,6 +474,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/object/src/core/http_client.rs
+++ b/seed/rust-sdk/object/src/core/http_client.rs
@@ -454,7 +454,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/object/src/core/http_client.rs
+++ b/seed/rust-sdk/object/src/core/http_client.rs
@@ -454,6 +454,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -477,7 +478,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -719,18 +720,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/object/src/core/http_client.rs
+++ b/seed/rust-sdk/object/src/core/http_client.rs
@@ -478,7 +478,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
+++ b/seed/rust-sdk/objects-with-imports/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/optional/src/core/http_client.rs
+++ b/seed/rust-sdk/optional/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/optional/src/core/http_client.rs
+++ b/seed/rust-sdk/optional/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/optional/src/core/http_client.rs
+++ b/seed/rust-sdk/optional/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/optional/src/core/http_client.rs
+++ b/seed/rust-sdk/optional/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/optional/src/core/http_client.rs
+++ b/seed/rust-sdk/optional/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/package-yml/src/core/http_client.rs
+++ b/seed/rust-sdk/package-yml/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/package-yml/src/core/http_client.rs
+++ b/seed/rust-sdk/package-yml/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/package-yml/src/core/http_client.rs
+++ b/seed/rust-sdk/package-yml/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/package-yml/src/core/http_client.rs
+++ b/seed/rust-sdk/package-yml/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/package-yml/src/core/http_client.rs
+++ b/seed/rust-sdk/package-yml/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/pagination-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/pagination-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/pagination-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/pagination-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/pagination-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-custom/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination-uri-path/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/pagination/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/pagination/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/pagination/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/pagination/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/pagination/src/core/http_client.rs
+++ b/seed/rust-sdk/pagination/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/path-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/path-parameters/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/path-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/path-parameters/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/path-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/path-parameters/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/path-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/path-parameters/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/path-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/path-parameters/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/plain-text/src/core/http_client.rs
+++ b/seed/rust-sdk/plain-text/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/plain-text/src/core/http_client.rs
+++ b/seed/rust-sdk/plain-text/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/plain-text/src/core/http_client.rs
+++ b/seed/rust-sdk/plain-text/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/plain-text/src/core/http_client.rs
+++ b/seed/rust-sdk/plain-text/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/plain-text/src/core/http_client.rs
+++ b/seed/rust-sdk/plain-text/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/property-access/src/core/http_client.rs
+++ b/seed/rust-sdk/property-access/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/property-access/src/core/http_client.rs
+++ b/seed/rust-sdk/property-access/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/property-access/src/core/http_client.rs
+++ b/seed/rust-sdk/property-access/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/property-access/src/core/http_client.rs
+++ b/seed/rust-sdk/property-access/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/property-access/src/core/http_client.rs
+++ b/seed/rust-sdk/property-access/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/public-object/src/core/http_client.rs
+++ b/seed/rust-sdk/public-object/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/public-object/src/core/http_client.rs
+++ b/seed/rust-sdk/public-object/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/public-object/src/core/http_client.rs
+++ b/seed/rust-sdk/public-object/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/public-object/src/core/http_client.rs
+++ b/seed/rust-sdk/public-object/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/public-object/src/core/http_client.rs
+++ b/seed/rust-sdk/public-object/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/query-param-name-conflict/src/core/http_client.rs
+++ b/seed/rust-sdk/query-param-name-conflict/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/query-param-name-conflict/src/core/http_client.rs
+++ b/seed/rust-sdk/query-param-name-conflict/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/query-param-name-conflict/src/core/http_client.rs
+++ b/seed/rust-sdk/query-param-name-conflict/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/query-param-name-conflict/src/core/http_client.rs
+++ b/seed/rust-sdk/query-param-name-conflict/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/query-param-name-conflict/src/core/http_client.rs
+++ b/seed/rust-sdk/query-param-name-conflict/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi-as-objects/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters-openapi/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/query-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters/src/core/http_client.rs
@@ -454,6 +454,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -706,5 +707,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/query-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters/src/core/http_client.rs
@@ -453,6 +453,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -469,6 +474,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/query-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters/src/core/http_client.rs
@@ -454,7 +454,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/query-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters/src/core/http_client.rs
@@ -454,6 +454,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -477,7 +478,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -719,18 +720,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/query-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/query-parameters/src/core/http_client.rs
@@ -478,7 +478,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/request-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/request-parameters/src/core/http_client.rs
@@ -454,6 +454,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -706,5 +707,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/request-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/request-parameters/src/core/http_client.rs
@@ -453,6 +453,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -469,6 +474,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/request-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/request-parameters/src/core/http_client.rs
@@ -454,7 +454,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/request-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/request-parameters/src/core/http_client.rs
@@ -454,6 +454,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -477,7 +478,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -719,18 +720,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/request-parameters/src/core/http_client.rs
+++ b/seed/rust-sdk/request-parameters/src/core/http_client.rs
@@ -478,7 +478,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/required-nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/required-nullable/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/required-nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/required-nullable/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/required-nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/required-nullable/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/required-nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/required-nullable/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/required-nullable/src/core/http_client.rs
+++ b/seed/rust-sdk/required-nullable/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
+++ b/seed/rust-sdk/reserved-keywords/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/response-property/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/response-property/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/response-property/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/response-property/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/response-property/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/schemaless-request-body-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/schemaless-request-body-examples/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/schemaless-request-body-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/schemaless-request-body-examples/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/schemaless-request-body-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/schemaless-request-body-examples/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/schemaless-request-body-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/schemaless-request-body-examples/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/schemaless-request-body-examples/src/core/http_client.rs
+++ b/seed/rust-sdk/schemaless-request-body-examples/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -763,18 +764,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -750,5 +751,36 @@ impl HttpClient {
 
         // Return SSE stream with per-event timeout
         crate::SseStream::new(response, terminator, timeout).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/server-sent-events-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/server-sent-events-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -763,18 +764,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/server-sent-events-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/server-sent-events-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -750,5 +751,36 @@ impl HttpClient {
 
         // Return SSE stream with per-event timeout
         crate::SseStream::new(response, terminator, timeout).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/server-sent-events-openapi/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events-openapi/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -763,18 +764,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -750,5 +751,36 @@ impl HttpClient {
 
         // Return SSE stream with per-event timeout
         crate::SseStream::new(response, terminator, timeout).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
+++ b/seed/rust-sdk/server-sent-events/with-wire-tests/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/server-url-templating/src/core/http_client.rs
+++ b/seed/rust-sdk/server-url-templating/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/server-url-templating/src/core/http_client.rs
+++ b/seed/rust-sdk/server-url-templating/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/server-url-templating/src/core/http_client.rs
+++ b/seed/rust-sdk/server-url-templating/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/server-url-templating/src/core/http_client.rs
+++ b/seed/rust-sdk/server-url-templating/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/server-url-templating/src/core/http_client.rs
+++ b/seed/rust-sdk/server-url-templating/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic-custom-config/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-api/basic/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/simple-fhir/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/simple-fhir/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/simple-fhir/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/simple-fhir/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/simple-fhir/src/core/http_client.rs
+++ b/seed/rust-sdk/simple-fhir/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/basic/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/single-url-environment-no-default/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -763,18 +764,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -750,5 +751,36 @@ impl HttpClient {
 
         // Return SSE stream with per-event timeout
         crate::SseStream::new(response, terminator, timeout).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/streaming/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/streaming/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -763,18 +764,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/streaming/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/streaming/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -750,5 +751,36 @@ impl HttpClient {
 
         // Return SSE stream with per-event timeout
         crate::SseStream::new(response, terminator, timeout).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/streaming/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/trace/src/core/http_client.rs
+++ b/seed/rust-sdk/trace/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/trace/src/core/http_client.rs
+++ b/seed/rust-sdk/trace/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/trace/src/core/http_client.rs
+++ b/seed/rust-sdk/trace/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/trace/src/core/http_client.rs
+++ b/seed/rust-sdk/trace/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/trace/src/core/http_client.rs
+++ b/seed/rust-sdk/trace/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-union-with-response-property/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
+++ b/seed/rust-sdk/undiscriminated-unions/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
+++ b/seed/rust-sdk/unions-with-local-date/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/unions/src/core/http_client.rs
+++ b/seed/rust-sdk/unions/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/unions/src/core/http_client.rs
+++ b/seed/rust-sdk/unions/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/unions/src/core/http_client.rs
+++ b/seed/rust-sdk/unions/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/unions/src/core/http_client.rs
+++ b/seed/rust-sdk/unions/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/unions/src/core/http_client.rs
+++ b/seed/rust-sdk/unions/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/unknown/src/core/http_client.rs
+++ b/seed/rust-sdk/unknown/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/unknown/src/core/http_client.rs
+++ b/seed/rust-sdk/unknown/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/unknown/src/core/http_client.rs
+++ b/seed/rust-sdk/unknown/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/unknown/src/core/http_client.rs
+++ b/seed/rust-sdk/unknown/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/unknown/src/core/http_client.rs
+++ b/seed/rust-sdk/unknown/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
+++ b/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
+++ b/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
+++ b/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
+++ b/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
+++ b/seed/rust-sdk/url-form-encoded/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/validation/src/core/http_client.rs
+++ b/seed/rust-sdk/validation/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/validation/src/core/http_client.rs
+++ b/seed/rust-sdk/validation/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/validation/src/core/http_client.rs
+++ b/seed/rust-sdk/validation/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/validation/src/core/http_client.rs
+++ b/seed/rust-sdk/validation/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/validation/src/core/http_client.rs
+++ b/seed/rust-sdk/validation/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/variables/src/core/http_client.rs
+++ b/seed/rust-sdk/variables/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/variables/src/core/http_client.rs
+++ b/seed/rust-sdk/variables/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/variables/src/core/http_client.rs
+++ b/seed/rust-sdk/variables/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/variables/src/core/http_client.rs
+++ b/seed/rust-sdk/variables/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/variables/src/core/http_client.rs
+++ b/seed/rust-sdk/variables/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/version-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/version-no-default/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/version-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/version-no-default/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/version-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/version-no-default/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/version-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/version-no-default/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/version-no-default/src/core/http_client.rs
+++ b/seed/rust-sdk/version-no-default/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/version/src/core/http_client.rs
+++ b/seed/rust-sdk/version/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/version/src/core/http_client.rs
+++ b/seed/rust-sdk/version/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/version/src/core/http_client.rs
+++ b/seed/rust-sdk/version/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/version/src/core/http_client.rs
+++ b/seed/rust-sdk/version/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/version/src/core/http_client.rs
+++ b/seed/rust-sdk/version/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/webhook-audience/src/core/http_client.rs
+++ b/seed/rust-sdk/webhook-audience/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/webhook-audience/src/core/http_client.rs
+++ b/seed/rust-sdk/webhook-audience/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/webhook-audience/src/core/http_client.rs
+++ b/seed/rust-sdk/webhook-audience/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/webhook-audience/src/core/http_client.rs
+++ b/seed/rust-sdk/webhook-audience/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/webhook-audience/src/core/http_client.rs
+++ b/seed/rust-sdk/webhook-audience/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/webhooks/src/core/http_client.rs
+++ b/seed/rust-sdk/webhooks/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/webhooks/src/core/http_client.rs
+++ b/seed/rust-sdk/webhooks/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/webhooks/src/core/http_client.rs
+++ b/seed/rust-sdk/webhooks/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/webhooks/src/core/http_client.rs
+++ b/seed/rust-sdk/webhooks/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/webhooks/src/core/http_client.rs
+++ b/seed/rust-sdk/webhooks/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-bearer-auth/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-inferred-auth/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/websocket/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket/src/core/http_client.rs
@@ -451,7 +451,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/websocket/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket/src/core/http_client.rs
@@ -451,6 +451,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -653,4 +654,35 @@ impl HttpClient {
         Ok(ByteStream::new(response))
     }
 
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
+    }
 }

--- a/seed/rust-sdk/websocket/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket/src/core/http_client.rs
@@ -450,6 +450,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -466,6 +471,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/websocket/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket/src/core/http_client.rs
@@ -451,6 +451,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -474,7 +475,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -665,18 +666,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/websocket/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket/src/core/http_client.rs
@@ -475,7 +475,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/x-fern-default/src/core/http_client.rs
+++ b/seed/rust-sdk/x-fern-default/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -651,5 +652,36 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         Ok(ByteStream::new(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_retryable_status() {
+        // Retryable 4xx
+        assert!(HttpClient::is_retryable_status(408));
+        assert!(HttpClient::is_retryable_status(429));
+
+        // Retryable 5xx (501–599)
+        assert!(HttpClient::is_retryable_status(501));
+        assert!(HttpClient::is_retryable_status(502));
+        assert!(HttpClient::is_retryable_status(503));
+        assert!(HttpClient::is_retryable_status(504));
+        assert!(HttpClient::is_retryable_status(599));
+
+        // 500 is NOT retryable
+        assert!(!HttpClient::is_retryable_status(500));
+
+        // Above 5xx range is NOT retryable
+        assert!(!HttpClient::is_retryable_status(600));
+
+        // Success and other 4xx codes are NOT retryable
+        assert!(!HttpClient::is_retryable_status(200));
+        assert!(!HttpClient::is_retryable_status(400));
+        assert!(!HttpClient::is_retryable_status(401));
+        assert!(!HttpClient::is_retryable_status(404));
     }
 }

--- a/seed/rust-sdk/x-fern-default/src/core/http_client.rs
+++ b/seed/rust-sdk/x-fern-default/src/core/http_client.rs
@@ -452,7 +452,6 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
-                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;

--- a/seed/rust-sdk/x-fern-default/src/core/http_client.rs
+++ b/seed/rust-sdk/x-fern-default/src/core/http_client.rs
@@ -452,6 +452,7 @@ impl HttpClient {
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
                 Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    drop(response);
                     // Exponential backoff for retryable HTTP status codes
                     let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
                     tokio::time::sleep(delay).await;
@@ -475,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
+        status_code == 408 || status_code == 429 || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>
@@ -664,18 +665,13 @@ mod tests {
         assert!(HttpClient::is_retryable_status(408));
         assert!(HttpClient::is_retryable_status(429));
 
-        // Retryable 5xx (501–599)
+        // Retryable 5xx (>= 500)
+        assert!(HttpClient::is_retryable_status(500));
         assert!(HttpClient::is_retryable_status(501));
         assert!(HttpClient::is_retryable_status(502));
         assert!(HttpClient::is_retryable_status(503));
         assert!(HttpClient::is_retryable_status(504));
         assert!(HttpClient::is_retryable_status(599));
-
-        // 500 is NOT retryable
-        assert!(!HttpClient::is_retryable_status(500));
-
-        // Above 5xx range is NOT retryable
-        assert!(!HttpClient::is_retryable_status(600));
 
         // Success and other 4xx codes are NOT retryable
         assert!(!HttpClient::is_retryable_status(200));

--- a/seed/rust-sdk/x-fern-default/src/core/http_client.rs
+++ b/seed/rust-sdk/x-fern-default/src/core/http_client.rs
@@ -451,6 +451,11 @@ impl HttpClient {
 
             match self.client.execute(cloned_request).await {
                 Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) if attempt < max_retries && Self::is_retryable_status(response.status().as_u16()) => {
+                    // Exponential backoff for retryable HTTP status codes
+                    let delay = std::time::Duration::from_millis(100 * 2_u64.pow(attempt));
+                    tokio::time::sleep(delay).await;
+                }
                 Ok(response) => {
                     let status_code = response.status().as_u16();
                     let body = response.text().await.ok();
@@ -467,6 +472,10 @@ impl HttpClient {
         }
 
         Err(ApiError::Network(last_error.unwrap()))
+    }
+
+    fn is_retryable_status(status_code: u16) -> bool {
+        status_code == 408 || status_code == 429 || (status_code >= 501 && status_code < 600)
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>

--- a/seed/rust-sdk/x-fern-default/src/core/http_client.rs
+++ b/seed/rust-sdk/x-fern-default/src/core/http_client.rs
@@ -476,7 +476,7 @@ impl HttpClient {
     }
 
     fn is_retryable_status(status_code: u16) -> bool {
-        status_code == 408 || status_code == 429 || status_code >= 500
+        [408, 429].contains(&status_code) || status_code >= 500
     }
 
     async fn parse_response<T>(&self, response: Response) -> Result<T, ApiError>


### PR DESCRIPTION
## Description
Linear ticket: Refs FER-6486

Adds a `retryStatusCodes` configuration option to the Rust SDK generator with two modes:

- **`legacy`** (default): Preserves existing behavior — retries `408`, `429`, and all `>= 500`
- **`recommended`**: Only retries `408`, `429`, `502`, `503`, `504` (excludes `500 Internal Server Error` to avoid retrying non-idempotent failures)

## Changes Made
- Added `retryStatusCodes: "legacy" | "recommended"` field to `BaseRustConfigSchema.ts`
- Reverted `http_client.rs` template to legacy behavior (`status_code >= 500`)
- Modified `RustProject.ts` to apply string replacement when config is `"recommended"`
- Created `1.0.0.ts` migration to auto-pin `legacy` for existing users on major version bump
- Registered Rust SDK migrations in `packages/generator-migrations/src/index.ts`
- Updated `features.yml` documenting both modes
- Updated snapshot test and seed `http_client.rs` files to legacy behavior

## Testing
- [x] `pnpm compile` passes (159/159 tasks)
- [x] Pre-commit hooks pass
- [ ] CI seed tests

Link to Devin session: https://app.devin.ai/sessions/6d2ebbd3c6a44761b2b3a939eaafd274
Requested by: @iamnamananand996