### PR TITLE
feat(cli): validate translation locale directories in fern check

### DIFF
--- a/packages/cli/cli/changes/unreleased/check-translation-directories.yml
+++ b/packages/cli/cli/changes/unreleased/check-translation-directories.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Add validation to `fern check` / `fern docs check` that verifies all configured
+    translation locales have a corresponding directory under `fern/translations/`.
+    If a directory is missing, a clear error message is printed showing the expected
+    directory structure.
+  type: feat

--- a/packages/cli/ete-tests/src/tests/validate/__snapshots__/validate.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/validate/__snapshots__/validate.test.ts.snap
@@ -6,7 +6,7 @@ No API definition found. Expected one of the following:
   - An api section in generators.yml pointing to your API spec(s)
   - A definition/ directory with Fern Definition files
 For more information, see https://buildwithfern.com/learn/api-definition/introduction/what-is-the-fern-folder
-Found 0 errors and 1 warning in __ELAPSED__ seconds. Run fern check --warnings to print out the warnings not shown."
+All checks passed"
 `;
 
 exports[`validate > no-api 1`] = `"Missing file: api.yml"`;

--- a/packages/cli/ete-tests/src/tests/validate/__snapshots__/validate.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/validate/__snapshots__/validate.test.ts.snap
@@ -6,7 +6,7 @@ No API definition found. Expected one of the following:
   - An api section in generators.yml pointing to your API spec(s)
   - A definition/ directory with Fern Definition files
 For more information, see https://buildwithfern.com/learn/api-definition/introduction/what-is-the-fern-folder
-All checks passed"
+Found 0 errors and 1 warning in __ELAPSED__ seconds. Run fern check --warnings to print out the warnings not shown."
 `;
 
 exports[`validate > no-api 1`] = `"Missing file: api.yml"`;

--- a/packages/cli/yaml/docs-validator/src/getAllRules.ts
+++ b/packages/cli/yaml/docs-validator/src/getAllRules.ts
@@ -7,6 +7,7 @@ import { NoCircularRedirectsRule } from "./rules/no-circular-redirects/index.js"
 import { NoNonComponentRefsRule } from "./rules/no-non-component-refs/index.js";
 import { NoOpenApiV2InDocsRule } from "./rules/no-openapi-v2-in-docs/index.js";
 import { OnlyVersionedNavigation } from "./rules/only-versioned-navigation/index.js";
+import { TranslationDirectoriesExistRule } from "./rules/translation-directories-exist/index.js";
 import { ValidDocsEndpoints } from "./rules/valid-docs-endpoints/index.js";
 import { ValidFileTypes } from "./rules/valid-file-types/index.js";
 import { ValidFrontmatter } from "./rules/valid-frontmatter/index.js";
@@ -34,7 +35,8 @@ const allRules = [
     ValidFileTypes,
     ValidDocsEndpoints,
     AllRolesMustBeDeclaredRule,
-    ValidFrontmatter
+    ValidFrontmatter,
+    TranslationDirectoriesExistRule
     // ValidMarkdownFileReferences
 ];
 

--- a/packages/cli/yaml/docs-validator/src/rules/index.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/index.ts
@@ -5,6 +5,7 @@ export * from "./missing-redirects/index.js";
 export * from "./no-circular-redirects/index.js";
 export * from "./only-versioned-navigation/index.js";
 export * from "./tab-with-href/index.js";
+export * from "./translation-directories-exist/index.js";
 export * from "./valid-docs-endpoints/index.js";
 export * from "./valid-file-types/index.js";
 export * from "./valid-frontmatter/index.js";

--- a/packages/cli/yaml/docs-validator/src/rules/translation-directories-exist/index.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/translation-directories-exist/index.ts
@@ -1,0 +1,1 @@
+export { TranslationDirectoriesExistRule } from "./translation-directories-exist.js";

--- a/packages/cli/yaml/docs-validator/src/rules/translation-directories-exist/translation-directories-exist.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/translation-directories-exist/translation-directories-exist.ts
@@ -81,9 +81,10 @@ function buildExpectedDirectoryTree({
     for (let i = 0; i < missingDirs.length; i++) {
         const isLast = i === missingDirs.length - 1;
         const connector = isLast ? "└" : "├";
-        lines.push(`  │   ${connector}── ${missingDirs[i]}/`);
-        lines.push(`  │   ${isLast ? " " : "│"}   └── pages/`);
-        lines.push(`  │   ${isLast ? " " : "│"}       └── ... (translated .mdx files)`);
+        const prefix = translationsDirExists ? "│" : " ";
+        lines.push(`  ${prefix}   ${connector}── ${missingDirs[i]}/`);
+        lines.push(`  ${prefix}   ${isLast ? " " : "│"}   └── pages/`);
+        lines.push(`  ${prefix}   ${isLast ? " " : "│"}       └── ... (translated .mdx files)`);
     }
     return lines.join("\n");
 }

--- a/packages/cli/yaml/docs-validator/src/rules/translation-directories-exist/translation-directories-exist.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/translation-directories-exist/translation-directories-exist.ts
@@ -1,0 +1,82 @@
+import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
+
+import { Rule, RuleViolation } from "../../Rule.js";
+
+export const TranslationDirectoriesExistRule: Rule = {
+    name: "translation-directories-exist",
+    create: ({ workspace }) => {
+        return {
+            file: async ({ config }) => {
+                const violations: RuleViolation[] = [];
+
+                const translations = config.translations;
+                if (translations == null || translations.length === 0) {
+                    return violations;
+                }
+
+                const defaultLocale = translations.find((t) => t.default === true)?.lang;
+                const translationsDir = join(workspace.absoluteFilePath, RelativeFilePath.of("translations"));
+                const translationsDirExists = await doesPathExist(translationsDir);
+
+                const missingDirs: string[] = [];
+
+                for (const translation of translations) {
+                    // The default locale's pages live in the top-level pages/ directory
+                    if (translation.lang === defaultLocale) {
+                        continue;
+                    }
+
+                    const langDir = join(translationsDir, RelativeFilePath.of(translation.lang)) as AbsoluteFilePath;
+
+                    if (!(await doesPathExist(langDir))) {
+                        missingDirs.push(translation.lang);
+                    }
+                }
+
+                if (missingDirs.length > 0) {
+                    const expectedTree = buildExpectedDirectoryTree({
+                        translationsDirExists,
+                        missingDirs,
+                        fernFolderPath: workspace.absoluteFilePath
+                    });
+
+                    violations.push({
+                        severity: "error",
+                        message:
+                            `Missing translation ${missingDirs.length === 1 ? "directory" : "directories"} for ` +
+                            `${missingDirs.length === 1 ? "locale" : "locales"}: ${missingDirs.join(", ")}\n\n` +
+                            `Expected directory structure:\n\n${expectedTree}\n\n` +
+                            `Each translation directory should mirror the same page paths used in your docs.yml navigation.\n` +
+                            `For example, if your navigation references "pages/getting-started.mdx", create a\n` +
+                            `translated version at "translations/${missingDirs[0]}/pages/getting-started.mdx".`
+                    });
+                }
+
+                return violations;
+            }
+        };
+    }
+};
+
+function buildExpectedDirectoryTree({
+    translationsDirExists,
+    missingDirs,
+    fernFolderPath
+}: {
+    translationsDirExists: boolean;
+    missingDirs: string[];
+    fernFolderPath: AbsoluteFilePath;
+}): string {
+    const fernDirName = fernFolderPath.split("/").pop() ?? "fern";
+    const lines: string[] = [];
+    lines.push(`  ${fernDirName}/`);
+    lines.push(`  ${translationsDirExists ? "├" : "└"}── translations/`);
+    for (let i = 0; i < missingDirs.length; i++) {
+        const isLast = i === missingDirs.length - 1;
+        const connector = isLast ? "└" : "├";
+        lines.push(`  │   ${connector}── ${missingDirs[i]}/`);
+        lines.push(`  │   ${isLast ? " " : "│"}   └── pages/`);
+        lines.push(`  │   ${isLast ? " " : "│"}       └── ... (translated .mdx files)`);
+    }
+    return lines.join("\n");
+}

--- a/packages/cli/yaml/docs-validator/src/rules/translation-directories-exist/translation-directories-exist.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/translation-directories-exist/translation-directories-exist.ts
@@ -40,15 +40,22 @@ export const TranslationDirectoriesExistRule: Rule = {
                         fernFolderPath: workspace.absoluteFilePath
                     });
 
+                    const pad = "            ";
+                    const indentedTree = expectedTree
+                        .split("\n")
+                        .map((line) => `${pad}${line}`)
+                        .join("\n");
+
                     violations.push({
                         severity: "error",
                         message:
                             `Missing translation ${missingDirs.length === 1 ? "directory" : "directories"} for ` +
                             `${missingDirs.length === 1 ? "locale" : "locales"}: ${missingDirs.join(", ")}\n\n` +
-                            `Expected directory structure:\n\n${expectedTree}\n\n` +
-                            `Each translation directory should mirror the same page paths used in your docs.yml navigation.\n` +
-                            `For example, if your navigation references "pages/getting-started.mdx", create a\n` +
-                            `translated version at "translations/${missingDirs[0]}/pages/getting-started.mdx".`
+                            `${pad}Expected directory structure:\n\n${indentedTree}\n\n` +
+                            `${pad}Each translation directory should mirror the same page paths used in your\n` +
+                            `${pad}docs.yml navigation. For example, if your navigation references\n` +
+                            `${pad}"pages/getting-started.mdx", create a translated version at\n` +
+                            `${pad}"translations/${missingDirs[0]}/pages/getting-started.mdx".`
                     });
                 }
 


### PR DESCRIPTION
## Description

Adds a new validation rule `translation-directories-exist` to `fern check` / `fern docs check`. When `translations` is configured in `docs.yml`, the rule verifies that each non-default locale has a corresponding `fern/translations/<lang>/` directory. If directories are missing, a clear, indented error message is printed showing the expected directory structure.

## Changes Made

- Added `translation-directories-exist` rule in `packages/cli/yaml/docs-validator/src/rules/translation-directories-exist/`
- Registered the rule in `getAllRules.ts` and `rules/index.ts`
- Error message body is properly indented under `[error]` with ASCII tree diagram and guidance text
- Tree prefix correctly uses spaces (not `│`) when the translations directory itself doesn't exist

### Example output

```
[docs] 1 error
    [error] Missing translation directories for locales: fr, ja

            Expected directory structure:

              fern/
              ├── translations/
              │   ├── fr/
              │   │   └── pages/
              │   │       └── ... (translated .mdx files)
              │   └── ja/
              │       └── pages/
              │           └── ... (translated .mdx files)

            Each translation directory should mirror the same page paths used in your
            docs.yml navigation. For example, if your navigation references
            "pages/getting-started.mdx", create a translated version at
            "translations/fr/pages/getting-started.mdx".

Found 1 error and 0 warnings in 0.001 seconds.
```

## Testing

- [x] Built CLI locally and tested with a fixture declaring 4 locales (`en` default, `es`, `fr`, `ja`) with only `es/` existing
- [x] Error correctly lists only `fr, ja` — skips default locale and existing directories
- [x] Creating the missing directories resolves the error ("All checks passed")
- [x] No translations configured = no error
- [x] Manual testing completed
- [x] CI green (30/30 checks passing)

Link to Devin session: https://app.devin.ai/sessions/0b447c039a864388a6602ec3734444f8
Requested by: @dsinghvi