### PR TITLE
chore(deps): bump @fern-api/generator-cli catalog pin to 0.9.17

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: 0.0.6-2ee1b7e28
       version: 0.0.6-2ee1b7e28
     '@fern-api/generator-cli':
-      specifier: 0.9.16
-      version: 0.9.16
+      specifier: 0.9.17
+      version: 0.9.17
     '@fern-api/venus-api-sdk':
       specifier: 0.22.34
       version: 0.22.34
@@ -628,7 +628,7 @@ importers:
         version: link:packages/configs
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.16
+        version: 0.9.17
       '@rolldown/binding-darwin-arm64':
         specifier: 'catalog:'
         version: 1.0.0-rc.5
@@ -697,7 +697,7 @@ importers:
         version: link:../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.16
+        version: 0.9.17
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../packages/ir-sdk
@@ -2437,7 +2437,7 @@ importers:
         version: link:../../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.16
+        version: 0.9.17
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../packages/cli/logger
@@ -9402,8 +9402,8 @@ packages:
   '@fern-api/fdr-sdk@1.1.23-d25ead8e05':
     resolution: {integrity: sha512-fkcBIQSCI8Pj8k+sLf7p/rfwVCIdNjB3Na5XpsAc/af30JTgVlCmcAip7TgxxFeGjfpBprD7k6XDN162E0ppXQ==}
 
-  '@fern-api/generator-cli@0.9.16':
-    resolution: {integrity: sha512-e+vIQog5IKNVIUca/xjxUCxNmUHAiJ3yIdtr+VQ7r1wQt3O55prQhlVtjcSX812+CWP4l3xpf89ON4WdmzDIrQ==}
+  '@fern-api/generator-cli@0.9.17':
+    resolution: {integrity: sha512-0FaK4t1/YYdFCpkIH73WL0+AK7ZCIeFOgiaATAcC6ct5MmJlwqqXdDJMt4eR0bK23txJb3wNxWMjl59cBJNeWg==}
     hasBin: true
 
   '@fern-api/replay@0.12.0':
@@ -16432,7 +16432,7 @@ snapshots:
       - encoding
       - typescript
 
-  '@fern-api/generator-cli@0.9.16':
+  '@fern-api/generator-cli@0.9.17':
     dependencies:
       '@boundaryml/baml': 0.219.0
       '@fern-api/replay': 0.12.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,7 +59,7 @@ catalog:
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.1.23-d25ead8e05
-  "@fern-api/generator-cli": 0.9.16
+  "@fern-api/generator-cli": 0.9.17
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Description

Bump the `@fern-api/generator-cli` catalog pin in `pnpm-workspace.yaml` from `0.9.16` to `0.9.17` so that consumer packages (generators) pick up the `upsertBranchRef` fix shipped in `0.9.17` ([#15491](https://github.com/fern-api/fern/pull/15491)).

## Changes Made

- `pnpm-workspace.yaml`: catalog pin `0.9.16` → `0.9.17`
- `pnpm-lock.yaml`: regenerated via `pnpm install`

## Testing

- [x] `pnpm install --frozen-lockfile` succeeds locally
- [x] `@fern-api/generator-cli@0.9.17` confirmed published to npm
- [ ] CI on this PR

Link to Devin session: https://app.devin.ai/sessions/0883fa7a323a4631ae24de0132063075
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
