### PR TITLE
fix(csharp): avoid list-of-list wrap for already-list query param examples

### DIFF
--- a/generators/csharp/sdk/changes/unreleased/fix-multivalue-query-param-list-example-snippets.yml
+++ b/generators/csharp/sdk/changes/unreleased/fix-multivalue-query-param-list-example-snippets.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix multi-value query parameter snippets when the example value is already
+    a list, which previously produced uncompilable list-of-list initializers
+    like `[new List<T>() { value }]` in mock server tests, reference docs, and
+    snippets.
+  type: fix

--- a/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
+++ b/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
@@ -331,19 +331,22 @@ export class WrappedRequestGenerator extends FileGenerator<CSharpFile, SdkGenera
         for (const exampleQueryParameter of example.queryParameters) {
             const isSingleQueryParameter =
                 exampleQueryParameter.shape == null || exampleQueryParameter.shape.type === "single";
+            const exampleShape = exampleQueryParameter.value.shape;
+            const isExampleAlreadyList = exampleShape.type === "container" && exampleShape.container.type === "list";
             const singleValueSnippet = this.exampleGenerator.getSnippetForTypeReference({
                 exampleTypeReference: exampleQueryParameter.value,
                 parseDatetimes
             });
-            const value = isSingleQueryParameter
-                ? singleValueSnippet
-                : this.csharp.codeblock((writer: Writer) =>
-                      writer.writeNode(
-                          this.csharp.list({
-                              entries: [singleValueSnippet]
-                          })
-                      )
-                  );
+            const value =
+                isSingleQueryParameter || isExampleAlreadyList
+                    ? singleValueSnippet
+                    : this.csharp.codeblock((writer: Writer) =>
+                          writer.writeNode(
+                              this.csharp.list({
+                                  entries: [singleValueSnippet]
+                              })
+                          )
+                      );
             orderedFields.push({
                 name: exampleQueryParameter.name,
                 value


### PR DESCRIPTION
## Summary

- For multi-value (`exploded` / `commaSeparated`) query parameters whose example value is itself a list (`container.list`), the generator was wrapping the already-list snippet in another `csharp.list({ entries: [...] })`, producing uncompilable list-of-list initializers in mock server tests, `reference.md`, and `snippet.json`.
- Fix: when the example value's shape is already `container.list`, use the snippet directly instead of wrapping it.

## Example

Before (auth0 `ListConnections`, `Strategy: IEnumerable<ConnectionStrategyEnum?>`):

```csharp
new ListConnectionsQueryParameters
{
    Strategy = [new List<ConnectionStrategyEnum?>() { ConnectionStrategyEnum.Ad }],
    // ^ CS0029: Cannot implicitly convert type 'List<...>' to 'ConnectionStrategyEnum?'
}
```

After:

```csharp
new ListConnectionsQueryParameters
{
    Strategy = new List<ConnectionStrategyEnum?>() { ConnectionStrategyEnum.Ad },
}
```

The pre-existing scalar-example case (e.g. `Query = ["query"]`, `Number = [1]` in the `exhaustive` fixture) is preserved by the existing `isSingleQueryParameter` branch.

## Test plan

- [x] `pnpm seed test --generator csharp-sdk --fixture exhaustive --skip-scripts` (6/6 pass, no diff)
- [x] Local seed run on auth0 fern config: zero remaining `[new List<` patterns in `tests/`, `snippet.json`, `reference.md`
- [x] auth0.net PR rebuild expected to clear the `CS0029` errors that were failing the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
