### PR TITLE
feat(php): add clientDefault support to PHP SDK generator

### DIFF
--- a/generators/php/sdk/changes/unreleased/add-client-default-support.yml
+++ b/generators/php/sdk/changes/unreleased/add-client-default-support.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Support `x-fern-default` as fallback value for parameters in generated PHP SDKs.
+    When a header, query parameter, or path parameter has a `clientDefault` value in the IR,
+    the generated PHP SDK makes that parameter optional with the default value automatically applied.
+  type: feat

--- a/generators/php/sdk/src/DefaultValueExtractor.ts
+++ b/generators/php/sdk/src/DefaultValueExtractor.ts
@@ -1,3 +1,4 @@
+import { assertNever } from "@fern-api/core-utils";
 import { php } from "@fern-api/php-codegen";
 import { FernIr } from "@fern-fern/ir-sdk";
 
@@ -130,5 +131,43 @@ export class DefaultValueExtractor {
      */
     private isSafeInteger(value: number): boolean {
         return Number.isSafeInteger(value);
+    }
+
+    /**
+     * Extracts a clientDefault literal as a PHP CodeBlock for use as a field initializer.
+     * Always applied regardless of the useDefaultRequestParameterValues flag.
+     */
+    public static extractClientDefaultCodeBlock(clientDefault: FernIr.Literal | undefined): php.CodeBlock | undefined {
+        if (clientDefault == null) {
+            return undefined;
+        }
+        switch (clientDefault.type) {
+            case "string": {
+                const escaped = clientDefault.string.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+                return php.codeblock(`'${escaped}'`);
+            }
+            case "boolean":
+                return php.codeblock(clientDefault.boolean ? "true" : "false");
+            default:
+                assertNever(clientDefault);
+        }
+    }
+
+    /**
+     * Returns the raw string representation of a clientDefault literal suitable for
+     * embedding in PHP string interpolation (e.g., path parameters, header values).
+     */
+    public static getClientDefaultStringValue(clientDefault: FernIr.Literal | undefined): string | undefined {
+        if (clientDefault == null) {
+            return undefined;
+        }
+        switch (clientDefault.type) {
+            case "string":
+                return clientDefault.string;
+            case "boolean":
+                return clientDefault.boolean ? "true" : "false";
+            default:
+                assertNever(clientDefault);
+        }
     }
 }

--- a/generators/php/sdk/src/endpoint/AbstractEndpointGenerator.ts
+++ b/generators/php/sdk/src/endpoint/AbstractEndpointGenerator.ts
@@ -3,6 +3,7 @@ import { assertNever } from "@fern-api/core-utils";
 import { php } from "@fern-api/php-codegen";
 import { FernIr } from "@fern-fern/ir-sdk";
 
+import { DefaultValueExtractor } from "../DefaultValueExtractor.js";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 import { EndpointSignatureInfo } from "./EndpointSignatureInfo.js";
 import { EndpointRequest } from "./request/EndpointRequest.js";
@@ -61,11 +62,16 @@ export abstract class AbstractEndpointGenerator {
                 includePathParametersInEndpointSignature: includePathParametersInSignature
             });
             if (includePathParametersInSignature) {
+                const clientDefaultInit = DefaultValueExtractor.extractClientDefaultCodeBlock(
+                    pathParam.clientDefault
+                );
+                const type = this.context.phpTypeMapper.convert({ reference: pathParam.valueType });
                 pathParameters.push(
                     php.parameter({
                         docs: pathParam.docs,
                         name: parameterName,
-                        type: this.context.phpTypeMapper.convert({ reference: pathParam.valueType })
+                        type,
+                        initializer: clientDefaultInit
                     })
                 );
             }

--- a/generators/php/sdk/src/endpoint/AbstractEndpointGenerator.ts
+++ b/generators/php/sdk/src/endpoint/AbstractEndpointGenerator.ts
@@ -62,9 +62,7 @@ export abstract class AbstractEndpointGenerator {
                 includePathParametersInEndpointSignature: includePathParametersInSignature
             });
             if (includePathParametersInSignature) {
-                const clientDefaultInit = DefaultValueExtractor.extractClientDefaultCodeBlock(
-                    pathParam.clientDefault
-                );
+                const clientDefaultInit = DefaultValueExtractor.extractClientDefaultCodeBlock(pathParam.clientDefault);
                 const type = this.context.phpTypeMapper.convert({ reference: pathParam.valueType });
                 pathParameters.push(
                     php.parameter({

--- a/generators/php/sdk/src/endpoint/request/WrappedEndpointRequest.ts
+++ b/generators/php/sdk/src/endpoint/request/WrappedEndpointRequest.ts
@@ -67,9 +67,7 @@ export class WrappedEndpointRequest extends EndpointRequest {
                         requestParameterName: this.requestParameterName,
                         propertyName: query.name
                     });
-                    const clientDefaultWire = DefaultValueExtractor.getClientDefaultStringValue(
-                        query.clientDefault
-                    );
+                    const clientDefaultWire = DefaultValueExtractor.getClientDefaultStringValue(query.clientDefault);
                     if (clientDefaultWire != null) {
                         const escaped = clientDefaultWire.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
                         writer.writeTextStatement(
@@ -112,9 +110,7 @@ export class WrappedEndpointRequest extends EndpointRequest {
                         requestParameterName: this.requestParameterName,
                         propertyName: header.name
                     });
-                    const clientDefaultWire = DefaultValueExtractor.getClientDefaultStringValue(
-                        header.clientDefault
-                    );
+                    const clientDefaultWire = DefaultValueExtractor.getClientDefaultStringValue(header.clientDefault);
                     if (clientDefaultWire != null) {
                         const escaped = clientDefaultWire.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
                         writer.writeTextStatement(

--- a/generators/php/sdk/src/endpoint/request/WrappedEndpointRequest.ts
+++ b/generators/php/sdk/src/endpoint/request/WrappedEndpointRequest.ts
@@ -3,6 +3,7 @@ import { assertNever } from "@fern-api/core-utils";
 import { php } from "@fern-api/php-codegen";
 import { FernIr } from "@fern-fern/ir-sdk";
 
+import { DefaultValueExtractor } from "../../DefaultValueExtractor.js";
 import { SdkGeneratorContext } from "../../SdkGeneratorContext.js";
 import {
     EndpointRequest,
@@ -66,9 +67,19 @@ export class WrappedEndpointRequest extends EndpointRequest {
                         requestParameterName: this.requestParameterName,
                         propertyName: query.name
                     });
-                    writer.controlFlow("if", php.codeblock(`${queryParameterReference} != null`));
-                    this.writeQueryParameter(writer, query);
-                    writer.endControlFlow();
+                    const clientDefaultWire = DefaultValueExtractor.getClientDefaultStringValue(
+                        query.clientDefault
+                    );
+                    if (clientDefaultWire != null) {
+                        const escaped = clientDefaultWire.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+                        writer.writeTextStatement(
+                            `${QUERY_PARAMETER_BAG_NAME}['${getWireValue(query.name)}'] = ${queryParameterReference} ?? '${escaped}'`
+                        );
+                    } else {
+                        writer.controlFlow("if", php.codeblock(`${queryParameterReference} != null`));
+                        this.writeQueryParameter(writer, query);
+                        writer.endControlFlow();
+                    }
                 }
             }),
             queryParameterBagReference: QUERY_PARAMETER_BAG_NAME
@@ -101,9 +112,19 @@ export class WrappedEndpointRequest extends EndpointRequest {
                         requestParameterName: this.requestParameterName,
                         propertyName: header.name
                     });
-                    writer.controlFlow("if", php.codeblock(`${headerParameterReference} != null`));
-                    this.writeHeader(writer, header);
-                    writer.endControlFlow();
+                    const clientDefaultWire = DefaultValueExtractor.getClientDefaultStringValue(
+                        header.clientDefault
+                    );
+                    if (clientDefaultWire != null) {
+                        const escaped = clientDefaultWire.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+                        writer.writeTextStatement(
+                            `${HEADER_BAG_NAME}['${getWireValue(header.name)}'] = ${headerParameterReference} ?? '${escaped}'`
+                        );
+                    } else {
+                        writer.controlFlow("if", php.codeblock(`${headerParameterReference} != null`));
+                        this.writeHeader(writer, header);
+                        writer.endControlFlow();
+                    }
                 }
             }),
             headerParameterBagReference: HEADER_BAG_NAME

--- a/generators/php/sdk/src/endpoint/request/WrappedEndpointRequestGenerator.ts
+++ b/generators/php/sdk/src/endpoint/request/WrappedEndpointRequestGenerator.ts
@@ -59,14 +59,22 @@ export class WrappedEndpointRequestGenerator extends FileGenerator<
         });
         if (includePathParameters) {
             for (const pathParameter of this.endpoint.allPathParameters) {
+                const clientDefaultInit = DefaultValueExtractor.extractClientDefaultCodeBlock(
+                    pathParameter.clientDefault
+                );
+                let type = this.context.phpTypeMapper.convert({ reference: pathParameter.valueType });
+                if (clientDefaultInit != null && !this.context.isOptional(pathParameter.valueType)) {
+                    type = php.Type.optional(type);
+                }
                 this.addFieldWithMethods({
                     clazz,
                     name: pathParameter.name,
                     field: php.field({
                         name: this.context.getPropertyName(pathParameter.name),
-                        type: this.context.phpTypeMapper.convert({ reference: pathParameter.valueType }),
+                        type,
                         access: this.context.getPropertyAccess(),
-                        docs: pathParameter.docs
+                        docs: pathParameter.docs,
+                        initializer: clientDefaultInit
                     }),
                     includeGetters,
                     includeSetters
@@ -75,10 +83,14 @@ export class WrappedEndpointRequestGenerator extends FileGenerator<
         }
 
         for (const query of this.endpoint.queryParameters) {
-            const initializer =
+            let initializer =
                 defaultExtractor != null && !query.allowMultiple
                     ? defaultExtractor.extractDefaultCodeBlock(query.valueType)
                     : undefined;
+            const clientDefaultInit = DefaultValueExtractor.extractClientDefaultCodeBlock(query.clientDefault);
+            if (clientDefaultInit != null) {
+                initializer = clientDefaultInit;
+            }
             this.addFieldWithMethods({
                 clazz,
                 name: query.name,
@@ -95,7 +107,11 @@ export class WrappedEndpointRequestGenerator extends FileGenerator<
         }
 
         for (const header of [...service.headers, ...this.endpoint.headers]) {
-            const initializer = defaultExtractor?.extractDefaultCodeBlock(header.valueType);
+            let initializer = defaultExtractor?.extractDefaultCodeBlock(header.valueType);
+            const clientDefaultInit = DefaultValueExtractor.extractClientDefaultCodeBlock(header.clientDefault);
+            if (clientDefaultInit != null) {
+                initializer = clientDefaultInit;
+            }
             this.addFieldWithMethods({
                 clazz,
                 name: header.name,

--- a/generators/php/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/php/sdk/src/root-client/RootClientGenerator.ts
@@ -22,6 +22,7 @@ interface ConstructorParameter {
     docs?: string;
     header?: HeaderInfo;
     environmentVariable?: string;
+    clientDefault?: FernIr.Literal;
 }
 
 interface LiteralParameter {
@@ -181,10 +182,14 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
 
         const parameters: php.Parameter[] = [];
         for (const param of [...constructorParameters.required, ...constructorParameters.optional]) {
+            let type = this.context.phpTypeMapper.convert({ reference: param.typeReference });
+            if (param.clientDefault != null && !this.context.isOptional(param.typeReference)) {
+                type = php.Type.optional(type);
+            }
             parameters.push(
                 php.parameter({
                     name: param.name,
-                    type: this.context.phpTypeMapper.convert({ reference: param.typeReference }),
+                    type,
                     docs: param.docs
                 })
             );
@@ -313,18 +318,35 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
             body: php.codeblock((writer) => {
                 for (const param of constructorParameters.optional) {
                     if (param.environmentVariable != null) {
-                        writer.write(`$${param.name} ??= `);
-                        writer.writeNodeStatement(
-                            php.invokeMethod({
-                                method: `$this->${GET_FROM_ENV_OR_THROW}`,
-                                arguments_: [
-                                    php.codeblock(`'${param.environmentVariable}'`),
-                                    php.codeblock(
-                                        `'Please pass in ${param.name} or set the environment variable ${param.environmentVariable}.'`
-                                    )
-                                ]
-                            })
-                        );
+                        if (param.clientDefault != null) {
+                            const defaultWire = this.getClientDefaultLiteralWireValue(param.clientDefault);
+                            const escaped = defaultWire.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+                            writer.writeLine(`$envValue = getenv('${param.environmentVariable}');`);
+                            writer.writeTextStatement(
+                                `$${param.name} ??= ($envValue !== false ? $envValue : '${escaped}')`
+                            );
+                        } else {
+                            writer.write(`$${param.name} ??= `);
+                            writer.writeNodeStatement(
+                                php.invokeMethod({
+                                    method: `$this->${GET_FROM_ENV_OR_THROW}`,
+                                    arguments_: [
+                                        php.codeblock(`'${param.environmentVariable}'`),
+                                        php.codeblock(
+                                            `'Please pass in ${param.name} or set the environment variable ${param.environmentVariable}.'`
+                                        )
+                                    ]
+                                })
+                            );
+                        }
+                    }
+                }
+
+                for (const param of constructorParameters.optional) {
+                    if (param.clientDefault != null && param.environmentVariable == null) {
+                        const defaultWire = this.getClientDefaultLiteralWireValue(param.clientDefault);
+                        const escaped = defaultWire.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+                        writer.writeTextStatement(`$${param.name} ??= '${escaped}'`);
                     }
                 }
 
@@ -555,7 +577,7 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
         }
 
         for (const param of allParameters) {
-            if (param.isOptional || param.environmentVariable != null) {
+            if (param.isOptional || param.environmentVariable != null || param.clientDefault != null) {
                 optionalParameters.push(param);
                 continue;
             }
@@ -716,7 +738,8 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
             },
             docs: header.docs,
             isOptional: this.context.isOptional(header.valueType),
-            typeReference: header.valueType
+            typeReference: header.valueType,
+            clientDefault: header.clientDefault
         };
     }
 
@@ -759,6 +782,17 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
 
     private getAuthParameterDocs({ docs, name }: { docs: string | undefined; name: string }): string {
         return docs ?? `The ${name} to use for authentication.`;
+    }
+
+    private getClientDefaultLiteralWireValue(literal: FernIr.Literal): string {
+        switch (literal.type) {
+            case "string":
+                return literal.string;
+            case "boolean":
+                return literal.boolean ? "true" : "false";
+            default:
+                assertNever(literal);
+        }
     }
 
     /**

--- a/seed/php-sdk/x-fern-default/.fern/metadata.json
+++ b/seed/php-sdk/x-fern-default/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/x-fern-default/src/Requests/TestGetRequest.php
+++ b/seed/php-sdk/x-fern-default/src/Requests/TestGetRequest.php
@@ -9,7 +9,7 @@ class TestGetRequest extends JsonSerializableType
     /**
      * @var ?string $limit
      */
-    public ?string $limit;
+    public ?string $limit = '100';
 
     /**
      * @param array{

--- a/seed/php-sdk/x-fern-default/src/SeedClient.php
+++ b/seed/php-sdk/x-fern-default/src/SeedClient.php
@@ -45,6 +45,7 @@ class SeedClient
         ?string $apiVersion = null,
         ?array $options = null,
     ) {
+        $apiVersion ??= '2024-02-08';
         $defaultHeaders = [
             'X-Fern-Language' => 'PHP',
             'X-Fern-SDK-Name' => 'Seed',
@@ -82,13 +83,11 @@ class SeedClient
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function testGet(string $region, TestGetRequest $request = new TestGetRequest(), ?array $options = null): ?TestGetResponse
+    public function testGet(string $region = 'us-east-1', TestGetRequest $request = new TestGetRequest(), ?array $options = null): ?TestGetResponse
     {
         $options = array_merge($this->options, $options ?? []);
         $query = [];
-        if ($request->limit != null) {
-            $query['limit'] = $request->limit;
-        }
+        $query['limit'] = $request->limit ?? '100';
         try {
             $response = $this->client->sendRequest(
                 new JsonApiRequest(


### PR DESCRIPTION
## Description

Add support for the `clientDefault` field on `HttpHeader`, `QueryParameter`, and `PathParameter` types in the PHP SDK generator. When a parameter has a `clientDefault` value (from the `x-fern-default` OpenAPI extension or `client-default` Fern Definition field), the generated PHP SDK makes that parameter optional with the default value automatically applied.

## Changes Made

- **`DefaultValueExtractor.ts`**: Added two static helper methods:
  - `extractClientDefaultCodeBlock()` — converts a `Literal` (string/boolean) to a PHP code block for use as a field/parameter initializer
  - `getClientDefaultStringValue()` — returns the raw string representation for embedding in PHP string interpolation
- **`AbstractEndpointGenerator.ts`**: Path parameters with `clientDefault` now get the default value as their parameter initializer (e.g., `string $region = 'us-east-1'`), keeping the type non-nullable to preserve parameter ordering
- **`WrappedEndpointRequestGenerator.ts`**: Query parameter and header fields on request wrapper classes get `clientDefault` as their field initializer; path parameters in inline mode get the same treatment
- **`WrappedEndpointRequest.ts`**: Optional query parameters and headers with `clientDefault` use `??` fallback instead of null-check guard (e.g., `$query['limit'] = $request->limit ?? '100'`)
- **`RootClientGenerator.ts`**: Global headers with `clientDefault` get `??=` fallback assignment in the constructor. For headers with both env var and `clientDefault`, precedence is: caller-provided > env var > clientDefault
- **Changelog**: Added `generators/php/sdk/changes/unreleased/add-client-default-support.yml`
- **Seed snapshots**: Updated `seed/php-sdk/x-fern-default/` to reflect new generated output

- [ ] Updated README.md generator (if applicable) — N/A

## Testing

- [x] Seed test passes: `pnpm seed test --generator php-sdk --fixture x-fern-default`
- [x] Additional seed fixtures verified: `exhaustive`, `path-parameters` (no regressions)
- [x] TypeScript compilation passes: `pnpm turbo run compile --filter @fern-api/php-sdk`
- [x] Manual review of generated PHP output confirms correct behavior for all three parameter types

Link to Devin session: https://app.devin.ai/sessions/302ae462e00f48019f81795e34b6937a
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
