### PR TITLE
chore(go): gate EncodeQueryValues on query-reachable unions

### DIFF
--- a/generators/go/internal/generator/file_writer.go
+++ b/generators/go/internal/generator/file_writer.go
@@ -90,6 +90,11 @@ type fileWriter struct {
 	coordinator                  *coordinator.Client
 	snippetWriter                *SnippetWriter
 
+	// queryReachableUnions is the set of undiscriminated union TypeIds that
+	// may be encoded as query parameters. Only unions in this set get an
+	// EncodeQueryValues method generated; populated by generateModelTypes.
+	queryReachableUnions map[common.TypeId]struct{}
+
 	buffer *bytes.Buffer
 
 	// testData collects information about types that need getter/setter tests

--- a/generators/go/internal/generator/generator.go
+++ b/generators/go/internal/generator/generator.go
@@ -154,6 +154,7 @@ func (g *Generator) Generate(mode Mode) ([]*File, error) {
 }
 
 func (g *Generator) generateModelTypes(ir *fernir.IntermediateRepresentation, mode Mode, rootClientInstantiation *ast.AssignStmt, rootPackageName string) ([]*File, []*GeneratedClient, error) {
+	queryReachableUnions := collectQueryReachableUnions(ir)
 	fileInfoToTypes, err := fileInfoToTypes(
 		rootPackageName,
 		ir.Types,
@@ -190,6 +191,7 @@ func (g *Generator) generateModelTypes(ir *fernir.IntermediateRepresentation, mo
 			ir.Errors,
 			g.coordinator,
 		)
+		writer.queryReachableUnions = queryReachableUnions
 		for _, typeToGenerate := range typesToGenerate {
 			switch {
 			case typeToGenerate.TypeDeclaration != nil:
@@ -423,7 +425,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				g.config.UseReaderForBytesRequest,
 				g.config.GettersPassByValue,
 				g.config.ExportAllRequestsAtRoot,
-					g.config.OmitEmptyRequestWrappers,
+				g.config.OmitEmptyRequestWrappers,
 				g.config.OmitFernHeaders,
 				g.config.UnionVersion,
 				g.config.CustomPagerName,
@@ -491,7 +493,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				g.config.UseReaderForBytesRequest,
 				g.config.GettersPassByValue,
 				g.config.ExportAllRequestsAtRoot,
-					g.config.OmitEmptyRequestWrappers,
+				g.config.OmitEmptyRequestWrappers,
 				g.config.OmitFernHeaders,
 				g.config.UnionVersion,
 				g.config.CustomPagerName,
@@ -519,7 +521,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				g.config.UseReaderForBytesRequest,
 				g.config.GettersPassByValue,
 				g.config.ExportAllRequestsAtRoot,
-					g.config.OmitEmptyRequestWrappers,
+				g.config.OmitEmptyRequestWrappers,
 				g.config.OmitFernHeaders,
 				g.config.UnionVersion,
 				g.config.CustomPagerName,
@@ -550,7 +552,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				g.config.UseReaderForBytesRequest,
 				g.config.GettersPassByValue,
 				g.config.ExportAllRequestsAtRoot,
-					g.config.OmitEmptyRequestWrappers,
+				g.config.OmitEmptyRequestWrappers,
 				g.config.OmitFernHeaders,
 				g.config.UnionVersion,
 				g.config.CustomPagerName,
@@ -635,7 +637,7 @@ func (g *Generator) generate(ir *fernir.IntermediateRepresentation, mode Mode) (
 				g.config.UseReaderForBytesRequest,
 				g.config.GettersPassByValue,
 				g.config.ExportAllRequestsAtRoot,
-					g.config.OmitEmptyRequestWrappers,
+				g.config.OmitEmptyRequestWrappers,
 				g.config.OmitFernHeaders,
 				g.config.UnionVersion,
 				g.config.CustomPagerName,
@@ -1148,7 +1150,6 @@ func hasOAuthScheme(auth *ir.ApiAuth) bool {
 	return false
 }
 
-
 // newPointerFile returns a *File containing the pointer helper functions
 // used to more easily instantiate pointers to primitive values (e.g. *string).
 //
@@ -1318,7 +1319,6 @@ func newApiErrorFile(coordinator *coordinator.Client) *File {
 		[]byte(apiErrorFile),
 	)
 }
-
 
 // func newErrorDecoderFile(coordinator *coordinator.Client, baseImportPath string) *File {
 // 	content := replaceCoreImportPath(errorDecoderFile, baseImportPath)
@@ -2103,4 +2103,69 @@ func valueOf[T any](value *T) T {
 		return result
 	}
 	return *value
+}
+
+// collectQueryReachableUnions returns the set of undiscriminated union TypeIds
+// that are reachable from a query parameter position. The Go runtime query
+// encoder dispatches via the QueryEncoder interface, so we only need to
+// generate EncodeQueryValues on unions that may actually be encoded as query
+// parameters.
+//
+// Reachability follows container wrappers (optional/list/set/nullable) and
+// alias chains, but does not recurse into union variants — generated union
+// EncodeQueryValues stringifies variants directly and does not call back into
+// QueryEncoder.
+func collectQueryReachableUnions(ir *fernir.IntermediateRepresentation) map[common.TypeId]struct{} {
+	reachable := make(map[common.TypeId]struct{})
+	visited := make(map[common.TypeId]struct{})
+	for _, service := range ir.Services {
+		for _, endpoint := range service.Endpoints {
+			for _, queryParameter := range endpoint.QueryParameters {
+				walkQueryReachableType(queryParameter.ValueType, ir.Types, reachable, visited)
+			}
+		}
+	}
+	return reachable
+}
+
+func walkQueryReachableType(
+	typeReference *fernir.TypeReference,
+	types map[common.TypeId]*fernir.TypeDeclaration,
+	reachable map[common.TypeId]struct{},
+	visited map[common.TypeId]struct{},
+) {
+	if typeReference == nil {
+		return
+	}
+	if container := typeReference.Container; container != nil {
+		switch {
+		case container.List != nil:
+			walkQueryReachableType(container.List, types, reachable, visited)
+		case container.Set != nil:
+			walkQueryReachableType(container.Set, types, reachable, visited)
+		case container.Optional != nil:
+			walkQueryReachableType(container.Optional, types, reachable, visited)
+		case container.Nullable != nil:
+			walkQueryReachableType(container.Nullable, types, reachable, visited)
+		}
+		return
+	}
+	named := typeReference.Named
+	if named == nil {
+		return
+	}
+	if _, seen := visited[named.TypeId]; seen {
+		return
+	}
+	visited[named.TypeId] = struct{}{}
+	declaration, ok := types[named.TypeId]
+	if !ok || declaration.Shape == nil {
+		return
+	}
+	switch {
+	case declaration.Shape.UndiscriminatedUnion != nil:
+		reachable[named.TypeId] = struct{}{}
+	case declaration.Shape.Alias != nil:
+		walkQueryReachableType(declaration.Shape.Alias.AliasOf, types, reachable, visited)
+	}
 }

--- a/generators/go/internal/generator/model.go
+++ b/generators/go/internal/generator/model.go
@@ -28,6 +28,7 @@ func (f *fileWriter) WriteType(
 ) error {
 	visitor := &typeVisitor{
 		typeName:                     typeDeclaration.Name.Name.PascalCase.UnsafeName,
+		typeId:                       typeDeclaration.Name.TypeId,
 		baseImportPath:               f.baseImportPath,
 		importPath:                   fernFilepathToImportPath(f.baseImportPath, typeDeclaration.Name.FernFilepath),
 		writer:                       f,
@@ -43,6 +44,7 @@ func (f *fileWriter) WriteType(
 // typeVisitor writes the internal properties of types (e.g. properties).
 type typeVisitor struct {
 	typeName       string
+	typeId         common.TypeId
 	baseImportPath string
 	importPath     string
 	writer         *fileWriter
@@ -1034,35 +1036,38 @@ func (t *typeVisitor) VisitUndiscriminatedUnion(union *ir.UndiscriminatedUnionTy
 
 	// Implement the QueryEncoder interface so undiscriminated unions can be used as query
 	// parameters. Without this, internal/query.go recurses into the struct, finds no `url`
-	// tags on the inner fields, and silently drops the parameter.
-	t.writer.P("func (", receiver, " *", t.typeName, ") EncodeQueryValues(key string, values *url.Values) error {")
-	t.writer.P("if ", receiver, " == nil {")
-	t.writer.P("return nil")
-	t.writer.P("}")
-	for _, member := range members {
-		if member.isLiteral {
-			// Literals are constants; the server doesn't need them echoed back as query values.
-			continue
-		}
-		field := fmt.Sprintf("%s.%s", receiver, member.field)
-		if member.date != nil && !member.isOptional {
-			t.writer.P(fmt.Sprintf("if %s.typ == %q || !%s.IsZero() {", receiver, member.field, field))
-		} else {
-			t.writer.P(fmt.Sprintf("if %s.typ == %q || %s != %s {", receiver, member.field, field, member.zeroValue))
-		}
-		if member.isList {
-			t.writer.P("for _, item := range ", field, " {")
-			t.writer.P(`values.Add(key, fmt.Sprintf("%v", item))`)
+	// tags on the inner fields, and silently drops the parameter. Only emit on unions
+	// reachable from a query parameter position to avoid bloating unrelated types.
+	if _, queryReachable := t.writer.queryReachableUnions[t.typeId]; queryReachable {
+		t.writer.P("func (", receiver, " *", t.typeName, ") EncodeQueryValues(key string, values *url.Values) error {")
+		t.writer.P("if ", receiver, " == nil {")
+		t.writer.P("return nil")
+		t.writer.P("}")
+		for _, member := range members {
+			if member.isLiteral {
+				// Literals are constants; the server doesn't need them echoed back as query values.
+				continue
+			}
+			field := fmt.Sprintf("%s.%s", receiver, member.field)
+			if member.date != nil && !member.isOptional {
+				t.writer.P(fmt.Sprintf("if %s.typ == %q || !%s.IsZero() {", receiver, member.field, field))
+			} else {
+				t.writer.P(fmt.Sprintf("if %s.typ == %q || %s != %s {", receiver, member.field, field, member.zeroValue))
+			}
+			if member.isList {
+				t.writer.P("for _, item := range ", field, " {")
+				t.writer.P(`values.Add(key, fmt.Sprintf("%v", item))`)
+				t.writer.P("}")
+			} else {
+				t.writer.P(`values.Add(key, fmt.Sprintf("%v", `, field, "))")
+			}
+			t.writer.P("return nil")
 			t.writer.P("}")
-		} else {
-			t.writer.P(`values.Add(key, fmt.Sprintf("%v", `, field, "))")
 		}
 		t.writer.P("return nil")
 		t.writer.P("}")
+		t.writer.P()
 	}
-	t.writer.P("return nil")
-	t.writer.P("}")
-	t.writer.P()
 
 	// Generate the Visitor interface.
 	t.writer.P("type ", t.typeName, "Visitor interface {")

--- a/generators/go/sdk/changes/unreleased/gate-encode-query-values-on-reachable-unions.yml
+++ b/generators/go/sdk/changes/unreleased/gate-encode-query-values-on-reachable-unions.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Only generate `EncodeQueryValues` on undiscriminated unions that are reachable from a query parameter position, instead of on every union.
+  type: chore

--- a/seed/go-sdk/circular-references-advanced/.fern/metadata.json
+++ b/seed/go-sdk/circular-references-advanced/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/circular-references-advanced/ast.go
+++ b/seed/go-sdk/circular-references-advanced/ast.go
@@ -7,7 +7,6 @@ import (
 	fmt "fmt"
 	internal "github.com/circular-references-advanced/fern/internal"
 	big "math/big"
-	url "net/url"
 )
 
 var (
@@ -139,21 +138,6 @@ func (a Animal) MarshalJSON() ([]byte, error) {
 		return json.Marshal(a.Dog)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", a)
-}
-
-func (a *Animal) EncodeQueryValues(key string, values *url.Values) error {
-	if a == nil {
-		return nil
-	}
-	if a.typ == "Cat" || a.Cat != nil {
-		values.Add(key, fmt.Sprintf("%v", a.Cat))
-		return nil
-	}
-	if a.typ == "Dog" || a.Dog != nil {
-		values.Add(key, fmt.Sprintf("%v", a.Dog))
-		return nil
-	}
-	return nil
 }
 
 type AnimalVisitor interface {
@@ -934,21 +918,6 @@ func (f Fruit) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", f)
 }
 
-func (f *Fruit) EncodeQueryValues(key string, values *url.Values) error {
-	if f == nil {
-		return nil
-	}
-	if f.typ == "Acai" || f.Acai != nil {
-		values.Add(key, fmt.Sprintf("%v", f.Acai))
-		return nil
-	}
-	if f.typ == "Fig" || f.Fig != nil {
-		values.Add(key, fmt.Sprintf("%v", f.Fig))
-		return nil
-	}
-	return nil
-}
-
 type FruitVisitor interface {
 	VisitAcai(*Acai) error
 	VisitFig(*Fig) error
@@ -1074,21 +1043,6 @@ func (n Node) MarshalJSON() ([]byte, error) {
 		return json.Marshal(n.LeafNode)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", n)
-}
-
-func (n *Node) EncodeQueryValues(key string, values *url.Values) error {
-	if n == nil {
-		return nil
-	}
-	if n.typ == "BranchNode" || n.BranchNode != nil {
-		values.Add(key, fmt.Sprintf("%v", n.BranchNode))
-		return nil
-	}
-	if n.typ == "LeafNode" || n.LeafNode != nil {
-		values.Add(key, fmt.Sprintf("%v", n.LeafNode))
-		return nil
-	}
-	return nil
 }
 
 type NodeVisitor interface {

--- a/seed/go-sdk/circular-references/.fern/metadata.json
+++ b/seed/go-sdk/circular-references/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/circular-references/ast.go
+++ b/seed/go-sdk/circular-references/ast.go
@@ -7,7 +7,6 @@ import (
 	fmt "fmt"
 	internal "github.com/circular-references/fern/internal"
 	big "math/big"
-	url "net/url"
 )
 
 type ContainerValue struct {
@@ -402,35 +401,6 @@ func (j JSONLike) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", j)
 }
 
-func (j *JSONLike) EncodeQueryValues(key string, values *url.Values) error {
-	if j == nil {
-		return nil
-	}
-	if j.typ == "JSONLikeList" || j.JSONLikeList != nil {
-		for _, item := range j.JSONLikeList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if j.typ == "StringJSONLikeMap" || j.StringJSONLikeMap != nil {
-		values.Add(key, fmt.Sprintf("%v", j.StringJSONLikeMap))
-		return nil
-	}
-	if j.typ == "String" || j.String != "" {
-		values.Add(key, fmt.Sprintf("%v", j.String))
-		return nil
-	}
-	if j.typ == "Integer" || j.Integer != 0 {
-		values.Add(key, fmt.Sprintf("%v", j.Integer))
-		return nil
-	}
-	if j.typ == "Boolean" || j.Boolean != false {
-		values.Add(key, fmt.Sprintf("%v", j.Boolean))
-		return nil
-	}
-	return nil
-}
-
 type JSONLikeVisitor interface {
 	VisitJSONLikeList([]*JSONLike) error
 	VisitStringJSONLikeMap(map[string]*JSONLike) error
@@ -554,35 +524,6 @@ func (j JSONLikeWithNullAndUndefined) MarshalJSON() ([]byte, error) {
 		return json.Marshal(j.BooleanOptional)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", j)
-}
-
-func (j *JSONLikeWithNullAndUndefined) EncodeQueryValues(key string, values *url.Values) error {
-	if j == nil {
-		return nil
-	}
-	if j.typ == "JSONLikeWithNullAndUndefinedOptionalList" || j.JSONLikeWithNullAndUndefinedOptionalList != nil {
-		for _, item := range j.JSONLikeWithNullAndUndefinedOptionalList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if j.typ == "StringJSONLikeWithNullAndUndefinedOptionalMap" || j.StringJSONLikeWithNullAndUndefinedOptionalMap != nil {
-		values.Add(key, fmt.Sprintf("%v", j.StringJSONLikeWithNullAndUndefinedOptionalMap))
-		return nil
-	}
-	if j.typ == "StringOptional" || j.StringOptional != nil {
-		values.Add(key, fmt.Sprintf("%v", j.StringOptional))
-		return nil
-	}
-	if j.typ == "IntegerOptional" || j.IntegerOptional != nil {
-		values.Add(key, fmt.Sprintf("%v", j.IntegerOptional))
-		return nil
-	}
-	if j.typ == "BooleanOptional" || j.BooleanOptional != nil {
-		values.Add(key, fmt.Sprintf("%v", j.BooleanOptional))
-		return nil
-	}
-	return nil
 }
 
 type JSONLikeWithNullAndUndefinedVisitor interface {
@@ -828,21 +769,6 @@ func (t TorU) MarshalJSON() ([]byte, error) {
 		return json.Marshal(t.U)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", t)
-}
-
-func (t *TorU) EncodeQueryValues(key string, values *url.Values) error {
-	if t == nil {
-		return nil
-	}
-	if t.typ == "T" || t.T != nil {
-		values.Add(key, fmt.Sprintf("%v", t.T))
-		return nil
-	}
-	if t.typ == "U" || t.U != nil {
-		values.Add(key, fmt.Sprintf("%v", t.U))
-		return nil
-	}
-	return nil
 }
 
 type TorUVisitor interface {

--- a/seed/go-sdk/enum/.fern/metadata.json
+++ b/seed/go-sdk/enum/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/always-send-required-properties/.fern/metadata.json
+++ b/seed/go-sdk/examples/always-send-required-properties/.fern/metadata.json
@@ -7,8 +7,7 @@
     "alwaysSendRequiredProperties": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/always-send-required-properties/types.go
+++ b/seed/go-sdk/examples/always-send-required-properties/types.go
@@ -9,7 +9,6 @@ import (
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
 	big "math/big"
-	url "net/url"
 	time "time"
 )
 
@@ -221,21 +220,6 @@ func (t Type) MarshalJSON() ([]byte, error) {
 		return json.Marshal(t.ComplexType)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", t)
-}
-
-func (t *Type) EncodeQueryValues(key string, values *url.Values) error {
-	if t == nil {
-		return nil
-	}
-	if t.typ == "BasicType" || t.BasicType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.BasicType))
-		return nil
-	}
-	if t.typ == "ComplexType" || t.ComplexType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.ComplexType))
-		return nil
-	}
-	return nil
 }
 
 type TypeVisitor interface {
@@ -891,25 +875,6 @@ func (c CastMember) MarshalJSON() ([]byte, error) {
 		return json.Marshal(c.StuntDouble)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", c)
-}
-
-func (c *CastMember) EncodeQueryValues(key string, values *url.Values) error {
-	if c == nil {
-		return nil
-	}
-	if c.typ == "Actor" || c.Actor != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actor))
-		return nil
-	}
-	if c.typ == "Actress" || c.Actress != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actress))
-		return nil
-	}
-	if c.typ == "StuntDouble" || c.StuntDouble != nil {
-		values.Add(key, fmt.Sprintf("%v", c.StuntDouble))
-		return nil
-	}
-	return nil
 }
 
 type CastMemberVisitor interface {

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/.fern/metadata.json
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/.fern/metadata.json
@@ -8,8 +8,7 @@
     "clientConstructorName": "New"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/types.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/types.go
@@ -9,7 +9,6 @@ import (
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
 	big "math/big"
-	url "net/url"
 	time "time"
 )
 
@@ -221,21 +220,6 @@ func (t Type) MarshalJSON() ([]byte, error) {
 		return json.Marshal(t.ComplexType)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", t)
-}
-
-func (t *Type) EncodeQueryValues(key string, values *url.Values) error {
-	if t == nil {
-		return nil
-	}
-	if t.typ == "BasicType" || t.BasicType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.BasicType))
-		return nil
-	}
-	if t.typ == "ComplexType" || t.ComplexType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.ComplexType))
-		return nil
-	}
-	return nil
 }
 
 type TypeVisitor interface {
@@ -891,25 +875,6 @@ func (c CastMember) MarshalJSON() ([]byte, error) {
 		return json.Marshal(c.StuntDouble)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", c)
-}
-
-func (c *CastMember) EncodeQueryValues(key string, values *url.Values) error {
-	if c == nil {
-		return nil
-	}
-	if c.typ == "Actor" || c.Actor != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actor))
-		return nil
-	}
-	if c.typ == "Actress" || c.Actress != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actress))
-		return nil
-	}
-	if c.typ == "StuntDouble" || c.StuntDouble != nil {
-		values.Add(key, fmt.Sprintf("%v", c.StuntDouble))
-		return nil
-	}
-	return nil
 }
 
 type CastMemberVisitor interface {

--- a/seed/go-sdk/examples/client-name/.fern/metadata.json
+++ b/seed/go-sdk/examples/client-name/.fern/metadata.json
@@ -7,8 +7,7 @@
     "clientName": "Acme"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/client-name/types.go
+++ b/seed/go-sdk/examples/client-name/types.go
@@ -9,7 +9,6 @@ import (
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
 	big "math/big"
-	url "net/url"
 	time "time"
 )
 
@@ -221,21 +220,6 @@ func (t Type) MarshalJSON() ([]byte, error) {
 		return json.Marshal(t.ComplexType)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", t)
-}
-
-func (t *Type) EncodeQueryValues(key string, values *url.Values) error {
-	if t == nil {
-		return nil
-	}
-	if t.typ == "BasicType" || t.BasicType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.BasicType))
-		return nil
-	}
-	if t.typ == "ComplexType" || t.ComplexType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.ComplexType))
-		return nil
-	}
-	return nil
 }
 
 type TypeVisitor interface {
@@ -891,25 +875,6 @@ func (c CastMember) MarshalJSON() ([]byte, error) {
 		return json.Marshal(c.StuntDouble)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", c)
-}
-
-func (c *CastMember) EncodeQueryValues(key string, values *url.Values) error {
-	if c == nil {
-		return nil
-	}
-	if c.typ == "Actor" || c.Actor != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actor))
-		return nil
-	}
-	if c.typ == "Actress" || c.Actress != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actress))
-		return nil
-	}
-	if c.typ == "StuntDouble" || c.StuntDouble != nil {
-		values.Add(key, fmt.Sprintf("%v", c.StuntDouble))
-		return nil
-	}
-	return nil
 }
 
 type CastMemberVisitor interface {

--- a/seed/go-sdk/examples/export-all-requests-at-root/.fern/metadata.json
+++ b/seed/go-sdk/examples/export-all-requests-at-root/.fern/metadata.json
@@ -7,8 +7,7 @@
     "exportAllRequestsAtRoot": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/export-all-requests-at-root/types.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/types.go
@@ -9,7 +9,6 @@ import (
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
 	big "math/big"
-	url "net/url"
 	time "time"
 )
 
@@ -221,21 +220,6 @@ func (t Type) MarshalJSON() ([]byte, error) {
 		return json.Marshal(t.ComplexType)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", t)
-}
-
-func (t *Type) EncodeQueryValues(key string, values *url.Values) error {
-	if t == nil {
-		return nil
-	}
-	if t.typ == "BasicType" || t.BasicType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.BasicType))
-		return nil
-	}
-	if t.typ == "ComplexType" || t.ComplexType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.ComplexType))
-		return nil
-	}
-	return nil
 }
 
 type TypeVisitor interface {
@@ -891,25 +875,6 @@ func (c CastMember) MarshalJSON() ([]byte, error) {
 		return json.Marshal(c.StuntDouble)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", c)
-}
-
-func (c *CastMember) EncodeQueryValues(key string, values *url.Values) error {
-	if c == nil {
-		return nil
-	}
-	if c.typ == "Actor" || c.Actor != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actor))
-		return nil
-	}
-	if c.typ == "Actress" || c.Actress != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actress))
-		return nil
-	}
-	if c.typ == "StuntDouble" || c.StuntDouble != nil {
-		values.Add(key, fmt.Sprintf("%v", c.StuntDouble))
-		return nil
-	}
-	return nil
 }
 
 type CastMemberVisitor interface {

--- a/seed/go-sdk/examples/exported-client-name/.fern/metadata.json
+++ b/seed/go-sdk/examples/exported-client-name/.fern/metadata.json
@@ -7,8 +7,7 @@
     "exportedClientName": "AcmeClient"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/exported-client-name/types.go
+++ b/seed/go-sdk/examples/exported-client-name/types.go
@@ -9,7 +9,6 @@ import (
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
 	big "math/big"
-	url "net/url"
 	time "time"
 )
 
@@ -221,21 +220,6 @@ func (t Type) MarshalJSON() ([]byte, error) {
 		return json.Marshal(t.ComplexType)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", t)
-}
-
-func (t *Type) EncodeQueryValues(key string, values *url.Values) error {
-	if t == nil {
-		return nil
-	}
-	if t.typ == "BasicType" || t.BasicType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.BasicType))
-		return nil
-	}
-	if t.typ == "ComplexType" || t.ComplexType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.ComplexType))
-		return nil
-	}
-	return nil
 }
 
 type TypeVisitor interface {
@@ -891,25 +875,6 @@ func (c CastMember) MarshalJSON() ([]byte, error) {
 		return json.Marshal(c.StuntDouble)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", c)
-}
-
-func (c *CastMember) EncodeQueryValues(key string, values *url.Values) error {
-	if c == nil {
-		return nil
-	}
-	if c.typ == "Actor" || c.Actor != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actor))
-		return nil
-	}
-	if c.typ == "Actress" || c.Actress != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actress))
-		return nil
-	}
-	if c.typ == "StuntDouble" || c.StuntDouble != nil {
-		values.Add(key, fmt.Sprintf("%v", c.StuntDouble))
-		return nil
-	}
-	return nil
 }
 
 type CastMemberVisitor interface {

--- a/seed/go-sdk/examples/getters-pass-by-value/.fern/metadata.json
+++ b/seed/go-sdk/examples/getters-pass-by-value/.fern/metadata.json
@@ -7,8 +7,7 @@
     "gettersPassByValue": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/getters-pass-by-value/types.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/types.go
@@ -9,7 +9,6 @@ import (
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
 	big "math/big"
-	url "net/url"
 	time "time"
 )
 
@@ -221,21 +220,6 @@ func (t Type) MarshalJSON() ([]byte, error) {
 		return json.Marshal(t.ComplexType)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", t)
-}
-
-func (t *Type) EncodeQueryValues(key string, values *url.Values) error {
-	if t == nil {
-		return nil
-	}
-	if t.typ == "BasicType" || t.BasicType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.BasicType))
-		return nil
-	}
-	if t.typ == "ComplexType" || t.ComplexType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.ComplexType))
-		return nil
-	}
-	return nil
 }
 
 type TypeVisitor interface {
@@ -891,25 +875,6 @@ func (c CastMember) MarshalJSON() ([]byte, error) {
 		return json.Marshal(c.StuntDouble)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", c)
-}
-
-func (c *CastMember) EncodeQueryValues(key string, values *url.Values) error {
-	if c == nil {
-		return nil
-	}
-	if c.typ == "Actor" || c.Actor != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actor))
-		return nil
-	}
-	if c.typ == "Actress" || c.Actress != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actress))
-		return nil
-	}
-	if c.typ == "StuntDouble" || c.StuntDouble != nil {
-		values.Add(key, fmt.Sprintf("%v", c.StuntDouble))
-		return nil
-	}
-	return nil
 }
 
 type CastMemberVisitor interface {

--- a/seed/go-sdk/examples/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/examples/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/no-custom-config/types.go
+++ b/seed/go-sdk/examples/no-custom-config/types.go
@@ -9,7 +9,6 @@ import (
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
 	big "math/big"
-	url "net/url"
 	time "time"
 )
 
@@ -221,21 +220,6 @@ func (t Type) MarshalJSON() ([]byte, error) {
 		return json.Marshal(t.ComplexType)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", t)
-}
-
-func (t *Type) EncodeQueryValues(key string, values *url.Values) error {
-	if t == nil {
-		return nil
-	}
-	if t.typ == "BasicType" || t.BasicType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.BasicType))
-		return nil
-	}
-	if t.typ == "ComplexType" || t.ComplexType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.ComplexType))
-		return nil
-	}
-	return nil
 }
 
 type TypeVisitor interface {
@@ -891,25 +875,6 @@ func (c CastMember) MarshalJSON() ([]byte, error) {
 		return json.Marshal(c.StuntDouble)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", c)
-}
-
-func (c *CastMember) EncodeQueryValues(key string, values *url.Values) error {
-	if c == nil {
-		return nil
-	}
-	if c.typ == "Actor" || c.Actor != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actor))
-		return nil
-	}
-	if c.typ == "Actress" || c.Actress != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actress))
-		return nil
-	}
-	if c.typ == "StuntDouble" || c.StuntDouble != nil {
-		values.Add(key, fmt.Sprintf("%v", c.StuntDouble))
-		return nil
-	}
-	return nil
 }
 
 type CastMemberVisitor interface {

--- a/seed/go-sdk/examples/package-path/.fern/metadata.json
+++ b/seed/go-sdk/examples/package-path/.fern/metadata.json
@@ -7,8 +7,7 @@
     "packagePath": "pleaseinhere"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/package-path/pleaseinhere/types.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/types.go
@@ -9,7 +9,6 @@ import (
 	internal "github.com/examples/fern/pleaseinhere/internal"
 	uuid "github.com/google/uuid"
 	big "math/big"
-	url "net/url"
 	time "time"
 )
 
@@ -221,21 +220,6 @@ func (t Type) MarshalJSON() ([]byte, error) {
 		return json.Marshal(t.ComplexType)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", t)
-}
-
-func (t *Type) EncodeQueryValues(key string, values *url.Values) error {
-	if t == nil {
-		return nil
-	}
-	if t.typ == "BasicType" || t.BasicType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.BasicType))
-		return nil
-	}
-	if t.typ == "ComplexType" || t.ComplexType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.ComplexType))
-		return nil
-	}
-	return nil
 }
 
 type TypeVisitor interface {
@@ -891,25 +875,6 @@ func (c CastMember) MarshalJSON() ([]byte, error) {
 		return json.Marshal(c.StuntDouble)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", c)
-}
-
-func (c *CastMember) EncodeQueryValues(key string, values *url.Values) error {
-	if c == nil {
-		return nil
-	}
-	if c.typ == "Actor" || c.Actor != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actor))
-		return nil
-	}
-	if c.typ == "Actress" || c.Actress != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actress))
-		return nil
-	}
-	if c.typ == "StuntDouble" || c.StuntDouble != nil {
-		values.Add(key, fmt.Sprintf("%v", c.StuntDouble))
-		return nil
-	}
-	return nil
 }
 
 type CastMemberVisitor interface {

--- a/seed/go-sdk/examples/readme-config/.fern/metadata.json
+++ b/seed/go-sdk/examples/readme-config/.fern/metadata.json
@@ -18,8 +18,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/readme-config/types.go
+++ b/seed/go-sdk/examples/readme-config/types.go
@@ -9,7 +9,6 @@ import (
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
 	big "math/big"
-	url "net/url"
 	time "time"
 )
 
@@ -221,21 +220,6 @@ func (t Type) MarshalJSON() ([]byte, error) {
 		return json.Marshal(t.ComplexType)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", t)
-}
-
-func (t *Type) EncodeQueryValues(key string, values *url.Values) error {
-	if t == nil {
-		return nil
-	}
-	if t.typ == "BasicType" || t.BasicType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.BasicType))
-		return nil
-	}
-	if t.typ == "ComplexType" || t.ComplexType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.ComplexType))
-		return nil
-	}
-	return nil
 }
 
 type TypeVisitor interface {
@@ -891,25 +875,6 @@ func (c CastMember) MarshalJSON() ([]byte, error) {
 		return json.Marshal(c.StuntDouble)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", c)
-}
-
-func (c *CastMember) EncodeQueryValues(key string, values *url.Values) error {
-	if c == nil {
-		return nil
-	}
-	if c.typ == "Actor" || c.Actor != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actor))
-		return nil
-	}
-	if c.typ == "Actress" || c.Actress != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actress))
-		return nil
-	}
-	if c.typ == "StuntDouble" || c.StuntDouble != nil {
-		values.Add(key, fmt.Sprintf("%v", c.StuntDouble))
-		return nil
-	}
-	return nil
 }
 
 type CastMemberVisitor interface {

--- a/seed/go-sdk/examples/v0/.fern/metadata.json
+++ b/seed/go-sdk/examples/v0/.fern/metadata.json
@@ -11,8 +11,7 @@
     "union": "v0"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/examples/v0/types.go
+++ b/seed/go-sdk/examples/v0/types.go
@@ -9,7 +9,6 @@ import (
 	internal "github.com/examples/fern/internal"
 	uuid "github.com/google/uuid"
 	big "math/big"
-	url "net/url"
 	time "time"
 )
 
@@ -229,21 +228,6 @@ func (t Type) MarshalJSON() ([]byte, error) {
 		return json.Marshal(t.ComplexType)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", t)
-}
-
-func (t *Type) EncodeQueryValues(key string, values *url.Values) error {
-	if t == nil {
-		return nil
-	}
-	if t.typ == "BasicType" || t.BasicType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.BasicType))
-		return nil
-	}
-	if t.typ == "ComplexType" || t.ComplexType != "" {
-		values.Add(key, fmt.Sprintf("%v", t.ComplexType))
-		return nil
-	}
-	return nil
 }
 
 type TypeVisitor interface {
@@ -911,25 +895,6 @@ func (c CastMember) MarshalJSON() ([]byte, error) {
 		return json.Marshal(c.StuntDouble)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", c)
-}
-
-func (c *CastMember) EncodeQueryValues(key string, values *url.Values) error {
-	if c == nil {
-		return nil
-	}
-	if c.typ == "Actor" || c.Actor != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actor))
-		return nil
-	}
-	if c.typ == "Actress" || c.Actress != nil {
-		values.Add(key, fmt.Sprintf("%v", c.Actress))
-		return nil
-	}
-	if c.typ == "StuntDouble" || c.StuntDouble != nil {
-		values.Add(key, fmt.Sprintf("%v", c.StuntDouble))
-		return nil
-	}
-	return nil
 }
 
 type CastMemberVisitor interface {

--- a/seed/go-sdk/exhaustive/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/exhaustive/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/exhaustive/no-custom-config/types/union.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/types/union.go
@@ -7,7 +7,6 @@ import (
 	fmt "fmt"
 	internal "github.com/exhaustive/fern/internal"
 	big "math/big"
-	url "net/url"
 )
 
 type Animal struct {
@@ -406,31 +405,6 @@ func (m MixedType) MarshalJSON() ([]byte, error) {
 		return json.Marshal(m.StringList)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", m)
-}
-
-func (m *MixedType) EncodeQueryValues(key string, values *url.Values) error {
-	if m == nil {
-		return nil
-	}
-	if m.typ == "Double" || m.Double != 0 {
-		values.Add(key, fmt.Sprintf("%v", m.Double))
-		return nil
-	}
-	if m.typ == "Boolean" || m.Boolean != false {
-		values.Add(key, fmt.Sprintf("%v", m.Boolean))
-		return nil
-	}
-	if m.typ == "String" || m.String != "" {
-		values.Add(key, fmt.Sprintf("%v", m.String))
-		return nil
-	}
-	if m.typ == "StringList" || m.StringList != nil {
-		for _, item := range m.StringList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	return nil
 }
 
 type MixedTypeVisitor interface {

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/.fern/metadata.json
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/.fern/metadata.json
@@ -7,8 +7,7 @@
     "omitEmptyRequestWrappers": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/types/union.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/types/union.go
@@ -7,7 +7,6 @@ import (
 	fmt "fmt"
 	internal "github.com/exhaustive/fern/internal"
 	big "math/big"
-	url "net/url"
 )
 
 type Animal struct {
@@ -406,31 +405,6 @@ func (m MixedType) MarshalJSON() ([]byte, error) {
 		return json.Marshal(m.StringList)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", m)
-}
-
-func (m *MixedType) EncodeQueryValues(key string, values *url.Values) error {
-	if m == nil {
-		return nil
-	}
-	if m.typ == "Double" || m.Double != 0 {
-		values.Add(key, fmt.Sprintf("%v", m.Double))
-		return nil
-	}
-	if m.typ == "Boolean" || m.Boolean != false {
-		values.Add(key, fmt.Sprintf("%v", m.Boolean))
-		return nil
-	}
-	if m.typ == "String" || m.String != "" {
-		values.Add(key, fmt.Sprintf("%v", m.String))
-		return nil
-	}
-	if m.typ == "StringList" || m.StringList != nil {
-		for _, item := range m.StringList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	return nil
 }
 
 type MixedTypeVisitor interface {

--- a/seed/go-sdk/go-deterministic-ordering/.fern/metadata.json
+++ b/seed/go-sdk/go-deterministic-ordering/.fern/metadata.json
@@ -7,8 +7,7 @@
     "exportAllRequestsAtRoot": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/go-deterministic-ordering/types/union.go
+++ b/seed/go-sdk/go-deterministic-ordering/types/union.go
@@ -7,7 +7,6 @@ import (
 	fmt "fmt"
 	internal "github.com/go-deterministic-ordering/fern/internal"
 	big "math/big"
-	url "net/url"
 )
 
 type Animal struct {
@@ -406,31 +405,6 @@ func (m MixedType) MarshalJSON() ([]byte, error) {
 		return json.Marshal(m.StringList)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", m)
-}
-
-func (m *MixedType) EncodeQueryValues(key string, values *url.Values) error {
-	if m == nil {
-		return nil
-	}
-	if m.typ == "Double" || m.Double != 0 {
-		values.Add(key, fmt.Sprintf("%v", m.Double))
-		return nil
-	}
-	if m.typ == "Boolean" || m.Boolean != false {
-		values.Add(key, fmt.Sprintf("%v", m.Boolean))
-		return nil
-	}
-	if m.typ == "String" || m.String != "" {
-		values.Add(key, fmt.Sprintf("%v", m.String))
-		return nil
-	}
-	if m.typ == "StringList" || m.StringList != nil {
-		for _, item := range m.StringList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	return nil
 }
 
 type MixedTypeVisitor interface {

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/.fern/metadata.json
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/.fern/metadata.json
@@ -10,8 +10,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/service.go
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/service.go
@@ -7,7 +7,6 @@ import (
 	fmt "fmt"
 	internal "github.com/go-undiscriminated-union-wire-tests/fern/internal"
 	big "math/big"
-	url "net/url"
 )
 
 type DocumentItem struct {
@@ -55,21 +54,6 @@ func (d DocumentItem) MarshalJSON() ([]byte, error) {
 		return json.Marshal(d.DocumentObject)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", d)
-}
-
-func (d *DocumentItem) EncodeQueryValues(key string, values *url.Values) error {
-	if d == nil {
-		return nil
-	}
-	if d.typ == "String" || d.String != "" {
-		values.Add(key, fmt.Sprintf("%v", d.String))
-		return nil
-	}
-	if d.typ == "DocumentObject" || d.DocumentObject != nil {
-		values.Add(key, fmt.Sprintf("%v", d.DocumentObject))
-		return nil
-	}
-	return nil
 }
 
 type DocumentItemVisitor interface {

--- a/seed/go-sdk/literal/.fern/metadata.json
+++ b/seed/go-sdk/literal/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/literal/inlined.go
+++ b/seed/go-sdk/literal/inlined.go
@@ -630,21 +630,6 @@ return json.Marshal(u.Boolean)
 return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
 }
 
-func (u *UndiscriminatedLiteral) EncodeQueryValues(key string, values *url.Values) error {
-if u == nil {
-return nil
-}
-if u.typ == "String" || u.String != "" {
-values.Add(key, fmt.Sprintf("%v", u.String))
-return nil
-}
-if u.typ == "Boolean" || u.Boolean != false {
-values.Add(key, fmt.Sprintf("%v", u.Boolean))
-return nil
-}
-return nil
-}
-
 type UndiscriminatedLiteralVisitor interface {
 VisitString(string) error
 VisitEndingStringLiteral(string) error

--- a/seed/go-sdk/literals-unions/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/literals-unions/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/literals-unions/no-custom-config/literals.go
+++ b/seed/go-sdk/literals-unions/no-custom-config/literals.go
@@ -5,7 +5,6 @@ package literalsunions
 import (
 	json "encoding/json"
 	fmt "fmt"
-	url "net/url"
 )
 
 // A string literal.
@@ -57,17 +56,6 @@ func (u UnionOverLiteral) MarshalJSON() ([]byte, error) {
 		return json.Marshal("literally")
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
-}
-
-func (u *UnionOverLiteral) EncodeQueryValues(key string, values *url.Values) error {
-	if u == nil {
-		return nil
-	}
-	if u.typ == "String" || u.String != "" {
-		values.Add(key, fmt.Sprintf("%v", u.String))
-		return nil
-	}
-	return nil
 }
 
 type UnionOverLiteralVisitor interface {

--- a/seed/go-sdk/multiple-request-bodies/.fern/metadata.json
+++ b/seed/go-sdk/multiple-request-bodies/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/multiple-request-bodies/types.go
+++ b/seed/go-sdk/multiple-request-bodies/types.go
@@ -7,7 +7,6 @@ import (
 	fmt "fmt"
 	internal "github.com/multiple-request-bodies/fern/internal"
 	big "math/big"
-	url "net/url"
 )
 
 var (
@@ -287,21 +286,6 @@ func (u UploadDocumentResponse) MarshalJSON() ([]byte, error) {
 		return json.Marshal(u.DocumentUploadResult)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
-}
-
-func (u *UploadDocumentResponse) EncodeQueryValues(key string, values *url.Values) error {
-	if u == nil {
-		return nil
-	}
-	if u.typ == "DocumentMetadata" || u.DocumentMetadata != nil {
-		values.Add(key, fmt.Sprintf("%v", u.DocumentMetadata))
-		return nil
-	}
-	if u.typ == "DocumentUploadResult" || u.DocumentUploadResult != nil {
-		values.Add(key, fmt.Sprintf("%v", u.DocumentUploadResult))
-		return nil
-	}
-	return nil
 }
 
 type UploadDocumentResponseVisitor interface {

--- a/seed/go-sdk/nullable/.fern/metadata.json
+++ b/seed/go-sdk/nullable/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/nullable/nullable.go
+++ b/seed/go-sdk/nullable/nullable.go
@@ -7,7 +7,6 @@ import (
 	fmt "fmt"
 	internal "github.com/nullable/fern/internal"
 	big "math/big"
-	url "net/url"
 	time "time"
 )
 
@@ -813,29 +812,6 @@ func (w WeirdNumber) MarshalJSON() ([]byte, error) {
 		return json.Marshal(w.Double)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", w)
-}
-
-func (w *WeirdNumber) EncodeQueryValues(key string, values *url.Values) error {
-	if w == nil {
-		return nil
-	}
-	if w.typ == "Integer" || w.Integer != 0 {
-		values.Add(key, fmt.Sprintf("%v", w.Integer))
-		return nil
-	}
-	if w.typ == "DoubleOptional" || w.DoubleOptional != nil {
-		values.Add(key, fmt.Sprintf("%v", w.DoubleOptional))
-		return nil
-	}
-	if w.typ == "StringOptional" || w.StringOptional != nil {
-		values.Add(key, fmt.Sprintf("%v", w.StringOptional))
-		return nil
-	}
-	if w.typ == "Double" || w.Double != 0 {
-		values.Add(key, fmt.Sprintf("%v", w.Double))
-		return nil
-	}
-	return nil
 }
 
 type WeirdNumberVisitor interface {

--- a/seed/go-sdk/property-access/.fern/metadata.json
+++ b/seed/go-sdk/property-access/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/property-access/types.go
+++ b/seed/go-sdk/property-access/types.go
@@ -7,7 +7,6 @@ import (
 	fmt "fmt"
 	internal "github.com/property-access/fern/internal"
 	big "math/big"
-	url "net/url"
 )
 
 // Admin user object
@@ -463,21 +462,6 @@ func (u UserOrAdmin) MarshalJSON() ([]byte, error) {
 		return json.Marshal(u.Admin)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
-}
-
-func (u *UserOrAdmin) EncodeQueryValues(key string, values *url.Values) error {
-	if u == nil {
-		return nil
-	}
-	if u.typ == "User" || u.User != nil {
-		values.Add(key, fmt.Sprintf("%v", u.User))
-		return nil
-	}
-	if u.typ == "Admin" || u.Admin != nil {
-		values.Add(key, fmt.Sprintf("%v", u.Admin))
-		return nil
-	}
-	return nil
 }
 
 type UserOrAdminVisitor interface {

--- a/seed/go-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
+++ b/seed/go-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/query-parameters-openapi/.fern/metadata.json
+++ b/seed/go-sdk/query-parameters-openapi/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/simple-fhir/.fern/metadata.json
+++ b/seed/go-sdk/simple-fhir/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/simple-fhir/types.go
+++ b/seed/go-sdk/simple-fhir/types.go
@@ -7,7 +7,6 @@ import (
 	fmt "fmt"
 	internal "github.com/simple-fhir/fern/internal"
 	big "math/big"
-	url "net/url"
 )
 
 var (
@@ -797,29 +796,6 @@ func (r ResourceList) MarshalJSON() ([]byte, error) {
 		return json.Marshal(r.Script)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", r)
-}
-
-func (r *ResourceList) EncodeQueryValues(key string, values *url.Values) error {
-	if r == nil {
-		return nil
-	}
-	if r.typ == "Account" || r.Account != nil {
-		values.Add(key, fmt.Sprintf("%v", r.Account))
-		return nil
-	}
-	if r.typ == "Patient" || r.Patient != nil {
-		values.Add(key, fmt.Sprintf("%v", r.Patient))
-		return nil
-	}
-	if r.typ == "Practitioner" || r.Practitioner != nil {
-		values.Add(key, fmt.Sprintf("%v", r.Practitioner))
-		return nil
-	}
-	if r.typ == "Script" || r.Script != nil {
-		values.Add(key, fmt.Sprintf("%v", r.Script))
-		return nil
-	}
-	return nil
 }
 
 type ResourceListVisitor interface {

--- a/seed/go-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/undiscriminated-union-with-response-property/types.go
+++ b/seed/go-sdk/undiscriminated-union-with-response-property/types.go
@@ -7,7 +7,6 @@ import (
 	fmt "fmt"
 	internal "github.com/undiscriminated-union-with-response-property/fern/internal"
 	big "math/big"
-	url "net/url"
 )
 
 // Undiscriminated union with multiple object variants.
@@ -75,25 +74,6 @@ func (m MyUnion) MarshalJSON() ([]byte, error) {
 		return json.Marshal(m.VariantC)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", m)
-}
-
-func (m *MyUnion) EncodeQueryValues(key string, values *url.Values) error {
-	if m == nil {
-		return nil
-	}
-	if m.typ == "VariantA" || m.VariantA != nil {
-		values.Add(key, fmt.Sprintf("%v", m.VariantA))
-		return nil
-	}
-	if m.typ == "VariantB" || m.VariantB != nil {
-		values.Add(key, fmt.Sprintf("%v", m.VariantB))
-		return nil
-	}
-	if m.typ == "VariantC" || m.VariantC != nil {
-		values.Add(key, fmt.Sprintf("%v", m.VariantC))
-		return nil
-	}
-	return nil
 }
 
 type MyUnionVisitor interface {

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/.fern/metadata.json
@@ -10,8 +10,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/undiscriminated-unions/no-custom-config/union.go
+++ b/seed/go-sdk/undiscriminated-unions/no-custom-config/union.go
@@ -7,7 +7,6 @@ import (
 	fmt "fmt"
 	internal "github.com/fern-api/undiscriminated-go/internal"
 	big "math/big"
-	url "net/url"
 )
 
 var (
@@ -112,21 +111,6 @@ func (a AliasedObjectUnion) MarshalJSON() ([]byte, error) {
 		return json.Marshal(a.AliasedLeafB)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", a)
-}
-
-func (a *AliasedObjectUnion) EncodeQueryValues(key string, values *url.Values) error {
-	if a == nil {
-		return nil
-	}
-	if a.typ == "AliasedLeafA" || a.AliasedLeafA != nil {
-		values.Add(key, fmt.Sprintf("%v", a.AliasedLeafA))
-		return nil
-	}
-	if a.typ == "AliasedLeafB" || a.AliasedLeafB != nil {
-		values.Add(key, fmt.Sprintf("%v", a.AliasedLeafB))
-		return nil
-	}
-	return nil
 }
 
 type AliasedObjectUnionVisitor interface {
@@ -289,17 +273,6 @@ func (k Key) MarshalJSON() ([]byte, error) {
 		return json.Marshal("default")
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", k)
-}
-
-func (k *Key) EncodeQueryValues(key string, values *url.Values) error {
-	if k == nil {
-		return nil
-	}
-	if k.typ == "KeyType" || k.KeyType != "" {
-		values.Add(key, fmt.Sprintf("%v", k.KeyType))
-		return nil
-	}
-	return nil
 }
 
 type KeyVisitor interface {
@@ -759,21 +732,6 @@ func (m MetadataUnion) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", m)
 }
 
-func (m *MetadataUnion) EncodeQueryValues(key string, values *url.Values) error {
-	if m == nil {
-		return nil
-	}
-	if m.typ == "OptionalMetadata" || m.OptionalMetadata != nil {
-		values.Add(key, fmt.Sprintf("%v", m.OptionalMetadata))
-		return nil
-	}
-	if m.typ == "NamedMetadata" || m.NamedMetadata != nil {
-		values.Add(key, fmt.Sprintf("%v", m.NamedMetadata))
-		return nil
-	}
-	return nil
-}
-
 type MetadataUnionVisitor interface {
 	VisitOptionalMetadata(OptionalMetadata) error
 	VisitNamedMetadata(*NamedMetadata) error
@@ -903,45 +861,6 @@ func (m MyUnion) MarshalJSON() ([]byte, error) {
 		return json.Marshal(m.StringSet)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", m)
-}
-
-func (m *MyUnion) EncodeQueryValues(key string, values *url.Values) error {
-	if m == nil {
-		return nil
-	}
-	if m.typ == "String" || m.String != "" {
-		values.Add(key, fmt.Sprintf("%v", m.String))
-		return nil
-	}
-	if m.typ == "StringList" || m.StringList != nil {
-		for _, item := range m.StringList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if m.typ == "Integer" || m.Integer != 0 {
-		values.Add(key, fmt.Sprintf("%v", m.Integer))
-		return nil
-	}
-	if m.typ == "IntegerList" || m.IntegerList != nil {
-		for _, item := range m.IntegerList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if m.typ == "IntegerListList" || m.IntegerListList != nil {
-		for _, item := range m.IntegerListList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if m.typ == "StringSet" || m.StringSet != nil {
-		for _, item := range m.StringSet {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	return nil
 }
 
 type MyUnionVisitor interface {
@@ -1127,21 +1046,6 @@ func (n NestedObjectUnion) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", n)
 }
 
-func (n *NestedObjectUnion) EncodeQueryValues(key string, values *url.Values) error {
-	if n == nil {
-		return nil
-	}
-	if n.typ == "LeafTypeA" || n.LeafTypeA != nil {
-		values.Add(key, fmt.Sprintf("%v", n.LeafTypeA))
-		return nil
-	}
-	if n.typ == "LeafTypeB" || n.LeafTypeB != nil {
-		values.Add(key, fmt.Sprintf("%v", n.LeafTypeB))
-		return nil
-	}
-	return nil
-}
-
 type NestedObjectUnionVisitor interface {
 	VisitLeafTypeA(*LeafTypeA) error
 	VisitLeafTypeB(*LeafTypeB) error
@@ -1239,33 +1143,6 @@ func (n NestedUnionL1) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", n)
 }
 
-func (n *NestedUnionL1) EncodeQueryValues(key string, values *url.Values) error {
-	if n == nil {
-		return nil
-	}
-	if n.typ == "Integer" || n.Integer != 0 {
-		values.Add(key, fmt.Sprintf("%v", n.Integer))
-		return nil
-	}
-	if n.typ == "StringSet" || n.StringSet != nil {
-		for _, item := range n.StringSet {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if n.typ == "StringList" || n.StringList != nil {
-		for _, item := range n.StringList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if n.typ == "NestedUnionL2" || n.NestedUnionL2 != nil {
-		values.Add(key, fmt.Sprintf("%v", n.NestedUnionL2))
-		return nil
-	}
-	return nil
-}
-
 type NestedUnionL1Visitor interface {
 	VisitInteger(int) error
 	VisitStringSet([]string) error
@@ -1354,29 +1231,6 @@ func (n NestedUnionL2) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", n)
 }
 
-func (n *NestedUnionL2) EncodeQueryValues(key string, values *url.Values) error {
-	if n == nil {
-		return nil
-	}
-	if n.typ == "Boolean" || n.Boolean != false {
-		values.Add(key, fmt.Sprintf("%v", n.Boolean))
-		return nil
-	}
-	if n.typ == "StringSet" || n.StringSet != nil {
-		for _, item := range n.StringSet {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if n.typ == "StringList" || n.StringList != nil {
-		for _, item := range n.StringList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	return nil
-}
-
 type NestedUnionL2Visitor interface {
 	VisitBoolean(bool) error
 	VisitStringSet([]string) error
@@ -1461,27 +1315,6 @@ func (n NestedUnionRoot) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", n)
 }
 
-func (n *NestedUnionRoot) EncodeQueryValues(key string, values *url.Values) error {
-	if n == nil {
-		return nil
-	}
-	if n.typ == "String" || n.String != "" {
-		values.Add(key, fmt.Sprintf("%v", n.String))
-		return nil
-	}
-	if n.typ == "StringList" || n.StringList != nil {
-		for _, item := range n.StringList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if n.typ == "NestedUnionL1" || n.NestedUnionL1 != nil {
-		values.Add(key, fmt.Sprintf("%v", n.NestedUnionL1))
-		return nil
-	}
-	return nil
-}
-
 type NestedUnionRootVisitor interface {
 	VisitString(string) error
 	VisitStringList([]string) error
@@ -1552,21 +1385,6 @@ func (o OuterNestedUnion) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", o)
 }
 
-func (o *OuterNestedUnion) EncodeQueryValues(key string, values *url.Values) error {
-	if o == nil {
-		return nil
-	}
-	if o.typ == "String" || o.String != "" {
-		values.Add(key, fmt.Sprintf("%v", o.String))
-		return nil
-	}
-	if o.typ == "WrapperObject" || o.WrapperObject != nil {
-		values.Add(key, fmt.Sprintf("%v", o.WrapperObject))
-		return nil
-	}
-	return nil
-}
-
 type OuterNestedUnionVisitor interface {
 	VisitString(string) error
 	VisitWrapperObject(*WrapperObject) error
@@ -1629,21 +1447,6 @@ func (p PaymentMethodUnion) MarshalJSON() ([]byte, error) {
 		return json.Marshal(p.ConvertToken)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", p)
-}
-
-func (p *PaymentMethodUnion) EncodeQueryValues(key string, values *url.Values) error {
-	if p == nil {
-		return nil
-	}
-	if p.typ == "TokenizeCard" || p.TokenizeCard != nil {
-		values.Add(key, fmt.Sprintf("%v", p.TokenizeCard))
-		return nil
-	}
-	if p.typ == "ConvertToken" || p.ConvertToken != nil {
-		values.Add(key, fmt.Sprintf("%v", p.ConvertToken))
-		return nil
-	}
-	return nil
 }
 
 type PaymentMethodUnionVisitor interface {
@@ -1978,21 +1781,6 @@ func (u UnionWithBaseProperties) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
 }
 
-func (u *UnionWithBaseProperties) EncodeQueryValues(key string, values *url.Values) error {
-	if u == nil {
-		return nil
-	}
-	if u.typ == "NamedMetadata" || u.NamedMetadata != nil {
-		values.Add(key, fmt.Sprintf("%v", u.NamedMetadata))
-		return nil
-	}
-	if u.typ == "OptionalMetadata" || u.OptionalMetadata != nil {
-		values.Add(key, fmt.Sprintf("%v", u.OptionalMetadata))
-		return nil
-	}
-	return nil
-}
-
 type UnionWithBasePropertiesVisitor interface {
 	VisitNamedMetadata(*NamedMetadata) error
 	VisitOptionalMetadata(OptionalMetadata) error
@@ -2090,33 +1878,6 @@ func (u UnionWithDuplicateTypes) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
 }
 
-func (u *UnionWithDuplicateTypes) EncodeQueryValues(key string, values *url.Values) error {
-	if u == nil {
-		return nil
-	}
-	if u.typ == "String" || u.String != "" {
-		values.Add(key, fmt.Sprintf("%v", u.String))
-		return nil
-	}
-	if u.typ == "StringList" || u.StringList != nil {
-		for _, item := range u.StringList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if u.typ == "Integer" || u.Integer != 0 {
-		values.Add(key, fmt.Sprintf("%v", u.Integer))
-		return nil
-	}
-	if u.typ == "StringSet" || u.StringSet != nil {
-		for _, item := range u.StringSet {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	return nil
-}
-
 type UnionWithDuplicateTypesVisitor interface {
 	VisitString(string) error
 	VisitStringList([]string) error
@@ -2205,25 +1966,6 @@ func (u UnionWithIdenticalPrimitives) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
 }
 
-func (u *UnionWithIdenticalPrimitives) EncodeQueryValues(key string, values *url.Values) error {
-	if u == nil {
-		return nil
-	}
-	if u.typ == "Integer" || u.Integer != 0 {
-		values.Add(key, fmt.Sprintf("%v", u.Integer))
-		return nil
-	}
-	if u.typ == "Double" || u.Double != 0 {
-		values.Add(key, fmt.Sprintf("%v", u.Double))
-		return nil
-	}
-	if u.typ == "String" || u.String != "" {
-		values.Add(key, fmt.Sprintf("%v", u.String))
-		return nil
-	}
-	return nil
-}
-
 type UnionWithIdenticalPrimitivesVisitor interface {
 	VisitInteger(int) error
 	VisitDouble(float64) error
@@ -2273,17 +2015,6 @@ func (u UnionWithIdenticalStrings) MarshalJSON() ([]byte, error) {
 		return json.Marshal(u.String)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
-}
-
-func (u *UnionWithIdenticalStrings) EncodeQueryValues(key string, values *url.Values) error {
-	if u == nil {
-		return nil
-	}
-	if u.typ == "String" || u.String != "" {
-		values.Add(key, fmt.Sprintf("%v", u.String))
-		return nil
-	}
-	return nil
 }
 
 type UnionWithIdenticalStringsVisitor interface {
@@ -2360,17 +2091,6 @@ func (u UnionWithReservedNames) MarshalJSON() ([]byte, error) {
 		return json.Marshal(u.String)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
-}
-
-func (u *UnionWithReservedNames) EncodeQueryValues(key string, values *url.Values) error {
-	if u == nil {
-		return nil
-	}
-	if u.typ == "String" || u.String != "" {
-		values.Add(key, fmt.Sprintf("%v", u.String))
-		return nil
-	}
-	return nil
 }
 
 type UnionWithReservedNamesVisitor interface {
@@ -2462,25 +2182,6 @@ func (u UnionWithTypeAliases) MarshalJSON() ([]byte, error) {
 		return json.Marshal(u.Name)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
-}
-
-func (u *UnionWithTypeAliases) EncodeQueryValues(key string, values *url.Values) error {
-	if u == nil {
-		return nil
-	}
-	if u.typ == "String" || u.String != "" {
-		values.Add(key, fmt.Sprintf("%v", u.String))
-		return nil
-	}
-	if u.typ == "UserID" || u.UserID != "" {
-		values.Add(key, fmt.Sprintf("%v", u.UserID))
-		return nil
-	}
-	if u.typ == "Name" || u.Name != "" {
-		values.Add(key, fmt.Sprintf("%v", u.Name))
-		return nil
-	}
-	return nil
 }
 
 type UnionWithTypeAliasesVisitor interface {

--- a/seed/go-sdk/undiscriminated-unions/v0/.fern/metadata.json
+++ b/seed/go-sdk/undiscriminated-unions/v0/.fern/metadata.json
@@ -11,8 +11,7 @@
     "union": "v0"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/undiscriminated-unions/v0/union.go
+++ b/seed/go-sdk/undiscriminated-unions/v0/union.go
@@ -7,7 +7,6 @@ import (
 	fmt "fmt"
 	internal "github.com/undiscriminated-unions/fern/internal"
 	big "math/big"
-	url "net/url"
 )
 
 var (
@@ -120,21 +119,6 @@ func (a AliasedObjectUnion) MarshalJSON() ([]byte, error) {
 		return json.Marshal(a.AliasedLeafB)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", a)
-}
-
-func (a *AliasedObjectUnion) EncodeQueryValues(key string, values *url.Values) error {
-	if a == nil {
-		return nil
-	}
-	if a.typ == "AliasedLeafA" || a.AliasedLeafA != nil {
-		values.Add(key, fmt.Sprintf("%v", a.AliasedLeafA))
-		return nil
-	}
-	if a.typ == "AliasedLeafB" || a.AliasedLeafB != nil {
-		values.Add(key, fmt.Sprintf("%v", a.AliasedLeafB))
-		return nil
-	}
-	return nil
 }
 
 type AliasedObjectUnionVisitor interface {
@@ -301,17 +285,6 @@ func (k Key) MarshalJSON() ([]byte, error) {
 		return json.Marshal("default")
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", k)
-}
-
-func (k *Key) EncodeQueryValues(key string, values *url.Values) error {
-	if k == nil {
-		return nil
-	}
-	if k.typ == "KeyType" || k.KeyType != "" {
-		values.Add(key, fmt.Sprintf("%v", k.KeyType))
-		return nil
-	}
-	return nil
 }
 
 type KeyVisitor interface {
@@ -779,21 +752,6 @@ func (m MetadataUnion) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", m)
 }
 
-func (m *MetadataUnion) EncodeQueryValues(key string, values *url.Values) error {
-	if m == nil {
-		return nil
-	}
-	if m.typ == "OptionalMetadata" || m.OptionalMetadata != nil {
-		values.Add(key, fmt.Sprintf("%v", m.OptionalMetadata))
-		return nil
-	}
-	if m.typ == "NamedMetadata" || m.NamedMetadata != nil {
-		values.Add(key, fmt.Sprintf("%v", m.NamedMetadata))
-		return nil
-	}
-	return nil
-}
-
 type MetadataUnionVisitor interface {
 	VisitOptionalMetadata(OptionalMetadata) error
 	VisitNamedMetadata(*NamedMetadata) error
@@ -947,45 +905,6 @@ func (m MyUnion) MarshalJSON() ([]byte, error) {
 		return json.Marshal(m.StringSet)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", m)
-}
-
-func (m *MyUnion) EncodeQueryValues(key string, values *url.Values) error {
-	if m == nil {
-		return nil
-	}
-	if m.typ == "String" || m.String != "" {
-		values.Add(key, fmt.Sprintf("%v", m.String))
-		return nil
-	}
-	if m.typ == "StringList" || m.StringList != nil {
-		for _, item := range m.StringList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if m.typ == "Integer" || m.Integer != 0 {
-		values.Add(key, fmt.Sprintf("%v", m.Integer))
-		return nil
-	}
-	if m.typ == "IntegerList" || m.IntegerList != nil {
-		for _, item := range m.IntegerList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if m.typ == "IntegerListList" || m.IntegerListList != nil {
-		for _, item := range m.IntegerListList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if m.typ == "StringSet" || m.StringSet != nil {
-		for _, item := range m.StringSet {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	return nil
 }
 
 type MyUnionVisitor interface {
@@ -1179,21 +1098,6 @@ func (n NestedObjectUnion) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", n)
 }
 
-func (n *NestedObjectUnion) EncodeQueryValues(key string, values *url.Values) error {
-	if n == nil {
-		return nil
-	}
-	if n.typ == "LeafTypeA" || n.LeafTypeA != nil {
-		values.Add(key, fmt.Sprintf("%v", n.LeafTypeA))
-		return nil
-	}
-	if n.typ == "LeafTypeB" || n.LeafTypeB != nil {
-		values.Add(key, fmt.Sprintf("%v", n.LeafTypeB))
-		return nil
-	}
-	return nil
-}
-
 type NestedObjectUnionVisitor interface {
 	VisitLeafTypeA(*LeafTypeA) error
 	VisitLeafTypeB(*LeafTypeB) error
@@ -1307,33 +1211,6 @@ func (n NestedUnionL1) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", n)
 }
 
-func (n *NestedUnionL1) EncodeQueryValues(key string, values *url.Values) error {
-	if n == nil {
-		return nil
-	}
-	if n.typ == "Integer" || n.Integer != 0 {
-		values.Add(key, fmt.Sprintf("%v", n.Integer))
-		return nil
-	}
-	if n.typ == "StringSet" || n.StringSet != nil {
-		for _, item := range n.StringSet {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if n.typ == "StringList" || n.StringList != nil {
-		for _, item := range n.StringList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if n.typ == "NestedUnionL2" || n.NestedUnionL2 != nil {
-		values.Add(key, fmt.Sprintf("%v", n.NestedUnionL2))
-		return nil
-	}
-	return nil
-}
-
 type NestedUnionL1Visitor interface {
 	VisitInteger(int) error
 	VisitStringSet([]string) error
@@ -1434,29 +1311,6 @@ func (n NestedUnionL2) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", n)
 }
 
-func (n *NestedUnionL2) EncodeQueryValues(key string, values *url.Values) error {
-	if n == nil {
-		return nil
-	}
-	if n.typ == "Boolean" || n.Boolean != false {
-		values.Add(key, fmt.Sprintf("%v", n.Boolean))
-		return nil
-	}
-	if n.typ == "StringSet" || n.StringSet != nil {
-		for _, item := range n.StringSet {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if n.typ == "StringList" || n.StringList != nil {
-		for _, item := range n.StringList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	return nil
-}
-
 type NestedUnionL2Visitor interface {
 	VisitBoolean(bool) error
 	VisitStringSet([]string) error
@@ -1553,27 +1407,6 @@ func (n NestedUnionRoot) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", n)
 }
 
-func (n *NestedUnionRoot) EncodeQueryValues(key string, values *url.Values) error {
-	if n == nil {
-		return nil
-	}
-	if n.typ == "String" || n.String != "" {
-		values.Add(key, fmt.Sprintf("%v", n.String))
-		return nil
-	}
-	if n.typ == "StringList" || n.StringList != nil {
-		for _, item := range n.StringList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if n.typ == "NestedUnionL1" || n.NestedUnionL1 != nil {
-		values.Add(key, fmt.Sprintf("%v", n.NestedUnionL1))
-		return nil
-	}
-	return nil
-}
-
 type NestedUnionRootVisitor interface {
 	VisitString(string) error
 	VisitStringList([]string) error
@@ -1652,21 +1485,6 @@ func (o OuterNestedUnion) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", o)
 }
 
-func (o *OuterNestedUnion) EncodeQueryValues(key string, values *url.Values) error {
-	if o == nil {
-		return nil
-	}
-	if o.typ == "String" || o.String != "" {
-		values.Add(key, fmt.Sprintf("%v", o.String))
-		return nil
-	}
-	if o.typ == "WrapperObject" || o.WrapperObject != nil {
-		values.Add(key, fmt.Sprintf("%v", o.WrapperObject))
-		return nil
-	}
-	return nil
-}
-
 type OuterNestedUnionVisitor interface {
 	VisitString(string) error
 	VisitWrapperObject(*WrapperObject) error
@@ -1737,21 +1555,6 @@ func (p PaymentMethodUnion) MarshalJSON() ([]byte, error) {
 		return json.Marshal(p.ConvertToken)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", p)
-}
-
-func (p *PaymentMethodUnion) EncodeQueryValues(key string, values *url.Values) error {
-	if p == nil {
-		return nil
-	}
-	if p.typ == "TokenizeCard" || p.TokenizeCard != nil {
-		values.Add(key, fmt.Sprintf("%v", p.TokenizeCard))
-		return nil
-	}
-	if p.typ == "ConvertToken" || p.ConvertToken != nil {
-		values.Add(key, fmt.Sprintf("%v", p.ConvertToken))
-		return nil
-	}
-	return nil
 }
 
 type PaymentMethodUnionVisitor interface {
@@ -2094,21 +1897,6 @@ func (u UnionWithBaseProperties) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
 }
 
-func (u *UnionWithBaseProperties) EncodeQueryValues(key string, values *url.Values) error {
-	if u == nil {
-		return nil
-	}
-	if u.typ == "NamedMetadata" || u.NamedMetadata != nil {
-		values.Add(key, fmt.Sprintf("%v", u.NamedMetadata))
-		return nil
-	}
-	if u.typ == "OptionalMetadata" || u.OptionalMetadata != nil {
-		values.Add(key, fmt.Sprintf("%v", u.OptionalMetadata))
-		return nil
-	}
-	return nil
-}
-
 type UnionWithBasePropertiesVisitor interface {
 	VisitNamedMetadata(*NamedMetadata) error
 	VisitOptionalMetadata(OptionalMetadata) error
@@ -2222,33 +2010,6 @@ func (u UnionWithDuplicateTypes) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
 }
 
-func (u *UnionWithDuplicateTypes) EncodeQueryValues(key string, values *url.Values) error {
-	if u == nil {
-		return nil
-	}
-	if u.typ == "String" || u.String != "" {
-		values.Add(key, fmt.Sprintf("%v", u.String))
-		return nil
-	}
-	if u.typ == "StringList" || u.StringList != nil {
-		for _, item := range u.StringList {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	if u.typ == "Integer" || u.Integer != 0 {
-		values.Add(key, fmt.Sprintf("%v", u.Integer))
-		return nil
-	}
-	if u.typ == "StringSet" || u.StringSet != nil {
-		for _, item := range u.StringSet {
-			values.Add(key, fmt.Sprintf("%v", item))
-		}
-		return nil
-	}
-	return nil
-}
-
 type UnionWithDuplicateTypesVisitor interface {
 	VisitString(string) error
 	VisitStringList([]string) error
@@ -2349,25 +2110,6 @@ func (u UnionWithIdenticalPrimitives) MarshalJSON() ([]byte, error) {
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
 }
 
-func (u *UnionWithIdenticalPrimitives) EncodeQueryValues(key string, values *url.Values) error {
-	if u == nil {
-		return nil
-	}
-	if u.typ == "Integer" || u.Integer != 0 {
-		values.Add(key, fmt.Sprintf("%v", u.Integer))
-		return nil
-	}
-	if u.typ == "Double" || u.Double != 0 {
-		values.Add(key, fmt.Sprintf("%v", u.Double))
-		return nil
-	}
-	if u.typ == "String" || u.String != "" {
-		values.Add(key, fmt.Sprintf("%v", u.String))
-		return nil
-	}
-	return nil
-}
-
 type UnionWithIdenticalPrimitivesVisitor interface {
 	VisitInteger(int) error
 	VisitDouble(float64) error
@@ -2421,17 +2163,6 @@ func (u UnionWithIdenticalStrings) MarshalJSON() ([]byte, error) {
 		return json.Marshal(u.String)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
-}
-
-func (u *UnionWithIdenticalStrings) EncodeQueryValues(key string, values *url.Values) error {
-	if u == nil {
-		return nil
-	}
-	if u.typ == "String" || u.String != "" {
-		values.Add(key, fmt.Sprintf("%v", u.String))
-		return nil
-	}
-	return nil
 }
 
 type UnionWithIdenticalStringsVisitor interface {
@@ -2512,17 +2243,6 @@ func (u UnionWithReservedNames) MarshalJSON() ([]byte, error) {
 		return json.Marshal(u.String)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
-}
-
-func (u *UnionWithReservedNames) EncodeQueryValues(key string, values *url.Values) error {
-	if u == nil {
-		return nil
-	}
-	if u.typ == "String" || u.String != "" {
-		values.Add(key, fmt.Sprintf("%v", u.String))
-		return nil
-	}
-	return nil
 }
 
 type UnionWithReservedNamesVisitor interface {
@@ -2626,25 +2346,6 @@ func (u UnionWithTypeAliases) MarshalJSON() ([]byte, error) {
 		return json.Marshal(u.Name)
 	}
 	return nil, fmt.Errorf("type %T does not include a non-empty union type", u)
-}
-
-func (u *UnionWithTypeAliases) EncodeQueryValues(key string, values *url.Values) error {
-	if u == nil {
-		return nil
-	}
-	if u.typ == "String" || u.String != "" {
-		values.Add(key, fmt.Sprintf("%v", u.String))
-		return nil
-	}
-	if u.typ == "UserID" || u.UserID != "" {
-		values.Add(key, fmt.Sprintf("%v", u.UserID))
-		return nil
-	}
-	if u.typ == "Name" || u.Name != "" {
-		values.Add(key, fmt.Sprintf("%v", u.Name))
-		return nil
-	}
-	return nil
 }
 
 type UnionWithTypeAliasesVisitor interface {

--- a/seed/go-sdk/union-query-parameters/.fern/metadata.json
+++ b/seed/go-sdk/union-query-parameters/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/unions/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/unions/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "enableWireTests": false
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/unions/package-name/.fern/metadata.json
+++ b/seed/go-sdk/unions/package-name/.fern/metadata.json
@@ -10,8 +10,7 @@
     }
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/unions/v0/.fern/metadata.json
+++ b/seed/go-sdk/unions/v0/.fern/metadata.json
@@ -11,8 +11,7 @@
     "union": "v0"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "v0.0.1"
 }


### PR DESCRIPTION
## Summary

- Follow-up to #15526. The original fix unconditionally generated `EncodeQueryValues` on every undiscriminated union, even ones that will never be encoded as a query parameter.
- This change pre-walks the IR's query-parameter positions (following container wrappers and alias chains) and only emits the method on unions actually reachable from a query parameter.
- For Auth0 this drops generated `EncodeQueryValues` methods from 107 → 0 with no behavior change. The SSE `oneOf` query-parameter case from the original report still works (verified by the `union-query-parameters` seed fixture).

## Example

For an SDK whose only query-parameter union is `event_type: oneOf<EventTypeEnum, list<EventTypeEnum>>`:

```go
// Before: EncodeQueryValues on every union, even unrelated ones (e.g. MixedType,
// JSONLike, TorU, ...). Each adds a `net/url` import to its file.

// After: only EventTypeParam (and StringOrListParam) get the method. Other
// unions stay clean:
func (e *EventTypeParam) EncodeQueryValues(key string, values *url.Values) error { … }
```

The walker recognizes:
- `optional<T>` / `list<T>` / `set<T>` / `nullable<T>` wrappers around a union
- alias chains terminating in a union
- but does NOT recurse into union variants (the generated body stringifies variants directly via `fmt.Sprintf("%v", …)`, so variants don't need their own QueryEncoder)

## Test plan

- [x] New `union-query-parameters` seed fixture's WireMock test still verifies the union encodes correctly.
- [x] Regenerated all seed fixtures with unions; only `union-query-parameters/events.go`, `enum/types.go` (`ColorOrOperand` query param), and the two `query-parameters-openapi*` fixtures retain `EncodeQueryValues` — all genuine query-param uses.
- [x] Re-ran Auth0 SDK generation: 107 unions, 0 `EncodeQueryValues` methods.
- [x] `go build ./...` and `go test ./...` in `generators/go` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)