### PR TITLE
chore(cli): improve translation logging to debug level with cleaner formatting

### DIFF
--- a/packages/cli/cli/changes/unreleased/improve-translation-logging.yml
+++ b/packages/cli/cli/changes/unreleased/improve-translation-logging.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Improved translation logging by moving verbose page array output to debug level and formatting as a concise count instead of raw JSON array.
+  type: chore

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -713,8 +713,9 @@ export async function publishDocs({
                                 root: updatedRoot
                             }
                         };
-                        context.logger.info(
-                            `Sending translation for locale "${locale}": pages=${JSON.stringify(Object.keys(localePages))}`
+                        const pageCount = Object.keys(localePages).length;
+                        context.logger.debug(
+                            `Sending translation for locale "${locale}" (${pageCount} page${pageCount === 1 ? "" : "s"})`
                         );
                         // Use a raw fetch instead of the oRPC client to send `docsDefinition`
                         // (the live server expects that field; the published fdr-sdk still uses `content`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Improved the translation logging by moving verbose page array output to debug level and formatting it as a concise count instead of a raw JSON array.

## Changes Made
- Changed `context.logger.info()` to `context.logger.debug()` for translation page logging
- Replaced `JSON.stringify(Object.keys(localePages))` with a cleaner format showing just the page count
- Added proper singular/plural handling for the page count message

## Testing
- [x] Compilation successful
- [x] Linting and formatting checks passed
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://buildwithfern.slack.com/archives/C09NULAN2H3/p1777387605298419?thread_ts=1777387605.298419&cid=C09NULAN2H3)

<div><a href="https://cursor.com/agents/bc-c4de211d-b24a-55e7-86e8-01ae55b1f5f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4de211d-b24a-55e7-86e8-01ae55b1f5f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

