### PR TITLE
fix(ci): reduce seed update CI noise — batch PRs, skip CI for seed commits, fix concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,13 @@ on:
         default: false
         type: boolean
 
-# Cancel previous workflows on previous push
+# Cancel previous workflows on previous push.
+# On PRs: group by PR number so new commits cancel stale runs.
+# On main: group by ref so rapid pushes share one slot instead of each
+#   getting a parallel CI run (avoids runner starvation from seed waves).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   DO_NOT_TRACK: "1"
@@ -26,7 +29,36 @@ env:
   TURBO_DAEMON: "false"
 
 jobs:
+  # Detect whether this push only touched seed snapshot files.
+  # If so, skip all CI jobs — seed changes cannot break the build.
+  changes-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      should-skip-ci: ${{ steps.check.outputs.should-skip }}
+    steps:
+      - name: Check if push only touches seed files
+        id: check
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          # Only consider skipping for pushes to main. PRs and dispatches always run CI.
+          if [[ "${{ github.event_name }}" != "push" || "${{ github.ref }}" != "refs/heads/main" ]]; then
+            echo "should-skip=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          # Fast path: if the commit message matches the seed update pattern, skip CI.
+          # Seed snapshot changes cannot break the build, so full CI is unnecessary.
+          FIRST_LINE=$(echo "$COMMIT_MSG" | head -1)
+          if echo "$FIRST_LINE" | grep -qP '^chore\(.+\): update .+-sdk seed|^chore\(.+\): update .+-model seed|^chore\(openapi\): update openapi seed|^chore\(seed\): update'; then
+            echo "should-skip=true" >> $GITHUB_OUTPUT
+            echo "Seed-only commit detected — skipping CI."
+          else
+            echo "should-skip=false" >> $GITHUB_OUTPUT
+          fi
+
   compile:
+    needs: [changes-filter]
+    if: needs.changes-filter.outputs.should-skip-ci != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -39,6 +71,8 @@ jobs:
         run: pnpm compile
 
   boundaries:
+    needs: [changes-filter]
+    if: needs.changes-filter.outputs.should-skip-ci != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -51,6 +85,8 @@ jobs:
         run: pnpm boundaries
 
   depcheck:
+    needs: [changes-filter]
+    if: needs.changes-filter.outputs.should-skip-ci != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -63,6 +99,8 @@ jobs:
         run: pnpm depcheck
 
   validate-cli-dependencies:
+    needs: [changes-filter]
+    if: needs.changes-filter.outputs.should-skip-ci != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -75,6 +113,8 @@ jobs:
         run: node scripts/validate-cli-dependencies.js
 
   lint:
+    needs: [changes-filter]
+    if: needs.changes-filter.outputs.should-skip-ci != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -101,6 +141,8 @@ jobs:
         run: git --no-pager diff --exit-code
 
   biome:
+    needs: [changes-filter]
+    if: needs.changes-filter.outputs.should-skip-ci != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -113,7 +155,8 @@ jobs:
         run: pnpm check:biome
 
   test:
-    if: github.repository == 'fern-api/fern'
+    needs: [changes-filter]
+    if: github.repository == 'fern-api/fern' && needs.changes-filter.outputs.should-skip-ci != 'true'
     runs-on: Test
     timeout-minutes: 25
     steps:
@@ -172,7 +215,8 @@ jobs:
         run: git --no-pager diff --exit-code
 
   test-ete:
-    if: github.repository == 'fern-api/fern'
+    needs: [changes-filter]
+    if: github.repository == 'fern-api/fern' && needs.changes-filter.outputs.should-skip-ci != 'true'
     runs-on: Test
     timeout-minutes: 25
     steps:
@@ -288,8 +332,9 @@ jobs:
         run: git --no-pager diff --exit-code
 
   live-test-dev:
+    needs: [changes-filter]
     environment: Fern Dev
-    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'fern-api/fern' }}
+    if: github.ref == 'refs/heads/main' && github.repository == 'fern-api/fern' && needs.changes-filter.outputs.should-skip-ci != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -310,8 +355,9 @@ jobs:
           ./scripts/live-test.sh "$cli_path" "$FERN_ORG_TOKEN_DEV"
 
   generate-docs-test-windows:
+    needs: [changes-filter]
     environment: Fern Dev
-    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'fern-api/fern' }}
+    if: github.ref == 'refs/heads/main' && github.repository == 'fern-api/fern' && needs.changes-filter.outputs.should-skip-ci != 'true'
     runs-on: windows-latest
     steps:
       - name: Checkout repo
@@ -346,8 +392,9 @@ jobs:
           }
 
   live-test-dev-windows:
+    needs: [changes-filter]
     environment: Fern Dev
-    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'fern-api/fern' }}
+    if: github.ref == 'refs/heads/main' && github.repository == 'fern-api/fern' && needs.changes-filter.outputs.should-skip-ci != 'true'
     runs-on: windows-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -1000,9 +1000,9 @@ jobs:
           fetch: false
           message: "Automated update of seed files"
 
-  # Verify that the branch is the default branch (running for PR to main)
-  # Always run this job to create PRs for generators that succeeded, even if some seed runs fail.
-  # Each matrix job will only create a PR if its corresponding seed-update job produced patches.
+  # Combine ALL generator seed patches into a single PR instead of one per generator.
+  # This reduces the number of main-branch pushes (and the resulting CI cascade) from
+  # up to 16 down to 1, dramatically cutting runner consumption and release latency.
   commit-seed-changes-by-pr:
     if: >-
       ${{
@@ -1033,60 +1033,6 @@ jobs:
       ]
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      matrix:
-        sdk-name:
-          [
-            ruby-sdk-v2,
-            pydantic,
-            python-sdk,
-            openapi,
-            java-sdk,
-            java-model,
-            ts-sdk,
-            go-model,
-            go-sdk,
-            csharp-model,
-            csharp-sdk,
-            php-model,
-            php-sdk,
-            swift-sdk,
-            rust-model,
-            rust-sdk
-          ]
-        include:
-          - language-name: ruby
-            sdk-name: ruby-sdk-v2
-          - language-name: python
-            sdk-name: pydantic
-          - language-name: python
-            sdk-name: python-sdk
-          - language-name: openapi
-            sdk-name: openapi
-          - language-name: java
-            sdk-name: java-sdk
-          - language-name: java
-            sdk-name: java-model
-          - language-name: typescript
-            sdk-name: ts-sdk
-          - language-name: go
-            sdk-name: go-model
-          - language-name: go
-            sdk-name: go-sdk
-          - language-name: csharp
-            sdk-name: csharp-model
-          - language-name: csharp
-            sdk-name: csharp-sdk
-          - language-name: php
-            sdk-name: php-model
-          - language-name: php
-            sdk-name: php-sdk
-          - language-name: swift
-            sdk-name: swift-sdk
-          - language-name: rust
-            sdk-name: rust-model
-          - language-name: rust
-            sdk-name: rust-sdk
     steps:
       - name: Checkout Action File
         uses: actions/checkout@v6
@@ -1094,43 +1040,40 @@ jobs:
           sparse-checkout: |
             .github/
 
-      # Don't set checkout-ref, applying by PR so we can checkout detached
-      # Only match to patches with this matrix name, since we are PR'ing per generator
+      # Apply ALL seed patches at once (seed-*.patch matches every generator)
       - name: Apply Patches
         id: apply-patches
         uses: ./.github/actions/apply-update-seed-patches
         with:
-          patch-pattern: seed-${{ matrix.sdk-name }}-*.patch
+          patch-pattern: seed-*.patch
 
       - name: Install
         if: steps.apply-patches.outputs.has-patches == 'true'
         uses: ./.github/actions/install
 
-      - name: Clean orphaned seed folders for ${{ matrix.sdk-name }}
+      - name: Clean orphaned seed folders
         if: steps.apply-patches.outputs.has-patches == 'true'
         shell: bash
         env:
           FORCE_COLOR: "2"
         run: |
-          pnpm seed:local clean --generator ${{ matrix.sdk-name }}
+          pnpm seed:local clean
 
-      # Create PR, approve and set to merge per generator
       - name: Create Pull Request
         if: steps.apply-patches.outputs.has-patches == 'true'
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.FERN_SUPPORT_GH_ACTIONS_PAT }}
-          commit-message: "chore(${{ matrix.language-name }}): update ${{ matrix.sdk-name }} seed"
-          title: "chore(${{ matrix.language-name }}): update ${{ matrix.sdk-name }} seed"
-          branch: update-${{ matrix.sdk-name }}-seed
-          body: "Auto-generated PR, triggered by GitHub event: ${{ github.event_name }} from branch: ${{ github.ref_name }}.\nGitHub workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          commit-message: "chore(seed): update all seed snapshots"
+          title: "chore(seed): update all seed snapshots"
+          branch: update-all-seed
+          body: "Auto-generated combined seed update PR.\nTrigger: ${{ github.event_name }} from branch: ${{ github.ref_name }}.\nWorkflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           delete-branch: true
           add-paths: |
             seed/**
           labels: |
             seed
-            language/${{ matrix.language-name }}
 
       - name: Log PR Creation Failure
         if: steps.cpr.outputs.pull-request-operation != 'created'


### PR DESCRIPTION
## Description

Addresses the CI bottleneck where seed regeneration waves block release jobs for 45-50+ minutes after merging fixes. After merging `fix(java)` on April 29, 13 seed commits auto-merged between the fix and its release — each triggering full CI and starving runners.

**By the numbers (past 7 days):** 171 of 375 main-branch commits (46%) were automated seed updates. Waves of 10-19 seed commits in a single hour were common.

## Changes Made

### 1. Batch seed PRs into one (`update-seed.yml`)
- Replaced the per-generator matrix in `commit-seed-changes-by-pr` (which created up to 16 separate PRs) with a single combined PR: `chore(seed): update all seed snapshots`
- Reduces main-branch pushes from ~16 to 1 per seed cycle
- All patches are applied at once, orphan cleanup runs for all generators

### 2. Skip CI for seed-only commits (`ci.yml`)
- Added `changes-filter` job that detects seed update commit messages on main
- All CI jobs (`compile`, `boundaries`, `depcheck`, `lint`, `biome`, `test`, `test-ete`, `live-test-dev`, `generate-docs-test-windows`, `live-test-dev-windows`) depend on the filter and skip when it's a seed-only push
- On PRs and `workflow_dispatch`, CI always runs (filter outputs `should-skip=false`)
- Matches both old per-generator patterns (`chore(java): update java-sdk seed`) and new batched pattern (`chore(seed): update all seed snapshots`)

### 3. Fix CI concurrency group (`ci.yml`)
- Changed concurrency group from `github.sha` to `github.ref` for main-branch pushes
- Previously: every push to main got its own parallel CI run (10 seed merges = 10 full CI runs)
- Now: rapid main pushes share one concurrency slot (1 running + 1 pending)
- PR behavior unchanged: still uses PR number for concurrency grouping
- `cancel-in-progress` only applies to PRs, not main pushes

### Expected impact
- Seed cycle: ~16 main pushes → 1
- CI runs per seed cycle: ~16 full CI runs → 0 (skipped)
- Release latency after merge: ~48 min → ~25-35 min (natural pipeline time)

- [ ] Updated README.md generator (if applicable) — N/A

## Testing
- [x] YAML syntax validated for both workflow files
- [ ] Manual testing completed — workflow changes can only be validated by running on main

Link to Devin session: https://app.devin.ai/sessions/3551df493ec646e9b0a0239ff2d9917d
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
