### PR TITLE
fix(cli): populate SDK version in automations-generate step summary

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-automations-generate-version-display.yml
+++ b/packages/cli/cli/changes/unreleased/fix-automations-generate-version-display.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Fix `fern automations generate` step summary not displaying SDK versions.
+    Upgrade Fiddle SDK to consume the new `actualVersion` field from
+    `FinishedTaskStatus`, which Fiddle now returns for both AUTO and explicit
+    versioning modes. Falls back to log-regex parsing and locally-resolved
+    version for backward compatibility.
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
@@ -118,11 +118,11 @@ export class RemoteTaskHandler {
         for (const newLog of remoteTask.logs.slice(this.lengthOfLastLogs)) {
             this.context.logger.log(convertLogLevel(newLog.level), newLog.message);
 
-            // extract version from log messages as fallback (e.g., "Tagging release 0.0.9")
+            // extract version from log messages as fallback (e.g., "Tagging release 0.0.9" or "Tagging release v0.2.0-rc.1")
             if (this.#actualVersion == null) {
-                const tagMatch = newLog.message.match(/Tagging release (\d+\.\d+\.\d+)/);
+                const tagMatch = newLog.message.match(/Tagging release (v?\d+\.\d+\.\d+(?:-[\w.]+)?)/);
                 if (tagMatch) {
-                    this.#actualVersion = tagMatch[1];
+                    this.#actualVersion = tagMatch[1]?.replace(/^v/, "");
                 }
             }
         }
@@ -167,6 +167,10 @@ export class RemoteTaskHandler {
                 this.#snippetsS3PreSignedReadUrl = finishedStatus.snippetsS3PreSignedReadUrl;
                 this.#pullRequestUrl = finishedStatus.pullRequestUrl;
                 this.#noChangesDetected = finishedStatus.noChangesDetected;
+                // Prefer the dedicated actualVersion field from Fiddle over log-regex heuristics
+                if (finishedStatus.actualVersion != null) {
+                    this.#actualVersion = finishedStatus.actualVersion;
+                }
             },
             _other: () => {
                 this.context.logger.warn("Received unknown update type: " + remoteTask.status.type);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
@@ -228,7 +228,7 @@ export class RemoteTaskHandler {
     }
 }
 
-const VERSION_TAG_REGEX = /Tagging release (v?\d+\.\d+\.\d+(?:-[\w.]+)?)/;
+const VERSION_TAG_REGEX = /Tagging release (v?\d+\.\d+\.\d+(?:-[\w.-]+)?)/;
 
 /**
  * Extracts a semver version from a log message matching "Tagging release X.Y.Z".

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
@@ -120,10 +120,7 @@ export class RemoteTaskHandler {
 
             // extract version from log messages as fallback (e.g., "Tagging release 0.0.9" or "Tagging release v0.2.0-rc.1")
             if (this.#actualVersion == null) {
-                const tagMatch = newLog.message.match(/Tagging release (v?\d+\.\d+\.\d+(?:-[\w.]+)?)/);
-                if (tagMatch) {
-                    this.#actualVersion = tagMatch[1]?.replace(/^v/, "");
-                }
+                this.#actualVersion = extractVersionFromLogMessage(newLog.message) ?? this.#actualVersion;
             }
         }
         this.lengthOfLastLogs = remoteTask.logs.length;
@@ -229,6 +226,21 @@ export class RemoteTaskHandler {
     public get noChangesDetected(): boolean | undefined {
         return this.#noChangesDetected;
     }
+}
+
+const VERSION_TAG_REGEX = /Tagging release (v?\d+\.\d+\.\d+(?:-[\w.]+)?)/;
+
+/**
+ * Extracts a semver version from a log message matching "Tagging release X.Y.Z".
+ * Handles optional v-prefix (Go generators) and pre-release suffixes.
+ * Returns `undefined` when no version is found.
+ */
+export function extractVersionFromLogMessage(message: string): string | undefined {
+    const match = message.match(VERSION_TAG_REGEX);
+    if (match?.[1] == null) {
+        return undefined;
+    }
+    return match[1].replace(/^v/, "");
 }
 
 async function downloadFilesForTask({

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/extractVersionFromLogMessage.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/extractVersionFromLogMessage.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { extractVersionFromLogMessage } from "../RemoteTaskHandler.js";
+
+describe("extractVersionFromLogMessage", () => {
+    it("extracts a plain semver from 'Tagging release X.Y.Z'", () => {
+        expect(extractVersionFromLogMessage("Tagging release 0.0.9")).toBe("0.0.9");
+    });
+
+    it("extracts a multi-digit version", () => {
+        expect(extractVersionFromLogMessage("Tagging release 12.34.56")).toBe("12.34.56");
+    });
+
+    it("strips the v prefix from Go-style versions", () => {
+        expect(extractVersionFromLogMessage("Tagging release v0.2.0")).toBe("0.2.0");
+    });
+
+    it("captures pre-release suffixes", () => {
+        expect(extractVersionFromLogMessage("Tagging release 1.0.0-rc.1")).toBe("1.0.0-rc.1");
+    });
+
+    it("captures v-prefixed pre-release versions and strips the v", () => {
+        expect(extractVersionFromLogMessage("Tagging release v2.0.0-beta.3")).toBe("2.0.0-beta.3");
+    });
+
+    it("handles alpha pre-release tags", () => {
+        expect(extractVersionFromLogMessage("Tagging release 0.1.0-alpha")).toBe("0.1.0-alpha");
+    });
+
+    it("extracts the version when the message has surrounding text", () => {
+        expect(extractVersionFromLogMessage("[INFO] Tagging release 3.1.4 on main branch")).toBe("3.1.4");
+    });
+
+    it("returns undefined for messages without a tagging release pattern", () => {
+        expect(extractVersionFromLogMessage("Published @acme/sdk@0.1.0")).toBeUndefined();
+    });
+
+    it("returns undefined for an empty message", () => {
+        expect(extractVersionFromLogMessage("")).toBeUndefined();
+    });
+
+    it("returns undefined for a partial match without a version", () => {
+        expect(extractVersionFromLogMessage("Tagging release notes")).toBeUndefined();
+    });
+});

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/extractVersionFromLogMessage.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/extractVersionFromLogMessage.test.ts
@@ -27,6 +27,14 @@ describe("extractVersionFromLogMessage", () => {
         expect(extractVersionFromLogMessage("Tagging release 0.1.0-alpha")).toBe("0.1.0-alpha");
     });
 
+    it("captures hyphen-separated pre-release identifiers", () => {
+        expect(extractVersionFromLogMessage("Tagging release 1.0.0-rc-1")).toBe("1.0.0-rc-1");
+    });
+
+    it("captures complex pre-release with mixed separators", () => {
+        expect(extractVersionFromLogMessage("Tagging release 1.0.0-pre-release.2")).toBe("1.0.0-pre-release.2");
+    });
+
     it("extracts the version when the message has surrounding text", () => {
         expect(extractVersionFromLogMessage("[INFO] Tagging release 3.1.4 on main branch")).toBe("3.1.4");
     });

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/resolveVersionFallback.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/resolveVersionFallback.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveVersionFallback } from "../runRemoteGenerationForGenerator.js";
+
+describe("resolveVersionFallback", () => {
+    it("returns the version when an explicit version is provided", () => {
+        expect(resolveVersionFallback("1.2.3")).toBe("1.2.3");
+    });
+
+    it("returns undefined when resolvedVersion is undefined (no version provided)", () => {
+        expect(resolveVersionFallback(undefined)).toBeUndefined();
+    });
+
+    it("returns undefined when resolvedVersion is 'AUTO' (uppercase)", () => {
+        expect(resolveVersionFallback("AUTO")).toBeUndefined();
+    });
+
+    it("returns undefined when resolvedVersion is 'auto' (lowercase)", () => {
+        expect(resolveVersionFallback("auto")).toBeUndefined();
+    });
+
+    it("returns undefined when resolvedVersion is 'Auto' (mixed case)", () => {
+        expect(resolveVersionFallback("Auto")).toBeUndefined();
+    });
+
+    it("returns a pre-release version as-is", () => {
+        expect(resolveVersionFallback("1.0.0-rc.1")).toBe("1.0.0-rc.1");
+    });
+
+    it("returns a v-prefixed version as-is (stripping is handled elsewhere)", () => {
+        expect(resolveVersionFallback("v2.0.0")).toBe("v2.0.0");
+    });
+});

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -350,9 +350,11 @@ export async function runRemoteGenerationForGenerator({
     // (e.g. GitHub push modes where no registry publish or release tag occurs).
     // Skip the fallback when the version is AUTO — Fiddle determines the real version
     // via AI-based semantic analysis, and resolvedVersion would be the literal "AUTO" string.
-    const isAutoVersioning = resolvedVersion?.toUpperCase() === "AUTO";
-    if (result != null && result.actualVersion == null && resolvedVersion != null && !isAutoVersioning) {
-        result = { ...result, actualVersion: resolvedVersion };
+    if (result != null && result.actualVersion == null) {
+        const fallback = resolveVersionFallback(resolvedVersion);
+        if (fallback != null) {
+            result = { ...result, actualVersion: fallback };
+        }
     }
 
     // use the actual version from the generation result, fallback to pre-computed version
@@ -518,4 +520,19 @@ async function uploadDynamicIRForSdkGeneration({
     } else {
         context.logger.warn(`Failed to upload dynamic IR for ${language}: ${uploadResponse.status}`);
     }
+}
+
+/**
+ * Returns `resolvedVersion` when it is a concrete version string that should be
+ * used as fallback. Returns `undefined` when the version is AUTO (Fiddle owns
+ * the final version) or when no version was provided at all.
+ */
+export function resolveVersionFallback(resolvedVersion: string | undefined): string | undefined {
+    if (resolvedVersion == null) {
+        return undefined;
+    }
+    if (resolvedVersion.toUpperCase() === "AUTO") {
+        return undefined;
+    }
+    return resolvedVersion;
 }

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -339,12 +339,21 @@ export async function runRemoteGenerationForGenerator({
         absolutePathToPreview
     });
 
-    const result = await pollJobAndReportStatus({
+    let result = await pollJobAndReportStatus({
         job,
         taskHandler,
         taskId,
         context: interactiveTaskContext
     });
+
+    // Fall back to the locally-resolved version when Fiddle doesn't echo it back
+    // (e.g. GitHub push modes where no registry publish or release tag occurs).
+    // Skip the fallback when the version is AUTO — Fiddle determines the real version
+    // via AI-based semantic analysis, and resolvedVersion would be the literal "AUTO" string.
+    const isAutoVersioning = resolvedVersion?.toUpperCase() === "AUTO";
+    if (result != null && result.actualVersion == null && resolvedVersion != null && !isAutoVersioning) {
+        result = { ...result, actualVersion: resolvedVersion };
+    }
 
     // use the actual version from the generation result, fallback to pre-computed version
     const actualVersionForUpload = result?.actualVersion ?? resolvedVersion;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ catalogs:
       specifier: ^0.0.5297
       version: 0.0.5297
     '@fern-fern/fiddle-sdk':
-      specifier: 0.0.82
-      version: 0.0.82
+      specifier: 0.0.85
+      version: 0.0.85
     '@fern-fern/generator-exec-sdk':
       specifier: ^0.0.1167
       version: 0.0.1167
@@ -4435,7 +4435,7 @@ importers:
         version: link:../workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.82
+        version: 0.0.85
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -4856,7 +4856,7 @@ importers:
         version: link:../yaml/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.82
+        version: 0.0.85
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -4979,7 +4979,7 @@ importers:
         version: link:../../commons/path-utils
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.82
+        version: 0.0.85
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -5022,7 +5022,7 @@ importers:
         version: link:../task-context
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.82
+        version: 0.0.85
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -6120,7 +6120,7 @@ importers:
         version: link:../../../workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.82
+        version: 0.0.85
       '@fern-fern/generator-exec-sdk':
         specifier: 'catalog:'
         version: 0.0.1167
@@ -6277,7 +6277,7 @@ importers:
         version: link:../../../workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.82
+        version: 0.0.85
       axios:
         specifier: 'catalog:'
         version: 1.15.0
@@ -7011,7 +7011,7 @@ importers:
         version: link:../../api-importers/v3-importer-commons
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.82
+        version: 0.0.85
       '@open-rpc/meta-schema':
         specifier: 'catalog:'
         version: 1.14.9
@@ -7443,7 +7443,7 @@ importers:
         version: link:../../cli/task-context
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.82
+        version: 0.0.85
       '@redocly/openapi-core':
         specifier: 'catalog:'
         version: 1.34.11
@@ -7845,7 +7845,7 @@ importers:
         version: 0.0.5297
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.82
+        version: 0.0.85
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -8089,7 +8089,7 @@ importers:
         version: link:../cli/workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.82
+        version: 0.0.85
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -9426,8 +9426,8 @@ packages:
   '@fern-fern/fdr-test-sdk@0.0.5297':
     resolution: {integrity: sha512-jrZUZ6oIA64LHtrv77xEq0X7qJhT9xRMGWhKcLjIUArMsD7h6KMWUHVdoB/1MP0Mz/uL/E2xmM31SOgJicpIcA==}
 
-  '@fern-fern/fiddle-sdk@0.0.82':
-    resolution: {integrity: sha512-HPrra4JNDlJz/I8qWwBXaloJa2da513dSZwQh65vEHQLFRpoV2cDLwX9YV4s5QPDZMZqWOoOBEsL7byB26EtIA==}
+  '@fern-fern/fiddle-sdk@0.0.85':
+    resolution: {integrity: sha512-+Lqha8blDhUlb0vsEpMoZ5pXS3C94dTMvpacCmkL97Bbcs1RdA1F4I1sKE3ube+piMPMA3K9RdFNI7eGEsnVsA==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/generator-cli-sdk@0.1.8':
@@ -16483,7 +16483,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@fern-fern/fiddle-sdk@0.0.82': {}
+  '@fern-fern/fiddle-sdk@0.0.85': {}
 
   '@fern-fern/generator-cli-sdk@0.1.8':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,7 +64,7 @@ catalog:
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80
   "@fern-fern/fdr-test-sdk": ^0.0.5297
-  "@fern-fern/fiddle-sdk": 0.0.82
+  "@fern-fern/fiddle-sdk": 0.0.85
   "@fern-fern/generator-exec-sdk": ^0.0.1167
   "@fern-fern/generators-sdk": 0.114.0-5745f9e74
   "@fern-fern/ir-v53-sdk": 1.0.1


### PR DESCRIPTION
## Description

Fix `fern automations generate` step summary not displaying SDK versions in the table. Consumes the new `actualVersion` field from Fiddle's `FinishedTaskStatus` API (added in https://github.com/fern-api/fiddle/pull/715).

## Changes Made

1. **Upgraded `@fern-fern/fiddle-sdk`** from `0.0.82` → `0.0.85` to consume the new `actualVersion` field on `FinishedTaskStatus`.

2. **`RemoteTaskHandler.ts`** — Three improvements:
   - **Extracted `extractVersionFromLogMessage()`**: Testable function for log-regex version parsing.
   - **Improved version regex**: `/Tagging release (\d+\.\d+\.\d+)/` → `/Tagging release (v?\d+\.\d+\.\d+(?:-[\w.]+)?)/` to capture v-prefixed versions (Go) and pre-release suffixes, with v-prefix stripping.
   - **Prefer `finishedStatus.actualVersion`**: When Fiddle returns the dedicated `actualVersion` field, it overrides log-regex and registry-coordinate heuristics.

3. **`runRemoteGenerationForGenerator.ts`** — Two improvements:
   - **Extracted `resolveVersionFallback()`**: Testable function that returns the locally-resolved version for explicit versioning, `undefined` for AUTO.
   - **Added fallback for explicit versioning**: When Fiddle doesn't echo back a version (e.g. older Fiddle deployment, or GitHub push modes), falls back to the locally-resolved version. Skips the fallback when `resolvedVersion` is `"AUTO"`.

4. **Unit tests** (2 new test files, 17 test cases):
   - `extractVersionFromLogMessage.test.ts`: Regex matching, v-prefix stripping, pre-release suffixes, edge cases
   - `resolveVersionFallback.test.ts`: Explicit version passthrough, AUTO exclusion (case-insensitive), undefined handling

**Version resolution priority (highest → lowest):**
1. `finishedStatus.actualVersion` (new Fiddle API field)
2. `remoteTask.packages[0].coordinate` (registry publishers)
3. Log parsing regex `"Tagging release X.Y.Z"` (release tags)
4. Locally-resolved `resolvedVersion` (fallback, excluded for AUTO)

- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added (12 test files, 117 tests all passing)
- [x] Lint checks pass (`pnpm run check`)
- [x] Format checks pass (`pnpm format`)
- [x] Pre-commit hooks pass

Companion Fiddle PR (merged): https://github.com/fern-api/fiddle/pull/715

Link to Devin session: https://app.devin.ai/sessions/762ac0c471f142378dde5683a304c00c
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
