### PR TITLE
chore(python): bump @fern-api/generator-cli to 0.9.21

### DIFF
--- a/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.21.yml
+++ b/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.21.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.21, which includes @fern-api/replay
+    0.14.0 with fixes for silent customization loss across apply and resolve
+    paths, per-patch-region diff, and clean follow-up patch preservation.
+  type: chore


### PR DESCRIPTION
## Description

Triggers a new Python SDK generator release that picks up `@fern-api/generator-cli` 0.9.21 (with `@fern-api/replay` 0.14.0).

## Changes Made

- Added unreleased changelog entry for the Python SDK generator to trigger a new Docker image build with the updated catalog-pinned generator-cli 0.9.21

### What's new in generator-cli 0.9.21:
- fix: close silent customization loss across apply + resolve paths
- fix: per-patch-region diff to prevent silent customization loss (FER-9983)
- fix: preserve clean follow-up patch when same-file predecessor conflicts

## Testing

- [ ] CI validates changelog entry format

Link to Devin session: https://app.devin.ai/sessions/7e1f232131034d6ab0b94f05d4c0310a
Requested by: @tstanmay13