### PR TITLE
feat(cli): support i18n overrides for navigation labels via YAML overlays

### DIFF
--- a/packages/cli/cli/changes/unreleased/add-i18n-navigation-overlays.yml
+++ b/packages/cli/cli/changes/unreleased/add-i18n-navigation-overlays.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Add support for translating navigation labels (tabs, products, versions, sections, pages, announcements)
+    via YAML overlay files in `translations/<lang>/fern/`. The overlay files use the same format as
+    `write-translation` output and are deep-merged over the source navigation configuration.
+  type: feat

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -2071,8 +2071,10 @@ async function loadTranslationNavigationOverlays({
     const translationsRootDir = path.join(absolutePathToFernFolder, "translations") as AbsoluteFilePath;
     const result: Record<string, docsYml.TranslationNavigationOverlay> = {};
 
+    const normalizedTranslations = translations.map((t) => docsYml.DocsYmlSchemas.normalizeTranslationConfig(t));
+
     await Promise.all(
-        translations.map(async ({ lang }) => {
+        normalizedTranslations.map(async ({ lang }) => {
             if (lang === defaultLocale) {
                 return;
             }
@@ -2183,7 +2185,16 @@ async function parseNavigationOverlayFromDocsYml({
 
             // If this product references a nav file, load its tab/navigation overrides
             if (typeof productObj.path === "string") {
-                const navFilePath = path.join(langFernDir, productObj.path) as AbsoluteFilePath;
+                // Validate path to prevent path traversal attacks
+                const resolvedNavFilePath = path.resolve(langFernDir, productObj.path) as AbsoluteFilePath;
+                if (!resolvedNavFilePath.startsWith(langFernDir)) {
+                    context.logger.warn(
+                        `Invalid path in product overlay: "${productObj.path}" escapes the translations directory. Skipping.`
+                    );
+                    overlay.products.push(productOverlay);
+                    continue;
+                }
+                const navFilePath = resolvedNavFilePath;
                 if (await doesPathExist(navFilePath)) {
                     try {
                         const navContent = yaml.load(await readFile(navFilePath, "utf-8"));

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -2243,7 +2243,8 @@ function parseTabOverlays(tabsObj: Record<string, unknown>): Record<string, docs
         if (isPlainObject(tabConfig)) {
             const tabConfigObj = tabConfig as Record<string, unknown>;
             result[tabId] = {
-                displayName: typeof tabConfigObj["display-name"] === "string" ? tabConfigObj["display-name"] : undefined
+                displayName: typeof tabConfigObj["display-name"] === "string" ? tabConfigObj["display-name"] : undefined,
+                slug: typeof tabConfigObj.slug === "string" ? tabConfigObj.slug : undefined
             };
         }
     }

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -2243,7 +2243,8 @@ function parseTabOverlays(tabsObj: Record<string, unknown>): Record<string, docs
         if (isPlainObject(tabConfig)) {
             const tabConfigObj = tabConfig as Record<string, unknown>;
             result[tabId] = {
-                displayName: typeof tabConfigObj["display-name"] === "string" ? tabConfigObj["display-name"] : undefined,
+                displayName:
+                    typeof tabConfigObj["display-name"] === "string" ? tabConfigObj["display-name"] : undefined,
                 slug: typeof tabConfigObj.slug === "string" ? tabConfigObj.slug : undefined
             };
         }

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -2173,7 +2173,9 @@ async function parseNavigationOverlayFromDocsYml({
                 slug: typeof productObj.slug === "string" ? productObj.slug : undefined,
                 displayName: typeof productObj["display-name"] === "string" ? productObj["display-name"] : undefined,
                 subtitle: typeof productObj.subtitle === "string" ? productObj.subtitle : undefined,
-                announcement: undefined
+                announcement: undefined,
+                tabs: undefined,
+                navigation: undefined
             };
 
             if (isPlainObject(productObj.announcement)) {
@@ -2184,6 +2186,7 @@ async function parseNavigationOverlayFromDocsYml({
             }
 
             // If this product references a nav file, load its tab/navigation overrides
+            // These are stored per-product to avoid collision when multiple products share tab IDs
             if (typeof productObj.path === "string") {
                 // Validate path to prevent path traversal attacks
                 const resolvedNavFilePath = path.resolve(langFernDir, productObj.path) as AbsoluteFilePath;
@@ -2200,19 +2203,13 @@ async function parseNavigationOverlayFromDocsYml({
                         const navContent = yaml.load(await readFile(navFilePath, "utf-8"));
                         if (isPlainObject(navContent)) {
                             const navObj = navContent as Record<string, unknown>;
-                            // Tabs defined in the nav file
+                            // Tabs defined in the nav file - stored per-product
                             if (isPlainObject(navObj.tabs)) {
-                                overlay.tabs = {
-                                    ...overlay.tabs,
-                                    ...parseTabOverlays(navObj.tabs as Record<string, unknown>)
-                                };
+                                productOverlay.tabs = parseTabOverlays(navObj.tabs as Record<string, unknown>);
                             }
-                            // Navigation items defined in the nav file
+                            // Navigation items defined in the nav file - stored per-product
                             if (Array.isArray(navObj.navigation)) {
-                                overlay.navigation = [
-                                    ...(overlay.navigation ?? []),
-                                    ...parseNavigationItemOverlays(navObj.navigation)
-                                ];
+                                productOverlay.navigation = parseNavigationItemOverlays(navObj.navigation);
                             }
                         }
                     } catch (error) {

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -164,6 +164,13 @@ export async function parseDocsConfiguration({
         })
     );
 
+    const translationNavigationOverlaysPromise = loadTranslationNavigationOverlays({
+        translations: rawDocsConfiguration.translations,
+        defaultLocale,
+        absolutePathToFernFolder,
+        context
+    });
+
     const [
         navigation,
         pages,
@@ -174,7 +181,8 @@ export async function parseDocsConfiguration({
         context7File,
         llmsTxtFile,
         llmsFullTxtFile,
-        translationPages
+        translationPages,
+        translationNavigationOverlays
     ] = await Promise.all([
         convertedNavigationPromise,
         pagesPromise,
@@ -185,7 +193,8 @@ export async function parseDocsConfiguration({
         context7FilePromise,
         llmsTxtFilePromise,
         llmsFullTxtFilePromise,
-        translationPagesPromise
+        translationPagesPromise,
+        translationNavigationOverlaysPromise
     ]);
 
     // Validate incompatible tabs configuration: sidebar placement + center alignment
@@ -214,6 +223,9 @@ export async function parseDocsConfiguration({
 
         /* per-locale translated page content */
         translationPages,
+
+        /* per-locale translated navigation overlays */
+        translationNavigationOverlays,
 
         /* navigation */
         landingPage,
@@ -2027,5 +2039,275 @@ async function loadTranslationPages({
         })
     );
 
+    return result;
+}
+
+/**
+ * Loads translated navigation overlay YAML files from `translations/<lang>/fern/` directories.
+ *
+ * For each locale declared in `translations`, this function:
+ * 1. Checks for `translations/<lang>/fern/docs.yml` (the top-level overlay).
+ * 2. If found, parses it and extracts translatable fields (title, products, versions,
+ *    announcement, tabs).
+ * 3. For products with a `path:` field, also loads the referenced nav YAML file
+ *    from `translations/<lang>/fern/` to extract tab and navigation overrides.
+ * 4. Returns a map of locale → TranslationNavigationOverlay.
+ */
+async function loadTranslationNavigationOverlays({
+    translations,
+    defaultLocale,
+    absolutePathToFernFolder,
+    context
+}: {
+    translations: docsYml.RawSchemas.TranslationConfig[] | undefined;
+    defaultLocale: string | undefined;
+    absolutePathToFernFolder: AbsoluteFilePath;
+    context: TaskContext;
+}): Promise<Record<string, docsYml.TranslationNavigationOverlay> | undefined> {
+    if (translations == null || translations.length === 0) {
+        return undefined;
+    }
+
+    const translationsRootDir = path.join(absolutePathToFernFolder, "translations") as AbsoluteFilePath;
+    const result: Record<string, docsYml.TranslationNavigationOverlay> = {};
+
+    await Promise.all(
+        translations.map(async ({ lang }) => {
+            if (lang === defaultLocale) {
+                return;
+            }
+
+            const langFernDir = path.join(translationsRootDir, lang, "fern") as AbsoluteFilePath;
+            const overlayDocsYmlPath = path.join(langFernDir, "docs.yml") as AbsoluteFilePath;
+
+            if (!(await doesPathExist(overlayDocsYmlPath))) {
+                return;
+            }
+
+            try {
+                const overlayContent = yaml.load(await readFile(overlayDocsYmlPath, "utf-8"));
+                if (!isPlainObject(overlayContent)) {
+                    context.logger.warn(
+                        `Translation overlay at "${overlayDocsYmlPath}" is not a valid YAML object. Skipping.`
+                    );
+                    return;
+                }
+
+                const overlay = await parseNavigationOverlayFromDocsYml({
+                    docsYmlContent: overlayContent as Record<string, unknown>,
+                    langFernDir,
+                    context
+                });
+
+                result[lang] = overlay;
+            } catch (error) {
+                context.logger.warn(
+                    `Failed to load translation overlay for locale "${lang}": ${String(error)}. Navigation labels will not be translated for this locale.`
+                );
+            }
+        })
+    );
+
+    if (Object.keys(result).length === 0) {
+        return undefined;
+    }
+
+    return result;
+}
+
+function extractString(obj: unknown, key: string): string | undefined {
+    if (isPlainObject(obj)) {
+        const value = (obj as Record<string, unknown>)[key];
+        if (typeof value === "string") {
+            return value;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Parses a translated `docs.yml` overlay and any referenced nav YAML files
+ * to produce a `TranslationNavigationOverlay`.
+ */
+async function parseNavigationOverlayFromDocsYml({
+    docsYmlContent,
+    langFernDir,
+    context
+}: {
+    docsYmlContent: Record<string, unknown>;
+    langFernDir: AbsoluteFilePath;
+    context: TaskContext;
+}): Promise<docsYml.TranslationNavigationOverlay> {
+    const overlay: docsYml.TranslationNavigationOverlay = {
+        tabs: undefined,
+        products: undefined,
+        versions: undefined,
+        announcement: undefined,
+        navigation: undefined
+    };
+
+    // Parse announcement
+    if (isPlainObject(docsYmlContent.announcement)) {
+        const message = extractString(docsYmlContent.announcement, "message");
+        if (message != null) {
+            overlay.announcement = { message };
+        }
+    }
+
+    // Parse top-level tabs
+    if (isPlainObject(docsYmlContent.tabs)) {
+        overlay.tabs = parseTabOverlays(docsYmlContent.tabs as Record<string, unknown>);
+    }
+
+    // Parse products
+    if (Array.isArray(docsYmlContent.products)) {
+        overlay.products = [];
+        for (const product of docsYmlContent.products) {
+            if (!isPlainObject(product)) {
+                continue;
+            }
+            const productObj = product as Record<string, unknown>;
+            const productOverlay: docsYml.ProductOverlay = {
+                slug: typeof productObj.slug === "string" ? productObj.slug : undefined,
+                displayName: typeof productObj["display-name"] === "string" ? productObj["display-name"] : undefined,
+                subtitle: typeof productObj.subtitle === "string" ? productObj.subtitle : undefined,
+                announcement: undefined
+            };
+
+            if (isPlainObject(productObj.announcement)) {
+                const message = extractString(productObj.announcement, "message");
+                if (message != null) {
+                    productOverlay.announcement = { message };
+                }
+            }
+
+            // If this product references a nav file, load its tab/navigation overrides
+            if (typeof productObj.path === "string") {
+                const navFilePath = path.join(langFernDir, productObj.path) as AbsoluteFilePath;
+                if (await doesPathExist(navFilePath)) {
+                    try {
+                        const navContent = yaml.load(await readFile(navFilePath, "utf-8"));
+                        if (isPlainObject(navContent)) {
+                            const navObj = navContent as Record<string, unknown>;
+                            // Tabs defined in the nav file
+                            if (isPlainObject(navObj.tabs)) {
+                                overlay.tabs = {
+                                    ...overlay.tabs,
+                                    ...parseTabOverlays(navObj.tabs as Record<string, unknown>)
+                                };
+                            }
+                            // Navigation items defined in the nav file
+                            if (Array.isArray(navObj.navigation)) {
+                                overlay.navigation = [
+                                    ...(overlay.navigation ?? []),
+                                    ...parseNavigationItemOverlays(navObj.navigation)
+                                ];
+                            }
+                        }
+                    } catch (error) {
+                        context.logger.warn(`Failed to load translation nav file "${navFilePath}": ${String(error)}`);
+                    }
+                }
+            }
+
+            overlay.products.push(productOverlay);
+        }
+    }
+
+    // Parse versions
+    if (Array.isArray(docsYmlContent.versions)) {
+        overlay.versions = [];
+        for (const version of docsYmlContent.versions) {
+            if (!isPlainObject(version)) {
+                continue;
+            }
+            const versionObj = version as Record<string, unknown>;
+            overlay.versions.push({
+                slug: typeof versionObj.slug === "string" ? versionObj.slug : undefined,
+                displayName: typeof versionObj["display-name"] === "string" ? versionObj["display-name"] : undefined
+            });
+        }
+    }
+
+    // Parse top-level navigation (for non-product configs that have navigation directly in docs.yml)
+    if (Array.isArray(docsYmlContent.navigation)) {
+        overlay.navigation = [...(overlay.navigation ?? []), ...parseNavigationItemOverlays(docsYmlContent.navigation)];
+    }
+
+    return overlay;
+}
+
+function parseTabOverlays(tabsObj: Record<string, unknown>): Record<string, docsYml.TabOverlay> {
+    const result: Record<string, docsYml.TabOverlay> = {};
+    for (const [tabId, tabConfig] of Object.entries(tabsObj)) {
+        if (isPlainObject(tabConfig)) {
+            const tabConfigObj = tabConfig as Record<string, unknown>;
+            result[tabId] = {
+                displayName: typeof tabConfigObj["display-name"] === "string" ? tabConfigObj["display-name"] : undefined
+            };
+        }
+    }
+    return result;
+}
+
+function parseNavigationItemOverlays(items: unknown[]): docsYml.NavigationItemOverlay[] {
+    const result: docsYml.NavigationItemOverlay[] = [];
+    for (const item of items) {
+        if (!isPlainObject(item)) {
+            continue;
+        }
+        const obj = item as Record<string, unknown>;
+
+        // A tabbed navigation item: { tab: <tabId>, layout: [...] }
+        if (typeof obj.tab === "string") {
+            const tabOverlay: docsYml.NavigationItemOverlay.Tab = {
+                type: "tab",
+                tabId: obj.tab,
+                layout: Array.isArray(obj.layout) ? parseNavigationItemOverlays(obj.layout) : undefined,
+                variants: Array.isArray(obj.variants) ? parseVariantOverlays(obj.variants) : undefined
+            };
+            result.push(tabOverlay);
+            continue;
+        }
+
+        // A section item: { section: "Title", contents: [...] }
+        if (typeof obj.section === "string") {
+            const sectionOverlay: docsYml.NavigationItemOverlay.Section = {
+                type: "section",
+                title: obj.section,
+                slug: typeof obj.slug === "string" ? obj.slug : undefined,
+                contents: Array.isArray(obj.contents) ? parseNavigationItemOverlays(obj.contents) : undefined
+            };
+            result.push(sectionOverlay);
+            continue;
+        }
+
+        // A page item: { page: "Title", path: "..." }
+        if (typeof obj.page === "string") {
+            const pageOverlay: docsYml.NavigationItemOverlay.Page = {
+                type: "page",
+                title: obj.page,
+                slug: typeof obj.slug === "string" ? obj.slug : undefined
+            };
+            result.push(pageOverlay);
+            continue;
+        }
+    }
+    return result;
+}
+
+function parseVariantOverlays(variants: unknown[]): docsYml.VariantOverlay[] {
+    const result: docsYml.VariantOverlay[] = [];
+    for (const variant of variants) {
+        if (!isPlainObject(variant)) {
+            continue;
+        }
+        const obj = variant as Record<string, unknown>;
+        result.push({
+            title: typeof obj.title === "string" ? obj.title : undefined,
+            subtitle: typeof obj.subtitle === "string" ? obj.subtitle : undefined,
+            slug: typeof obj.slug === "string" ? obj.slug : undefined
+        });
+    }
     return result;
 }

--- a/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
@@ -57,6 +57,9 @@ export interface ParsedDocsConfiguration {
     /* per-locale translated page content: locale → { relativeFilePath → markdown } */
     translationPages: Record<string, Record<RelativeFilePath, string>> | undefined;
 
+    /* per-locale translated navigation overlays: locale → NavigationOverlay */
+    translationNavigationOverlays: Record<string, TranslationNavigationOverlay> | undefined;
+
     /* RBAC declaration */
     roles: string[] | undefined;
 
@@ -532,4 +535,84 @@ export interface ParsedLibraryConfiguration {
     };
     /** The programming language of the library source code */
     lang: LibraryLanguage;
+}
+
+/**
+ * Represents a navigation overlay for a single locale, extracted from
+ * `translations/<lang>/fern/docs.yml` and any referenced product/version YAML files.
+ *
+ * These overlays contain only the translatable fields (display-name, title, subtitle,
+ * announcement message) keyed by the identifiers used in the source YAML (tab IDs,
+ * product slugs/display-names, etc.). They are applied to the resolved nav tree before
+ * the translated DocsDefinition is sent to FDR.
+ */
+export interface TranslationNavigationOverlay {
+    /** Translated tab display names, keyed by tab ID */
+    tabs: Record<string, TabOverlay> | undefined;
+    /** Translated product entries, matched by slug or display-name */
+    products: ProductOverlay[] | undefined;
+    /** Translated version entries, matched by slug or display-name */
+    versions: VersionOverlay[] | undefined;
+    /** Translated announcement message */
+    announcement: AnnouncementOverlay | undefined;
+    /** Translated navigation items (sections, pages), from the navigation YAML */
+    navigation: NavigationItemOverlay[] | undefined;
+}
+
+export interface TabOverlay {
+    displayName: string | undefined;
+}
+
+export interface ProductOverlay {
+    slug: string | undefined;
+    displayName: string | undefined;
+    subtitle: string | undefined;
+    announcement: AnnouncementOverlay | undefined;
+}
+
+export interface VersionOverlay {
+    slug: string | undefined;
+    displayName: string | undefined;
+}
+
+export interface AnnouncementOverlay {
+    message: string | undefined;
+}
+
+export type NavigationItemOverlay =
+    | NavigationItemOverlay.Page
+    | NavigationItemOverlay.Section
+    | NavigationItemOverlay.Tab
+    | NavigationItemOverlay.Variant;
+
+export declare namespace NavigationItemOverlay {
+    export interface Page {
+        type: "page";
+        title: string | undefined;
+        slug: string | undefined;
+    }
+    export interface Section {
+        type: "section";
+        title: string | undefined;
+        slug: string | undefined;
+        contents: NavigationItemOverlay[] | undefined;
+    }
+    export interface Tab {
+        type: "tab";
+        tabId: string;
+        layout: NavigationItemOverlay[] | undefined;
+        variants: VariantOverlay[] | undefined;
+    }
+    export interface Variant {
+        type: "variant";
+        title: string | undefined;
+        subtitle: string | undefined;
+        slug: string | undefined;
+    }
+}
+
+export interface VariantOverlay {
+    title: string | undefined;
+    subtitle: string | undefined;
+    slug: string | undefined;
 }

--- a/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
@@ -569,6 +569,10 @@ export interface ProductOverlay {
     displayName: string | undefined;
     subtitle: string | undefined;
     announcement: AnnouncementOverlay | undefined;
+    /** Per-product tab overlays from the referenced nav file */
+    tabs: Record<string, TabOverlay> | undefined;
+    /** Per-product navigation overlays from the referenced nav file */
+    navigation: NavigationItemOverlay[] | undefined;
 }
 
 export interface VersionOverlay {

--- a/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
@@ -561,6 +561,7 @@ export interface TranslationNavigationOverlay {
 
 export interface TabOverlay {
     displayName: string | undefined;
+    slug: string | undefined;
 }
 
 export interface ProductOverlay {

--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -8,7 +8,12 @@ import {
     stripMdxComments,
     transformAtPrefixImports
 } from "@fern-api/docs-markdown-utils";
-import { DocsDefinitionResolver, filterOssWorkspaces, stitchGlobalTheme } from "@fern-api/docs-resolver";
+import {
+    DocsDefinitionResolver,
+    filterOssWorkspaces,
+    stitchGlobalTheme,
+    type TranslationNavigationOverlay
+} from "@fern-api/docs-resolver";
 import {
     APIV1Read,
     APIV1Write,
@@ -135,9 +140,7 @@ export interface PreviewDocsResult {
      * Per-locale translated navigation overlays from translations/<lang>/fern/ YAML files.
      * Key is locale, value is a parsed overlay with translated display-names, titles, etc.
      */
-    translationNavigationOverlays:
-        | Record<string, import("@fern-api/configuration").docsYml.TranslationNavigationOverlay>
-        | undefined;
+    translationNavigationOverlays: Record<string, TranslationNavigationOverlay> | undefined;
     /**
      * File IDs collected during docs resolution, needed for image path replacement
      * in translated pages.

--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -132,6 +132,13 @@ export interface PreviewDocsResult {
      */
     translationPages: Record<string, Record<RelativeFilePath, string>> | undefined;
     /**
+     * Per-locale translated navigation overlays from translations/<lang>/fern/ YAML files.
+     * Key is locale, value is a parsed overlay with translated display-names, titles, etc.
+     */
+    translationNavigationOverlays:
+        | Record<string, import("@fern-api/configuration").docsYml.TranslationNavigationOverlay>
+        | undefined;
+    /**
      * File IDs collected during docs resolution, needed for image path replacement
      * in translated pages.
      */
@@ -288,6 +295,7 @@ export async function getPreviewDocsDefinition({
             return {
                 docsDefinition: previousDocsDefinition,
                 translationPages: previousPreviewResult.translationPages,
+                translationNavigationOverlays: previousPreviewResult.translationNavigationOverlays,
                 collectedFileIds: previousPreviewResult.collectedFileIds,
                 docsWorkspacePath: previousPreviewResult.docsWorkspacePath
             };
@@ -376,13 +384,15 @@ export async function getPreviewDocsDefinition({
         docsDefinition = { ...substitutedDocs, jsFiles };
     }
 
-    // Get translation pages and collected file IDs for building translated definitions
+    // Get translation pages, navigation overlays, and collected file IDs for building translated definitions
     const translationPages = resolver.getTranslationPages();
+    const translationNavigationOverlays = resolver.getTranslationNavigationOverlays();
     const collectedFileIds = resolver.getCollectedFileIds();
 
     return {
         docsDefinition,
         translationPages,
+        translationNavigationOverlays,
         collectedFileIds,
         docsWorkspacePath: docsWorkspace.absoluteFilePath
     };

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -1,6 +1,8 @@
 import { extractErrorMessage } from "@fern-api/core-utils";
 import {
     applyTranslatedFrontmatterToNavTree,
+    applyTranslatedNavigationOverlays,
+    getTranslatedAnnouncement,
     replaceImagePathsAndUrls,
     stripMdxComments,
     wrapWithHttps
@@ -711,7 +713,8 @@ export async function runAppPreviewServer({
      */
     function computeTranslatedDefinitions(result: PreviewDocsResult): Map<string, DocsV1Read.DocsDefinition> {
         const translations = new Map<string, DocsV1Read.DocsDefinition>();
-        const { docsDefinition, translationPages, collectedFileIds, docsWorkspacePath } = result;
+        const { docsDefinition, translationPages, translationNavigationOverlays, collectedFileIds, docsWorkspacePath } =
+            result;
 
         if (translationPages == null || Object.keys(translationPages).length === 0) {
             return translations;
@@ -761,18 +764,27 @@ export async function runAppPreviewServer({
                 }
 
                 // Apply translated frontmatter to nav tree
-                const updatedRoot = applyTranslatedFrontmatterToNavTree(
+                let updatedRoot = applyTranslatedFrontmatterToNavTree(
                     docsDefinition.config.root,
                     localePages as Record<string, string>,
                     context
                 );
+
+                // Apply navigation overlay (translated display-names, titles, etc.)
+                const localeNavOverlay = translationNavigationOverlays?.[locale];
+                let translatedAnnouncement = docsDefinition.config.announcement;
+                if (localeNavOverlay != null) {
+                    updatedRoot = applyTranslatedNavigationOverlays(updatedRoot, localeNavOverlay);
+                    translatedAnnouncement = getTranslatedAnnouncement(localeNavOverlay) ?? translatedAnnouncement;
+                }
 
                 const translatedDefinition: DocsV1Read.DocsDefinition = {
                     ...docsDefinition,
                     pages: translatedPages,
                     config: {
                         ...docsDefinition.config,
-                        root: updatedRoot
+                        root: updatedRoot,
+                        announcement: translatedAnnouncement
                     }
                 };
 

--- a/packages/cli/docs-preview/src/runPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runPreviewServer.ts
@@ -1,5 +1,7 @@
 import {
     applyTranslatedFrontmatterToNavTree,
+    applyTranslatedNavigationOverlays,
+    getTranslatedAnnouncement,
     replaceImagePathsAndUrls,
     stripMdxComments,
     wrapWithHttps
@@ -144,7 +146,8 @@ export async function runPreviewServer({
      */
     function computeTranslatedDefinitions(result: PreviewDocsResult): Map<string, DocsV1Read.DocsDefinition> {
         const translations = new Map<string, DocsV1Read.DocsDefinition>();
-        const { docsDefinition, translationPages, collectedFileIds, docsWorkspacePath } = result;
+        const { docsDefinition, translationPages, translationNavigationOverlays, collectedFileIds, docsWorkspacePath } =
+            result;
 
         if (translationPages == null || Object.keys(translationPages).length === 0) {
             return translations;
@@ -194,18 +197,27 @@ export async function runPreviewServer({
                 }
 
                 // Apply translated frontmatter to nav tree
-                const updatedRoot = applyTranslatedFrontmatterToNavTree(
+                let updatedRoot = applyTranslatedFrontmatterToNavTree(
                     docsDefinition.config.root,
                     localePages as Record<string, string>,
                     context
                 );
+
+                // Apply navigation overlay (translated display-names, titles, etc.)
+                const localeNavOverlay = translationNavigationOverlays?.[locale];
+                let translatedAnnouncement = docsDefinition.config.announcement;
+                if (localeNavOverlay != null) {
+                    updatedRoot = applyTranslatedNavigationOverlays(updatedRoot, localeNavOverlay);
+                    translatedAnnouncement = getTranslatedAnnouncement(localeNavOverlay) ?? translatedAnnouncement;
+                }
 
                 const translatedDefinition: DocsV1Read.DocsDefinition = {
                     ...docsDefinition,
                     pages: translatedPages,
                     config: {
                         ...docsDefinition.config,
-                        root: updatedRoot
+                        root: updatedRoot,
+                        announcement: translatedAnnouncement
                     }
                 };
 

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -272,6 +272,17 @@ export class DocsDefinitionResolver {
     }
 
     /**
+     * Returns per-locale translated navigation overlays loaded from
+     * `translations/<lang>/fern/docs.yml` and referenced nav YAML files.
+     * Must be called after `resolve()`.
+     */
+    public getTranslationNavigationOverlays():
+        | Record<string, import("@fern-api/configuration").docsYml.TranslationNavigationOverlay>
+        | undefined {
+        return this._parsedDocsConfig?.translationNavigationOverlays;
+    }
+
+    /**
      * Returns the map of absolute file paths to uploaded file IDs.
      * Used by translation processing to rewrite image paths in translated pages.
      * Must be called after `resolve()`.

--- a/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
@@ -1,0 +1,302 @@
+import { docsYml } from "@fern-api/configuration";
+import { FernNavigation } from "@fern-api/fdr-sdk";
+import { describe, expect, it } from "vitest";
+
+import { applyTranslatedNavigationOverlays, getTranslatedAnnouncement } from "../applyTranslatedNavigationOverlays.js";
+
+function asRoot(obj: unknown): FernNavigation.V1.RootNode {
+    return obj as FernNavigation.V1.RootNode;
+}
+
+function emptyOverlay(): docsYml.TranslationNavigationOverlay {
+    return {
+        tabs: undefined,
+        products: undefined,
+        versions: undefined,
+        announcement: undefined,
+        navigation: undefined
+    };
+}
+
+describe("applyTranslatedNavigationOverlays", () => {
+    it("returns undefined when root is undefined", () => {
+        const result = applyTranslatedNavigationOverlays(undefined, emptyOverlay());
+        expect(result).toBeUndefined();
+    });
+
+    it("returns original root when overlay is empty", () => {
+        const root = {
+            type: "root",
+            child: {
+                type: "page",
+                title: "Welcome",
+                slug: "welcome"
+            }
+        };
+        const result = applyTranslatedNavigationOverlays(asRoot(root), emptyOverlay());
+        expect(result).toEqual(root);
+    });
+
+    it("applies product display-name override", () => {
+        const root = {
+            type: "root",
+            child: {
+                type: "productgroup",
+                children: [
+                    {
+                        type: "product",
+                        productId: "Home",
+                        title: "Home",
+                        subtitle: "",
+                        slug: "docs/home",
+                        child: { type: "unversioned", child: { type: "sidebarRoot", children: [] } }
+                    }
+                ]
+            }
+        };
+        const overlay: docsYml.TranslationNavigationOverlay = {
+            ...emptyOverlay(),
+            products: [
+                {
+                    slug: "home",
+                    displayName: "ホーム",
+                    subtitle: "ようこそ",
+                    announcement: undefined
+                }
+            ]
+        };
+
+        const result = applyTranslatedNavigationOverlays(asRoot(root), overlay);
+        const productGroup = (result as unknown as Record<string, unknown>).child as Record<string, unknown>;
+        const products = productGroup.children as Array<Record<string, unknown>>;
+        expect(products[0]?.title).toBe("ホーム");
+        expect(products[0]?.subtitle).toBe("ようこそ");
+    });
+
+    it("applies version display-name override", () => {
+        const root = {
+            type: "root",
+            child: {
+                type: "productgroup",
+                children: [
+                    {
+                        type: "product",
+                        productId: "SDK",
+                        title: "SDK",
+                        subtitle: "",
+                        slug: "docs/sdk",
+                        child: {
+                            type: "versioned",
+                            children: [
+                                {
+                                    type: "version",
+                                    versionId: "v2",
+                                    title: "v2",
+                                    slug: "docs/sdk/v2",
+                                    child: { type: "sidebarRoot", children: [] }
+                                },
+                                {
+                                    type: "version",
+                                    versionId: "v1",
+                                    title: "v1",
+                                    slug: "docs/sdk/v1",
+                                    child: { type: "sidebarRoot", children: [] }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        };
+        const overlay: docsYml.TranslationNavigationOverlay = {
+            ...emptyOverlay(),
+            versions: [
+                { slug: "v2", displayName: "v2 (最新)" },
+                { slug: "v1", displayName: "v1 (旧)" }
+            ]
+        };
+
+        const result = applyTranslatedNavigationOverlays(asRoot(root), overlay);
+        const pg = (result as unknown as Record<string, unknown>).child as Record<string, unknown>;
+        const products = pg.children as Array<Record<string, unknown>>;
+        const versioned = products[0]?.child as Record<string, unknown>;
+        const versions = versioned.children as Array<Record<string, unknown>>;
+        expect(versions[0]?.title).toBe("v2 (最新)");
+        expect(versions[1]?.title).toBe("v1 (旧)");
+    });
+
+    it("applies tab display-name override", () => {
+        const root = {
+            type: "root",
+            child: {
+                type: "unversioned",
+                child: {
+                    type: "tabbed",
+                    children: [
+                        {
+                            type: "tab",
+                            title: "Documentation",
+                            slug: "docs/documentation",
+                            child: { type: "sidebarRoot", children: [] }
+                        },
+                        {
+                            type: "tab",
+                            title: "API Reference",
+                            slug: "docs/api-reference",
+                            child: { type: "sidebarRoot", children: [] }
+                        }
+                    ]
+                }
+            }
+        };
+        const overlay: docsYml.TranslationNavigationOverlay = {
+            ...emptyOverlay(),
+            tabs: {
+                documentation: { displayName: "ドキュメント" },
+                "api-reference": { displayName: "APIリファレンス" }
+            }
+        };
+
+        const result = applyTranslatedNavigationOverlays(asRoot(root), overlay);
+        const unversioned = (result as unknown as Record<string, unknown>).child as Record<string, unknown>;
+        const tabbed = unversioned.child as Record<string, unknown>;
+        const tabs = tabbed.children as Array<Record<string, unknown>>;
+        expect(tabs[0]?.title).toBe("ドキュメント");
+        expect(tabs[1]?.title).toBe("APIリファレンス");
+    });
+
+    it("applies section and page title overrides from navigation overlay", () => {
+        const root = {
+            type: "root",
+            child: {
+                type: "unversioned",
+                child: {
+                    type: "tabbed",
+                    children: [
+                        {
+                            type: "tab",
+                            title: "Documentation",
+                            slug: "docs/documentation",
+                            child: {
+                                type: "sidebarRoot",
+                                children: [
+                                    {
+                                        type: "page",
+                                        title: "Getting Started",
+                                        slug: "docs/documentation/getting-started",
+                                        pageId: "pages/getting-started.mdx"
+                                    },
+                                    {
+                                        type: "section",
+                                        title: "API Guide",
+                                        slug: "docs/documentation/api-guide",
+                                        children: [
+                                            {
+                                                type: "page",
+                                                title: "Overview",
+                                                slug: "docs/documentation/api-guide/overview",
+                                                pageId: "pages/api/overview.mdx"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        };
+        const overlay: docsYml.TranslationNavigationOverlay = {
+            ...emptyOverlay(),
+            tabs: {
+                documentation: { displayName: "ドキュメント" }
+            },
+            navigation: [
+                {
+                    type: "tab",
+                    tabId: "documentation",
+                    layout: [
+                        { type: "page", title: "はじめに", slug: "getting-started" },
+                        {
+                            type: "section",
+                            title: "APIガイド",
+                            slug: "api-guide",
+                            contents: [{ type: "page", title: "概要", slug: "overview" }]
+                        }
+                    ],
+                    variants: undefined
+                }
+            ]
+        };
+
+        const result = applyTranslatedNavigationOverlays(asRoot(root), overlay);
+        const unversioned = (result as unknown as Record<string, unknown>).child as Record<string, unknown>;
+        const tabbed = unversioned.child as Record<string, unknown>;
+        const tabs = tabbed.children as Array<Record<string, unknown>>;
+        const tab = tabs[0] as Record<string, unknown>;
+        expect(tab.title).toBe("ドキュメント");
+
+        const sidebarRoot = tab.child as Record<string, unknown>;
+        const sidebarChildren = sidebarRoot.children as Array<Record<string, unknown>>;
+        expect(sidebarChildren[0]?.title).toBe("はじめに");
+
+        const section = sidebarChildren[1] as Record<string, unknown>;
+        expect(section.title).toBe("APIガイド");
+
+        const sectionChildren = section.children as Array<Record<string, unknown>>;
+        expect(sectionChildren[0]?.title).toBe("概要");
+    });
+
+    it("applies product announcement override", () => {
+        const root = {
+            type: "root",
+            child: {
+                type: "productgroup",
+                children: [
+                    {
+                        type: "product",
+                        productId: "SDK",
+                        title: "SDK",
+                        subtitle: "",
+                        slug: "docs/sdk",
+                        announcement: { text: "v2 released!" },
+                        child: { type: "unversioned", child: { type: "sidebarRoot", children: [] } }
+                    }
+                ]
+            }
+        };
+        const overlay: docsYml.TranslationNavigationOverlay = {
+            ...emptyOverlay(),
+            products: [
+                {
+                    slug: "sdk",
+                    displayName: undefined,
+                    subtitle: undefined,
+                    announcement: { message: "v2がリリースされました！" }
+                }
+            ]
+        };
+
+        const result = applyTranslatedNavigationOverlays(asRoot(root), overlay);
+        const pg = (result as unknown as Record<string, unknown>).child as Record<string, unknown>;
+        const products = pg.children as Array<Record<string, unknown>>;
+        const announcement = products[0]?.announcement as Record<string, unknown>;
+        expect(announcement.text).toBe("v2がリリースされました！");
+    });
+});
+
+describe("getTranslatedAnnouncement", () => {
+    it("returns undefined when no announcement override", () => {
+        const result = getTranslatedAnnouncement(emptyOverlay());
+        expect(result).toBeUndefined();
+    });
+
+    it("returns translated announcement text", () => {
+        const overlay: docsYml.TranslationNavigationOverlay = {
+            ...emptyOverlay(),
+            announcement: { message: "新しいバージョンがリリースされました" }
+        };
+        const result = getTranslatedAnnouncement(overlay);
+        expect(result).toEqual({ text: "新しいバージョンがリリースされました" });
+    });
+});

--- a/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
@@ -152,8 +152,8 @@ describe("applyTranslatedNavigationOverlays", () => {
         const overlay: docsYml.TranslationNavigationOverlay = {
             ...emptyOverlay(),
             tabs: {
-                documentation: { displayName: "ドキュメント" },
-                "api-reference": { displayName: "APIリファレンス" }
+                documentation: { displayName: "ドキュメント", slug: undefined },
+                "api-reference": { displayName: "APIリファレンス", slug: undefined }
             }
         };
 
@@ -209,7 +209,7 @@ describe("applyTranslatedNavigationOverlays", () => {
         const overlay: docsYml.TranslationNavigationOverlay = {
             ...emptyOverlay(),
             tabs: {
-                documentation: { displayName: "ドキュメント" }
+                documentation: { displayName: "ドキュメント", slug: undefined }
             },
             navigation: [
                 {
@@ -245,6 +245,63 @@ describe("applyTranslatedNavigationOverlays", () => {
 
         const sectionChildren = section.children as Array<Record<string, unknown>>;
         expect(sectionChildren[0]?.title).toBe("概要");
+    });
+
+    it("matches tabs by overlay slug when tab ID differs from nav slug", () => {
+        const root = {
+            type: "root",
+            child: {
+                type: "unversioned",
+                child: {
+                    type: "tabbed",
+                    children: [
+                        {
+                            type: "tab",
+                            title: "Documentation",
+                            slug: "home/documentation",
+                            child: {
+                                type: "sidebarRoot",
+                                children: [
+                                    {
+                                        type: "page",
+                                        title: "Getting Started",
+                                        slug: "home/documentation/getting-started",
+                                        pageId: "pages/getting-started.mdx"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        };
+        const overlay: docsYml.TranslationNavigationOverlay = {
+            ...emptyOverlay(),
+            tabs: {
+                docs: { displayName: "ドキュメント", slug: "documentation" }
+            },
+            navigation: [
+                {
+                    type: "tab",
+                    tabId: "docs",
+                    layout: [
+                        { type: "page", title: "はじめに", slug: "getting-started" }
+                    ],
+                    variants: undefined
+                }
+            ]
+        };
+
+        const result = applyTranslatedNavigationOverlays(asRoot(root), overlay);
+        const unversioned = (result as unknown as Record<string, unknown>).child as Record<string, unknown>;
+        const tabbed = unversioned.child as Record<string, unknown>;
+        const tabs = tabbed.children as Array<Record<string, unknown>>;
+        const tab = tabs[0] as Record<string, unknown>;
+        expect(tab.title).toBe("ドキュメント");
+
+        const sidebarRoot = tab.child as Record<string, unknown>;
+        const sidebarChildren = sidebarRoot.children as Array<Record<string, unknown>>;
+        expect(sidebarChildren[0]?.title).toBe("はじめに");
     });
 
     it("applies product announcement override", () => {

--- a/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
@@ -61,7 +61,9 @@ describe("applyTranslatedNavigationOverlays", () => {
                     slug: "home",
                     displayName: "ホーム",
                     subtitle: "ようこそ",
-                    announcement: undefined
+                    announcement: undefined,
+                    tabs: undefined,
+                    navigation: undefined
                 }
             ]
         };
@@ -327,7 +329,9 @@ describe("applyTranslatedNavigationOverlays", () => {
                     slug: "sdk",
                     displayName: undefined,
                     subtitle: undefined,
-                    announcement: { message: "v2がリリースされました！" }
+                    announcement: { message: "v2がリリースされました！" },
+                    tabs: undefined,
+                    navigation: undefined
                 }
             ]
         };

--- a/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
@@ -338,6 +338,63 @@ describe("applyTranslatedNavigationOverlays", () => {
         const announcement = products[0]?.announcement as Record<string, unknown>;
         expect(announcement.text).toBe("v2がリリースされました！");
     });
+
+    it("does not mutate the original root when applying tab overlays", () => {
+        const root = {
+            type: "root",
+            child: {
+                type: "productgroup",
+                children: [
+                    {
+                        type: "product",
+                        title: "Home",
+                        slug: "home",
+                        children: [
+                            {
+                                type: "tabbed",
+                                children: [
+                                    {
+                                        type: "tab",
+                                        title: "Documentation",
+                                        slug: "home/documentation",
+                                        children: []
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+        const overlay: docsYml.TranslationNavigationOverlay = {
+            ...emptyOverlay(),
+            tabs: {
+                docs: {
+                    displayName: "ドキュメント",
+                    slug: "documentation"
+                }
+            }
+        };
+
+        // Apply overlay — this should NOT mutate the original root
+        const result = applyTranslatedNavigationOverlays(asRoot(root), overlay);
+
+        // The result should have the translated title
+        const resultProduct = (result as unknown as Record<string, unknown>).child as Record<string, unknown>;
+        const resultTabbed = (resultProduct.children as Array<Record<string, unknown>>)[0]?.children as Array<
+            Record<string, unknown>
+        >;
+        const resultTab = (resultTabbed[0]?.children as Array<Record<string, unknown>>)[0];
+        expect(resultTab?.title).toBe("ドキュメント");
+
+        // The ORIGINAL root must still have the English title
+        const origProduct = root.child as Record<string, unknown>;
+        const origTabbed = (origProduct.children as Array<Record<string, unknown>>)[0]?.children as Array<
+            Record<string, unknown>
+        >;
+        const origTab = (origTabbed[0]?.children as Array<Record<string, unknown>>)[0];
+        expect(origTab?.title).toBe("Documentation");
+    });
 });
 
 describe("getTranslatedAnnouncement", () => {

--- a/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
@@ -284,9 +284,7 @@ describe("applyTranslatedNavigationOverlays", () => {
                 {
                     type: "tab",
                     tabId: "docs",
-                    layout: [
-                        { type: "page", title: "はじめに", slug: "getting-started" }
-                    ],
+                    layout: [{ type: "page", title: "はじめに", slug: "getting-started" }],
                     variants: undefined
                 }
             ]

--- a/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
+++ b/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
@@ -1,0 +1,414 @@
+import { docsYml } from "@fern-api/configuration";
+import { FernNavigation } from "@fern-api/fdr-sdk";
+
+/**
+ * Applies translated navigation overlays to the resolved nav tree.
+ *
+ * This walks the navigation tree (as a plain object) and overrides `title`,
+ * `subtitle`, and `announcement` fields based on the overlay data parsed from
+ * `translations/<lang>/fern/docs.yml` and nav YAML files.
+ *
+ * Matching strategy:
+ * - Products: matched positionally against the overlay's products array
+ * - Versions: matched positionally against the overlay's versions array
+ * - Tabs: matched by looking up the tab slug in the overlay's `tabs` map
+ * - Sections/Pages: matched positionally within the overlay's navigation items
+ */
+export function applyTranslatedNavigationOverlays(
+    root: FernNavigation.V1.RootNode | undefined,
+    overlay: docsYml.TranslationNavigationOverlay
+): FernNavigation.V1.RootNode | undefined {
+    if (root == null) {
+        return undefined;
+    }
+
+    const result = walkAndApply(root, overlay) as FernNavigation.V1.RootNode;
+    return result;
+}
+
+/**
+ * Returns the translated announcement text, or undefined if no override.
+ */
+export function getTranslatedAnnouncement(overlay: docsYml.TranslationNavigationOverlay): { text: string } | undefined {
+    if (overlay.announcement?.message != null) {
+        return { text: overlay.announcement.message };
+    }
+    return undefined;
+}
+
+function walkAndApply(node: unknown, overlay: docsYml.TranslationNavigationOverlay): unknown {
+    if (node == null || typeof node !== "object") {
+        return node;
+    }
+    if (Array.isArray(node)) {
+        return node.map((item) => walkAndApply(item, overlay));
+    }
+
+    const obj = node as Record<string, unknown>;
+    const updated: Record<string, unknown> = {};
+
+    for (const [k, v] of Object.entries(obj)) {
+        if (k === "children" && Array.isArray(v)) {
+            updated[k] = applyChildOverlays(v, obj, overlay);
+        } else {
+            updated[k] = walkAndApply(v, overlay);
+        }
+    }
+
+    return updated;
+}
+
+function applyChildOverlays(
+    children: unknown[],
+    parent: Record<string, unknown>,
+    overlay: docsYml.TranslationNavigationOverlay
+): unknown[] {
+    const parentType = parent["type"] as string | undefined;
+
+    // Product group children → match with overlay.products
+    if (parentType === "productgroup" && overlay.products != null) {
+        return children.map((child, index) => {
+            const childObj = child as Record<string, unknown> | null;
+            if (childObj == null || typeof childObj !== "object") {
+                return walkAndApply(child, overlay);
+            }
+            const productOverlay = findProductOverlay(childObj, overlay.products ?? [], index);
+            const walked = walkAndApply(child, overlay) as Record<string, unknown>;
+            if (productOverlay != null) {
+                return applyProductOverlayToNode(walked, productOverlay);
+            }
+            return walked;
+        });
+    }
+
+    // Versioned children → match with overlay.versions
+    if (parentType === "versioned" && overlay.versions != null) {
+        return children.map((child, index) => {
+            const childObj = child as Record<string, unknown> | null;
+            if (childObj == null || typeof childObj !== "object") {
+                return walkAndApply(child, overlay);
+            }
+            const versionOverlay = findVersionOverlay(childObj, overlay.versions ?? [], index);
+            const walked = walkAndApply(child, overlay) as Record<string, unknown>;
+            if (versionOverlay != null) {
+                return applyVersionOverlayToNode(walked, versionOverlay);
+            }
+            return walked;
+        });
+    }
+
+    // Tabbed children → match tabs with overlay.tabs and overlay.navigation
+    if (parentType === "tabbed") {
+        return children.map((child) => {
+            const childObj = child as Record<string, unknown> | null;
+            if (childObj == null || typeof childObj !== "object") {
+                return walkAndApply(child, overlay);
+            }
+            if (childObj["type"] === "tab") {
+                return applyTabOverlayToNode(childObj, overlay);
+            }
+            return walkAndApply(child, overlay);
+        });
+    }
+
+    // SidebarRoot children → match sections/pages with overlay.navigation
+    if (parentType === "sidebarRoot") {
+        const navOverlays = collectFlatNavigationOverlays(overlay);
+        if (navOverlays.length > 0) {
+            return applySidebarChildOverlays(children, navOverlays, overlay);
+        }
+    }
+
+    // Section children → recursively apply section content overlays
+    if (parentType === "section") {
+        // Section children are handled via the section overlay's contents
+        // This is managed through the section overlay propagation
+        return children.map((child) => walkAndApply(child, overlay));
+    }
+
+    return children.map((child) => walkAndApply(child, overlay));
+}
+
+function findProductOverlay(
+    node: Record<string, unknown>,
+    products: docsYml.ProductOverlay[],
+    index: number
+): docsYml.ProductOverlay | undefined {
+    // Match by slug
+    const nodeSlug = extractLastSlugSegment(node["slug"] as string | undefined);
+    if (nodeSlug != null) {
+        for (const p of products) {
+            if (p.slug != null && p.slug === nodeSlug) {
+                return p;
+            }
+        }
+    }
+
+    // Match by productId/title
+    const nodeTitle = node["title"] as string | undefined;
+    const nodeProductId = node["productId"] as string | undefined;
+    for (const p of products) {
+        if (p.displayName != null) {
+            if (nodeTitle === p.displayName || nodeProductId === p.displayName) {
+                return p;
+            }
+        }
+    }
+
+    // Fall back to positional
+    if (index < products.length) {
+        return products[index];
+    }
+
+    return undefined;
+}
+
+function findVersionOverlay(
+    node: Record<string, unknown>,
+    versions: docsYml.VersionOverlay[],
+    index: number
+): docsYml.VersionOverlay | undefined {
+    const nodeSlug = extractLastSlugSegment(node["slug"] as string | undefined);
+    if (nodeSlug != null) {
+        for (const v of versions) {
+            if (v.slug != null && v.slug === nodeSlug) {
+                return v;
+            }
+        }
+    }
+
+    const nodeTitle = node["title"] as string | undefined;
+    const nodeVersionId = node["versionId"] as string | undefined;
+    for (const v of versions) {
+        if (v.displayName != null) {
+            if (nodeTitle === v.displayName || nodeVersionId === v.displayName) {
+                return v;
+            }
+        }
+    }
+
+    if (index < versions.length) {
+        return versions[index];
+    }
+
+    return undefined;
+}
+
+function applyProductOverlayToNode(
+    node: Record<string, unknown>,
+    productOverlay: docsYml.ProductOverlay
+): Record<string, unknown> {
+    if (productOverlay.displayName != null) {
+        node["title"] = productOverlay.displayName;
+    }
+    if (productOverlay.subtitle != null) {
+        node["subtitle"] = productOverlay.subtitle;
+    }
+    if (productOverlay.announcement?.message != null) {
+        node["announcement"] = { text: productOverlay.announcement.message };
+    }
+    return node;
+}
+
+function applyVersionOverlayToNode(
+    node: Record<string, unknown>,
+    versionOverlay: docsYml.VersionOverlay
+): Record<string, unknown> {
+    if (versionOverlay.displayName != null) {
+        node["title"] = versionOverlay.displayName;
+    }
+    return node;
+}
+
+function applyTabOverlayToNode(node: Record<string, unknown>, overlay: docsYml.TranslationNavigationOverlay): unknown {
+    const tabSlug = extractLastSlugSegment(node["slug"] as string | undefined);
+    const tabTitle = node["title"] as string | undefined;
+
+    // Look up tab display-name override from overlay.tabs
+    if (overlay.tabs != null && tabSlug != null) {
+        // Try matching by slug (tab ID is typically the slug)
+        for (const [tabId, tabOverlay] of Object.entries(overlay.tabs)) {
+            if (tabId === tabSlug && tabOverlay.displayName != null) {
+                node["title"] = tabOverlay.displayName;
+                break;
+            }
+        }
+    }
+
+    // Find matching tab navigation overlay for child overrides
+    const tabNavOverlay = findTabNavOverlay(tabSlug, tabTitle, overlay);
+
+    if (tabNavOverlay != null) {
+        // Apply tab title override from the tabs map if not already applied
+        if (overlay.tabs != null) {
+            const tabOverlayEntry = overlay.tabs[tabNavOverlay.tabId];
+            if (tabOverlayEntry?.displayName != null) {
+                node["title"] = tabOverlayEntry.displayName;
+            }
+        }
+
+        // Create a scoped overlay for this tab's children
+        if (tabNavOverlay.layout != null) {
+            const scopedOverlay: docsYml.TranslationNavigationOverlay = {
+                tabs: undefined,
+                products: undefined,
+                versions: undefined,
+                announcement: undefined,
+                navigation: tabNavOverlay.layout
+            };
+            return walkAndApply(node, scopedOverlay);
+        }
+    }
+
+    return walkAndApply(node, overlay);
+}
+
+function findTabNavOverlay(
+    tabSlug: string | undefined,
+    tabTitle: string | undefined,
+    overlay: docsYml.TranslationNavigationOverlay
+): docsYml.NavigationItemOverlay.Tab | undefined {
+    if (overlay.navigation == null) {
+        return undefined;
+    }
+
+    for (const navItem of overlay.navigation) {
+        if (navItem.type !== "tab") {
+            continue;
+        }
+        // Match by tab ID against slug
+        if (tabSlug != null && navItem.tabId === tabSlug) {
+            return navItem;
+        }
+        // Match by tab ID against a tab slug from the tabs map
+        if (overlay.tabs != null) {
+            const tabConfig = overlay.tabs[navItem.tabId];
+            if (tabConfig?.displayName != null && tabConfig.displayName === tabTitle) {
+                return navItem;
+            }
+        }
+    }
+
+    return undefined;
+}
+
+/**
+ * Collects all non-tab navigation overlays (sections and pages) from the overlay's
+ * navigation items, flattening tab layouts into a single list.
+ */
+function collectFlatNavigationOverlays(overlay: docsYml.TranslationNavigationOverlay): docsYml.NavigationItemOverlay[] {
+    if (overlay.navigation == null) {
+        return [];
+    }
+
+    // If the navigation contains tab items, the sidebar content is inside
+    // each tab's layout — those are handled by applyTabOverlayToNode.
+    // For untabbed navigation, return all items directly.
+    const nonTabItems = overlay.navigation.filter((item) => item.type !== "tab");
+    return nonTabItems;
+}
+
+function applySidebarChildOverlays(
+    children: unknown[],
+    navOverlays: docsYml.NavigationItemOverlay[],
+    overlay: docsYml.TranslationNavigationOverlay
+): unknown[] {
+    let sectionIdx = 0;
+    let pageIdx = 0;
+
+    return children.map((child) => {
+        const childObj = child as Record<string, unknown> | null;
+        if (childObj == null || typeof childObj !== "object") {
+            return walkAndApply(child, overlay);
+        }
+
+        const childType = childObj["type"] as string | undefined;
+
+        if (childType === "section") {
+            const sectionOverlays = navOverlays.filter(
+                (item): item is docsYml.NavigationItemOverlay.Section => item.type === "section"
+            );
+            const matched = matchSectionOverlay(childObj, sectionOverlays, sectionIdx);
+            sectionIdx++;
+
+            if (matched != null) {
+                const walked = walkAndApply(child, overlay) as Record<string, unknown>;
+                if (matched.title != null) {
+                    walked["title"] = matched.title;
+                }
+                if (matched.contents != null) {
+                    // Re-apply section content overlays recursively
+                    const childArray = walked["children"] as unknown[] | undefined;
+                    if (childArray != null) {
+                        walked["children"] = applySidebarChildOverlays(childArray, matched.contents, overlay);
+                    }
+                }
+                return walked;
+            }
+            return walkAndApply(child, overlay);
+        }
+
+        if (childType === "page" || childType === "landingPage") {
+            const pageOverlays = navOverlays.filter(
+                (item): item is docsYml.NavigationItemOverlay.Page => item.type === "page"
+            );
+            const matched = matchPageOverlay(childObj, pageOverlays, pageIdx);
+            pageIdx++;
+
+            if (matched?.title != null) {
+                const walked = walkAndApply(child, overlay) as Record<string, unknown>;
+                walked["title"] = matched.title;
+                return walked;
+            }
+            return walkAndApply(child, overlay);
+        }
+
+        return walkAndApply(child, overlay);
+    });
+}
+
+function matchSectionOverlay(
+    section: Record<string, unknown>,
+    overlays: docsYml.NavigationItemOverlay.Section[],
+    positionIndex: number
+): docsYml.NavigationItemOverlay.Section | undefined {
+    const sectionSlug = extractLastSlugSegment(section["slug"] as string | undefined);
+
+    for (const o of overlays) {
+        if (o.slug != null && o.slug === sectionSlug) {
+            return o;
+        }
+    }
+
+    if (positionIndex < overlays.length) {
+        return overlays[positionIndex];
+    }
+    return undefined;
+}
+
+function matchPageOverlay(
+    page: Record<string, unknown>,
+    overlays: docsYml.NavigationItemOverlay.Page[],
+    positionIndex: number
+): docsYml.NavigationItemOverlay.Page | undefined {
+    const pageSlug = extractLastSlugSegment(page["slug"] as string | undefined);
+
+    for (const o of overlays) {
+        if (o.slug != null && o.slug === pageSlug) {
+            return o;
+        }
+    }
+
+    if (positionIndex < overlays.length) {
+        return overlays[positionIndex];
+    }
+    return undefined;
+}
+
+function extractLastSlugSegment(slug: string | undefined): string | undefined {
+    if (slug == null) {
+        return undefined;
+    }
+    const parts = slug.split("/");
+    return parts[parts.length - 1];
+}

--- a/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
+++ b/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
@@ -384,14 +384,18 @@ function matchSectionOverlay(
 ): docsYml.NavigationItemOverlay.Section | undefined {
     const sectionSlug = extractLastSlugSegment(section["slug"] as string | undefined);
 
+    // First, try to match by slug
     for (const o of overlays) {
         if (o.slug != null && o.slug === sectionSlug) {
             return o;
         }
     }
 
-    if (positionIndex < overlays.length) {
-        return overlays[positionIndex];
+    // Positional fallback: only use overlays that don't have a slug defined,
+    // to avoid incorrectly applying a slug-targeted overlay to the wrong sibling.
+    const noSlugOverlays = overlays.filter((o) => o.slug == null);
+    if (positionIndex < noSlugOverlays.length) {
+        return noSlugOverlays[positionIndex];
     }
     return undefined;
 }
@@ -403,14 +407,18 @@ function matchPageOverlay(
 ): docsYml.NavigationItemOverlay.Page | undefined {
     const pageSlug = extractLastSlugSegment(page["slug"] as string | undefined);
 
+    // First, try to match by slug
     for (const o of overlays) {
         if (o.slug != null && o.slug === pageSlug) {
             return o;
         }
     }
 
-    if (positionIndex < overlays.length) {
-        return overlays[positionIndex];
+    // Positional fallback: only use overlays that don't have a slug defined,
+    // to avoid incorrectly applying a slug-targeted overlay to the wrong sibling.
+    const noSlugOverlays = overlays.filter((o) => o.slug == null);
+    if (positionIndex < noSlugOverlays.length) {
+        return noSlugOverlays[positionIndex];
     }
     return undefined;
 }

--- a/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
+++ b/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
@@ -226,9 +226,11 @@ function applyTabOverlayToNode(node: Record<string, unknown>, overlay: docsYml.T
 
     // Look up tab display-name override from overlay.tabs
     if (overlay.tabs != null && tabSlug != null) {
-        // Try matching by slug (tab ID is typically the slug)
         for (const [tabId, tabOverlay] of Object.entries(overlay.tabs)) {
-            if (tabId === tabSlug && tabOverlay.displayName != null) {
+            // Match by tab ID (YAML key) against nav tree slug segment, or
+            // by the overlay's explicit slug field against the slug segment
+            const isMatch = tabId === tabSlug || (tabOverlay.slug != null && tabOverlay.slug === tabSlug);
+            if (isMatch && tabOverlay.displayName != null) {
                 node["title"] = tabOverlay.displayName;
                 break;
             }
@@ -280,7 +282,14 @@ function findTabNavOverlay(
         if (tabSlug != null && navItem.tabId === tabSlug) {
             return navItem;
         }
-        // Match by tab ID against a tab slug from the tabs map
+        // Match by overlay tab's explicit slug field against the nav tree slug
+        if (tabSlug != null && overlay.tabs != null) {
+            const tabConfig = overlay.tabs[navItem.tabId];
+            if (tabConfig?.slug != null && tabConfig.slug === tabSlug) {
+                return navItem;
+            }
+        }
+        // Fallback: match by overlay tab's display name against the nav tree title
         if (overlay.tabs != null) {
             const tabConfig = overlay.tabs[navItem.tabId];
             if (tabConfig?.displayName != null && tabConfig.displayName === tabTitle) {

--- a/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
+++ b/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
@@ -105,7 +105,8 @@ function applyChildOverlays(
                 return walkAndApply(child, overlay);
             }
             if (childObj["type"] === "tab") {
-                return applyTabOverlayToNode(childObj, overlay);
+                const walked = walkAndApply(child, overlay) as Record<string, unknown>;
+                return applyTabOverlayToNode(walked, overlay);
             }
             return walkAndApply(child, overlay);
         });

--- a/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
+++ b/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
@@ -73,11 +73,19 @@ function applyChildOverlays(
                 return walkAndApply(child, overlay);
             }
             const productOverlay = findProductOverlay(childObj, overlay.products ?? [], index);
-            const walked = walkAndApply(child, overlay) as Record<string, unknown>;
             if (productOverlay != null) {
+                // Create a scoped overlay with product-specific tabs/navigation
+                const scopedOverlay: docsYml.TranslationNavigationOverlay = {
+                    tabs: productOverlay.tabs ?? overlay.tabs,
+                    products: undefined,
+                    versions: overlay.versions,
+                    announcement: productOverlay.announcement ?? overlay.announcement,
+                    navigation: productOverlay.navigation ?? overlay.navigation
+                };
+                const walked = walkAndApply(child, scopedOverlay) as Record<string, unknown>;
                 return applyProductOverlayToNode(walked, productOverlay);
             }
-            return walked;
+            return walkAndApply(child, overlay);
         });
     }
 
@@ -114,6 +122,15 @@ function applyChildOverlays(
 
     // SidebarRoot children → match sections/pages with overlay.navigation
     if (parentType === "sidebarRoot") {
+        const navOverlays = collectFlatNavigationOverlays(overlay);
+        if (navOverlays.length > 0) {
+            return applySidebarChildOverlays(children, navOverlays, overlay);
+        }
+    }
+
+    // SidebarGroup children → match sections/pages with overlay.navigation
+    // This handles top-level pages that are wrapped in sidebarGroup nodes by DocsDefinitionResolver
+    if (parentType === "sidebarGroup") {
         const navOverlays = collectFlatNavigationOverlays(overlay);
         if (navOverlays.length > 0) {
             return applySidebarChildOverlays(children, navOverlays, overlay);
@@ -223,7 +240,6 @@ function applyVersionOverlayToNode(
 
 function applyTabOverlayToNode(node: Record<string, unknown>, overlay: docsYml.TranslationNavigationOverlay): unknown {
     const tabSlug = extractLastSlugSegment(node["slug"] as string | undefined);
-    const tabTitle = node["title"] as string | undefined;
 
     // Look up tab display-name override from overlay.tabs
     if (overlay.tabs != null && tabSlug != null) {
@@ -239,7 +255,7 @@ function applyTabOverlayToNode(node: Record<string, unknown>, overlay: docsYml.T
     }
 
     // Find matching tab navigation overlay for child overrides
-    const tabNavOverlay = findTabNavOverlay(tabSlug, tabTitle, overlay);
+    const tabNavOverlay = findTabNavOverlay(tabSlug, overlay);
 
     if (tabNavOverlay != null) {
         // Apply tab title override from the tabs map if not already applied
@@ -247,6 +263,17 @@ function applyTabOverlayToNode(node: Record<string, unknown>, overlay: docsYml.T
             const tabOverlayEntry = overlay.tabs[tabNavOverlay.tabId];
             if (tabOverlayEntry?.displayName != null) {
                 node["title"] = tabOverlayEntry.displayName;
+            }
+        }
+
+        // Handle tab variants if present
+        if (tabNavOverlay.variants != null && tabNavOverlay.variants.length > 0) {
+            const tabChild = node["child"] as Record<string, unknown> | undefined;
+            if (tabChild != null && tabChild["type"] === "variants") {
+                const variantsChildren = tabChild["children"] as unknown[] | undefined;
+                if (variantsChildren != null) {
+                    tabChild["children"] = applyVariantOverlays(variantsChildren, tabNavOverlay.variants);
+                }
             }
         }
 
@@ -268,7 +295,6 @@ function applyTabOverlayToNode(node: Record<string, unknown>, overlay: docsYml.T
 
 function findTabNavOverlay(
     tabSlug: string | undefined,
-    tabTitle: string | undefined,
     overlay: docsYml.TranslationNavigationOverlay
 ): docsYml.NavigationItemOverlay.Tab | undefined {
     if (overlay.navigation == null) {
@@ -287,13 +313,6 @@ function findTabNavOverlay(
         if (tabSlug != null && overlay.tabs != null) {
             const tabConfig = overlay.tabs[navItem.tabId];
             if (tabConfig?.slug != null && tabConfig.slug === tabSlug) {
-                return navItem;
-            }
-        }
-        // Fallback: match by overlay tab's display name against the nav tree title
-        if (overlay.tabs != null) {
-            const tabConfig = overlay.tabs[navItem.tabId];
-            if (tabConfig?.displayName != null && tabConfig.displayName === tabTitle) {
                 return navItem;
             }
         }
@@ -429,4 +448,46 @@ function extractLastSlugSegment(slug: string | undefined): string | undefined {
     }
     const parts = slug.split("/");
     return parts[parts.length - 1];
+}
+
+/**
+ * Applies variant overlays to tab variant children.
+ * Matches variants by slug first, then falls back to positional matching.
+ */
+function applyVariantOverlays(variants: unknown[], overlays: docsYml.VariantOverlay[]): unknown[] {
+    return variants.map((variant, index) => {
+        const variantObj = variant as Record<string, unknown> | null;
+        if (variantObj == null || typeof variantObj !== "object") {
+            return variant;
+        }
+
+        const variantSlug = extractLastSlugSegment(variantObj["slug"] as string | undefined);
+        let matchedOverlay: docsYml.VariantOverlay | undefined;
+
+        // First, try to match by slug
+        if (variantSlug != null) {
+            matchedOverlay = overlays.find((o) => o.slug != null && o.slug === variantSlug);
+        }
+
+        // Positional fallback: only use overlays that don't have a slug defined
+        if (matchedOverlay == null) {
+            const noSlugOverlays = overlays.filter((o) => o.slug == null);
+            if (index < noSlugOverlays.length) {
+                matchedOverlay = noSlugOverlays[index];
+            }
+        }
+
+        if (matchedOverlay != null) {
+            const result = { ...variantObj };
+            if (matchedOverlay.title != null) {
+                result["title"] = matchedOverlay.title;
+            }
+            if (matchedOverlay.subtitle != null) {
+                result["subtitle"] = matchedOverlay.subtitle;
+            }
+            return result;
+        }
+
+        return variant;
+    });
 }

--- a/packages/cli/docs-resolver/src/index.ts
+++ b/packages/cli/docs-resolver/src/index.ts
@@ -1,3 +1,5 @@
+import { type docsYml } from "@fern-api/configuration";
+
 // Re-export markdown utilities needed for translation processing
 export { replaceImagePathsAndUrls, stripMdxComments } from "@fern-api/docs-markdown-utils";
 export { applyTranslatedFrontmatterToNavTree } from "./applyTranslatedFrontmatterToNavTree.js";
@@ -5,7 +7,6 @@ export {
     applyTranslatedNavigationOverlays,
     getTranslatedAnnouncement
 } from "./applyTranslatedNavigationOverlays.js";
-import { type docsYml } from "@fern-api/configuration";
 export type TranslationNavigationOverlay = docsYml.TranslationNavigationOverlay;
 export { DocsDefinitionResolver, type UploadedFile } from "./DocsDefinitionResolver.js";
 export { stitchGlobalTheme } from "./stitchGlobalTheme.js";

--- a/packages/cli/docs-resolver/src/index.ts
+++ b/packages/cli/docs-resolver/src/index.ts
@@ -1,6 +1,10 @@
 // Re-export markdown utilities needed for translation processing
 export { replaceImagePathsAndUrls, stripMdxComments } from "@fern-api/docs-markdown-utils";
 export { applyTranslatedFrontmatterToNavTree } from "./applyTranslatedFrontmatterToNavTree.js";
+export {
+    applyTranslatedNavigationOverlays,
+    getTranslatedAnnouncement
+} from "./applyTranslatedNavigationOverlays.js";
 export { DocsDefinitionResolver, type UploadedFile } from "./DocsDefinitionResolver.js";
 export { stitchGlobalTheme } from "./stitchGlobalTheme.js";
 export { convertIrToApiDefinition } from "./utils/convertIrToApiDefinition.js";

--- a/packages/cli/docs-resolver/src/index.ts
+++ b/packages/cli/docs-resolver/src/index.ts
@@ -5,6 +5,8 @@ export {
     applyTranslatedNavigationOverlays,
     getTranslatedAnnouncement
 } from "./applyTranslatedNavigationOverlays.js";
+import { type docsYml } from "@fern-api/configuration";
+export type TranslationNavigationOverlay = docsYml.TranslationNavigationOverlay;
 export { DocsDefinitionResolver, type UploadedFile } from "./DocsDefinitionResolver.js";
 export { stitchGlobalTheme } from "./stitchGlobalTheme.js";
 export { convertIrToApiDefinition } from "./utils/convertIrToApiDefinition.js";

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -5,7 +5,9 @@ import { createFdrService } from "@fern-api/core";
 import { MediaType, replaceEnvVariables } from "@fern-api/core-utils";
 import {
     applyTranslatedFrontmatterToNavTree,
+    applyTranslatedNavigationOverlays,
     DocsDefinitionResolver,
+    getTranslatedAnnouncement,
     replaceImagePathsAndUrls,
     stripMdxComments,
     UploadedFile,
@@ -631,6 +633,7 @@ export async function publishDocs({
         // In preview mode, register translations against the preview URL (not the production domain)
         // so that translated docs are visible in preview without overwriting production translations.
         const translationPages = resolver.getTranslationPages();
+        const translationNavigationOverlays = resolver.getTranslationNavigationOverlays();
         const translationDomain = preview ? urlToOutput : domain;
         if (translationPages != null && Object.keys(translationPages).length > 0) {
             context.logger.info(`Registering translations for ${Object.keys(translationPages).length} locale(s)...`);
@@ -699,18 +702,29 @@ export async function publishDocs({
                                 })
                             )
                         };
-                        const updatedRoot = applyTranslatedFrontmatterToNavTree(
+                        let updatedRoot = applyTranslatedFrontmatterToNavTree(
                             docsDefinition.config.root,
                             // localePages is Record<RelativeFilePath, string> (path -> raw markdown)
                             localePages as Record<string, string>,
                             context
                         );
+
+                        // Apply navigation overlay (translated display-names, titles, etc.)
+                        const localeNavOverlay = translationNavigationOverlays?.[locale];
+                        let translatedAnnouncement = docsDefinition.config.announcement;
+                        if (localeNavOverlay != null) {
+                            updatedRoot = applyTranslatedNavigationOverlays(updatedRoot, localeNavOverlay);
+                            translatedAnnouncement =
+                                getTranslatedAnnouncement(localeNavOverlay) ?? translatedAnnouncement;
+                        }
+
                         const translatedDefinition: DocsDefinition = {
                             ...docsDefinition,
                             pages: translatedPages,
                             config: {
                                 ...docsDefinition.config,
-                                root: updatedRoot
+                                root: updatedRoot,
+                                announcement: translatedAnnouncement
                             }
                         };
                         const pageCount = Object.keys(localePages).length;


### PR DESCRIPTION
## Description

Adds support for translating navigation labels (tabs, products, versions, sections, pages, announcements) via YAML overlay files in `translations/<lang>/fern/`. The overlay files use the exact same format that `fern write-translation` already generates, so users can simply translate the values in place.

This closes the gap where `translations:` config only loaded per-language `.mdx` page content but had no mechanism for translating navigation chrome fields (tab names, product titles, version labels, section headings, etc.).

## How it works

1. Users place translated YAML overlay files at `translations/<lang>/fern/docs.yml` and referenced nav YAML files (e.g., `nav.yml`)
2. During docs publishing, the CLI loads these overlay files and extracts translatable fields into a `TranslationNavigationOverlay` structure
3. When building per-locale `DocsDefinition`, the overlay is applied to the nav tree by walking it and matching products (by slug), versions (by slug), tabs (by ID/slug), and sections/pages (by slug or position)
4. Translated announcement messages are also applied to the per-locale config

### Example

Source `docs.yml`:
```yaml
products:
  - display-name: Home
    path: ./nav.yml
    slug: home
```

Translation overlay at `translations/ja/fern/docs.yml`:
```yaml
products:
  - display-name: ホーム
    path: ./nav.yml
    slug: home
```

Translation overlay at `translations/ja/fern/nav.yml`:
```yaml
tabs:
  docs:
    display-name: ドキュメント
navigation:
  - tab: docs
    layout:
      - page: はじめに
        path: ./pages/getting-started.mdx
        slug: getting-started
      - section: APIガイド
        contents:
          - page: 概要
            path: ./pages/api/overview.mdx
            slug: overview
        slug: api-guide
```

## Changes Made

- **`ParsedDocsConfiguration.ts`**: Added `translationNavigationOverlays` field and full type hierarchy (`TranslationNavigationOverlay`, `ProductOverlay`, `VersionOverlay`, `TabOverlay`, `AnnouncementOverlay`, `NavigationItemOverlay`, `VariantOverlay`)
- **`parseDocsConfiguration.ts`**: Added `loadTranslationNavigationOverlays()` function that loads and parses overlay YAML files alongside the existing `loadTranslationPages()`
- **`applyTranslatedNavigationOverlays.ts`**: New nav tree walker that applies overlay overrides to product titles, version names, tab display-names, section headings, page titles, and announcements
- **`publishDocs.ts`**: Wired navigation overlays into per-locale `DocsDefinition` construction
- **`runAppPreviewServer.ts` / `runPreviewServer.ts` / `previewDocs.ts`**: Wired navigation overlays into local preview translated definitions
- **`DocsDefinitionResolver.ts`**: Exposed `getTranslationNavigationOverlays()` accessor

## Testing

- [x] Unit tests added (`applyTranslatedNavigationOverlays.test.ts` — 9 tests covering products, versions, tabs, sections/pages, announcements, and edge cases)
- [x] All tests pass
- [x] Lint and format checks pass


Link to Devin session: https://app.devin.ai/sessions/26c0bb49462141559dc4e5d28995b904
Requested by: @dsinghvi