### PR TITLE
chore(seed): validate staged changelog entries in `changes/` dirs

### DIFF
--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -7,8 +7,10 @@ on:
     paths:
       - "packages/seed/src/commands/validate/**/*"
       - "packages/cli/cli/versions.yml"
+      - "packages/cli/cli/changes/**"
       - "packages/generator-cli/versions.yml"
       - "generators/**/versions.yml"
+      - "generators/**/changes/**"
       - "scripts/validate-all-changelogs.sh"
       - ".github/workflows/validate-changelog.yml"
   pull_request:
@@ -17,8 +19,10 @@ on:
     paths:
       - "packages/seed/src/commands/validate/**/*"
       - "packages/cli/cli/versions.yml"
+      - "packages/cli/cli/changes/**"
       - "packages/generator-cli/versions.yml"
       - "generators/**/versions.yml"
+      - "generators/**/changes/**"
       - "scripts/validate-all-changelogs.sh"
       - ".github/workflows/validate-changelog.yml"
 

--- a/generators/ruby-v2/sdk/changes/1.10.0/rubocop-removal.yml
+++ b/generators/ruby-v2/sdk/changes/1.10.0/rubocop-removal.yml
@@ -1,6 +1,6 @@
 - summary: |
     Fix Ruby string interpolation injection vulnerability in TypeLiteral string emitter.
-    Untrusted API spec default values containing #{} are now properly escaped in generated
+    Untrusted API spec default values containing `#{}` are now properly escaped in generated
     double-quoted Ruby strings.
   type: fix
 - summary: |

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -22,7 +22,7 @@
   changelogEntry:
     - summary: |
         Fix Ruby string interpolation injection vulnerability in TypeLiteral string emitter.
-        Untrusted API spec default values containing #{} are now properly escaped in generated
+        Untrusted API spec default values containing `#{}` are now properly escaped in generated
         double-quoted Ruby strings.
       type: fix
     - summary: |

--- a/packages/cli/cli/changes/unreleased/validate-staged-changelog-entries.yml
+++ b/packages/cli/cli/changes/unreleased/validate-staged-changelog-entries.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Validate staged changelog entries in `changes/<version>/*.yml` (not just `versions.yml`)
+    and trigger the workflow on PRs that touch those staged files. Catches unescaped
+    `{}` / `<>` / `#{}` patterns at PR time instead of after autorelease promotes the
+    entry to `versions.yml` on `main`.
+  type: internal

--- a/packages/seed/src/commands/validate/validateCliChangelog.ts
+++ b/packages/seed/src/commands/validate/validateCliChangelog.ts
@@ -8,6 +8,7 @@ import yaml from "js-yaml";
 import { loadCliWorkspace } from "../../loadGeneratorWorkspaces.js";
 import { validateAngleBracketEscaping } from "./angleBracketValidator.js";
 import { assertValidSemVerChangeOrThrow, assertValidSemVerOrThrow } from "./semVerUtils.js";
+import { validateStagedChanges } from "./validateStagedChanges.js";
 
 export async function validateCliRelease({ context }: { context: TaskContext }): Promise<void> {
     const cliWorkspace = await loadCliWorkspace();
@@ -84,6 +85,9 @@ async function validateCliChangelog({
             }
         }
     }
+
+    hasErrors = (await validateStagedChanges({ absolutePathToChangelog, context, label: "cli" })) || hasErrors;
+
     if (!hasErrors) {
         context.logger.info(chalk.green("All changelogs are valid"));
     } else {

--- a/packages/seed/src/commands/validate/validateGeneratorChangelog.ts
+++ b/packages/seed/src/commands/validate/validateGeneratorChangelog.ts
@@ -7,6 +7,7 @@ import yaml from "js-yaml";
 import { GeneratorWorkspace } from "../../loadGeneratorWorkspaces.js";
 import { validateAngleBracketEscaping } from "./angleBracketValidator.js";
 import { assertValidSemVerChangeOrThrow, assertValidSemVerOrThrow } from "./semVerUtils.js";
+import { validateStagedChanges } from "./validateStagedChanges.js";
 
 const parseReleaseOrThrow = serializers.generators.GeneratorReleaseRequest.parseOrThrow;
 
@@ -90,6 +91,9 @@ async function validateGeneratorChangelog({
             }
         }
     }
+
+    hasErrors = (await validateStagedChanges({ absolutePathToChangelog, context, label: generatorId })) || hasErrors;
+
     if (!hasErrors) {
         context.logger.info(chalk.green("All changelogs are valid"));
     } else {

--- a/packages/seed/src/commands/validate/validateStagedChanges.ts
+++ b/packages/seed/src/commands/validate/validateStagedChanges.ts
@@ -1,0 +1,62 @@
+import { AbsoluteFilePath, dirname, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
+import { TaskContext } from "@fern-api/task-context";
+import chalk from "chalk";
+import { readdir, readFile } from "fs/promises";
+import yaml from "js-yaml";
+
+import { ChangelogEntry, validateAngleBracketEscaping } from "./angleBracketValidator.js";
+
+export async function validateStagedChanges({
+    absolutePathToChangelog,
+    context,
+    label
+}: {
+    absolutePathToChangelog: AbsoluteFilePath;
+    context: TaskContext;
+    label: string;
+}): Promise<boolean> {
+    const changesDir = join(dirname(absolutePathToChangelog), RelativeFilePath.of("changes"));
+    if (!(await doesPathExist(changesDir))) {
+        return false;
+    }
+
+    let hasErrors = false;
+    const versionEntries = await readdir(changesDir, { withFileTypes: true });
+    for (const versionEntry of versionEntries) {
+        if (!versionEntry.isDirectory()) {
+            continue;
+        }
+        const versionName = versionEntry.name;
+        const versionDir = join(changesDir, RelativeFilePath.of(versionName));
+        const files = await readdir(versionDir);
+        for (const file of files) {
+            if (!file.endsWith(".yml") && !file.endsWith(".yaml")) {
+                continue;
+            }
+            const filePath = join(versionDir, RelativeFilePath.of(file));
+            const relPath = `changes/${versionName}/${file}`;
+            let items: unknown;
+            try {
+                items = yaml.load((await readFile(filePath)).toString());
+            } catch (e) {
+                hasErrors = true;
+                context.logger.error(chalk.red(`[${label}]: ${relPath} failed to parse: ${(e as Error).message}`));
+                continue;
+            }
+            if (!Array.isArray(items)) {
+                continue;
+            }
+            const entry: ChangelogEntry = { version: versionName, changelogEntry: items };
+            const angleBracketErrors = validateAngleBracketEscaping(entry);
+            context.logger.debug(`Checking ${relPath}: Found ${angleBracketErrors.length} angle bracket errors`);
+            if (angleBracketErrors.length > 0) {
+                hasErrors = true;
+                for (const error of angleBracketErrors) {
+                    context.logger.error(chalk.red(`${relPath}: ${error}`));
+                }
+            }
+        }
+    }
+
+    return hasErrors;
+}


### PR DESCRIPTION
## Summary

- The Validate Changelogs workflow only ran on changes to `versions.yml`, so bad copy added under `generators/<lang>/.../changes/<version>/*.yml` (the staged-change files autorelease later promotes) slipped past PR CI and only failed on the post-merge release commit on `main`. See [the failing run](https://github.com/fern-api/fern/actions/runs/25124872028/job/73635065948) where ruby-v2 1.10.0 had unescaped `#{}` and tripped the validator only after the release commit.
- This PR (a) extends the seed validator to walk `<changelog-dir>/changes/<version>/*.yml` and run the same angle-bracket / curly-brace / double-backtick checks against each staged entry, (b) adds `packages/cli/cli/changes/**` and `generators/**/changes/**` to the workflow trigger paths, and (c) fixes the offending ruby-v2 entry in place (both `versions.yml` and the source `changes/1.10.0/rubocop-removal.yml`) so the next promotion doesn't reintroduce it.

## Example

Without this PR, a staged change like:

```yaml
# generators/ruby-v2/sdk/changes/1.10.0/rubocop-removal.yml
- summary: |
    Untrusted API spec default values containing #{} are now properly escaped...
  type: fix
```

passed PR CI (workflow didn't trigger on that path) and only failed on `main` after autorelease rolled it into `versions.yml`. With this PR, the same file fails on the PR:

```
[ruby-sdk-v2]: Checking changes/1.10.0/rubocop-removal.yml: Found 1 angle bracket errors
[ruby-sdk-v2]: changes/1.10.0/rubocop-removal.yml: Version 1.10.0: Found unescaped curly braces in changelog summary. Patterns like "{}" should be wrapped in backticks. Example: `{}`
```

## Test plan

- [x] Built the seed CLI and ran `validate generator ruby-sdk-v2` — passes after the in-place fix; output now lists every `changes/<version>/<file>.yml` it inspects.
- [x] Injected a deliberate bad staged entry with `{curly}`, `#{}`, and `<angle>` patterns; validator emitted 2 errors (curly + angle) with the file path and exit code 1. After removing the test file, exit code returned to 0.
- [ ] Verify on this PR that the Validate Changelogs check now runs (it should, because the diff touches the new trigger paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)