### PR TITLE
fix(ruby): alias @client to @raw_client for root service endpoints

### DIFF
--- a/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
@@ -226,6 +226,9 @@ export class RootClientGenerator extends FileGenerator<RubyFile, SdkCustomConfig
                 }
                 writer.dedent();
                 writer.writeLine(`)`);
+                if (this.context.ir.rootPackage.service != null) {
+                    writer.writeLine(`@client = @raw_client`);
+                }
             })
         );
 

--- a/seed/ruby-sdk-v2/x-fern-default/lib/seed/client.rb
+++ b/seed/ruby-sdk-v2/x-fern-default/lib/seed/client.rb
@@ -54,6 +54,7 @@ module Seed
           "X-API-Version" => api_version.to_s
         }
       )
+      @client = @raw_client
     end
   end
 end


### PR DESCRIPTION
## Description

Follow-up fix from #15445 — root service endpoint methods generated by `HttpEndpointGenerator` reference `@client` to send HTTP requests, but the root client (`RootClientGenerator`) stores the raw HTTP client as `@raw_client`. Without this alias, any call to a root service endpoint method would fail at runtime with a Ruby `NoMethodError` because `@client` is `nil`.

This was flagged by Devin Review on the original PR.

## Changes Made

- Added `@client = @raw_client` alias in `RootClientGenerator.getInitializeMethod()`, gated on `rootPackage.service != null` so it only appears when there are root service endpoints
- Updated x-fern-default seed snapshot to include the alias

## Testing

- [x] Compilation passes (`pnpm compile --filter @fern-api/ruby-sdk...`)
- [x] Seed test passes: `pnpm seed test --generator ruby-sdk-v2 --fixture x-fern-default --skip-scripts`
- [x] Generated `client.rb` includes `@client = @raw_client` after `@raw_client` initialization

Link to Devin session: https://app.devin.ai/sessions/91f742878e6249fab63239e8f46b4fb7
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
