### PR TITLE
fix(internal): mark @boundaryml/baml external in shared buildGenerator

### DIFF
--- a/packages/configs/build-utils.mjs
+++ b/packages/configs/build-utils.mjs
@@ -68,10 +68,7 @@ export async function buildGenerator(dirname, options = {}) {
     // generators never trigger the code path that uses it (autoversioning), so
     // marking it external is safe. Merge with any caller-supplied externals.
     const callerExternal = tsupOptions.external ?? [];
-    const mergedExternal = [
-        "@boundaryml/baml",
-        ...(Array.isArray(callerExternal) ? callerExternal : [callerExternal])
-    ];
+    const mergedExternal = ["@boundaryml/baml", ...(Array.isArray(callerExternal) ? callerExternal : [callerExternal])];
 
     // Build with tsup (merge default options with custom ones)
     const defaultTsupOptions = {

--- a/packages/configs/build-utils.mjs
+++ b/packages/configs/build-utils.mjs
@@ -63,6 +63,16 @@ export async function buildGenerator(dirname, options = {}) {
 
     const outDir = tsupOptions.outDir ?? "dist";
 
+    // @boundaryml/baml contains platform-specific native .node files that esbuild
+    // cannot bundle. It's a transitive dependency via generator-cli → cli-ai, but
+    // generators never trigger the code path that uses it (autoversioning), so
+    // marking it external is safe. Merge with any caller-supplied externals.
+    const callerExternal = tsupOptions.external ?? [];
+    const mergedExternal = [
+        "@boundaryml/baml",
+        ...(Array.isArray(callerExternal) ? callerExternal : [callerExternal])
+    ];
+
     // Build with tsup (merge default options with custom ones)
     const defaultTsupOptions = {
         entry: [entry],
@@ -74,7 +84,8 @@ export async function buildGenerator(dirname, options = {}) {
 
     await tsup.build({
         ...defaultTsupOptions,
-        ...tsupOptions
+        ...tsupOptions,
+        external: mergedExternal
     });
 
     // Rewrite source map paths to be repo-root-relative so Sentry displays


### PR DESCRIPTION
## Description

Fixes the `Failed to build the container for csharp-sdk` (and python-sdk, etc.) CI failures that started after `@boundaryml/baml` was added as a transitive dependency of all generators.

## Changes Made

- Mark `@boundaryml/baml` as external in the shared `buildGenerator()` function in `packages/configs/build-utils.mjs`
- Merge with any caller-supplied `external` array so generator-specific build configs aren't overridden

### Root Cause

`@boundaryml/baml` contains platform-specific native `.node` files (e.g. `baml.win32-arm64-msvc.node`) that esbuild cannot bundle. The dependency chain is:

```
generator (e.g. csharp-sdk) → base-generator → generator-cli → cli-ai → @boundaryml/baml
```

PR #15287 fixed this for `generator-cli/build.mjs` but missed the shared `buildGenerator()` in `packages/configs/build-utils.mjs`, which is used by all 17 generator build scripts.

### Why This Is Safe

The only code path that uses `@boundaryml/baml` is autoversioning (`AutoVersionStep.ts`), which:
1. Uses a **dynamic** import (`await import("@fern-api/cli-ai")`) — not a top-level require
2. Is only triggered from the CLI, **never** inside generator Docker containers

So the external `require('@boundaryml/baml')` in the bundle will never be reached at runtime in generators.

## Testing

- Verified `dist:cli` for `@fern-api/fern-csharp-sdk` now builds successfully (was failing before the fix)
- Verified `dist:cli` for `@fern-api/python-sdk` also builds successfully
- [ ] Manual testing completed


Link to Devin session: https://app.devin.ai/sessions/826cdead52c14deabce3f6557581aeb1
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
