### PR TITLE
fix(cli): treat first locale as default when no explicit default is set

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-default-locale-translation-check.yml
+++ b/packages/cli/cli/changes/unreleased/fix-default-locale-translation-check.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix translation directory check to treat the first locale as the default when no explicit `default: true` is set, matching the behavior of the rest of the CLI.
+  type: fix

--- a/packages/cli/yaml/docs-validator/src/rules/translation-directories-exist/translation-directories-exist.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/translation-directories-exist/translation-directories-exist.ts
@@ -14,7 +14,7 @@ export const TranslationDirectoriesExistRule: Rule = {
                     return violations;
                 }
 
-                const defaultLocale = translations.find((t) => t.default === true)?.lang;
+                const defaultLocale = (translations.find((t) => t.default === true) ?? translations[0])?.lang;
                 const translationsDir = join(workspace.absoluteFilePath, RelativeFilePath.of("translations"));
                 const translationsDirExists = await doesPathExist(translationsDir);
 


### PR DESCRIPTION
## Description

Fixes `fern check` incorrectly requiring a translation directory for the default locale when no locale has `default: true` explicitly set.

When a user configures translations like:
```yaml
translations:
  - lang: en
  - lang: fr
  - lang: es
```

The rule was only skipping locales with `default: true`, so it flagged `en` as missing a directory. The rest of the codebase (e.g. `DocsDefinitionResolver.ts`) treats the first locale as the implicit default via `translations.find(t => t.default === true) ?? translations[0]`. This PR aligns the validation rule with that behavior.

## Changes Made

- Updated `translation-directories-exist` rule to fall back to `translations[0]` when no locale has `default: true`, matching `DocsDefinitionResolver.ts`
- Added changelog entry

## Testing

- [x] Verified the fix matches the pattern used in `DocsDefinitionResolver.ts:296`
- [x] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/0b447c039a864388a6602ec3734444f8
Requested by: @dsinghvi