### PR TITLE
chore(deps): bump @fern-api/replay to 0.13.0 in generator-cli

### DIFF
--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -39,7 +39,7 @@
     "@fern-api/cli-ai": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
-    "@fern-api/replay": "0.12.0",
+    "@fern-api/replay": "0.13.0",
     "@fern-api/task-context": "workspace:*",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,16 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Bump `@fern-api/replay` from 0.12.0 to 0.13.0. Picks up per-commit
+        detection in non-linear-history fallback (FER-10201), which produces
+        per-commit patches with proper attribution for squash-merged divergent
+        PRs instead of one composite patch.
+      type: feat
+  createdAt: "2026-04-28"
+  version: 0.9.20
+
+- changelogEntry:
+    - summary: |
         Send `gitattributesEntries` from `replayInit()` so Fiddle can mark
         `.fern/replay.lock` as `linguist-generated=true` in the PR it builds.
         Previously the local CLI wrote `.gitattributes` into a temp clone that

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7881,8 +7881,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/logging-execa
       '@fern-api/replay':
-        specifier: 0.12.0
-        version: 0.12.0
+        specifier: 0.13.0
+        version: 0.13.0
       '@fern-api/task-context':
         specifier: workspace:*
         version: link:../cli/task-context
@@ -9408,6 +9408,11 @@ packages:
 
   '@fern-api/replay@0.12.0':
     resolution: {integrity: sha512-vz9YbR+lSmR+lv0lX0A3Bk2CWwn+aEWfVwZUIgvmfXJ5PQ5K3U9SWnnSKlJnfChBKd/YBavroDmCmA7jxXne9Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@fern-api/replay@0.13.0':
+    resolution: {integrity: sha512-oxDuDT8Yan8tMYD+cYntxTeKxtqXLG1NBuCPtXd6mMToRMrulaGzId9ZWofF/OVKKNE4RAn4Qj63En+ZZkX8Pw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16444,6 +16449,15 @@ snapshots:
       - supports-color
 
   '@fern-api/replay@0.12.0':
+    dependencies:
+      minimatch: 10.2.5
+      node-diff3: 3.2.0
+      simple-git: 3.35.2
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@fern-api/replay@0.13.0':
     dependencies:
       minimatch: 10.2.5
       node-diff3: 3.2.0


### PR DESCRIPTION
## Description

Bump `@fern-api/replay` from `0.12.0` to `0.13.0` in `packages/generator-cli/package.json` and add generator-cli version `0.9.20`.

`0.13.0` brings per-commit detection in non-linear-history fallback (FER-10201), which produces per-commit patches with proper attribution for squash-merged divergent PRs instead of one composite patch. Also includes the `prepareReplay`/`applyPreparedReplay` split (0.12.0) and accumulator bugfixes (0.11.0).

## Changes Made

- `packages/generator-cli/package.json`: `@fern-api/replay` `0.12.0` → `0.13.0`
- `packages/generator-cli/versions.yml`: add `0.9.20` version entry
- `pnpm-lock.yaml`: regenerated via `pnpm install`

## Follow-up PRs

- Bump catalog pin in `pnpm-workspace.yaml` to `0.9.20` (after this is published to npm)
- Bump `@fern-api/generator-cli` in fiddle Dockerfile to `0.9.20`

## Testing

- [x] `pnpm install` succeeds locally
- [x] `@fern-api/replay@0.13.0` confirmed published to npm
- [ ] CI on this PR

Link to Devin session: https://app.devin.ai/sessions/7d89a6ba03e84bb18c8f9af998fc817d
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
