### PR TITLE
fix(docs): serve translated page content in fern docs dev

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-docs-dev-localization.yml
+++ b/packages/cli/cli/changes/unreleased/fix-docs-dev-localization.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix `fern docs dev` to serve translated page content when viewing localized pages.
+  type: fix

--- a/packages/cli/docs-preview/src/createBunServer.ts
+++ b/packages/cli/docs-preview/src/createBunServer.ts
@@ -34,7 +34,12 @@ interface BunNamespace {
 export interface BunServerOptions {
     port: number;
     debugLogger: DebugLogger;
-    getDocsLoadResponse(): DocsV2Read.LoadDocsForUrlResponse;
+    getDocsLoadResponse(locale?: string): DocsV2Read.LoadDocsForUrlResponse;
+    /**
+     * Extracts the locale from a URL path.
+     * E.g., "/fr/getting-started" -> "fr", "/getting-started" -> undefined
+     */
+    extractLocaleFromPath?(urlPath: string | undefined): string | undefined;
 }
 
 export interface BunServer {
@@ -52,7 +57,7 @@ export function createBunServer(options: BunServerOptions): BunServer | undefine
         return undefined;
     }
 
-    const { port, debugLogger, getDocsLoadResponse } = options;
+    const { port, debugLogger, getDocsLoadResponse, extractLocaleFromPath } = options;
 
     type WsData = { connectionId: string };
     const connections = new Map<BunServerWebSocket<WsData>, { pingInterval: NodeJS.Timeout; lastPong: number }>();
@@ -93,9 +98,22 @@ export function createBunServer(options: BunServerOptions): BunServer | undefine
 
             // POST /v2/registry/docs/load-with-url
             if (req.method === "POST" && url.pathname === "/v2/registry/docs/load-with-url") {
-                return new Response(JSON.stringify(getDocsLoadResponse()), {
-                    headers: { "Content-Type": "application/json", ...CORS_HEADERS }
-                });
+                // Parse request body to extract locale from URL if present
+                return req
+                    .json()
+                    .then((body: { url?: string } | undefined) => {
+                        const urlPath = body?.url;
+                        const locale = extractLocaleFromPath?.(urlPath);
+                        return new Response(JSON.stringify(getDocsLoadResponse(locale)), {
+                            headers: { "Content-Type": "application/json", ...CORS_HEADERS }
+                        });
+                    })
+                    .catch(() => {
+                        // If JSON parsing fails, just return the default response
+                        return new Response(JSON.stringify(getDocsLoadResponse()), {
+                            headers: { "Content-Type": "application/json", ...CORS_HEADERS }
+                        });
+                    });
             }
 
             // GET /_local/...

--- a/packages/cli/docs-preview/src/createBunServer.ts
+++ b/packages/cli/docs-preview/src/createBunServer.ts
@@ -83,7 +83,7 @@ export function createBunServer(options: BunServerOptions): BunServer | undefine
 
     const server = bun.serve<WsData>({
         port,
-        fetch(req, bunHttpServer) {
+        async fetch(req, bunHttpServer) {
             if (req.method === "OPTIONS") {
                 return new Response(null, { status: 204, headers: CORS_HEADERS });
             }
@@ -98,22 +98,18 @@ export function createBunServer(options: BunServerOptions): BunServer | undefine
 
             // POST /v2/registry/docs/load-with-url
             if (req.method === "POST" && url.pathname === "/v2/registry/docs/load-with-url") {
-                // Parse request body to extract locale from URL if present
-                return req
-                    .json()
-                    .then((body: { url?: string } | undefined) => {
-                        const urlPath = body?.url;
-                        const locale = extractLocaleFromPath?.(urlPath);
-                        return new Response(JSON.stringify(getDocsLoadResponse(locale)), {
-                            headers: { "Content-Type": "application/json", ...CORS_HEADERS }
-                        });
-                    })
-                    .catch(() => {
-                        // If JSON parsing fails, just return the default response
-                        return new Response(JSON.stringify(getDocsLoadResponse()), {
-                            headers: { "Content-Type": "application/json", ...CORS_HEADERS }
-                        });
+                try {
+                    const body = (await req.json()) as { url?: string } | undefined;
+                    const locale = extractLocaleFromPath?.(body?.url);
+                    return new Response(JSON.stringify(getDocsLoadResponse(locale)), {
+                        headers: { "Content-Type": "application/json", ...CORS_HEADERS }
                     });
+                } catch {
+                    // If JSON parsing fails, just return the default response
+                    return new Response(JSON.stringify(getDocsLoadResponse()), {
+                        headers: { "Content-Type": "application/json", ...CORS_HEADERS }
+                    });
+                }
             }
 
             // GET /_local/...

--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -22,7 +22,13 @@ import {
     FernNavigation,
     SDKSnippetHolder
 } from "@fern-api/fdr-sdk";
-import { AbsoluteFilePath, convertToFernHostAbsoluteFilePath, doesPathExist, relative } from "@fern-api/fs-utils";
+import {
+    AbsoluteFilePath,
+    convertToFernHostAbsoluteFilePath,
+    doesPathExist,
+    RelativeFilePath,
+    relative
+} from "@fern-api/fs-utils";
 import { IntermediateRepresentation } from "@fern-api/ir-sdk";
 import { getOriginalName } from "@fern-api/ir-utils";
 import { Project } from "@fern-api/project-loader";
@@ -114,19 +120,47 @@ function extractFrontmatterSlug(markdown: string): string | undefined {
     }
 }
 
+/**
+ * Result from getPreviewDocsDefinition that includes both the docs definition
+ * and data needed to compute translated definitions for each locale.
+ */
+export interface PreviewDocsResult {
+    docsDefinition: DocsV1Read.DocsDefinition;
+    /**
+     * Per-locale translated page content from translations/<lang>/ directories.
+     * Key is locale (e.g., "fr", "ja"), value is a map of page path to raw markdown.
+     */
+    translationPages: Record<string, Record<RelativeFilePath, string>> | undefined;
+    /**
+     * File IDs collected during docs resolution, needed for image path replacement
+     * in translated pages.
+     */
+    collectedFileIds: ReadonlyMap<AbsoluteFilePath, string>;
+    /**
+     * Absolute path to the fern docs workspace folder.
+     */
+    docsWorkspacePath: AbsoluteFilePath;
+}
+
 export async function getPreviewDocsDefinition({
     domain,
     project,
     context,
     previousDocsDefinition,
-    editedAbsoluteFilepaths
+    editedAbsoluteFilepaths,
+    previousPreviewResult
 }: {
     domain: string;
     project: Project;
     context: TaskContext;
     previousDocsDefinition?: DocsV1Read.DocsDefinition;
     editedAbsoluteFilepaths?: AbsoluteFilePath[];
-}): Promise<DocsV1Read.DocsDefinition> {
+    /**
+     * Previous preview result (for incremental updates).
+     * This is used to preserve translation data during incremental page updates.
+     */
+    previousPreviewResult?: PreviewDocsResult;
+}): Promise<PreviewDocsResult> {
     const docsWorkspace = project.docsWorkspaces;
     const apiWorkspaces = project.apiWorkspaces;
     if (docsWorkspace == null) {
@@ -249,8 +283,14 @@ export async function getPreviewDocsDefinition({
             };
         }
 
-        if (allMarkdownFiles && !navAffectingChange) {
-            return previousDocsDefinition;
+        if (allMarkdownFiles && !navAffectingChange && previousPreviewResult != null) {
+            // Return updated definition with preserved translation data
+            return {
+                docsDefinition: previousDocsDefinition,
+                translationPages: previousPreviewResult.translationPages,
+                collectedFileIds: previousPreviewResult.collectedFileIds,
+                docsWorkspacePath: previousPreviewResult.docsWorkspacePath
+            };
         }
     }
 
@@ -336,7 +376,16 @@ export async function getPreviewDocsDefinition({
         docsDefinition = { ...substitutedDocs, jsFiles };
     }
 
-    return docsDefinition;
+    // Get translation pages and collected file IDs for building translated definitions
+    const translationPages = resolver.getTranslationPages();
+    const collectedFileIds = resolver.getCollectedFileIds();
+
+    return {
+        docsDefinition,
+        translationPages,
+        collectedFileIds,
+        docsWorkspacePath: docsWorkspace.absoluteFilePath
+    };
 }
 
 async function applyGlobalThemeIfNeeded(

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -1,5 +1,10 @@
 import { extractErrorMessage } from "@fern-api/core-utils";
-import { wrapWithHttps } from "@fern-api/docs-resolver";
+import {
+    applyTranslatedFrontmatterToNavTree,
+    replaceImagePathsAndUrls,
+    stripMdxComments,
+    wrapWithHttps
+} from "@fern-api/docs-resolver";
 import { DocsV1Read, DocsV2Read, FernNavigation } from "@fern-api/fdr-sdk";
 import { AbsoluteFilePath, dirname, doesPathExist, listFiles, RelativeFilePath, resolve } from "@fern-api/fs-utils";
 import { runExeca } from "@fern-api/logging-execa";
@@ -21,7 +26,7 @@ import { type BunServer, createBunServer } from "./createBunServer.js";
 import { DebugLogger } from "./DebugLogger.js";
 import { downloadBundle, getPathToBundleFolder, getPathToPreviewFolder } from "./downloadLocalDocsBundle.js";
 import { writeNodePolyfillScript } from "./nodePolyfills.js";
-import { getPreviewDocsDefinition } from "./previewDocs.js";
+import { getPreviewDocsDefinition, type PreviewDocsResult } from "./previewDocs.js";
 
 const EMPTY_DOCS_DEFINITION: DocsV1Read.DocsDefinition = {
     pages: {},
@@ -685,7 +690,9 @@ export async function runAppPreviewServer({
     );
 
     let project = initialProject;
-    let docsDefinition: DocsV1Read.DocsDefinition | undefined;
+    let previewResult: PreviewDocsResult | undefined;
+    // Pre-computed translated definitions for each locale (excluding default)
+    let translatedDefinitions: Map<string, DocsV1Read.DocsDefinition> = new Map();
 
     // Initialize the snippet dependency tracker
     const snippetTracker = new SnippetDependencyTracker(context);
@@ -697,6 +704,87 @@ export async function runAppPreviewServer({
     let reloadTimer: NodeJS.Timeout | null = null;
     let isReloading = false;
     const RELOAD_DEBOUNCE_MS = 1000;
+
+    /**
+     * Computes translated definitions for each locale.
+     * Similar to what publishDocs.ts does for production, but for local preview.
+     */
+    function computeTranslatedDefinitions(result: PreviewDocsResult): Map<string, DocsV1Read.DocsDefinition> {
+        const translations = new Map<string, DocsV1Read.DocsDefinition>();
+        const { docsDefinition, translationPages, collectedFileIds, docsWorkspacePath } = result;
+
+        if (translationPages == null || Object.keys(translationPages).length === 0) {
+            return translations;
+        }
+
+        const defaultLocale = docsDefinition.config.translations?.defaultLocale;
+
+        for (const [locale, localePages] of Object.entries(translationPages)) {
+            // Skip the default locale - we use the base definition for that
+            if (locale === defaultLocale) {
+                continue;
+            }
+
+            try {
+                // Build translated pages by merging base pages with locale-specific pages
+                // Start by copying all defined pages from the base definition
+                const translatedPages: Record<string, DocsV1Read.PageContent> = {};
+                for (const [pageId, page] of Object.entries(docsDefinition.pages)) {
+                    if (page != null) {
+                        translatedPages[pageId] = page;
+                    }
+                }
+
+                for (const [pagePath, rawMarkdown] of Object.entries(localePages)) {
+                    const basePage = translatedPages[pagePath];
+                    // Strip MDX comments first
+                    let processedMarkdown = stripMdxComments(rawMarkdown);
+                    // Replace image paths using collected file IDs
+                    const absolutePathToMarkdownFile = resolve(docsWorkspacePath, RelativeFilePath.of(pagePath));
+                    processedMarkdown = replaceImagePathsAndUrls(
+                        processedMarkdown,
+                        collectedFileIds,
+                        {}, // markdownFilesToPathName not needed for translations
+                        {
+                            absolutePathToMarkdownFile,
+                            absolutePathToFernFolder: docsWorkspacePath
+                        },
+                        context
+                    );
+
+                    translatedPages[pagePath] = {
+                        markdown: processedMarkdown,
+                        rawMarkdown: processedMarkdown,
+                        editThisPageUrl: basePage?.editThisPageUrl,
+                        editThisPageLaunch: basePage?.editThisPageLaunch
+                    };
+                }
+
+                // Apply translated frontmatter to nav tree
+                const updatedRoot = applyTranslatedFrontmatterToNavTree(
+                    docsDefinition.config.root,
+                    localePages as Record<string, string>,
+                    context
+                );
+
+                const translatedDefinition: DocsV1Read.DocsDefinition = {
+                    ...docsDefinition,
+                    pages: translatedPages,
+                    config: {
+                        ...docsDefinition.config,
+                        root: updatedRoot
+                    }
+                };
+
+                translations.set(locale, translatedDefinition);
+                context.logger.debug(`Computed translated definition for locale "${locale}"`);
+            } catch (error) {
+                context.logger.warn(`Failed to compute translation for locale "${locale}": ${String(error)}`);
+            }
+        }
+
+        return translations;
+    }
 
     const reloadDocsDefinition = async (editedAbsoluteFilepaths?: AbsoluteFilePath[]) => {
         context.logger.info("Reloading docs...");
@@ -729,12 +817,13 @@ export async function runAppPreviewServer({
                 });
 
             const docsGenStartTime = Date.now();
-            const newDocsDefinition = await getPreviewDocsDefinition({
+            const newPreviewResult = await getPreviewDocsDefinition({
                 domain: `${instance.host}${instance.pathname}`,
                 project,
                 context,
-                previousDocsDefinition: docsDefinition,
-                editedAbsoluteFilepaths
+                previousDocsDefinition: previewResult?.docsDefinition,
+                editedAbsoluteFilepaths,
+                previousPreviewResult: previewResult
             });
             const docsGenTime = Date.now() - docsGenStartTime;
 
@@ -753,7 +842,7 @@ export async function runAppPreviewServer({
             });
             void debugLogger.logCliMemory();
 
-            return newDocsDefinition;
+            return newPreviewResult;
         } catch (err) {
             const totalTime = Date.now() - startTime;
 
@@ -764,7 +853,7 @@ export async function runAppPreviewServer({
             });
             void debugLogger.logCliMemory();
 
-            if (docsDefinition == null) {
+            if (previewResult == null) {
                 context.logger.error("Failed to read docs configuration. Rendering blank page.");
             } else {
                 context.logger.error("Failed to read docs configuration. Rendering last successful configuration.");
@@ -775,15 +864,23 @@ export async function runAppPreviewServer({
                     context.logger.debug(`Stack Trace:\n${err.stack}`);
                 }
             }
-            return docsDefinition;
+            return previewResult;
         }
     };
 
-    docsDefinition = await reloadDocsDefinition();
+    previewResult = await reloadDocsDefinition();
+
+    // Compute translated definitions after loading
+    if (previewResult != null) {
+        translatedDefinitions = computeTranslatedDefinitions(previewResult);
+        if (translatedDefinitions.size > 0) {
+            context.logger.info(`Computed translations for ${translatedDefinitions.size} locale(s)`);
+        }
+    }
 
     // Initialize slug mappings from the initial docs definition
-    if (docsDefinition) {
-        slugTracker.initialize(docsDefinition);
+    if (previewResult?.docsDefinition) {
+        slugTracker.initialize(previewResult.docsDefinition);
     }
 
     const additionalFilepaths = project.apiWorkspaces.flatMap((workspace) => workspace.getAbsoluteFilePaths());
@@ -798,10 +895,44 @@ export async function runAppPreviewServer({
 
     const editedAbsoluteFilepaths: AbsoluteFilePath[] = [];
 
-    function buildDocsLoadResponse(): DocsV2Read.LoadDocsForUrlResponse {
+    /**
+     * Extracts the locale from a URL path.
+     * E.g., "/fr/getting-started" -> "fr", "/getting-started" -> undefined
+     */
+    function extractLocaleFromPath(urlPath: string | undefined): string | undefined {
+        if (urlPath == null) {
+            return undefined;
+        }
+        const defaultLocale = previewResult?.docsDefinition.config.translations?.defaultLocale;
+        const availableLocales = previewResult?.docsDefinition.config.translations?.translations;
+
+        if (availableLocales == null || availableLocales.length === 0) {
+            return undefined;
+        }
+
+        // Check if path starts with a locale prefix
+        const pathParts = urlPath.split("/").filter((p) => p.length > 0);
+        if (pathParts.length > 0) {
+            const firstPart = pathParts[0];
+            if (firstPart != null && availableLocales.includes(firstPart) && firstPart !== defaultLocale) {
+                return firstPart;
+            }
+        }
+        return undefined;
+    }
+
+    function buildDocsLoadResponse(locale?: string): DocsV2Read.LoadDocsForUrlResponse {
         // Fall back to empty definition if the initial load failed
-        const definition = docsDefinition ?? EMPTY_DOCS_DEFINITION;
-        const translationsConfig = definition.config.translations;
+        const baseDefinition = previewResult?.docsDefinition ?? EMPTY_DOCS_DEFINITION;
+
+        // Use translated definition if available for the requested locale
+        let definition = baseDefinition;
+        if (locale != null && translatedDefinitions.has(locale)) {
+            definition = translatedDefinitions.get(locale) ?? baseDefinition;
+            context.logger.debug(`Serving translated definition for locale "${locale}"`);
+        }
+
+        const translationsConfig = baseDefinition.config.translations;
         return {
             baseUrl: { domain: instance.host, basePath: instance.pathname },
             definition,
@@ -813,10 +944,18 @@ export async function runAppPreviewServer({
         };
     }
 
+    // Parse JSON body middleware for the load-with-url endpoint
+    app.use(express.json());
+
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    app.post("/v2/registry/docs/load-with-url", async (_, res) => {
+    app.post("/v2/registry/docs/load-with-url", async (req, res) => {
         try {
-            res.send(buildDocsLoadResponse());
+            // Extract locale from the request body URL if present
+            const requestBody = req.body as { url?: string } | undefined;
+            const urlPath = requestBody?.url;
+            const locale = extractLocaleFromPath(urlPath);
+
+            res.send(buildDocsLoadResponse(locale));
         } catch (error) {
             context.logger.error("Stack trace:", (error as Error).stack ?? "");
             context.logger.error("Error loading docs", (error as Error).message);
@@ -832,7 +971,12 @@ export async function runAppPreviewServer({
     //
     // In Bun, http.createServer does not emit the 'upgrade' event that
     // the ws package relies on (re: oven-sh/bun#5951).
-    const bunHandle = createBunServer({ port: backendPort, debugLogger, getDocsLoadResponse: buildDocsLoadResponse });
+    const bunHandle = createBunServer({
+        port: backendPort,
+        debugLogger,
+        getDocsLoadResponse: buildDocsLoadResponse,
+        extractLocaleFromPath
+    });
     if (bunHandle != null) {
         sendData = bunHandle.sendData;
         bunServer = bunHandle;
@@ -968,7 +1112,7 @@ export async function runAppPreviewServer({
                     type: "startReload"
                 });
 
-                const reloadedDocsDefinition = await reloadDocsDefinition(filesToReload);
+                const reloadedPreviewResult = await reloadDocsDefinition(filesToReload);
 
                 editedAbsoluteFilepaths.length = 0;
 
@@ -979,11 +1123,17 @@ export async function runAppPreviewServer({
                     type: "finishReload"
                 });
 
-                if (reloadedDocsDefinition != null) {
+                if (reloadedPreviewResult != null) {
                     // Detect slug changes before updating the docs definition
-                    const slugChanges = slugTracker.updateAndDetectChanges(reloadedDocsDefinition);
+                    const slugChanges = slugTracker.updateAndDetectChanges(reloadedPreviewResult.docsDefinition);
 
-                    docsDefinition = reloadedDocsDefinition;
+                    previewResult = reloadedPreviewResult;
+
+                    // Recompute translated definitions
+                    translatedDefinitions = computeTranslatedDefinitions(reloadedPreviewResult);
+                    if (translatedDefinitions.size > 0) {
+                        context.logger.debug(`Recomputed translations for ${translatedDefinitions.size} locale(s)`);
+                    }
 
                     // Send navigateToSlug events for any slug changes
                     if (slugChanges.length > 0) {

--- a/packages/cli/docs-preview/src/runPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runPreviewServer.ts
@@ -1,6 +1,11 @@
-import { wrapWithHttps } from "@fern-api/docs-resolver";
+import {
+    applyTranslatedFrontmatterToNavTree,
+    replaceImagePathsAndUrls,
+    stripMdxComments,
+    wrapWithHttps
+} from "@fern-api/docs-resolver";
 import { DocsV1Read, DocsV2Read, FernNavigation } from "@fern-api/fdr-sdk";
-import { AbsoluteFilePath, dirname, doesPathExist } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, dirname, doesPathExist, RelativeFilePath, resolve } from "@fern-api/fs-utils";
 import { Project } from "@fern-api/project-loader";
 import { CliError, TaskContext } from "@fern-api/task-context";
 
@@ -13,7 +18,7 @@ import Watcher from "watcher";
 import { type WebSocket, WebSocketServer } from "ws";
 
 import { downloadBundle, getPathToBundleFolder } from "./downloadLocalDocsBundle.js";
-import { getPreviewDocsDefinition } from "./previewDocs.js";
+import { getPreviewDocsDefinition, type PreviewDocsResult } from "./previewDocs.js";
 
 const EMPTY_DOCS_DEFINITION: DocsV1Read.DocsDefinition = {
     pages: {},
@@ -126,11 +131,93 @@ export async function runPreviewServer({
     );
 
     let project = initialProject;
-    let docsDefinition: DocsV1Read.DocsDefinition | undefined;
+    let previewResult: PreviewDocsResult | undefined;
+    // Pre-computed translated definitions for each locale (excluding default)
+    let translatedDefinitions: Map<string, DocsV1Read.DocsDefinition> = new Map();
 
     let reloadTimer: NodeJS.Timeout | null = null;
     let isReloading = false;
     const RELOAD_DEBOUNCE_MS = 1000;
+
+    /**
+     * Computes translated definitions for each locale.
+     */
+    function computeTranslatedDefinitions(result: PreviewDocsResult): Map<string, DocsV1Read.DocsDefinition> {
+        const translations = new Map<string, DocsV1Read.DocsDefinition>();
+        const { docsDefinition, translationPages, collectedFileIds, docsWorkspacePath } = result;
+
+        if (translationPages == null || Object.keys(translationPages).length === 0) {
+            return translations;
+        }
+
+        const defaultLocale = docsDefinition.config.translations?.defaultLocale;
+
+        for (const [locale, localePages] of Object.entries(translationPages)) {
+            // Skip the default locale - we use the base definition for that
+            if (locale === defaultLocale) {
+                continue;
+            }
+
+            try {
+                // Build translated pages by merging base pages with locale-specific pages
+                // Start by copying all defined pages from the base definition
+                const translatedPages: Record<string, DocsV1Read.PageContent> = {};
+                for (const [pageId, page] of Object.entries(docsDefinition.pages)) {
+                    if (page != null) {
+                        translatedPages[pageId] = page;
+                    }
+                }
+
+                for (const [pagePath, rawMarkdown] of Object.entries(localePages)) {
+                    const basePage = translatedPages[pagePath];
+                    // Strip MDX comments first
+                    let processedMarkdown = stripMdxComments(rawMarkdown);
+                    // Replace image paths using collected file IDs
+                    const absolutePathToMarkdownFile = resolve(docsWorkspacePath, RelativeFilePath.of(pagePath));
+                    processedMarkdown = replaceImagePathsAndUrls(
+                        processedMarkdown,
+                        collectedFileIds,
+                        {}, // markdownFilesToPathName not needed for translations
+                        {
+                            absolutePathToMarkdownFile,
+                            absolutePathToFernFolder: docsWorkspacePath
+                        },
+                        context
+                    );
+
+                    translatedPages[pagePath] = {
+                        markdown: processedMarkdown,
+                        rawMarkdown: processedMarkdown,
+                        editThisPageUrl: basePage?.editThisPageUrl,
+                        editThisPageLaunch: basePage?.editThisPageLaunch
+                    };
+                }
+
+                // Apply translated frontmatter to nav tree
+                const updatedRoot = applyTranslatedFrontmatterToNavTree(
+                    docsDefinition.config.root,
+                    localePages as Record<string, string>,
+                    context
+                );
+
+                const translatedDefinition: DocsV1Read.DocsDefinition = {
+                    ...docsDefinition,
+                    pages: translatedPages,
+                    config: {
+                        ...docsDefinition.config,
+                        root: updatedRoot
+                    }
+                };
+
+                translations.set(locale, translatedDefinition);
+                context.logger.debug(`Computed translated definition for locale "${locale}"`);
+            } catch (error) {
+                context.logger.warn(`Failed to compute translation for locale "${locale}": ${String(error)}`);
+            }
+        }
+
+        return translations;
+    }
 
     const reloadDocsDefinition = async (editedAbsoluteFilepaths?: AbsoluteFilePath[]) => {
         context.logger.info("Reloading docs...");
@@ -139,17 +226,18 @@ export async function runPreviewServer({
             project = await reloadProject();
             context.logger.info("Validating docs...");
             await validateProject(project);
-            const newDocsDefinition = await getPreviewDocsDefinition({
+            const newPreviewResult = await getPreviewDocsDefinition({
                 domain: `${instance.host}${instance.pathname}`,
                 project,
                 context,
-                previousDocsDefinition: docsDefinition,
-                editedAbsoluteFilepaths
+                previousDocsDefinition: previewResult?.docsDefinition,
+                editedAbsoluteFilepaths,
+                previousPreviewResult: previewResult
             });
             context.logger.info(`Reload completed in ${Date.now() - startTime}ms`);
-            return newDocsDefinition;
+            return newPreviewResult;
         } catch (err) {
-            if (docsDefinition == null) {
+            if (previewResult == null) {
                 context.logger.error("Failed to read docs configuration. Rendering blank page.");
             } else {
                 context.logger.error("Failed to read docs configuration. Rendering last successful configuration.");
@@ -160,12 +248,20 @@ export async function runPreviewServer({
                     context.logger.debug(`Stack Trace:\n${err.stack}`);
                 }
             }
-            return docsDefinition;
+            return previewResult;
         }
     };
 
     // initialize docs definition
-    docsDefinition = await reloadDocsDefinition();
+    previewResult = await reloadDocsDefinition();
+
+    // Compute translated definitions after loading
+    if (previewResult != null) {
+        translatedDefinitions = computeTranslatedDefinitions(previewResult);
+        if (translatedDefinitions.size > 0) {
+            context.logger.info(`Computed translations for ${translatedDefinitions.size} locale(s)`);
+        }
+    }
 
     const additionalFilepaths = project.apiWorkspaces.flatMap((workspace) => workspace.getAbsoluteFilePaths());
     const bundleRoot = bundlePath ? AbsoluteFilePath.of(path.resolve(bundlePath)) : getPathToBundleFolder({});
@@ -204,9 +300,14 @@ export async function runPreviewServer({
                     type: "startReload"
                 });
 
-                const reloadedDocsDefinition = await reloadDocsDefinition(editedAbsoluteFilepaths);
-                if (reloadedDocsDefinition != null) {
-                    docsDefinition = reloadedDocsDefinition;
+                const reloadedPreviewResult = await reloadDocsDefinition(editedAbsoluteFilepaths);
+                if (reloadedPreviewResult != null) {
+                    previewResult = reloadedPreviewResult;
+                    // Recompute translated definitions
+                    translatedDefinitions = computeTranslatedDefinitions(reloadedPreviewResult);
+                    if (translatedDefinitions.size > 0) {
+                        context.logger.debug(`Recomputed translations for ${translatedDefinitions.size} locale(s)`);
+                    }
                 }
 
                 editedAbsoluteFilepaths.length = 0;
@@ -220,12 +321,55 @@ export async function runPreviewServer({
         }, RELOAD_DEBOUNCE_MS);
     });
 
+    /**
+     * Extracts the locale from a URL path.
+     * E.g., "/fr/getting-started" -> "fr", "/getting-started" -> undefined
+     */
+    function extractLocaleFromPath(urlPath: string | undefined): string | undefined {
+        if (urlPath == null) {
+            return undefined;
+        }
+        const baseDefinition = previewResult?.docsDefinition;
+        const defaultLocale = baseDefinition?.config.translations?.defaultLocale;
+        const availableLocales = baseDefinition?.config.translations?.translations;
+
+        if (availableLocales == null || availableLocales.length === 0) {
+            return undefined;
+        }
+
+        // Check if path starts with a locale prefix
+        const pathParts = urlPath.split("/").filter((p) => p.length > 0);
+        if (pathParts.length > 0) {
+            const firstPart = pathParts[0];
+            if (firstPart != null && availableLocales.includes(firstPart) && firstPart !== defaultLocale) {
+                return firstPart;
+            }
+        }
+        return undefined;
+    }
+
+    // Parse JSON body middleware
+    app.use(express.json());
+
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    app.post("/v2/registry/docs/load-with-url", async (_, res) => {
+    app.post("/v2/registry/docs/load-with-url", async (req, res) => {
         try {
-            // set to empty in case docsDefinition is null which happens when the initial docs definition is invalid
-            const definition = docsDefinition ?? EMPTY_DOCS_DEFINITION;
-            const translationsConfig = definition.config.translations;
+            // set to empty in case previewResult is null which happens when the initial docs definition is invalid
+            const baseDefinition = previewResult?.docsDefinition ?? EMPTY_DOCS_DEFINITION;
+
+            // Extract locale from the request body URL if present
+            const requestBody = req.body as { url?: string } | undefined;
+            const urlPath = requestBody?.url;
+            const locale = extractLocaleFromPath(urlPath);
+
+            // Use translated definition if available for the requested locale
+            let definition = baseDefinition;
+            if (locale != null && translatedDefinitions.has(locale)) {
+                definition = translatedDefinitions.get(locale) ?? baseDefinition;
+                context.logger.debug(`Serving translated definition for locale "${locale}"`);
+            }
+
+            const translationsConfig = baseDefinition.config.translations;
             const response: DocsV2Read.LoadDocsForUrlResponse = {
                 baseUrl: {
                     domain: instance.host,
@@ -251,8 +395,8 @@ export async function runPreviewServer({
 
         // Build a set of allowed file paths from the docs definition
         const allowedPaths = new Set<string>();
-        if (docsDefinition?.filesV2) {
-            for (const file of Object.values(docsDefinition.filesV2)) {
+        if (previewResult?.docsDefinition?.filesV2) {
+            for (const file of Object.values(previewResult.docsDefinition.filesV2)) {
                 if (file != null && file.type === "url") {
                     const urlPath = file.url.replace(/^\/_local/, "");
                     allowedPaths.add(urlPath);


### PR DESCRIPTION
## Summary

- Fixes issue where `fern docs dev` shows English content even when visiting localized URLs (e.g., `/fr/getting-started`, `/ja/getting-started`)
- The preview server was returning translation metadata (`defaultLocale`, `translations`) but not actually serving translated page content

## Changes

- Modified `previewDocs.ts` to return translation pages along with the docs definition via new `PreviewDocsResult` interface
- Added `computeTranslatedDefinitions()` to build locale-specific docs definitions by merging base pages with translated pages
- Added `extractLocaleFromPath()` to detect locale from URL path (e.g., `/fr/getting-started` → `fr`)
- Updated `/v2/registry/docs/load-with-url` handler to serve locale-specific content based on the requested URL
- Updated `createBunServer.ts` to support locale parameter for Bun runtime

## Test plan

- [ ] Run `fern docs dev` on a project with translations configured
- [ ] Verify visiting `/fr/getting-started` shows French content
- [ ] Verify visiting `/ja/getting-started` shows Japanese content
- [ ] Verify the default locale (English) still works at `/getting-started`
- [ ] Verify hot reload works and translations update when files change

🤖 Generated with [Claude Code](https://claude.com/claude-code)