### PR TITLE
fix(cli): suppress additional Sentry false positives

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-sentry-false-positives-2.yml
+++ b/packages/cli/cli/changes/unreleased/fix-sentry-false-positives-2.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Suppress additional Sentry false positives: EADDRINUSE port conflicts,
+    MDX/acorn parse errors from docs preview and publishing, version range
+    strings in generators.yml, missing fern project when using --id flag,
+    non-JSON fern.config.json, and absolute filepath in OpenAPI spec config.
+  type: fix

--- a/packages/cli/cli/src/cli-context/upgrade-utils/getGeneratorVersions.ts
+++ b/packages/cli/cli/src/cli-context/upgrade-utils/getGeneratorVersions.ts
@@ -8,7 +8,7 @@ import {
 import { Logger } from "@fern-api/logger";
 import { Project } from "@fern-api/project-loader";
 import { isVersionAhead } from "@fern-api/semver-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
 
 import { ReleaseType } from "@fern-fern/generators-sdk/api/resources/generators";
@@ -203,10 +203,15 @@ export function processGeneratorGroups(
     for (const [groupName, group] of Object.entries(groups)) {
         for (const [generatorName, generatorVersions] of Object.entries(group)) {
             logger.debug(`Checking if ${generatorName} in group ${groupName} has an upgrade available...`);
-            const isUpgradeAvailable = isVersionAhead(
-                generatorVersions.latestVersion,
-                generatorVersions.previousVersion
-            );
+            let isUpgradeAvailable: boolean;
+            try {
+                isUpgradeAvailable = isVersionAhead(generatorVersions.latestVersion, generatorVersions.previousVersion);
+            } catch {
+                throw new CliError({
+                    message: `Generator "${generatorName}" has an invalid version "${generatorVersions.previousVersion}" in generators.yml. Use an exact version like 1.2.3.`,
+                    code: CliError.Code.ConfigError
+                });
+            }
 
             logger.debug(
                 `Latest version: ${generatorVersions.latestVersion}. ` +

--- a/packages/cli/cli/src/commands/docs-preview/deleteDocsPreview.ts
+++ b/packages/cli/cli/src/commands/docs-preview/deleteDocsPreview.ts
@@ -18,7 +18,9 @@ async function resolvePreviewUrlFromId({
     if (fernDirectory == null) {
         return cliContext.failAndThrow(
             "No fern directory found. The --id flag requires a Fern project to resolve the organization.\n" +
-                "Run this command from within a Fern project directory, or use the URL argument instead."
+                "Run this command from within a Fern project directory, or use the URL argument instead.",
+            undefined,
+            { code: CliError.Code.ValidationError }
         );
     }
 

--- a/packages/cli/configuration-loader/src/fern-config-json/loadProjectConfig.ts
+++ b/packages/cli/configuration-loader/src/fern-config-json/loadProjectConfig.ts
@@ -1,6 +1,7 @@
 import { fernConfigJson, PROJECT_CONFIG_FILENAME } from "@fern-api/configuration";
+import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { readFile } from "fs/promises";
 
 import { validateSchema } from "../commons/validateSchema.js";
@@ -15,7 +16,15 @@ export async function loadProjectConfig({
 }): Promise<fernConfigJson.ProjectConfig> {
     const pathToConfig = join(directory, RelativeFilePath.of(PROJECT_CONFIG_FILENAME));
     const projectConfigStr = await readFile(pathToConfig);
-    const projectConfigParsed = JSON.parse(projectConfigStr.toString()) as unknown;
+    let projectConfigParsed: unknown;
+    try {
+        projectConfigParsed = JSON.parse(projectConfigStr.toString()) as unknown;
+    } catch (error) {
+        throw new CliError({
+            message: `Failed to parse ${PROJECT_CONFIG_FILENAME}: ${extractErrorMessage(error)}`,
+            code: CliError.Code.ParseError
+        });
+    }
     const rawProjectConfig = await validateSchema({
         schema: ProjectConfigSchema,
         value: projectConfigParsed,

--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -1,4 +1,4 @@
-import { replaceEnvVariables } from "@fern-api/core-utils";
+import { extractErrorMessage, replaceEnvVariables } from "@fern-api/core-utils";
 import {
     isValidRelativeSlug,
     parseImagePaths,
@@ -236,10 +236,19 @@ export async function getPreviewDocsDefinition({
                 absolutePathToMarkdownFile: absoluteFilePath
             });
 
-            const { markdown: markdownWithAbsPaths, filepaths } = parseImagePaths(markdownReplacedMdAndCode, {
-                absolutePathToFernFolder: docsWorkspace.absoluteFilePath,
-                absolutePathToMarkdownFile: absoluteFilePath
-            });
+            let markdownWithAbsPaths: string;
+            let filepaths: AbsoluteFilePath[];
+            try {
+                ({ markdown: markdownWithAbsPaths, filepaths } = parseImagePaths(markdownReplacedMdAndCode, {
+                    absolutePathToFernFolder: docsWorkspace.absoluteFilePath,
+                    absolutePathToMarkdownFile: absoluteFilePath
+                }));
+            } catch (error) {
+                throw new CliError({
+                    message: `Failed to parse markdown in ${absoluteFilePath}: ${extractErrorMessage(error)}`,
+                    code: CliError.Code.ParseError
+                });
+            }
 
             if (previousDocsDefinition.filesV2 == null) {
                 previousDocsDefinition.filesV2 = {};

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -469,7 +469,10 @@ export class DocsDefinitionResolver {
                 }
             } catch (error) {
                 this.taskContext.logger.error(`Failed to parse ${relativePath}: ${extractErrorMessage(error)}`);
-                throw error;
+                throw new CliError({
+                    message: `Failed to parse markdown file ${relativePath}: ${extractErrorMessage(error)}`,
+                    code: CliError.Code.ParseError
+                });
             }
         }
         const imageParseTime = performance.now() - imageParseStart;

--- a/packages/cli/task-context/src/CliError.ts
+++ b/packages/cli/task-context/src/CliError.ts
@@ -112,7 +112,8 @@ const USER_ENVIRONMENT_ERRNOS: ReadonlySet<string> = new Set([
     "EROFS",
     "EMFILE",
     "ENFILE",
-    "EBUSY"
+    "EBUSY",
+    "EADDRINUSE"
 ]);
 
 // `ErrnoException` codes from `node:net` / `node:dns` / `undici` that mean

--- a/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
@@ -72,6 +72,17 @@ function collapseSpecBooleanSetting(
     return values.every((v) => v == null || v === true);
 }
 
+function toRelativePath(raw: string, field: string): RelativeFilePath {
+    try {
+        return RelativeFilePath.of(raw);
+    } catch {
+        throw new CliError({
+            message: `"${field}: ${raw}" must be a relative path, not an absolute one.`,
+            code: CliError.Code.ConfigError
+        });
+    }
+}
+
 function convertRemoveDiscriminantsFromSchemas(
     specs: (OpenAPISpec | ProtobufSpec)[]
 ): generatorsYml.RemoveDiscriminantsFromSchemas {
@@ -636,7 +647,7 @@ export class OSSWorkspace extends BaseOpenAPIWorkspace {
 
         for (const spec of specsOverride) {
             if (generatorsYml.isOpenApiSpecSchema(spec)) {
-                const absoluteFilepath = join(this.absoluteFilePath, RelativeFilePath.of(spec.openapi));
+                const absoluteFilepath = join(this.absoluteFilePath, toRelativePath(spec.openapi, "openapi"));
                 // Handle both single override path and array of override paths
                 let absoluteFilepathToOverrides: AbsoluteFilePath | AbsoluteFilePath[] | undefined;
                 const specOverridePaths: AbsoluteFilePath[] = [];
@@ -646,11 +657,13 @@ export class OSSWorkspace extends BaseOpenAPIWorkspace {
                     if (Array.isArray(spec.overrides)) {
                         specOverridePaths.push(
                             ...spec.overrides.map((override) =>
-                                join(this.absoluteFilePath, RelativeFilePath.of(override))
+                                join(this.absoluteFilePath, toRelativePath(override, "overrides"))
                             )
                         );
                     } else {
-                        specOverridePaths.push(join(this.absoluteFilePath, RelativeFilePath.of(spec.overrides)));
+                        specOverridePaths.push(
+                            join(this.absoluteFilePath, toRelativePath(spec.overrides, "overrides"))
+                        );
                     }
                 }
 
@@ -660,7 +673,7 @@ export class OSSWorkspace extends BaseOpenAPIWorkspace {
                         specOverridePaths.length === 1 ? specOverridePaths[0] : specOverridePaths;
                 }
                 const absoluteFilepathToOverlays = spec.overlays
-                    ? join(this.absoluteFilePath, RelativeFilePath.of(spec.overlays))
+                    ? join(this.absoluteFilePath, toRelativePath(spec.overlays, "overlays"))
                     : undefined;
 
                 // Create a minimal OpenAPI spec with default settings


### PR DESCRIPTION
## Description

Follow-up to Sentry false-positive triage: classify user- and environment-provoked errors at the call site (or via errno mapping) so they are not reported as `InternalError` in the `cli` Sentry project.

Supersedes #15483 (branch renamed to \`FedeZara/fix/cli-sentry-false-positives-2\`).

## Changes Made

- **`CliError` / `resolveErrorCode`:** add `EADDRINUSE` to `USER_ENVIRONMENT_ERRNOS` (port already in use maps to `EnvironmentError`, non-reportable).
- **Docs / MDX:** `parseImagePaths` failures in `DocsDefinitionResolver` and `previewDocs` now throw `CliError(ParseError)` instead of raw VFile/acorn errors.
- **Generator upgrades:** wrap `isVersionAhead` in `getGeneratorVersions`; invalid pinned versions in `generators.yml` (e.g. `1.x`, `*`) throw `CliError(ConfigError)`.
- **OpenAPI spec paths:** `toRelativePath` helper in `OSSWorkspace` for `openapi` / `overrides` / `overlays` from `generators.yml` — absolute paths yield `ConfigError` with a clear message.
- **`fern docs preview --id`:** when no fern directory is found, `failAndThrow` uses `ValidationError`.
- **`fern.config.json`:** `JSON.parse` failure in `loadProjectConfig` throws `ParseError`.
- Changelog: `packages/cli/cli/changes/unreleased/fix-sentry-false-positives-2.yml`.

## Testing

- [ ] Unit tests added/updated
- [x] Compile verified on touched packages where possible
- [ ] Manual testing completed
