### PR TITLE
chore(deps): bump @fern-api/generator-cli catalog pin to 0.9.18

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: 0.0.6-2ee1b7e28
       version: 0.0.6-2ee1b7e28
     '@fern-api/generator-cli':
-      specifier: 0.9.17
-      version: 0.9.17
+      specifier: 0.9.18
+      version: 0.9.18
     '@fern-api/venus-api-sdk':
       specifier: 0.22.34
       version: 0.22.34
@@ -628,7 +628,7 @@ importers:
         version: link:packages/configs
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.17
+        version: 0.9.18
       '@rolldown/binding-darwin-arm64':
         specifier: 'catalog:'
         version: 1.0.0-rc.5
@@ -697,7 +697,7 @@ importers:
         version: link:../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.17
+        version: 0.9.18
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../packages/ir-sdk
@@ -2437,7 +2437,7 @@ importers:
         version: link:../../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.17
+        version: 0.9.18
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../packages/cli/logger
@@ -9402,8 +9402,8 @@ packages:
   '@fern-api/fdr-sdk@1.1.23-d25ead8e05':
     resolution: {integrity: sha512-fkcBIQSCI8Pj8k+sLf7p/rfwVCIdNjB3Na5XpsAc/af30JTgVlCmcAip7TgxxFeGjfpBprD7k6XDN162E0ppXQ==}
 
-  '@fern-api/generator-cli@0.9.17':
-    resolution: {integrity: sha512-0FaK4t1/YYdFCpkIH73WL0+AK7ZCIeFOgiaATAcC6ct5MmJlwqqXdDJMt4eR0bK23txJb3wNxWMjl59cBJNeWg==}
+  '@fern-api/generator-cli@0.9.18':
+    resolution: {integrity: sha512-LLz3E7MXFugvdti40N1uKCNaBdk/Lex3iCv9DIBax5UTX8rfEg/T4VvNWi2BPvpAxgoGd6lBkNObJdv9fnzCkQ==}
     hasBin: true
 
   '@fern-api/replay@0.12.0':
@@ -16432,7 +16432,7 @@ snapshots:
       - encoding
       - typescript
 
-  '@fern-api/generator-cli@0.9.17':
+  '@fern-api/generator-cli@0.9.18':
     dependencies:
       '@boundaryml/baml': 0.219.0
       '@fern-api/replay': 0.12.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,7 +59,7 @@ catalog:
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.1.23-d25ead8e05
-  "@fern-api/generator-cli": 0.9.17
+  "@fern-api/generator-cli": 0.9.18
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Summary

Bumps the catalog pin to pick up [`@fern-api/generator-cli@0.9.18`](https://www.npmjs.com/package/@fern-api/generator-cli/v/0.9.18), published from #15502.

In 0.9.18, `PostGenerationPipeline` and the surrounding pipeline types are no longer re-exported from the package's main barrel — they live under the `@fern-api/generator-cli/pipeline` subpath. With this catalog bump, every consumer that resolves `@fern-api/generator-cli` via `catalog:` (notably `@fern-api/base-generator`, which every SDK generator depends on) now imports a barrel whose static graph no longer reaches `@fern-api/cli-ai` → `@boundaryml/baml` → platform-specific `.node` files. SDK generator `tsup` builds stop failing with the 23 native-module resolution errors that prompted the temporary `external: ["@boundaryml/baml"]` workaround in `packages/configs/build-utils.mjs` (#15501).

This is the second half of the standard generator-cli release pattern (publish first, bump catalog second), matching the precedent set by #15496 (0.9.17) and earlier catalog bumps.

## Test plan

- [ ] `pnpm install` resolves cleanly against the new pin
- [ ] `pnpm seed test --generator ts-sdk` (and any other SDK generator) builds without depending on the shared `external: ["@boundaryml/baml"]` workaround
- [ ] Once this lands, the workaround in `packages/configs/build-utils.mjs` from #15501 can be reverted in a follow-up
