### PR TITLE
fix(java): strip optional/nullable wrappers from snippet list items

### DIFF
--- a/generators/java-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/java-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -17,37 +17,35 @@ const STRING_TYPE_REFERENCE: FernIr.dynamic.TypeReference = {
     value: "STRING"
 };
 
+function stripOptionalAndNullable(item: FernIr.dynamic.TypeReference): FernIr.dynamic.TypeReference {
+    let current = item;
+    while (current.type === "optional" || current.type === "nullable") {
+        current = current.value;
+    }
+    return current;
+}
+
 /**
- * For query parameters with allow-multiple and optional types, the Dynamic IR produces
- * optional<list<optional<T>>> or list<optional<T>>. However, Java SDK builders have
- * convenience overloads that accept List<T> directly. This function unwraps the optional
- * from list items so we generate List<T> instead of List<Optional<T>>.
- *
- * Note: We only unwrap "optional", not "nullable". Nullable list items (list<nullable<T>>)
- * are a distinct case where items genuinely can be null, and the SDK expects List<Optional<T>>.
+ * For query parameters with allow-multiple, the Dynamic IR may produce list items wrapped
+ * in optional<...>, nullable<...>, or both (e.g. list<optional<nullable<T>>>). The Java SDK
+ * builders only expose List<T> overloads — there is no List<Optional<T>> or List<Nullable<T>>.
+ * Strip those wrappers from list items so we generate List<T>.
  */
-function unwrapOptionalFromListItems(typeReference: FernIr.dynamic.TypeReference): FernIr.dynamic.TypeReference {
+function stripListItemWrappers(typeReference: FernIr.dynamic.TypeReference): FernIr.dynamic.TypeReference {
     if (typeReference.type === "optional" && typeReference.value.type === "list") {
-        const listType = typeReference.value;
-        const itemType = listType.value;
-        if (itemType.type === "optional") {
-            return {
-                type: "optional",
-                value: {
-                    type: "list",
-                    value: itemType.value
-                }
-            };
+        const itemType = typeReference.value.value;
+        const stripped = stripOptionalAndNullable(itemType);
+        if (stripped === itemType) {
+            return typeReference;
         }
+        return { type: "optional", value: { type: "list", value: stripped } };
     }
     if (typeReference.type === "list") {
-        const itemType = typeReference.value;
-        if (itemType.type === "optional") {
-            return {
-                type: "list",
-                value: itemType.value
-            };
+        const stripped = stripOptionalAndNullable(typeReference.value);
+        if (stripped === typeReference.value) {
+            return typeReference;
         }
+        return { type: "list", value: stripped };
     }
     return typeReference;
 }
@@ -825,9 +823,7 @@ export class EndpointSnippetGenerator {
         const queryParameterFields = sortedQueryParameters.map((queryParameter) => ({
             name: this.context.getMethodName(queryParameter.name.name),
             value: this.context.dynamicTypeLiteralMapper.convert({
-                // Unwrap optional from list items for allow-multiple query params.
-                // Java SDK builders have convenience overloads that accept List<T>.
-                typeReference: unwrapOptionalFromListItems(queryParameter.typeReference),
+                typeReference: stripListItemWrappers(queryParameter.typeReference),
                 value: queryParameter.value,
                 as: "request"
             })

--- a/generators/java/sdk/changes/unreleased/fix-list-item-wrappers-in-snippets.yml
+++ b/generators/java/sdk/changes/unreleased/fix-list-item-wrappers-in-snippets.yml
@@ -1,0 +1,10 @@
+- summary: |
+    Fix Java SDK snippet and wire test generation for `allow-multiple` query
+    parameters when `coerce-optional-schemas-to-nullable: true` is set.
+    Previously, list items wrapped in `optional<...>` and/or `nullable<...>`
+    produced calls like `.strategy(Arrays.asList(Optional.of(...)))`, which
+    failed to compile because the generated builders only expose `List<T>`
+    overloads (no `List<Optional<T>>` or `List<Nullable<T>>`). The snippet
+    generator now strips both `optional` and `nullable` wrappers from list
+    items, so the emitted code matches an existing builder signature.
+  type: fix


### PR DESCRIPTION
## Summary

- For `allow-multiple` query params with `coerce-optional-schemas-to-nullable: true`, the Dynamic IR produces list items wrapped in `optional<...>`, `nullable<...>`, or both (e.g. `list<optional<nullable<T>>>`).
- The snippet generator was emitting `.method(Arrays.asList(Optional.of(value)))`, which fails to compile because the generated Java builders only expose `List<T>` overloads — there is no `List<Optional<T>>` or `List<Nullable<T>>`.
- Fix strips both wrappers from list items so the snippet matches an existing builder signature. Wire tests reuse the snippet generator via `SnippetExtractor`, so this also fixes wire-test compile failures.

## Example

Customer config (auth0):
```yaml
settings:
  coerce-optional-schemas-to-nullable: true
  wrap-references-to-nullable-in-optional: true
```

OpenAPI:
```yaml
- name: strategy
  in: query
  style: form
  explode: true
  schema:
    type: array
    items:
      $ref: '#/components/schemas/ConnectionStrategyEnum'
```

Generated builder method (already correct):
```java
public Builder strategy(List<ConnectionStrategyEnum> strategy) { ... }
```

Before this fix:
```java
.strategy(Arrays.asList(Optional.of(ConnectionStrategyEnum.AD)))  // does not compile
```

After this fix:
```java
.strategy(Arrays.asList(ConnectionStrategyEnum.AD))
```

## Test plan

- [x] `pnpm seed run --generator java-sdk --path <auth0-fern-config> --local` regenerates auth0-java with zero `Arrays.asList(Optional.of(...))` occurrences (was 9 wire-test compile errors + 48 snippet examples)
- [x] `pnpm test` in `generators/java-v2/dynamic-snippets` (32 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
