### PR TITLE
fix(cli): make translation resilient to individual MDX page parse failures

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-translation-per-page-resilience.yml
+++ b/packages/cli/cli/changes/unreleased/fix-translation-per-page-resilience.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Translation no longer fails for an entire locale when a single MDX file has a parse error. 
+    Invalid pages are skipped with a warning that includes the file path, and the base page is used as a fallback.
+  type: fix

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -739,28 +739,34 @@ export async function runAppPreviewServer({
                 }
 
                 for (const [pagePath, rawMarkdown] of Object.entries(localePages)) {
-                    const basePage = translatedPages[pagePath];
-                    // Strip MDX comments first
-                    let processedMarkdown = stripMdxComments(rawMarkdown);
-                    // Replace image paths using collected file IDs
-                    const absolutePathToMarkdownFile = resolve(docsWorkspacePath, RelativeFilePath.of(pagePath));
-                    processedMarkdown = replaceImagePathsAndUrls(
-                        processedMarkdown,
-                        collectedFileIds,
-                        {}, // markdownFilesToPathName not needed for translations
-                        {
-                            absolutePathToMarkdownFile,
-                            absolutePathToFernFolder: docsWorkspacePath
-                        },
-                        context
-                    );
+                    try {
+                        const basePage = translatedPages[pagePath];
+                        // Strip MDX comments first
+                        let processedMarkdown = stripMdxComments(rawMarkdown);
+                        // Replace image paths using collected file IDs
+                        const absolutePathToMarkdownFile = resolve(docsWorkspacePath, RelativeFilePath.of(pagePath));
+                        processedMarkdown = replaceImagePathsAndUrls(
+                            processedMarkdown,
+                            collectedFileIds,
+                            {}, // markdownFilesToPathName not needed for translations
+                            {
+                                absolutePathToMarkdownFile,
+                                absolutePathToFernFolder: docsWorkspacePath
+                            },
+                            context
+                        );
 
-                    translatedPages[pagePath] = {
-                        markdown: processedMarkdown,
-                        rawMarkdown: processedMarkdown,
-                        editThisPageUrl: basePage?.editThisPageUrl,
-                        editThisPageLaunch: basePage?.editThisPageLaunch
-                    };
+                        translatedPages[pagePath] = {
+                            markdown: processedMarkdown,
+                            rawMarkdown: processedMarkdown,
+                            editThisPageUrl: basePage?.editThisPageUrl,
+                            editThisPageLaunch: basePage?.editThisPageLaunch
+                        };
+                    } catch (pageError) {
+                        context.logger.warn(
+                            `Failed to process translated page "${pagePath}" for locale "${locale}": ${String(pageError)}. Falling back to base page.`
+                        );
+                    }
                 }
 
                 // Apply translated frontmatter to nav tree

--- a/packages/cli/docs-preview/src/runPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runPreviewServer.ts
@@ -172,28 +172,34 @@ export async function runPreviewServer({
                 }
 
                 for (const [pagePath, rawMarkdown] of Object.entries(localePages)) {
-                    const basePage = translatedPages[pagePath];
-                    // Strip MDX comments first
-                    let processedMarkdown = stripMdxComments(rawMarkdown);
-                    // Replace image paths using collected file IDs
-                    const absolutePathToMarkdownFile = resolve(docsWorkspacePath, RelativeFilePath.of(pagePath));
-                    processedMarkdown = replaceImagePathsAndUrls(
-                        processedMarkdown,
-                        collectedFileIds,
-                        {}, // markdownFilesToPathName not needed for translations
-                        {
-                            absolutePathToMarkdownFile,
-                            absolutePathToFernFolder: docsWorkspacePath
-                        },
-                        context
-                    );
+                    try {
+                        const basePage = translatedPages[pagePath];
+                        // Strip MDX comments first
+                        let processedMarkdown = stripMdxComments(rawMarkdown);
+                        // Replace image paths using collected file IDs
+                        const absolutePathToMarkdownFile = resolve(docsWorkspacePath, RelativeFilePath.of(pagePath));
+                        processedMarkdown = replaceImagePathsAndUrls(
+                            processedMarkdown,
+                            collectedFileIds,
+                            {}, // markdownFilesToPathName not needed for translations
+                            {
+                                absolutePathToMarkdownFile,
+                                absolutePathToFernFolder: docsWorkspacePath
+                            },
+                            context
+                        );
 
-                    translatedPages[pagePath] = {
-                        markdown: processedMarkdown,
-                        rawMarkdown: processedMarkdown,
-                        editThisPageUrl: basePage?.editThisPageUrl,
-                        editThisPageLaunch: basePage?.editThisPageLaunch
-                    };
+                        translatedPages[pagePath] = {
+                            markdown: processedMarkdown,
+                            rawMarkdown: processedMarkdown,
+                            editThisPageUrl: basePage?.editThisPageUrl,
+                            editThisPageLaunch: basePage?.editThisPageLaunch
+                        };
+                    } catch (pageError) {
+                        context.logger.warn(
+                            `Failed to process translated page "${pagePath}" for locale "${locale}": ${String(pageError)}. Falling back to base page.`
+                        );
+                    }
                 }
 
                 // Apply translated frontmatter to nav tree

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -658,48 +658,57 @@ export async function publishDocs({
                         const translatedPages = {
                             ...docsDefinition.pages,
                             ...Object.fromEntries(
-                                Object.entries(localePages).map(([path, rawMarkdown]) => {
-                                    const basePage = docsDefinition.pages[path as DocsV1Write.PageId];
-                                    // Strip MDX comments first
-                                    let processedMarkdown = stripMdxComments(rawMarkdown);
-                                    // Replace image paths using the base page's location for resolution
-                                    // (translated pages reference the same images as the default locale)
-                                    const absolutePathToMarkdownFile = resolve(
-                                        docsWorkspacePath,
-                                        RelativeFilePath.of(path)
-                                    );
-                                    processedMarkdown = replaceImagePathsAndUrls(
-                                        processedMarkdown,
-                                        collectedFileIds,
-                                        {}, // markdownFilesToPathName not needed for translations
-                                        {
-                                            absolutePathToMarkdownFile,
-                                            absolutePathToFernFolder: docsWorkspacePath
-                                        },
-                                        context
-                                    );
-                                    // Rewrite editThisPageUrl to point to the translated file
-                                    // URL format: .../fern/${path}?plain=1 -> .../fern/translations/${locale}/${path}?plain=1
-                                    let editThisPageUrl = basePage?.editThisPageUrl;
-                                    if (editThisPageUrl != null) {
-                                        // Replace /fern/${path} with /fern/translations/${locale}/${path}
-                                        const fernPathPattern = `/fern/${path}`;
-                                        const translatedPath = `/fern/translations/${locale}/${path}`;
-                                        editThisPageUrl = editThisPageUrl.replace(
-                                            fernPathPattern,
-                                            translatedPath
-                                        ) as typeof editThisPageUrl;
-                                    }
-                                    return [
-                                        path,
-                                        {
-                                            markdown: processedMarkdown,
-                                            rawMarkdown: processedMarkdown,
-                                            editThisPageUrl,
-                                            editThisPageLaunch: basePage?.editThisPageLaunch
+                                Object.entries(localePages)
+                                    .map(([path, rawMarkdown]) => {
+                                        try {
+                                            const basePage = docsDefinition.pages[path as DocsV1Write.PageId];
+                                            // Strip MDX comments first
+                                            let processedMarkdown = stripMdxComments(rawMarkdown);
+                                            // Replace image paths using the base page's location for resolution
+                                            // (translated pages reference the same images as the default locale)
+                                            const absolutePathToMarkdownFile = resolve(
+                                                docsWorkspacePath,
+                                                RelativeFilePath.of(path)
+                                            );
+                                            processedMarkdown = replaceImagePathsAndUrls(
+                                                processedMarkdown,
+                                                collectedFileIds,
+                                                {}, // markdownFilesToPathName not needed for translations
+                                                {
+                                                    absolutePathToMarkdownFile,
+                                                    absolutePathToFernFolder: docsWorkspacePath
+                                                },
+                                                context
+                                            );
+                                            // Rewrite editThisPageUrl to point to the translated file
+                                            // URL format: .../fern/${path}?plain=1 -> .../fern/translations/${locale}/${path}?plain=1
+                                            let editThisPageUrl = basePage?.editThisPageUrl;
+                                            if (editThisPageUrl != null) {
+                                                // Replace /fern/${path} with /fern/translations/${locale}/${path}
+                                                const fernPathPattern = `/fern/${path}`;
+                                                const translatedPath = `/fern/translations/${locale}/${path}`;
+                                                editThisPageUrl = editThisPageUrl.replace(
+                                                    fernPathPattern,
+                                                    translatedPath
+                                                ) as typeof editThisPageUrl;
+                                            }
+                                            return [
+                                                path,
+                                                {
+                                                    markdown: processedMarkdown,
+                                                    rawMarkdown: processedMarkdown,
+                                                    editThisPageUrl,
+                                                    editThisPageLaunch: basePage?.editThisPageLaunch
+                                                }
+                                            ];
+                                        } catch (pageError) {
+                                            context.logger.warn(
+                                                `Failed to process translated page "${path}" for locale "${locale}": ${String(pageError)}. Falling back to base page.`
+                                            );
+                                            return undefined;
                                         }
-                                    ];
-                                })
+                                    })
+                                    .filter((entry): entry is NonNullable<typeof entry> => entry != null)
                             )
                         };
                         let updatedRoot = applyTranslatedFrontmatterToNavTree(


### PR DESCRIPTION
## Description

When a single translated MDX file contains invalid syntax (e.g., acorn parse errors from curly braces), the entire locale translation would fail with a generic error like:
```
Failed to compute translation for locale "ja": 70:11: Could not parse expression with acorn
```

This made it impossible to identify *which* file caused the error, and all translated pages for that locale were lost.

## Changes Made

- Wrapped per-page translation processing in individual try/catch blocks so a single failing page doesn't take down the entire locale
- Error messages now include the specific file path (e.g., `Failed to process translated page "pages/getting-started.mdx" for locale "ja": ...`)
- When a page fails to process, the base (default locale) page is used as a fallback instead of losing the entire locale
- Applied the fix consistently across all three code paths:
  - `runAppPreviewServer.ts` (new app preview server)
  - `runPreviewServer.ts` (legacy preview server)
  - `publishDocs.ts` (production docs publishing)

## Testing
- [x] Lint passes (`pnpm run check`)
- [x] Manual review of all three changed files to verify error handling is consistent


Link to Devin session: https://app.devin.ai/sessions/efea9000ce954e25930a47e05dc4f7cc
Requested by: @dsinghvi