### PR TITLE
feat(csharp): add clientDefault support to C# SDK generator

### DIFF
--- a/generators/csharp/sdk/changes/unreleased/add-client-default-support.yml
+++ b/generators/csharp/sdk/changes/unreleased/add-client-default-support.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Support `x-fern-default` as fallback value for parameters in generated C# SDKs.
+    When a header, query parameter, or path parameter has a `clientDefault` value in the IR,
+    the generated C# SDK makes that parameter optional with the default value automatically applied.
+  type: feat

--- a/generators/csharp/sdk/src/DefaultValueExtractor.ts
+++ b/generators/csharp/sdk/src/DefaultValueExtractor.ts
@@ -1,3 +1,4 @@
+import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "./SdkGeneratorContext.js";
 
@@ -105,6 +106,49 @@ export class DefaultValueExtractor {
             unknown: () => undefined,
             _other: () => undefined
         });
+    }
+
+    /**
+     * Extracts the default value from a clientDefault Literal, if present.
+     * clientDefault is always applied regardless of the useDefaultRequestParameterValues flag.
+     */
+    public extractClientDefault(clientDefault: FernIr.Literal | undefined): ExtractedDefault | undefined {
+        if (clientDefault == null) {
+            return undefined;
+        }
+        switch (clientDefault.type) {
+            case "string":
+                return { value: this.escapeString(clientDefault.string), csharpType: "string", isConst: true };
+            case "boolean":
+                return {
+                    value: clientDefault.boolean ? "true" : "false",
+                    csharpType: "bool",
+                    isConst: true
+                };
+            default:
+                assertNever(clientDefault);
+        }
+    }
+
+    /**
+     * Extracts the effective default, preferring clientDefault over type-level defaults.
+     */
+    public extractEffectiveDefault(
+        typeReference: FernIr.TypeReference,
+        clientDefault: FernIr.Literal | undefined
+    ): ExtractedDefault | undefined {
+        const clientDefaultValue = this.extractClientDefault(clientDefault);
+        if (clientDefaultValue != null) {
+            return clientDefaultValue;
+        }
+        return this.extractDefault(typeReference);
+    }
+
+    /**
+     * Checks whether a parameter has any default (clientDefault or type-level).
+     */
+    public hasAnyDefault(typeReference: FernIr.TypeReference, clientDefault: FernIr.Literal | undefined): boolean {
+        return clientDefault != null || this.extractDefault(typeReference) != null;
     }
 
     /**

--- a/generators/csharp/sdk/src/endpoint/AbstractEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/endpoint/AbstractEndpointGenerator.ts
@@ -113,8 +113,12 @@ export abstract class AbstractEndpointGenerator extends WithGeneration {
             default:
                 assertNever(endpointType);
         }
+        const requiredPathParameters = pathParameters.filter((p) => p.initializer == null);
+        const optionalPathParameters = pathParameters.filter((p) => p.initializer != null);
         return {
-            baseParameters: [...pathParameters, requestParameter].filter((p): p is ast.Parameter => p != null),
+            baseParameters: [...requiredPathParameters, requestParameter, ...optionalPathParameters].filter(
+                (p): p is ast.Parameter => p != null
+            ),
             pathParameters,
             pathParameterReferences,
             request,

--- a/generators/csharp/sdk/src/endpoint/AbstractEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/endpoint/AbstractEndpointGenerator.ts
@@ -9,6 +9,7 @@ type HttpEndpoint = FernIr.HttpEndpoint;
 type PathParameter = FernIr.PathParameter;
 type ServiceId = FernIr.ServiceId;
 
+import { DefaultValueExtractor } from "../DefaultValueExtractor.js";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 import { WrappedRequestGenerator } from "../wrapped-request/WrappedRequestGenerator.js";
 import { EndpointSignatureInfo } from "./EndpointSignatureInfo.js";
@@ -22,11 +23,13 @@ type PagingEndpoint = HttpEndpoint & {
 export abstract class AbstractEndpointGenerator extends WithGeneration {
     private exampleGenerator: ExampleGenerator;
     protected readonly context: SdkGeneratorContext;
+    protected readonly defaultValueExtractor: DefaultValueExtractor;
 
     public constructor({ context }: { context: SdkGeneratorContext }) {
         super(context.generation);
         this.context = context;
         this.exampleGenerator = new ExampleGenerator(context);
+        this.defaultValueExtractor = new DefaultValueExtractor(context);
     }
 
     public getEndpointSignatureInfo({
@@ -212,18 +215,35 @@ export abstract class AbstractEndpointGenerator extends WithGeneration {
                 includePathParametersInEndpointSignature,
                 requestParameter
             });
+            const clientDefault = this.defaultValueExtractor.extractClientDefault(pathParam.clientDefault);
             if (includePathParametersInEndpointSignature) {
-                pathParameters.push(
-                    this.csharp.parameter({
-                        docs: pathParam.docs,
-                        name: parameterName,
-                        type: this.context.csharpTypeMapper.convert({
-                            reference: pathParam.valueType
+                if (clientDefault != null) {
+                    pathParameters.push(
+                        this.csharp.parameter({
+                            docs: pathParam.docs,
+                            name: parameterName,
+                            type: this.context.csharpTypeMapper.convert({
+                                reference: pathParam.valueType
+                            }).asOptional(),
+                            initializer: "null"
                         })
-                    })
-                );
+                    );
+                } else {
+                    pathParameters.push(
+                        this.csharp.parameter({
+                            docs: pathParam.docs,
+                            name: parameterName,
+                            type: this.context.csharpTypeMapper.convert({
+                                reference: pathParam.valueType
+                            })
+                        })
+                    );
+                }
             }
-            pathParameterReferences[getOriginalName(pathParam.name)] = parameterName;
+            pathParameterReferences[getOriginalName(pathParam.name)] =
+                clientDefault != null && includePathParametersInEndpointSignature
+                    ? `${parameterName} ?? ${clientDefault.value}`
+                    : parameterName;
         }
         return {
             pathParameters,

--- a/generators/csharp/sdk/src/endpoint/AbstractEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/endpoint/AbstractEndpointGenerator.ts
@@ -222,9 +222,11 @@ export abstract class AbstractEndpointGenerator extends WithGeneration {
                         this.csharp.parameter({
                             docs: pathParam.docs,
                             name: parameterName,
-                            type: this.context.csharpTypeMapper.convert({
-                                reference: pathParam.valueType
-                            }).asOptional(),
+                            type: this.context.csharpTypeMapper
+                                .convert({
+                                    reference: pathParam.valueType
+                                })
+                                .asOptional(),
                             initializer: "null"
                         })
                     );

--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -42,6 +42,11 @@ interface ConstructorParameter {
      * Falls back to parameter name if not provided
      */
     exampleValue?: string;
+    /**
+     * The client default value from x-fern-default.
+     * When present, the parameter is optional and uses this value as fallback.
+     */
+    clientDefault?: Literal;
 }
 
 interface LiteralParameter {
@@ -260,13 +265,14 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
         for (const param of [...requiredParameters, ...optionalParameters]) {
             if (param.header != null) {
                 const access = paramAccess(param);
+                const fallback = this.getHeaderFallback(param);
                 authHeaderEntries.push({
                     key: this.csharp.codeblock(this.csharp.string_({ string: param.header.name })),
                     value: this.csharp.codeblock(
                         param.header.prefix != null
-                            ? `$"${param.header.prefix} {${param.isOptional ? `${access} ?? ""` : access}}"`
+                            ? `$"${param.header.prefix} {${param.isOptional ? `${access} ?? ${fallback}` : access}}"`
                             : param.isOptional || param.type.isOptional
-                              ? `${access} ?? ""`
+                              ? `${access} ?? ${fallback}`
                               : access
                     )
                 });
@@ -945,6 +951,7 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
     }
 
     private getParameterForHeader(header: HttpHeader): ConstructorParameter {
+        const hasClientDefault = header.clientDefault != null;
         return {
             name:
                 header.valueType.type === "container" && header.valueType.container.type === "literal"
@@ -954,13 +961,30 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                 name: getWireValue(header.name)
             },
             docs: header.docs,
-            isOptional: header.valueType.type === "container" && header.valueType.container.type === "optional",
+            isOptional:
+                hasClientDefault ||
+                (header.valueType.type === "container" && header.valueType.container.type === "optional"),
             typeReference: header.valueType,
             type: this.context.csharpTypeMapper.convert({
                 reference: header.valueType
             }),
-            exampleValue: this.case.screamingSnakeSafe(header.name)
+            exampleValue: this.case.screamingSnakeSafe(header.name),
+            clientDefault: header.clientDefault
         };
+    }
+
+    private getHeaderFallback(param: ConstructorParameter): string {
+        if (param.clientDefault != null) {
+            switch (param.clientDefault.type) {
+                case "string":
+                    return `"${escapeForCSharpString(param.clientDefault.string)}"`;
+                case "boolean":
+                    return param.clientDefault.boolean ? `"${true.toString()}"` : `"${false.toString()}"`;
+                default:
+                    assertNever(param.clientDefault);
+            }
+        }
+        return `""`;
     }
 
     private getFromEnvironmentOrThrowMethod(cls: ast.Class) {

--- a/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
+++ b/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
@@ -93,9 +93,7 @@ export class WrappedRequestGenerator extends FileGenerator<CSharpFile, SdkGenera
                 if (bodyPropertyPascalNames.has(this.case.pascalSafe(pathParameter.name))) {
                     continue;
                 }
-                const pathDefaultValue = this.defaultValueExtractor.extractClientDefault(
-                    pathParameter.clientDefault
-                );
+                const pathDefaultValue = this.defaultValueExtractor.extractClientDefault(pathParameter.clientDefault);
                 class_.addField({
                     origin: pathParameter,
                     type: this.context.csharpTypeMapper.convert({

--- a/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
+++ b/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
@@ -93,6 +93,9 @@ export class WrappedRequestGenerator extends FileGenerator<CSharpFile, SdkGenera
                 if (bodyPropertyPascalNames.has(this.case.pascalSafe(pathParameter.name))) {
                     continue;
                 }
+                const pathDefaultValue = this.defaultValueExtractor.extractClientDefault(
+                    pathParameter.clientDefault
+                );
                 class_.addField({
                     origin: pathParameter,
                     type: this.context.csharpTypeMapper.convert({
@@ -102,10 +105,13 @@ export class WrappedRequestGenerator extends FileGenerator<CSharpFile, SdkGenera
                     get: true,
                     set: true,
                     summary: pathParameter.docs,
-                    useRequired: true,
-                    initializer: this.context.getLiteralInitializerFromTypeReference({
-                        typeReference: pathParameter.valueType
-                    }),
+                    useRequired: pathDefaultValue == null,
+                    initializer:
+                        pathDefaultValue != null
+                            ? this.csharp.codeblock(pathDefaultValue.value)
+                            : this.context.getLiteralInitializerFromTypeReference({
+                                  typeReference: pathParameter.valueType
+                              }),
                     annotations: [this.System.Text.Json.Serialization.JsonIgnore]
                 });
             }
@@ -114,7 +120,7 @@ export class WrappedRequestGenerator extends FileGenerator<CSharpFile, SdkGenera
         const useDefaults = this.generation.settings.useDefaultRequestParameterValues;
         for (const query of this.endpoint.queryParameters) {
             const defaultValue = !query.allowMultiple
-                ? this.getDefaultIfEnabled(query.valueType, useDefaults)
+                ? this.getEffectiveDefault(query.valueType, query.clientDefault, useDefaults)
                 : undefined;
 
             const type = query.allowMultiple
@@ -155,7 +161,7 @@ export class WrappedRequestGenerator extends FileGenerator<CSharpFile, SdkGenera
         }
 
         for (const header of [...(service?.headers ?? []), ...this.endpoint.headers]) {
-            const defaultValue = this.getDefaultIfEnabled(header.valueType, useDefaults);
+            const defaultValue = this.getEffectiveDefault(header.valueType, header.clientDefault, useDefaults);
 
             const type = this.context.csharpTypeMapper.convert({ reference: header.valueType });
 
@@ -441,9 +447,18 @@ export class WrappedRequestGenerator extends FileGenerator<CSharpFile, SdkGenera
     }
 
     /**
-     * Returns the extracted default value if the feature is enabled, otherwise undefined.
+     * Returns the effective default value for a parameter, preferring clientDefault over type-level defaults.
+     * clientDefault is always applied regardless of the useDefaultRequestParameterValues flag.
      */
-    private getDefaultIfEnabled(typeReference: TypeReference, useDefaults: boolean): ExtractedDefault | undefined {
+    private getEffectiveDefault(
+        typeReference: TypeReference,
+        clientDefault: FernIr.Literal | undefined,
+        useDefaults: boolean
+    ): ExtractedDefault | undefined {
+        const clientDefaultValue = this.defaultValueExtractor.extractClientDefault(clientDefault);
+        if (clientDefaultValue != null) {
+            return clientDefaultValue;
+        }
         if (!useDefaults) {
             return undefined;
         }

--- a/seed/csharp-sdk/accept-header/.fern/metadata.json
+++ b/seed/csharp-sdk/accept-header/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/alias-extends/.fern/metadata.json
+++ b/seed/csharp-sdk/alias-extends/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/alias/.fern/metadata.json
+++ b/seed/csharp-sdk/alias/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/allof-inline/.fern/metadata.json
+++ b/seed/csharp-sdk/allof-inline/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/allof/.fern/metadata.json
+++ b/seed/csharp-sdk/allof/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/any-auth/.fern/metadata.json
+++ b/seed/csharp-sdk/any-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/api-wide-base-path/.fern/metadata.json
+++ b/seed/csharp-sdk/api-wide-base-path/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/audiences/.fern/metadata.json
+++ b/seed/csharp-sdk/audiences/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/basic-auth-environment-variables/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth-environment-variables/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/basic-auth-pw-omitted/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth-pw-omitted/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/basic-auth/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/basic-auth/unified-client-options/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/.fern/metadata.json
@@ -6,8 +6,7 @@
     "unified-client-options": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/basic-auth/wire-tests/.fern/metadata.json
+++ b/seed/csharp-sdk/basic-auth/wire-tests/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable-wire-tests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/.fern/metadata.json
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/.fern/metadata.json
@@ -6,8 +6,7 @@
     "unified-client-options": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/bytes-download/.fern/metadata.json
+++ b/seed/csharp-sdk/bytes-download/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/bytes-upload/.fern/metadata.json
+++ b/seed/csharp-sdk/bytes-upload/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/circular-references-advanced/.fern/metadata.json
+++ b/seed/csharp-sdk/circular-references-advanced/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/circular-references-extends/.fern/metadata.json
+++ b/seed/csharp-sdk/circular-references-extends/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/circular-references/.fern/metadata.json
+++ b/seed/csharp-sdk/circular-references/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/client-side-params/.fern/metadata.json
+++ b/seed/csharp-sdk/client-side-params/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/content-type/.fern/metadata.json
+++ b/seed/csharp-sdk/content-type/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/cross-package-type-names/.fern/metadata.json
+++ b/seed/csharp-sdk/cross-package-type-names/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/.fern/metadata.json
@@ -6,8 +6,7 @@
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/.fern/metadata.json
@@ -6,8 +6,7 @@
     "package-id": "Seed.Client"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/.fern/metadata.json
@@ -8,8 +8,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-inline-types/inline-types/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-inline-types/inline-types/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable-inline-types": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/.fern/metadata.json
@@ -8,8 +8,7 @@
     "explicit-namespaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/.fern/metadata.json
@@ -7,8 +7,7 @@
     "experimental-dotnet-format": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/.fern/metadata.json
@@ -9,8 +9,7 @@
     "experimental-fully-qualified-namespaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/.fern/metadata.json
@@ -8,8 +8,7 @@
     "explicit-namespaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/.fern/metadata.json
@@ -8,8 +8,7 @@
     "experimental-fully-qualified-namespaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-readonly-request/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-readonly-request/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-system-collision/system-client/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/.fern/metadata.json
@@ -6,8 +6,7 @@
     "client-class-name": "System"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/dollar-string-examples/.fern/metadata.json
+++ b/seed/csharp-sdk/dollar-string-examples/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/empty-clients/.fern/metadata.json
+++ b/seed/csharp-sdk/empty-clients/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/endpoint-security-auth/.fern/metadata.json
+++ b/seed/csharp-sdk/endpoint-security-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/enum/forward-compatible-enums/.fern/metadata.json
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/enum/plain-enums/.fern/metadata.json
+++ b/seed/csharp-sdk/enum/plain-enums/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enable-forward-compatible-enums": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/error-property/.fern/metadata.json
+++ b/seed/csharp-sdk/error-property/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/errors/.fern/metadata.json
+++ b/seed/csharp-sdk/errors/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/examples/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/examples/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/examples/readme-config/.fern/metadata.json
+++ b/seed/csharp-sdk/examples/readme-config/.fern/metadata.json
@@ -15,8 +15,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/.fern/metadata.json
@@ -6,8 +6,7 @@
     "explicit-namespaces": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/.fern/metadata.json
@@ -6,8 +6,7 @@
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/.fern/metadata.json
@@ -6,8 +6,7 @@
     "generate-error-types": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/.fern/metadata.json
@@ -6,8 +6,7 @@
     "root-namespace-for-core-classes": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/.fern/metadata.json
@@ -6,8 +6,7 @@
     "redact-response-body-on-error": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/.fern/metadata.json
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use-undiscriminated-unions": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/extends/.fern/metadata.json
+++ b/seed/csharp-sdk/extends/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/extra-properties/.fern/metadata.json
+++ b/seed/csharp-sdk/extra-properties/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/file-download/.fern/metadata.json
+++ b/seed/csharp-sdk/file-download/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/file-upload-openapi/.fern/metadata.json
+++ b/seed/csharp-sdk/file-upload-openapi/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/file-upload/.fern/metadata.json
+++ b/seed/csharp-sdk/file-upload/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/folders/.fern/metadata.json
+++ b/seed/csharp-sdk/folders/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/header-auth-environment-variable/.fern/metadata.json
+++ b/seed/csharp-sdk/header-auth-environment-variable/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/header-auth/.fern/metadata.json
+++ b/seed/csharp-sdk/header-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/http-head/.fern/metadata.json
+++ b/seed/csharp-sdk/http-head/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/idempotency-headers/.fern/metadata.json
+++ b/seed/csharp-sdk/idempotency-headers/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/exception-class-names/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/exception-class-names/.fern/metadata.json
@@ -7,8 +7,7 @@
     "base-exception-class-name": "CustomException"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/exported-client-class-name/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/.fern/metadata.json
@@ -8,8 +8,7 @@
     "maxRetries": 5
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/extra-dependencies-override/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/extra-dependencies-override/.fern/metadata.json
@@ -8,8 +8,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/extra-dependencies/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/extra-dependencies/.fern/metadata.json
@@ -9,8 +9,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/include-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/include-exception-handler/.fern/metadata.json
@@ -6,8 +6,7 @@
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/imdb/omit-fern-headers/.fern/metadata.json
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/.fern/metadata.json
@@ -6,8 +6,7 @@
     "omit-fern-headers": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inferred-auth-explicit/.fern/metadata.json
+++ b/seed/csharp-sdk/inferred-auth-explicit/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/.fern/metadata.json
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/inferred-auth-implicit/.fern/metadata.json
+++ b/seed/csharp-sdk/inferred-auth-implicit/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/license/custom-license/.fern/metadata.json
+++ b/seed/csharp-sdk/license/custom-license/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/license/mit-license/.fern/metadata.json
+++ b/seed/csharp-sdk/license/mit-license/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/literal/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/literal/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/literal/readonly-constants/.fern/metadata.json
+++ b/seed/csharp-sdk/literal/readonly-constants/.fern/metadata.json
@@ -6,8 +6,7 @@
     "generate-literals": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/literals-unions/.fern/metadata.json
+++ b/seed/csharp-sdk/literals-unions/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/mixed-case/.fern/metadata.json
+++ b/seed/csharp-sdk/mixed-case/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/mixed-file-directory/.fern/metadata.json
+++ b/seed/csharp-sdk/mixed-file-directory/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-line-docs/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-line-docs/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-url-environment-no-default/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-url-environment-no-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-url-environment-reference/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-url-environment-reference/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/.fern/metadata.json
@@ -6,8 +6,7 @@
     "environment-class-name": "CustomEnvironment"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/.fern/metadata.json
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/.fern/metadata.json
@@ -6,8 +6,7 @@
     "pascal-case-environments": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/multiple-request-bodies/.fern/metadata.json
+++ b/seed/csharp-sdk/multiple-request-bodies/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/no-content-response/.fern/metadata.json
+++ b/seed/csharp-sdk/no-content-response/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/no-environment/.fern/metadata.json
+++ b/seed/csharp-sdk/no-environment/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/no-retries/.fern/metadata.json
+++ b/seed/csharp-sdk/no-retries/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/null-type/.fern/metadata.json
+++ b/seed/csharp-sdk/null-type/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable-allof-extends/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable-allof-extends/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/.fern/metadata.json
@@ -6,8 +6,7 @@
     "experimental-explicit-nullable-optional": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable-request-body/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable-request-body/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/.fern/metadata.json
@@ -6,8 +6,7 @@
     "experimental-explicit-nullable-optional": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/nullable/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/nullable/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-custom/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-default/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/.fern/metadata.json
@@ -6,8 +6,7 @@
     "unified-client-options": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-reference/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/.fern/metadata.json
@@ -6,8 +6,7 @@
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/object/.fern/metadata.json
+++ b/seed/csharp-sdk/object/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/objects-with-imports/.fern/metadata.json
+++ b/seed/csharp-sdk/objects-with-imports/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/optional/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/optional/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/.fern/metadata.json
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/.fern/metadata.json
@@ -6,8 +6,7 @@
     "simplify-object-dictionaries": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/package-yml/.fern/metadata.json
+++ b/seed/csharp-sdk/package-yml/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination-custom/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination-custom/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination-uri-path/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination-uri-path/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/.fern/metadata.json
@@ -7,8 +7,7 @@
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination/custom-pager/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination/custom-pager/.fern/metadata.json
@@ -6,8 +6,7 @@
     "custom-pager-name": "MyPager"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/pagination/page-index-semantics/.fern/metadata.json
+++ b/seed/csharp-sdk/pagination/page-index-semantics/.fern/metadata.json
@@ -6,8 +6,7 @@
     "offset-semantics": "page-index"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/path-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/.fern/metadata.json
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/.fern/metadata.json
@@ -6,8 +6,7 @@
     "inline-path-parameters": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/plain-text/.fern/metadata.json
+++ b/seed/csharp-sdk/plain-text/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/property-access/.fern/metadata.json
+++ b/seed/csharp-sdk/property-access/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/public-object/.fern/metadata.json
+++ b/seed/csharp-sdk/public-object/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/query-param-name-conflict/.fern/metadata.json
+++ b/seed/csharp-sdk/query-param-name-conflict/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/query-parameters-openapi/.fern/metadata.json
+++ b/seed/csharp-sdk/query-parameters-openapi/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/query-parameters/.fern/metadata.json
+++ b/seed/csharp-sdk/query-parameters/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/request-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/request-parameters/with-defaults/.fern/metadata.json
+++ b/seed/csharp-sdk/request-parameters/with-defaults/.fern/metadata.json
@@ -8,8 +8,7 @@
     "use-undiscriminated-unions": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/.fern/metadata.json
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/.fern/metadata.json
@@ -6,8 +6,7 @@
     "experimental-explicit-nullable-optional": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/required-nullable/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/reserved-keywords/.fern/metadata.json
+++ b/seed/csharp-sdk/reserved-keywords/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/response-property/.fern/metadata.json
+++ b/seed/csharp-sdk/response-property/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/schemaless-request-body-examples/.fern/metadata.json
+++ b/seed/csharp-sdk/schemaless-request-body-examples/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-sent-event-examples/.fern/metadata.json
+++ b/seed/csharp-sdk/server-sent-event-examples/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-sent-events-openapi/.fern/metadata.json
+++ b/seed/csharp-sdk/server-sent-events-openapi/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-sent-events/.fern/metadata.json
+++ b/seed/csharp-sdk/server-sent-events/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/server-url-templating/.fern/metadata.json
+++ b/seed/csharp-sdk/server-url-templating/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/.fern/metadata.json
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/.fern/metadata.json
@@ -11,8 +11,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/simple-api/custom-output-path/.fern/metadata.json
+++ b/seed/csharp-sdk/simple-api/custom-output-path/.fern/metadata.json
@@ -6,8 +6,7 @@
     "output-path": "custom-src"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/simple-api/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/simple-api/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/simple-api/use-sln-format/.fern/metadata.json
+++ b/seed/csharp-sdk/simple-api/use-sln-format/.fern/metadata.json
@@ -6,8 +6,7 @@
     "sln-format": "sln"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/simple-fhir/.fern/metadata.json
+++ b/seed/csharp-sdk/simple-fhir/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/single-url-environment-default/.fern/metadata.json
+++ b/seed/csharp-sdk/single-url-environment-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/single-url-environment-no-default/.fern/metadata.json
+++ b/seed/csharp-sdk/single-url-environment-no-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/streaming-parameter/.fern/metadata.json
+++ b/seed/csharp-sdk/streaming-parameter/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/streaming/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/streaming/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/.fern/metadata.json
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/.fern/metadata.json
@@ -6,8 +6,7 @@
     "redact-response-body-on-error": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/trace/.fern/metadata.json
+++ b/seed/csharp-sdk/trace/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/.fern/metadata.json
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use-undiscriminated-unions": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/unions-with-local-date/.fern/metadata.json
+++ b/seed/csharp-sdk/unions-with-local-date/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/unions/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/unions/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/unions/no-discriminated-unions/.fern/metadata.json
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/.fern/metadata.json
@@ -6,8 +6,7 @@
     "use-discriminated-unions": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/unknown/.fern/metadata.json
+++ b/seed/csharp-sdk/unknown/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/validation/.fern/metadata.json
+++ b/seed/csharp-sdk/validation/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/variables/.fern/metadata.json
+++ b/seed/csharp-sdk/variables/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/version-no-default/.fern/metadata.json
+++ b/seed/csharp-sdk/version-no-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/version/.fern/metadata.json
+++ b/seed/csharp-sdk/version/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/webhook-audience/.fern/metadata.json
+++ b/seed/csharp-sdk/webhook-audience/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/webhooks/.fern/metadata.json
+++ b/seed/csharp-sdk/webhooks/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket-bearer-auth/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket-bearer-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket-inferred-auth/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket-inferred-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket-multi-url/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket-multi-url/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "experimental-enable-websockets": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/websocket/with-websockets/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket/with-websockets/.fern/metadata.json
@@ -7,8 +7,7 @@
     "experimental-enable-websockets": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/x-fern-default/.fern/metadata.json
+++ b/seed/csharp-sdk/x-fern-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/x-fern-default/src/SeedApi/Requests/TestGetRequest.cs
+++ b/seed/csharp-sdk/x-fern-default/src/SeedApi/Requests/TestGetRequest.cs
@@ -7,10 +7,10 @@ namespace SeedApi;
 public record TestGetRequest
 {
     [JsonIgnore]
-    public required string Region { get; set; }
+    public string Region { get; set; } = "us-east-1";
 
     [JsonIgnore]
-    public string? Limit { get; set; }
+    public string? Limit { get; set; } = "100";
 
     /// <inheritdoc />
     public override string ToString()

--- a/seed/csharp-sdk/x-fern-default/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/x-fern-default/src/SeedApi/SeedApiClient.cs
@@ -28,7 +28,7 @@ public partial class SeedApiClient : ISeedApiClient
         }
         var clientOptionsWithAuth = clientOptions.Clone();
         var authHeaders = new Headers(
-            new Dictionary<string, string>() { { "X-API-Version", apiVersion ?? "" } }
+            new Dictionary<string, string>() { { "X-API-Version", apiVersion ?? "2024-02-08" } }
         );
         foreach (var header in authHeaders)
         {


### PR DESCRIPTION
## Description

Implements `clientDefault` (x-fern-default) support in the C# SDK generator, bringing it to feature parity with TypeScript (PR #15216), Python (PR #14440), Go (PR #15215), and Java (PR #15214).

When a header, query parameter, or path parameter has a `clientDefault` value in the IR, the generated C# SDK makes that parameter optional and uses the default value as a fallback when the caller omits it.

## Changes Made

### `generators/csharp/sdk/src/DefaultValueExtractor.ts`
- Added `extractClientDefault()` to extract default values from `Literal` (string/boolean) clientDefault fields
- Added `extractEffectiveDefault()` to prefer clientDefault over type-level defaults
- Added `hasAnyDefault()` to check for either clientDefault or type-level defaults

### `generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts`
- Path parameters with clientDefault are no longer `required` and get a default initializer
- Query parameters and headers use `getEffectiveDefault()` which prefers clientDefault over type-level defaults (clientDefault is always applied regardless of `useDefaultRequestParameterValues` flag)

### `generators/csharp/sdk/src/endpoint/AbstractEndpointGenerator.ts`
- Path parameters with clientDefault in endpoint signatures become optional (`string?`) with `null` default
- Path parameter references in URL formatting use `?? "defaultValue"` fallback (only for endpoint signature params, not wrapped request fields which already have initializers)
- Optional path parameters are placed after all required parameters (including the request parameter) to ensure valid C# method signatures

### `generators/csharp/sdk/src/root-client/RootClientGenerator.ts`
- Global headers with clientDefault use the default value as fallback instead of empty string
- Header parameters with clientDefault are marked as optional
- Precedence: caller-provided > env var > clientDefault

### Generated output changes (`seed/csharp-sdk/x-fern-default/`)
- `TestGetRequest.Region`: `required string` → `string = "us-east-1"`
- `TestGetRequest.Limit`: `string?` → `string? = "100"`
- `SeedApiClient` constructor: `apiVersion ?? ""` → `apiVersion ?? "2024-02-08"`

## Testing
- [x] All 170 seed tests pass (`pnpm seed test --generator csharp-sdk --skip-scripts`)
- [x] `x-fern-default` fixture generates correct output with clientDefault applied
- [x] TypeScript compilation succeeds
- [x] Biome formatting passes
- [x] Changelog entry added

Link to Devin session: https://app.devin.ai/sessions/c5ef1f871b7641f7bac15adcba66ff2b
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
