### PR TITLE
fix(seed): mark @boundaryml/baml external in shared buildGenerator

### DIFF
--- a/packages/configs/build-utils.mjs
+++ b/packages/configs/build-utils.mjs
@@ -64,12 +64,15 @@ export async function buildGenerator(dirname, options = {}) {
     const outDir = tsupOptions.outDir ?? "dist";
 
     // Build with tsup (merge default options with custom ones)
+    // Keep @boundaryml/baml external so esbuild does not try to bundle its
+    // platform-specific native .node files (transitive dep via generator-cli).
     const defaultTsupOptions = {
         entry: [entry],
         format: ["cjs"],
         sourcemap: true,
         clean: true,
-        outDir
+        outDir,
+        external: ["@boundaryml/baml"]
     };
 
     await tsup.build({


### PR DESCRIPTION
## Description

Fixes all seed CI failures that occur when the turbo remote cache is invalidated for generator `dist:cli` tasks — e.g. any PR that touches `@fern-api/configuration` source files (like #15478).

**Root cause chain:**
1. Every generator CLI transitively depends on `@boundaryml/baml` via `generator-cli → base-generator → generator-cli → @boundaryml/baml`
2. PR #15287 fixed `packages/generator-cli/build.mjs` by marking `@boundaryml/baml` as external, but missed the shared `buildGenerator()` in `packages/configs/build-utils.mjs` used by **all** generator CLIs
3. When turbo cache is valid, pre-built `dist/` artifacts are restored and the bug is hidden
4. When any change invalidates the compile cache chain (e.g. editing `@fern-api/configuration/src/**`), all generator `dist:cli` tasks rebuild from scratch, esbuild tries to bundle baml's platform-specific `.node` files, and the build fails with `Cannot find module './baml.android-arm64.node'`
5. This causes **all** seed tests to fail simultaneously (151 failures across ts-sdk, go-sdk, python-sdk, java-sdk, csharp-sdk, php-sdk, swift-sdk, ruby-sdk, openapi)

## Changes Made
- Added `external: ["@boundaryml/baml"]` to `buildGenerator()` default tsup options in `packages/configs/build-utils.mjs`, matching the approach already used in `packages/generator-cli/build.mjs`

## Testing
- [x] Verified locally: `pnpm turbo run dist:cli --filter @fern-typescript/sdk-generator-cli` now succeeds (41/41 tasks) after previously failing with baml bundling errors
- [ ] CI will confirm seed tests pass once this lands and repopulates the turbo remote cache

Link to Devin session: https://app.devin.ai/sessions/aef83d7db3d74e9480ad4472080bd706
Requested by: @patrickthornton