### PR TITLE
fix(docs): handle full URLs in extractLocaleFromPath

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-docs-dev-localization.yml
+++ b/packages/cli/cli/changes/unreleased/fix-docs-dev-localization.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix `fern docs dev` to serve translated page content when viewing localized pages.
+  type: fix

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -896,8 +896,8 @@ export async function runAppPreviewServer({
     const editedAbsoluteFilepaths: AbsoluteFilePath[] = [];
 
     /**
-     * Extracts the locale from a URL path.
-     * E.g., "/fr/getting-started" -> "fr", "/getting-started" -> undefined
+     * Extracts the locale from a URL or path.
+     * E.g., "/fr/getting-started" -> "fr", "http://localhost:3000/ja/intro" -> "ja"
      */
     function extractLocaleFromPath(urlPath: string | undefined): string | undefined {
         if (urlPath == null) {
@@ -910,8 +910,16 @@ export async function runAppPreviewServer({
             return undefined;
         }
 
+        // Parse as URL if it's a full URL, otherwise treat as path
+        let pathname = urlPath;
+        try {
+            pathname = new URL(urlPath).pathname;
+        } catch {
+            // urlPath is already a bare path (e.g. "/fr/getting-started")
+        }
+
         // Check if path starts with a locale prefix
-        const pathParts = urlPath.split("/").filter((p) => p.length > 0);
+        const pathParts = pathname.split("/").filter((p) => p.length > 0);
         if (pathParts.length > 0) {
             const firstPart = pathParts[0];
             if (firstPart != null && availableLocales.includes(firstPart) && firstPart !== defaultLocale) {

--- a/packages/cli/docs-preview/src/runPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runPreviewServer.ts
@@ -322,8 +322,8 @@ export async function runPreviewServer({
     });
 
     /**
-     * Extracts the locale from a URL path.
-     * E.g., "/fr/getting-started" -> "fr", "/getting-started" -> undefined
+     * Extracts the locale from a URL or path.
+     * E.g., "/fr/getting-started" -> "fr", "http://localhost:3000/ja/intro" -> "ja"
      */
     function extractLocaleFromPath(urlPath: string | undefined): string | undefined {
         if (urlPath == null) {
@@ -337,8 +337,16 @@ export async function runPreviewServer({
             return undefined;
         }
 
+        // Parse as URL if it's a full URL, otherwise treat as path
+        let pathname = urlPath;
+        try {
+            pathname = new URL(urlPath).pathname;
+        } catch {
+            // urlPath is already a bare path (e.g. "/fr/getting-started")
+        }
+
         // Check if path starts with a locale prefix
-        const pathParts = urlPath.split("/").filter((p) => p.length > 0);
+        const pathParts = pathname.split("/").filter((p) => p.length > 0);
         if (pathParts.length > 0) {
             const firstPart = pathParts[0];
             if (firstPart != null && availableLocales.includes(firstPart) && firstPart !== defaultLocale) {


### PR DESCRIPTION
## Summary
- Fix `extractLocaleFromPath` to properly handle full URLs (e.g., `http://localhost:3000/fr/getting-started`) in addition to bare paths
- Parse with `new URL()` to extract pathname, falling back to treating the value as a bare path if parsing fails
- Addresses review comment on #15443

## Test plan
- [x] Tested with `fern docs dev` using localized pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)