### PR TITLE
feat(cli): make service-level auth optional in Fern Definition

### DIFF
--- a/fern.schema.json
+++ b/fern.schema.json
@@ -3171,7 +3171,14 @@
           ]
         },
         "auth": {
-          "type": "boolean"
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "oneOf": [
@@ -3250,7 +3257,6 @@
         }
       },
       "required": [
-        "auth",
         "base-path",
         "endpoints"
       ],

--- a/fern/apis/fern-definition/definition/service.yml
+++ b/fern/apis/fern-definition/definition/service.yml
@@ -13,7 +13,7 @@ types:
       - commons.DeclarationWithoutDocsSchema
       - commons.WithDisplayName
     properties:
-      auth: boolean
+      auth: optional<boolean>
       url: optional<string>
       base-path: string
       path-parameters: optional<map<string, types.TypeReferenceSchema>>

--- a/package-yml.schema.json
+++ b/package-yml.schema.json
@@ -3191,7 +3191,14 @@
           ]
         },
         "auth": {
-          "type": "boolean"
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "oneOf": [
@@ -3270,7 +3277,6 @@
         }
       },
       "required": [
-        "auth",
         "base-path",
         "endpoints"
       ],

--- a/packages/cli/api-importers/commons/src/FernDefinitionBuilder.ts
+++ b/packages/cli/api-importers/commons/src/FernDefinitionBuilder.ts
@@ -148,6 +148,7 @@ export class FernDefinitionBuilderImpl implements FernDefinitionBuilder {
         if (fernFile.service == null) {
             // Set to default values if service is null
             fernFile.service = {
+                auth: false,
                 "base-path": "",
                 endpoints: {}
             };
@@ -411,6 +412,7 @@ export class FernDefinitionBuilderImpl implements FernDefinitionBuilder {
         const fernFile = this.getOrCreateFile(file);
         if (fernFile.service == null) {
             fernFile.service = {
+                auth: false,
                 "base-path": "",
                 endpoints: {}
             };
@@ -495,7 +497,7 @@ export class FernDefinitionBuilderImpl implements FernDefinitionBuilder {
             const allEndpointsHaveAuthTrue = endpoints.every((endpoint) => endpoint.auth === true);
 
             if (allEndpointsHaveAuthTrue) {
-                delete file.service.auth;
+                file.service.auth = true;
                 for (const endpoint of Object.values(file.service.endpoints)) {
                     delete endpoint.auth;
                 }

--- a/packages/cli/api-importers/commons/src/FernDefinitionBuilder.ts
+++ b/packages/cli/api-importers/commons/src/FernDefinitionBuilder.ts
@@ -148,7 +148,6 @@ export class FernDefinitionBuilderImpl implements FernDefinitionBuilder {
         if (fernFile.service == null) {
             // Set to default values if service is null
             fernFile.service = {
-                auth: false,
                 "base-path": "",
                 endpoints: {}
             };
@@ -412,7 +411,6 @@ export class FernDefinitionBuilderImpl implements FernDefinitionBuilder {
         const fernFile = this.getOrCreateFile(file);
         if (fernFile.service == null) {
             fernFile.service = {
-                auth: false,
                 "base-path": "",
                 endpoints: {}
             };
@@ -497,7 +495,7 @@ export class FernDefinitionBuilderImpl implements FernDefinitionBuilder {
             const allEndpointsHaveAuthTrue = endpoints.every((endpoint) => endpoint.auth === true);
 
             if (allEndpointsHaveAuthTrue) {
-                file.service.auth = true;
+                delete file.service.auth;
                 for (const endpoint of Object.values(file.service.endpoints)) {
                     delete endpoint.auth;
                 }

--- a/packages/cli/cli/changes/unreleased/make-service-auth-optional.yml
+++ b/packages/cli/cli/changes/unreleased/make-service-auth-optional.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Make `auth` optional at the service level in Fern Definition files.
+    When omitted, auth defaults to `true` (inheriting from the API-level auth scheme).
+    This allows users to only specify `auth: false` when they explicitly want to disable auth.
+  type: feat

--- a/packages/cli/cli/changes/unreleased/make-service-auth-optional.yml
+++ b/packages/cli/cli/changes/unreleased/make-service-auth-optional.yml
@@ -1,5 +1,5 @@
 - summary: |
     Make `auth` optional at the service level in Fern Definition files.
-    When omitted, auth defaults to `true` (inheriting from the API-level auth scheme).
+    When omitted, auth is inherited from the root API-level auth scheme.
     This allows users to only specify `auth: false` when they explicitly want to disable auth.
   type: feat

--- a/packages/cli/fern-definition/schema/src/schemas/api/resources/service/types/HttpServiceSchema.ts
+++ b/packages/cli/fern-definition/schema/src/schemas/api/resources/service/types/HttpServiceSchema.ts
@@ -3,7 +3,7 @@
 import type * as FernDefinition from "../../../index.js";
 
 export interface HttpServiceSchema extends FernDefinition.DeclarationWithoutDocsSchema, FernDefinition.WithDisplayName {
-    auth: boolean;
+    auth?: boolean;
     url?: string;
     "base-path": string;
     "path-parameters"?: Record<string, FernDefinition.TypeReferenceSchema>;

--- a/packages/cli/fern-definition/schema/src/schemas/serialization/resources/service/types/HttpServiceSchema.ts
+++ b/packages/cli/fern-definition/schema/src/schemas/serialization/resources/service/types/HttpServiceSchema.ts
@@ -15,7 +15,7 @@ export const HttpServiceSchema: core.serialization.ObjectSchema<
     FernDefinition.HttpServiceSchema
 > = core.serialization
     .object({
-        auth: core.serialization.boolean(),
+        auth: core.serialization.boolean().optional(),
         url: core.serialization.string().optional(),
         "base-path": core.serialization.string(),
         "path-parameters": core.serialization.record(core.serialization.string(), TypeReferenceSchema).optional(),
@@ -30,7 +30,7 @@ export const HttpServiceSchema: core.serialization.ObjectSchema<
 
 export declare namespace HttpServiceSchema {
     export interface Raw extends DeclarationWithoutDocsSchema.Raw, WithDisplayName.Raw {
-        auth: boolean;
+        auth?: boolean | null;
         url?: string | null;
         "base-path": string;
         "path-parameters"?: Record<string, TypeReferenceSchema.Raw> | null;

--- a/packages/cli/fern-definition/validator/src/rules/no-missing-auth/no-missing-auth.ts
+++ b/packages/cli/fern-definition/validator/src/rules/no-missing-auth/no-missing-auth.ts
@@ -7,7 +7,7 @@ export const NoMissingAuthRule: Rule = {
         return {
             definitionFile: {
                 httpService: (service) => {
-                    if (service.auth && !authIsDefined) {
+                    if ((service.auth ?? true) && !authIsDefined) {
                         return [
                             {
                                 severity: "fatal",

--- a/packages/cli/fern-definition/validator/src/rules/no-missing-auth/no-missing-auth.ts
+++ b/packages/cli/fern-definition/validator/src/rules/no-missing-auth/no-missing-auth.ts
@@ -7,7 +7,7 @@ export const NoMissingAuthRule: Rule = {
         return {
             definitionFile: {
                 httpService: (service) => {
-                    if ((service.auth ?? true) && !authIsDefined) {
+                    if ((service.auth ?? authIsDefined) && !authIsDefined) {
                         return [
                             {
                                 severity: "fatal",

--- a/packages/cli/generation/ir-generator/src/converters/services/convertHttpService.ts
+++ b/packages/cli/generation/ir-generator/src/converters/services/convertHttpService.ts
@@ -168,10 +168,10 @@ export function convertHttpService({
                         ? endpoint.auth
                         : endpoint.auth != null
                           ? endpoint.auth.length > 0
-                          : serviceDefinition.auth,
+                          : (serviceDefinition.auth ?? true),
                 security:
                     typeof endpoint.auth === "undefined" || typeof endpoint.auth === "boolean"
-                        ? (endpoint.auth ?? serviceDefinition.auth === true)
+                        ? (endpoint.auth ?? (serviceDefinition.auth ?? true) === true)
                             ? AuthSchemesRequirement._visit<Record<string, string[]>[] | undefined>(auth.requirement, {
                                   any: () => auth.schemes.map((scheme) => ({ [scheme.key]: [] })),
                                   all: () => [auth.schemes.reduce((acc, scheme) => ({ ...acc, [scheme.key]: [] }), {})],

--- a/packages/cli/generation/ir-generator/src/converters/services/convertHttpService.ts
+++ b/packages/cli/generation/ir-generator/src/converters/services/convertHttpService.ts
@@ -168,10 +168,10 @@ export function convertHttpService({
                         ? endpoint.auth
                         : endpoint.auth != null
                           ? endpoint.auth.length > 0
-                          : (serviceDefinition.auth ?? true),
+                          : (serviceDefinition.auth ?? auth.schemes.length > 0),
                 security:
                     typeof endpoint.auth === "undefined" || typeof endpoint.auth === "boolean"
-                        ? (endpoint.auth ?? (serviceDefinition.auth ?? true) === true)
+                        ? (endpoint.auth ?? (serviceDefinition.auth ?? auth.schemes.length > 0) === true)
                             ? AuthSchemesRequirement._visit<Record<string, string[]>[] | undefined>(auth.requirement, {
                                   any: () => auth.schemes.map((scheme) => ({ [scheme.key]: [] })),
                                   all: () => [auth.schemes.reduce((acc, scheme) => ({ ...acc, [scheme.key]: [] }), {})],

--- a/packages/cli/workspace/lazy-fern-workspace/src/fern.schema.json
+++ b/packages/cli/workspace/lazy-fern-workspace/src/fern.schema.json
@@ -3171,7 +3171,14 @@
           ]
         },
         "auth": {
-          "type": "boolean"
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "oneOf": [
@@ -3250,7 +3257,6 @@
         }
       },
       "required": [
-        "auth",
         "base-path",
         "endpoints"
       ],

--- a/packages/cli/workspace/lazy-fern-workspace/src/package-yml.schema.json
+++ b/packages/cli/workspace/lazy-fern-workspace/src/package-yml.schema.json
@@ -3191,7 +3191,14 @@
           ]
         },
         "auth": {
-          "type": "boolean"
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "url": {
           "oneOf": [
@@ -3270,7 +3277,6 @@
         }
       },
       "required": [
-        "auth",
         "base-path",
         "endpoints"
       ],


### PR DESCRIPTION
## Description

Make `auth` optional at the service level in Fern Definition files. When omitted, auth is inherited from the root API-level auth scheme (i.e., if root auth is defined, the service uses it; if not, the service has no auth).

This allows users to only specify `auth: false` when they explicitly want to disable auth on a service.

## Changes Made

- **Schema** (`service.yml`): Changed `auth: boolean` to `auth: optional<boolean>` on `HttpServiceSchema`
- **Auto-generated types**: Updated `HttpServiceSchema.ts` API type, serialization schema, and Raw type to make `auth` optional
- **IR generator** (`convertHttpService.ts`): When `serviceDefinition.auth` is omitted, inherit from root auth via `auth.schemes.length > 0` instead of hardcoding `true`
- **Validator** (`no-missing-auth.ts`): When `service.auth` is omitted, inherit from root via `authIsDefined` instead of hardcoding `true`
- **JSON schemas** (4 files): Regenerated — `auth` field now `oneOf` [boolean, null] and removed from `required`
- **Changelog**: Added unreleased changelog entry
- **Not changed**: `FernDefinitionBuilder.ts` — OpenAPI imports keep explicit `auth: false` defaults since they set auth later via `setServiceInfo`

## Testing

- [x] `pnpm compile` passes (except pre-existing ruby-base issue)
- [x] `pnpm test:update` passes with no snapshot changes
- [x] `pnpm format:fix` clean
- [x] `pnpm jsonschema` regenerated

Link to Devin session: https://app.devin.ai/sessions/8ee1cb93ab644c228b61b191843ffd21
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
