### PR TITLE
fix(php): fix boolean clientDefault quoting and inline path param type handling

### DIFF
--- a/generators/php/sdk/changes/unreleased/fix-client-default-boolean-quoting.yml
+++ b/generators/php/sdk/changes/unreleased/fix-client-default-boolean-quoting.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix boolean `clientDefault` values being incorrectly wrapped in quotes in the
+    generated PHP SDK constructor. Boolean literals now emit bare `true`/`false` instead
+    of string `'true'`/`'false'`.
+  type: fix
+- summary: |
+    Fix inline path parameters with `clientDefault` in wrapped request classes.
+    The field type is no longer made optional, which preserves the `clientDefault`
+    initializer in the generated constructor instead of discarding it with `?? null`.
+  type: fix

--- a/generators/php/sdk/src/endpoint/request/WrappedEndpointRequestGenerator.ts
+++ b/generators/php/sdk/src/endpoint/request/WrappedEndpointRequestGenerator.ts
@@ -62,10 +62,7 @@ export class WrappedEndpointRequestGenerator extends FileGenerator<
                 const clientDefaultInit = DefaultValueExtractor.extractClientDefaultCodeBlock(
                     pathParameter.clientDefault
                 );
-                let type = this.context.phpTypeMapper.convert({ reference: pathParameter.valueType });
-                if (clientDefaultInit != null && !this.context.isOptional(pathParameter.valueType)) {
-                    type = php.Type.optional(type);
-                }
+                const type = this.context.phpTypeMapper.convert({ reference: pathParameter.valueType });
                 this.addFieldWithMethods({
                     clazz,
                     name: pathParameter.name,

--- a/generators/php/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/php/sdk/src/root-client/RootClientGenerator.ts
@@ -319,11 +319,10 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                 for (const param of constructorParameters.optional) {
                     if (param.environmentVariable != null) {
                         if (param.clientDefault != null) {
-                            const defaultWire = this.getClientDefaultLiteralWireValue(param.clientDefault);
-                            const escaped = defaultWire.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+                            const phpLiteral = this.getClientDefaultPhpLiteral(param.clientDefault);
                             writer.writeLine(`$envValue = getenv('${param.environmentVariable}');`);
                             writer.writeTextStatement(
-                                `$${param.name} ??= ($envValue !== false ? $envValue : '${escaped}')`
+                                `$${param.name} ??= ($envValue !== false ? $envValue : ${phpLiteral})`
                             );
                         } else {
                             writer.write(`$${param.name} ??= `);
@@ -344,9 +343,8 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
 
                 for (const param of constructorParameters.optional) {
                     if (param.clientDefault != null && param.environmentVariable == null) {
-                        const defaultWire = this.getClientDefaultLiteralWireValue(param.clientDefault);
-                        const escaped = defaultWire.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
-                        writer.writeTextStatement(`$${param.name} ??= '${escaped}'`);
+                        const phpLiteral = this.getClientDefaultPhpLiteral(param.clientDefault);
+                        writer.writeTextStatement(`$${param.name} ??= ${phpLiteral}`);
                     }
                 }
 
@@ -788,6 +786,19 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
         switch (literal.type) {
             case "string":
                 return literal.string;
+            case "boolean":
+                return literal.boolean ? "true" : "false";
+            default:
+                assertNever(literal);
+        }
+    }
+
+    private getClientDefaultPhpLiteral(literal: FernIr.Literal): string {
+        switch (literal.type) {
+            case "string": {
+                const escaped = literal.string.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+                return `'${escaped}'`;
+            }
             case "boolean":
                 return literal.boolean ? "true" : "false";
             default:


### PR DESCRIPTION
## Description

Follow-up to #15465. Fixes two edge-case bugs in the PHP SDK generator's `clientDefault` support identified by code review.

## Changes Made

- **`RootClientGenerator.ts`**: Added `getClientDefaultPhpLiteral()` helper that returns properly formatted PHP literals — single-quoted strings for string values, bare `true`/`false` for boolean values. Previously, boolean clientDefault values were incorrectly wrapped in quotes (e.g., `$param ??= 'true'` instead of `$param ??= true`), causing a PHP type mismatch when the parameter is typed as `?bool`.
- **`WrappedEndpointRequestGenerator.ts`**: Removed the `php.Type.optional()` wrapping for inline path parameters with `clientDefault`. The `DataClass` constructor (line 62-63 of `DataClass.ts`) uses `?? null` for optional-typed fields, which discards the clientDefault initializer. Keeping the non-optional type preserves the initializer via `?? <initializer>` (line 64-66).
- **Changelog**: Added `generators/php/sdk/changes/unreleased/fix-client-default-boolean-quoting.yml`

- [ ] Updated README.md generator (if applicable) — N/A

## Testing

- [x] Seed test passes: `pnpm seed test --generator php-sdk --fixture x-fern-default --skip-scripts --local`
- [x] TypeScript compilation passes: `pnpm turbo run compile --filter @fern-api/php-sdk`
- [x] Biome formatting passes: `pnpm check:biome`
- [x] No snapshot changes (the x-fern-default fixture only uses string clientDefaults, so these edge-case fixes don't affect its output)

Link to Devin session: https://app.devin.ai/sessions/302ae462e00f48019f81795e34b6937a
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
