### PR TITLE
chore(deps): bump @fern-api/replay to 0.14.0 in generator-cli

### DIFF
--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -39,7 +39,7 @@
     "@fern-api/cli-ai": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
-    "@fern-api/replay": "0.13.0",
+    "@fern-api/replay": "0.14.0",
     "@fern-api/task-context": "workspace:*",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,17 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Bump `@fern-api/replay` from 0.13.0 to 0.14.0. Picks up fixes for
+        silent customization loss across apply and resolve paths (FER-9983),
+        per-patch-region diff to prevent silent customization loss, and
+        preservation of clean follow-up patches when same-file predecessors
+        conflict.
+      type: fix
+  createdAt: "2026-04-30"
+  version: 0.9.21
+
+- changelogEntry:
+    - summary: |
         Bump `@fern-api/replay` from 0.12.0 to 0.13.0. Picks up per-commit
         detection in non-linear-history fallback (FER-10201), which produces
         per-commit patches with proper attribution for squash-merged divergent

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7881,8 +7881,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/logging-execa
       '@fern-api/replay':
-        specifier: 0.13.0
-        version: 0.13.0
+        specifier: 0.14.0
+        version: 0.14.0
       '@fern-api/task-context':
         specifier: workspace:*
         version: link:../cli/task-context
@@ -9411,8 +9411,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@fern-api/replay@0.13.0':
-    resolution: {integrity: sha512-oxDuDT8Yan8tMYD+cYntxTeKxtqXLG1NBuCPtXd6mMToRMrulaGzId9ZWofF/OVKKNE4RAn4Qj63En+ZZkX8Pw==}
+  '@fern-api/replay@0.14.0':
+    resolution: {integrity: sha512-Sps+V/hb3T3XSR9Qsi2Zp19biHRdvOcyxBjV/CZnOGgeDYPz37TuG9OZdAKuW2DsXjcCAvDjsvU3TQDeHjzD5w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16457,7 +16457,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fern-api/replay@0.13.0':
+  '@fern-api/replay@0.14.0':
     dependencies:
       minimatch: 10.2.5
       node-diff3: 3.2.0


### PR DESCRIPTION
## Description

Bumps `@fern-api/replay` from 0.13.0 to 0.14.0 in `packages/generator-cli`. This triggers a new generator-cli release (0.9.21).

## Changes Made

- Updated `@fern-api/replay` dependency from `0.13.0` to `0.14.0` in `packages/generator-cli/package.json`
- Added `versions.yml` entry for generator-cli `0.9.21` with changelog

### Replay 0.14.0 changelog:
- fix(replay): close silent customization loss across apply + resolve paths
- fix(replay): per-patch-region diff to prevent silent customization loss (FER-9983)
- fix(replay): preserve clean follow-up patch when same-file predecessor conflicts

## Testing

- [x] `pnpm install` passes
- [ ] CI validates

Link to Devin session: https://app.devin.ai/sessions/7e1f232131034d6ab0b94f05d4c0310a
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
