### PR TITLE
fix(go): include service/root path params in wiremock + force form-urlencoded for OAuth token

### DIFF
--- a/generators/go-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/go-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -3,7 +3,7 @@ import { assertNever } from "@fern-api/core-utils";
 import { go } from "@fern-api/go-ast";
 import { FernIr } from "@fern-fern/ir-sdk";
 
-import { isPlainStringType } from "../../authUtils.js";
+import { getOAuthClientCredentialsScheme, isPlainStringType } from "../../authUtils.js";
 import { SdkGeneratorContext } from "../../SdkGeneratorContext.js";
 import { AbstractEndpointGenerator } from "../AbstractEndpointGenerator.js";
 import { EndpointSignatureInfo } from "../EndpointSignatureInfo.js";
@@ -1191,6 +1191,14 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
     }
 
     private getContentTypeHeaderValue({ endpoint }: { endpoint: FernIr.HttpEndpoint }): string | undefined {
+        // OAuth 2.0 token endpoints must use form-urlencoded encoding (RFC 6749 §4.4.2).
+        const oauthScheme = getOAuthClientCredentialsScheme(this.context.ir);
+        if (oauthScheme?.configuration?.type === "clientCredentials") {
+            const tokenEndpointId = oauthScheme.configuration.tokenEndpoint.endpointReference.endpointId;
+            if (endpoint.id === tokenEndpointId) {
+                return "application/x-www-form-urlencoded";
+            }
+        }
         const sdkRequest = endpoint.sdkRequest;
         if (sdkRequest == null) {
             return undefined;

--- a/generators/go/sdk/changes/unreleased/fix-oauth-form-urlencoded-content-type.yml
+++ b/generators/go/sdk/changes/unreleased/fix-oauth-form-urlencoded-content-type.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix OAuth token endpoint to use application/x-www-form-urlencoded content type.
+    Per RFC 6749 §4.4.2, the OAuth 2.0 client credentials token request must be
+    form-encoded. The generated raw_client.go now emits the correct Content-Type
+    header for the token endpoint instead of application/json.
+  type: fix

--- a/generators/go/sdk/changes/unreleased/fix-service-path-params-wiremock.yml
+++ b/generators/go/sdk/changes/unreleased/fix-service-path-params-wiremock.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix wire test generation for endpoints with service-level base-path parameters.
+    The wiremock mapping now includes service and root path parameters alongside
+    endpoint path parameters, so test verification URLs use actual example values
+    instead of URL-encoded placeholder syntax.
+  type: fix

--- a/packages/commons/mock-utils/src/index.ts
+++ b/packages/commons/mock-utils/src/index.ts
@@ -171,9 +171,14 @@ export class WireMock {
         // Build URL path template
         const urlPathTemplate = this.buildUrlPathTemplate(endpoint);
 
-        // Extract path parameters from example
+        // Extract path parameters from example (root, service, and endpoint levels)
         const pathParameters: Record<string, { equalTo: string }> = {};
-        for (const param of example?.endpointPathParameters || []) {
+        const allPathParams = [
+            ...(example?.rootPathParameters || []),
+            ...(example?.servicePathParameters || []),
+            ...(example?.endpointPathParameters || [])
+        ];
+        for (const param of allPathParams) {
             const paramValue = this.extractExampleValue(param.value);
             if (paramValue !== null) {
                 const paramName = getOriginalName(param.name);


### PR DESCRIPTION
## Description
Refs: Kard SDK test failures in fern-demo/kard-go-sdk and fern-demo/kard-csharp-sdk

### Fix 1: Wire test generation for service-level path parameters
Fix wire test generation for endpoints where path parameters are defined at the service level (`base-path`) or root level, not just the endpoint level. Previously, only `endpointPathParameters` were extracted when building WireMock mappings, causing `VerifyRequestCount` URLs to contain URL-encoded placeholder syntax (e.g., `%3CorganizationId%3E`) instead of actual example values.

### Fix 2: OAuth token endpoint Content-Type (RFC 6749 §4.4.2)
The Go SDK generator was emitting `Content-Type: application/json` for OAuth token endpoints, but RFC 6749 §4.4.2 requires `application/x-www-form-urlencoded`. Added early detection of OAuth token endpoints via the IR in `getContentTypeHeaderValue` to force the correct content type.

## Changes Made
- Updated `packages/commons/mock-utils/src/index.ts` to collect path parameters from all three levels: `rootPathParameters`, `servicePathParameters`, and `endpointPathParameters`
- Updated `generators/go-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts` to detect OAuth token endpoints and force `application/x-www-form-urlencoded` content type
- Added unreleased changelog entries for both fixes

## Testing
- [x] Unit tests pass (4/4 in mock-utils)
- [x] Verified the fix resolves Kard Go SDK wire test failures for service-level base-path params
- [x] Verified OAuth token endpoint now generates `Content-Type: application/x-www-form-urlencoded` in regenerated Kard Go SDK
- [x] Go SDK PR #10 (fern-demo/kard-go-sdk) — all CI checks pass (compile, lint, test)

Link to Devin session: https://app.devin.ai/sessions/3134d589434f41e78b49e493949a4e96
Requested by: @fern-support