### PR TITLE
feat(cli): support registering translated API definitions in docs publish

### DIFF
--- a/packages/cli/cli/changes/unreleased/add-api-translation-registration.yml
+++ b/packages/cli/cli/changes/unreleased/add-api-translation-registration.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Support registering translated API definitions alongside translated docs pages.
+    Users can place translated API definition JSON files in `translations/<lang>/apis/<api-name>.json`
+    and they will be included in the translation registration request to FDR.
+  type: feat

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -2054,7 +2054,6 @@ async function loadTranslationPages({
 
     return result;
 }
-<<<<<<< HEAD
 
 /**
  * Loads translated navigation overlay YAML files from `translations/<lang>/fern/` directories.

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -2335,7 +2335,6 @@ function parseVariantOverlays(variants: unknown[]): docsYml.VariantOverlay[] {
     return result;
 }
 
-
 /**
  * Loads translated API definition JSON files from `translations/<lang>/apis/` directories.
  *

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -171,6 +171,14 @@ export async function parseDocsConfiguration({
         context
     });
 
+    const translationLocales =
+        rawDocsConfiguration.translations?.map((t) => docsYml.DocsYmlSchemas.normalizeTranslationConfig(t).lang) ?? [];
+    const translationApiDefinitionsPromise = loadTranslationApiDefinitions({
+        locales: translationLocales,
+        defaultLocale,
+        absolutePathToFernFolder,
+        context
+    });
     const [
         navigation,
         pages,
@@ -182,7 +190,8 @@ export async function parseDocsConfiguration({
         llmsTxtFile,
         llmsFullTxtFile,
         translationPages,
-        translationNavigationOverlays
+        translationNavigationOverlays,
+        translationApiDefinitions
     ] = await Promise.all([
         convertedNavigationPromise,
         pagesPromise,
@@ -194,7 +203,8 @@ export async function parseDocsConfiguration({
         llmsTxtFilePromise,
         llmsFullTxtFilePromise,
         translationPagesPromise,
-        translationNavigationOverlaysPromise
+        translationNavigationOverlaysPromise,
+        translationApiDefinitionsPromise
     ]);
 
     // Validate incompatible tabs configuration: sidebar placement + center alignment
@@ -226,6 +236,9 @@ export async function parseDocsConfiguration({
 
         /* per-locale translated navigation overlays */
         translationNavigationOverlays,
+
+        /* per-locale translated API definitions */
+        translationApiDefinitions,
 
         /* navigation */
         landingPage,
@@ -2041,6 +2054,7 @@ async function loadTranslationPages({
 
     return result;
 }
+<<<<<<< HEAD
 
 /**
  * Loads translated navigation overlay YAML files from `translations/<lang>/fern/` directories.
@@ -2320,4 +2334,78 @@ function parseVariantOverlays(variants: unknown[]): docsYml.VariantOverlay[] {
         });
     }
     return result;
+}
+
+
+/**
+ * Loads translated API definition JSON files from `translations/<lang>/apis/` directories.
+ *
+ * For each locale declared in `translations`, this function:
+ * 1. Checks for a `translations/<lang>/apis/` directory.
+ * 2. Reads all `.json` files from that directory.
+ * 3. Returns a map of locale → { apiName → parsed JSON definition }.
+ *
+ * The apiName is derived from the filename (e.g., `my-api.json` → `my-api`).
+ */
+async function loadTranslationApiDefinitions({
+    locales,
+    defaultLocale,
+    absolutePathToFernFolder,
+    context
+}: {
+    locales: string[];
+    defaultLocale: string | undefined;
+    absolutePathToFernFolder: AbsoluteFilePath;
+    context: TaskContext;
+}): Promise<Record<string, Record<string, unknown>> | undefined> {
+    if (locales.length === 0) {
+        return undefined;
+    }
+
+    const translationsRootDir = path.join(absolutePathToFernFolder, "translations") as AbsoluteFilePath;
+
+    const result: Record<string, Record<string, unknown>> = {};
+    let hasAny = false;
+
+    await Promise.all(
+        locales.map(async (lang) => {
+            if (lang === defaultLocale) {
+                return;
+            }
+
+            const apisDir = path.join(translationsRootDir, lang, "apis") as AbsoluteFilePath;
+
+            if (!(await doesPathExist(apisDir))) {
+                return;
+            }
+
+            const jsonFiles = await listFiles(apisDir, "json");
+            if (jsonFiles.length === 0) {
+                return;
+            }
+
+            const apiDefs: Record<string, unknown> = {};
+            await Promise.all(
+                jsonFiles.map(async (filePath) => {
+                    const filename = path.basename(filePath);
+                    const apiName = filename.replace(/\.json$/, "");
+                    try {
+                        const content = await readFile(filePath, "utf-8");
+                        apiDefs[apiName] = JSON.parse(content);
+                    } catch (error) {
+                        context.logger.warn(
+                            `Failed to parse translated API definition at translations/${lang}/apis/${filename}: ${String(error)}`
+                        );
+                    }
+                })
+            );
+
+            if (Object.keys(apiDefs).length > 0) {
+                result[lang] = apiDefs;
+                hasAny = true;
+            }
+        })
+    );
+
+    return hasAny ? result : undefined;
 }

--- a/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
@@ -60,6 +60,9 @@ export interface ParsedDocsConfiguration {
     /* per-locale translated navigation overlays: locale → NavigationOverlay */
     translationNavigationOverlays: Record<string, TranslationNavigationOverlay> | undefined;
 
+    /* per-locale translated API definitions: locale → { apiName → JSON definition } */
+    translationApiDefinitions: Record<string, Record<string, unknown>> | undefined;
+
     /* RBAC declaration */
     roles: string[] | undefined;
 

--- a/packages/cli/configuration/tsconfig.json
+++ b/packages/cli/configuration/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "@fern-api/configs/tsconfig/main.json",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src",
-    "types": ["node"]
+    "rootDir": "src"
   },
   "include": ["./src/**/*"]
 }

--- a/packages/cli/configuration/tsconfig.json
+++ b/packages/cli/configuration/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@fern-api/configs/tsconfig/main.json",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["node"]
   },
   "include": ["./src/**/*"]
 }

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -283,6 +283,15 @@ export class DocsDefinitionResolver {
     }
 
     /**
+     * Returns per-locale translated API definitions loaded from `translations/<lang>/apis/` directories.
+     * Each entry maps locale → { apiName → JSON definition }.
+     * Must be called after `resolve()`.
+     */
+    public getTranslationApiDefinitions(): Record<string, Record<string, unknown>> | undefined {
+        return this._parsedDocsConfig?.translationApiDefinitions;
+    }
+
+    /**
      * Returns the map of absolute file paths to uploaded file IDs.
      * Used by translation processing to rewrite image paths in translated pages.
      * Must be called after `resolve()`.

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -634,6 +634,7 @@ export async function publishDocs({
         // so that translated docs are visible in preview without overwriting production translations.
         const translationPages = resolver.getTranslationPages();
         const translationNavigationOverlays = resolver.getTranslationNavigationOverlays();
+        const translationApiDefinitions = resolver.getTranslationApiDefinitions();
         const translationDomain = preview ? urlToOutput : domain;
         if (translationPages != null && Object.keys(translationPages).length > 0) {
             context.logger.info(`Registering translations for ${Object.keys(translationPages).length} locale(s)...`);
@@ -727,12 +728,15 @@ export async function publishDocs({
                                 announcement: translatedAnnouncement
                             }
                         };
-                        const pageCount = Object.keys(localePages).length;
-                        context.logger.debug(
-                            `Sending translation for locale "${locale}" (${pageCount} page${pageCount === 1 ? "" : "s"})`
-                        );
                         // Use a raw fetch instead of the oRPC client to send `docsDefinition`
                         // (the live server expects that field; the published fdr-sdk still uses `content`).
+                        const localeApiDefs = translationApiDefinitions?.[locale];
+                        const pageCount = Object.keys(localePages).length;
+                        const apiDefNames = localeApiDefs != null ? Object.keys(localeApiDefs) : [];
+                        context.logger.debug(
+                            `Sending translation for locale "${locale}" (${pageCount} page${pageCount === 1 ? "" : "s"})` +
+                                (apiDefNames.length > 0 ? `, apiDefinitions=${JSON.stringify(apiDefNames)}` : "")
+                        );
                         const translationResponse = await fetch(`${fdrOrigin}/v2/registry/docs/translations/register`, {
                             method: "POST",
                             headers: {
@@ -744,7 +748,8 @@ export async function publishDocs({
                                 domain: translationDomain,
                                 orgId: organization,
                                 locale,
-                                docsDefinition: translatedDefinition
+                                docsDefinition: translatedDefinition,
+                                ...(localeApiDefs != null ? { apiDefinitions: localeApiDefs } : {})
                             })
                         });
                         if (!translationResponse.ok) {


### PR DESCRIPTION
## Description

Extends the docs publish flow to support registering translated API definitions alongside translated pages. Users can place translated API definition JSON files in `translations/<lang>/apis/<api-name>.json` and they will be included in the translation registration request to FDR.

**Companion PR**: https://github.com/fern-api/fern-platform/pull/10196 (FDR backend changes to accept and merge translated API definitions)

## Changes Made

- **`ParsedDocsConfiguration`** (`packages/cli/configuration/`): Added `translationApiDefinitions` field — `Record<string, Record<string, unknown>> | undefined` — mapping locale → { apiName → JSON definition }
- **`parseDocsConfiguration.ts`** (`packages/cli/configuration-loader/`): Added `loadTranslationApiDefinitions()` function that scans `translations/<lang>/apis/*.json` directories and loads translated API definition JSON files
- **`DocsDefinitionResolver`** (`packages/cli/docs-resolver/`): Added `getTranslationApiDefinitions()` getter to expose loaded translation API definitions
- **`publishDocs.ts`** (`packages/cli/generation/remote-generation/remote-workspace-runner/`): Updated translation registration to include `apiDefinitions` in the request body when available, with logging of included API definition names
- Added changelog entry for the new feature

## Testing

- [x] TypeScript compilation passes for all modified packages (45/45 tasks successful)
- [x] Biome lint/check passes on all modified files
- [x] Pre-commit hooks pass

Link to Devin session: https://app.devin.ai/sessions/36455db2d89641e3b8dd32c39a792643
Requested by: @dsinghvi