### PR TITLE
fix(cli): register translations for preview docs URLs

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-preview-translations.yml
+++ b/packages/cli/cli/changes/unreleased/fix-preview-translations.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix `fern generate --docs --preview` to register translations for preview URLs.
+    Previously, translation registration was skipped entirely in preview mode,
+    causing translated docs to not appear in preview deployments.
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -628,9 +628,11 @@ export async function publishDocs({
         context.logger.debug(`Docs published to FDR in ${publishTime.toFixed(0)}ms`);
 
         // Register translated page content for each configured locale.
-        // Skip translation registration in preview mode to avoid overwriting production translations.
+        // In preview mode, register translations against the preview URL (not the production domain)
+        // so that translated docs are visible in preview without overwriting production translations.
         const translationPages = resolver.getTranslationPages();
-        if (!preview && translationPages != null && Object.keys(translationPages).length > 0) {
+        const translationDomain = preview ? urlToOutput : domain;
+        if (translationPages != null && Object.keys(translationPages).length > 0) {
             context.logger.info(`Registering translations for ${Object.keys(translationPages).length} locale(s)...`);
             await Promise.all(
                 Object.entries(translationPages).map(async ([locale, localePages]) => {
@@ -724,7 +726,7 @@ export async function publishDocs({
                                 ...headers // Include telemetry headers (X-CLI-Version, X-CI-Source, etc.)
                             },
                             body: JSON.stringify({
-                                domain,
+                                domain: translationDomain,
                                 orgId: organization,
                                 locale,
                                 docsDefinition: translatedDefinition


### PR DESCRIPTION
## Description

Fixes `fern generate --docs --preview` not working with translated docs.

## Changes Made

- Removed the `!preview` guard in `publishDocs.ts` that was skipping translation registration entirely in preview mode
- Added `translationDomain` variable that uses the preview URL (`urlToOutput`) in preview mode and the production domain otherwise
- Updated the `registerTranslation` fetch call to use `translationDomain` instead of the hardcoded production `domain`

### Root Cause

In `publishDocs.ts`, translation registration was explicitly skipped in preview mode (line 633: `if (!preview && ...)`). The original comment said this was "to avoid overwriting production translations." However, the real issue was that the code always used the production `domain` for the `registerTranslation` call — not the preview URL. By using the preview URL (`urlToOutput`) as the domain when in preview mode, translations are correctly registered against the preview site without any risk of overwriting production translations.

The server-side `registerTranslation` handler uses `ParsedBaseUrl.parse(domain)` which handles both bare hostnames and `https://`-prefixed URLs, and the preview URL is already registered in the `docsV2` table by the time `finishDocsRegister` completes (which happens before translation registration).

## Testing

- [x] Verified lint passes (`pnpm run check`)
- [ ] Manual testing with a translated docs project using `--preview` flag

Link to Devin session: https://app.devin.ai/sessions/708666b10d8c462082d8120d41cdaec1
Requested by: @dsinghvi