### PR TITLE
chore(deps): bump @fern-api/generator-cli catalog pin to 0.9.20

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: 0.0.6-2ee1b7e28
       version: 0.0.6-2ee1b7e28
     '@fern-api/generator-cli':
-      specifier: 0.9.18
-      version: 0.9.18
+      specifier: 0.9.20
+      version: 0.9.20
     '@fern-api/venus-api-sdk':
       specifier: 0.22.34
       version: 0.22.34
@@ -628,7 +628,7 @@ importers:
         version: link:packages/configs
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.18
+        version: 0.9.20
       '@rolldown/binding-darwin-arm64':
         specifier: 'catalog:'
         version: 1.0.0-rc.5
@@ -697,7 +697,7 @@ importers:
         version: link:../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.18
+        version: 0.9.20
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../packages/ir-sdk
@@ -2437,7 +2437,7 @@ importers:
         version: link:../../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.18
+        version: 0.9.20
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../packages/cli/logger
@@ -9402,13 +9402,8 @@ packages:
   '@fern-api/fdr-sdk@1.1.23-d25ead8e05':
     resolution: {integrity: sha512-fkcBIQSCI8Pj8k+sLf7p/rfwVCIdNjB3Na5XpsAc/af30JTgVlCmcAip7TgxxFeGjfpBprD7k6XDN162E0ppXQ==}
 
-  '@fern-api/generator-cli@0.9.18':
-    resolution: {integrity: sha512-LLz3E7MXFugvdti40N1uKCNaBdk/Lex3iCv9DIBax5UTX8rfEg/T4VvNWi2BPvpAxgoGd6lBkNObJdv9fnzCkQ==}
-    hasBin: true
-
-  '@fern-api/replay@0.12.0':
-    resolution: {integrity: sha512-vz9YbR+lSmR+lv0lX0A3Bk2CWwn+aEWfVwZUIgvmfXJ5PQ5K3U9SWnnSKlJnfChBKd/YBavroDmCmA7jxXne9Q==}
-    engines: {node: '>=18'}
+  '@fern-api/generator-cli@0.9.20':
+    resolution: {integrity: sha512-a9UDM+LzrdMA1p5WZCq1njX8Keml864ihKOAsM3kfxCvxmF3LwKKA2I/tmvTqzBL7IAdU0vVaN7pOn1mwZLgxQ==}
     hasBin: true
 
   '@fern-api/replay@0.13.0':
@@ -16437,23 +16432,14 @@ snapshots:
       - encoding
       - typescript
 
-  '@fern-api/generator-cli@0.9.18':
+  '@fern-api/generator-cli@0.9.20':
     dependencies:
       '@boundaryml/baml': 0.219.0
-      '@fern-api/replay': 0.12.0
+      '@fern-api/replay': 0.13.0
       '@octokit/rest': 22.0.1
       es-toolkit: 1.45.1
       semver: 7.7.4
       tmp-promise: 3.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@fern-api/replay@0.12.0':
-    dependencies:
-      minimatch: 10.2.5
-      node-diff3: 3.2.0
-      simple-git: 3.35.2
-      yaml: 2.8.3
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,7 +59,7 @@ catalog:
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.1.23-d25ead8e05
-  "@fern-api/generator-cli": 0.9.18
+  "@fern-api/generator-cli": 0.9.20
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Description

Bump the `@fern-api/generator-cli` catalog pin in `pnpm-workspace.yaml` from `0.9.18` to `0.9.20` so that consumer packages (generators) pick up the `@fern-api/replay` 0.13.0 upgrade shipped in `0.9.20` ([#15532](https://github.com/fern-api/fern/pull/15532)).

## Changes Made

- `pnpm-workspace.yaml`: catalog pin `0.9.18` → `0.9.20`
- `pnpm-lock.yaml`: regenerated via `pnpm install`

## Testing

- [x] `pnpm install` succeeds locally
- [x] `@fern-api/generator-cli@0.9.20` confirmed published to npm
- [ ] CI on this PR

Link to Devin session: https://app.devin.ai/sessions/7d89a6ba03e84bb18c8f9af998fc817d
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
