### PR TITLE
fix(generator-cli): handle 422 from GitHub updateRef when branch does not exist

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-upsert-branch-ref.yml
+++ b/packages/cli/cli/changes/unreleased/fix-upsert-branch-ref.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump generator-cli to 0.9.17 which fixes branch creation during signed
+    commit push. GitHub's updateRef API returns 422 (not 404) when the
+    target branch does not exist, so the createRef fallback was unreachable.
+  type: fix

--- a/packages/cli/cli/changes/unreleased/fix-upsert-branch-ref.yml
+++ b/packages/cli/cli/changes/unreleased/fix-upsert-branch-ref.yml
@@ -1,5 +1,5 @@
 - summary: |
-    Bump generator-cli to 0.9.17 which fixes branch creation during signed
-    commit push. GitHub's updateRef API returns 422 (not 404) when the
-    target branch does not exist, so the createRef fallback was unreachable.
+    Fix branch creation during signed commit push in generator-cli. GitHub's
+    updateRef API returns 422 (not 404) when the target branch does not exist,
+    so the createRef fallback was unreachable.
   type: fix

--- a/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
+++ b/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
@@ -181,7 +181,15 @@ function hasNumericStatus(err: unknown): err is { status: number } {
 }
 
 function isNotFoundError(err: unknown): boolean {
-    return hasNumericStatus(err) && err.status === 404;
+    if (hasNumericStatus(err) && err.status === 404) {
+        return true;
+    }
+    // GitHub's updateRef returns 422 (not 404) when the branch doesn't exist yet.
+    if (hasNumericStatus(err) && err.status === 422) {
+        const message = extractErrorMessage(err).toLowerCase();
+        return message.includes("reference does not exist");
+    }
+    return false;
 }
 
 export function isNonFastForwardError(err: unknown): boolean {

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,17 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix `upsertBranchRef` failing on first-generation runs after replay
+        lockfile reset. GitHub's `updateRef` API returns HTTP 422 (not 404)
+        when the target branch does not exist, so the `createRef` fallback
+        was never reached. Now `isNotFoundError` also matches 422 responses
+        whose message contains "Reference does not exist".
+      type: fix
+  createdAt: "2026-04-28"
+  version: 0.9.17
+
+- changelogEntry:
+    - summary: |
         Bundle the private workspace deps used by the autoversion pipeline
         (`@fern-api/logging-execa`, `@fern-api/task-context`, `@fern-api/cli-ai`)
         into the published `dist/api.js`. They were added to generator-cli as

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,7 +59,7 @@ catalog:
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.1.23-d25ead8e05
-  "@fern-api/generator-cli": 0.9.16
+  "@fern-api/generator-cli": 0.9.17
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,7 +59,7 @@ catalog:
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.1.23-d25ead8e05
-  "@fern-api/generator-cli": 0.9.17
+  "@fern-api/generator-cli": 0.9.16
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Description

Fix `upsertBranchRef` in `pushSignedCommit.ts` failing on first-generation and post-lockfile-reset flows.

## Root Cause

GitHub's `updateRef` API returns HTTP 422 (not 404) when the target branch doesn't exist yet. `isNotFoundError()` only checked for 404, so the `createRef` fallback was unreachable. This broke all generation flows where the PR branch doesn't exist yet — including first-generation after `fern replay init` and any flow after lockfile reset.

## Changes Made

- `packages/generator-cli/src/pipeline/github/pushSignedCommit.ts`: Extend `isNotFoundError()` to also catch 422 with "Reference does not exist" message
- `packages/generator-cli/versions.yml`: Bump to 0.9.17
- `packages/cli/cli/changes/unreleased/fix-upsert-branch-ref.yml`: CLI changelog entry

**Note**: The catalog pin bump to 0.9.17 in `pnpm-workspace.yaml` was reverted — it should be done in a follow-up PR after 0.9.17 is published to npm (same pattern as PR #15297).

## Testing

- [ ] Run `fern generate --group ts-sdk` against a testbed repo with freshly initialized replay → PR should be created successfully
- [ ] Verify existing flows (normal regeneration with existing branch) still work

Link to Devin session: https://app.devin.ai/sessions/0883fa7a323a4631ae24de0132063075
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
