### PR TITLE
fix(cli): read translation docs.yml directly from translations/<locale>

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-translation-overlay-docs-yml-location.yml
+++ b/packages/cli/cli/changes/unreleased/fix-translation-overlay-docs-yml-location.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Translated `docs.yml` overlays are now read directly from `translations/<locale>/docs.yml`,
+    so an extra nested `fern/` folder is no longer required. The legacy
+    `translations/<locale>/fern/docs.yml` location continues to work as a fallback.
+  type: fix

--- a/packages/cli/configuration-loader/src/docs-yml/__test__/translationsDocsConfiguration.test.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/__test__/translationsDocsConfiguration.test.ts
@@ -187,3 +187,117 @@ describe("parseDocsConfiguration — translation pages loading", () => {
         expect(parsed.translationPages?.["ja"]?.[RelativeFilePath.of("pages/index.mdx")]).toBe("# ホーム");
     });
 });
+
+describe("parseDocsConfiguration — translation navigation overlay docs.yml location", () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await mkdtemp(path.join(os.tmpdir(), "fern-translations-overlay-test-"));
+    });
+
+    afterEach(async () => {
+        await rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it("should read overlay docs.yml directly from translations/<lang>/ without a nested fern folder", async () => {
+        const fernDir = tmpDir as AbsoluteFilePath;
+        const configPath = path.join(tmpDir, "docs.yml") as AbsoluteFilePath;
+        await writeFile(configPath, "");
+
+        // Place the overlay directly under translations/fr — no nested fern/ folder
+        const frDir = path.join(tmpDir, "translations", "fr");
+        await mkdir(frDir, { recursive: true });
+        await writeFile(path.join(frDir, "docs.yml"), "title: Documentation\nannouncement:\n  message: Bienvenue\n");
+
+        const config = makeMinimalRawConfig({
+            translations: [{ lang: "en", default: true }, { lang: "fr" }]
+        });
+
+        const parsed = await parseDocsConfiguration({
+            rawDocsConfiguration: config,
+            absolutePathToFernFolder: fernDir,
+            absoluteFilepathToDocsConfig: configPath,
+            context: createMockTaskContext()
+        });
+
+        expect(parsed.translationNavigationOverlays?.["fr"]?.announcement?.message).toBe("Bienvenue");
+    });
+
+    it("should fall back to translations/<lang>/fern/docs.yml when the canonical location is missing", async () => {
+        const fernDir = tmpDir as AbsoluteFilePath;
+        const configPath = path.join(tmpDir, "docs.yml") as AbsoluteFilePath;
+        await writeFile(configPath, "");
+
+        // Place the overlay only under the legacy nested fern/ location
+        const frFernDir = path.join(tmpDir, "translations", "fr", "fern");
+        await mkdir(frFernDir, { recursive: true });
+        await writeFile(path.join(frFernDir, "docs.yml"), "title: Documentation\nannouncement:\n  message: Bonjour\n");
+
+        const config = makeMinimalRawConfig({
+            translations: [{ lang: "en", default: true }, { lang: "fr" }]
+        });
+
+        const parsed = await parseDocsConfiguration({
+            rawDocsConfiguration: config,
+            absolutePathToFernFolder: fernDir,
+            absoluteFilepathToDocsConfig: configPath,
+            context: createMockTaskContext()
+        });
+
+        expect(parsed.translationNavigationOverlays?.["fr"]?.announcement?.message).toBe("Bonjour");
+    });
+
+    it("should prefer translations/<lang>/docs.yml when both locations exist", async () => {
+        const fernDir = tmpDir as AbsoluteFilePath;
+        const configPath = path.join(tmpDir, "docs.yml") as AbsoluteFilePath;
+        await writeFile(configPath, "");
+
+        const frDir = path.join(tmpDir, "translations", "fr");
+        const frFernDir = path.join(frDir, "fern");
+        await mkdir(frFernDir, { recursive: true });
+        await writeFile(path.join(frDir, "docs.yml"), "announcement:\n  message: from-canonical\n");
+        await writeFile(path.join(frFernDir, "docs.yml"), "announcement:\n  message: from-legacy\n");
+
+        const config = makeMinimalRawConfig({
+            translations: [{ lang: "en", default: true }, { lang: "fr" }]
+        });
+
+        const parsed = await parseDocsConfiguration({
+            rawDocsConfiguration: config,
+            absolutePathToFernFolder: fernDir,
+            absoluteFilepathToDocsConfig: configPath,
+            context: createMockTaskContext()
+        });
+
+        expect(parsed.translationNavigationOverlays?.["fr"]?.announcement?.message).toBe("from-canonical");
+    });
+
+    it("should resolve product nav file paths relative to translations/<lang>/", async () => {
+        const fernDir = tmpDir as AbsoluteFilePath;
+        const configPath = path.join(tmpDir, "docs.yml") as AbsoluteFilePath;
+        await writeFile(configPath, "");
+
+        const frDir = path.join(tmpDir, "translations", "fr");
+        await mkdir(frDir, { recursive: true });
+        await writeFile(
+            path.join(frDir, "docs.yml"),
+            "products:\n  - display-name: Produit\n    path: ./product.yml\n"
+        );
+        await writeFile(path.join(frDir, "product.yml"), "tabs:\n  guides:\n    display-name: Guides\n");
+
+        const config = makeMinimalRawConfig({
+            translations: [{ lang: "en", default: true }, { lang: "fr" }]
+        });
+
+        const parsed = await parseDocsConfiguration({
+            rawDocsConfiguration: config,
+            absolutePathToFernFolder: fernDir,
+            absoluteFilepathToDocsConfig: configPath,
+            context: createMockTaskContext()
+        });
+
+        const productOverlay = parsed.translationNavigationOverlays?.["fr"]?.products?.[0];
+        expect(productOverlay?.displayName).toBe("Produit");
+        expect(productOverlay?.tabs?.["guides"]?.displayName).toBe("Guides");
+    });
+});

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -2043,14 +2043,16 @@ async function loadTranslationPages({
 }
 
 /**
- * Loads translated navigation overlay YAML files from `translations/<lang>/fern/` directories.
+ * Loads translated navigation overlay YAML files from `translations/<lang>/` directories.
  *
  * For each locale declared in `translations`, this function:
- * 1. Checks for `translations/<lang>/fern/docs.yml` (the top-level overlay).
+ * 1. Checks for `translations/<lang>/docs.yml` (the top-level overlay). For backwards
+ *    compatibility, falls back to `translations/<lang>/fern/docs.yml` if not present.
  * 2. If found, parses it and extracts translatable fields (title, products, versions,
  *    announcement, tabs).
  * 3. For products with a `path:` field, also loads the referenced nav YAML file
- *    from `translations/<lang>/fern/` to extract tab and navigation overrides.
+ *    from the same directory as the overlay `docs.yml` to extract tab and navigation
+ *    overrides.
  * 4. Returns a map of locale → TranslationNavigationOverlay.
  */
 async function loadTranslationNavigationOverlays({
@@ -2079,12 +2081,15 @@ async function loadTranslationNavigationOverlays({
                 return;
             }
 
-            const langFernDir = path.join(translationsRootDir, lang, "fern") as AbsoluteFilePath;
-            const overlayDocsYmlPath = path.join(langFernDir, "docs.yml") as AbsoluteFilePath;
-
-            if (!(await doesPathExist(overlayDocsYmlPath))) {
+            const overlayLookup = await resolveTranslationOverlayDocsYml({
+                translationsRootDir,
+                lang
+            });
+            if (overlayLookup == null) {
                 return;
             }
+
+            const { overlayDocsYmlPath, overlayDir } = overlayLookup;
 
             try {
                 const overlayContent = yaml.load(await readFile(overlayDocsYmlPath, "utf-8"));
@@ -2097,7 +2102,7 @@ async function loadTranslationNavigationOverlays({
 
                 const overlay = await parseNavigationOverlayFromDocsYml({
                     docsYmlContent: overlayContent as Record<string, unknown>,
-                    langFernDir,
+                    langFernDir: overlayDir,
                     context
                 });
 
@@ -2117,6 +2122,37 @@ async function loadTranslationNavigationOverlays({
     return result;
 }
 
+/**
+ * Resolves the translation overlay `docs.yml` for a locale.
+ *
+ * Prefers `translations/<lang>/docs.yml` (the canonical location) and falls
+ * back to `translations/<lang>/fern/docs.yml` for backwards compatibility with
+ * translation directories produced by older versions of `fern write-translation`.
+ *
+ * Returns `undefined` if neither path exists.
+ */
+async function resolveTranslationOverlayDocsYml({
+    translationsRootDir,
+    lang
+}: {
+    translationsRootDir: AbsoluteFilePath;
+    lang: string;
+}): Promise<{ overlayDocsYmlPath: AbsoluteFilePath; overlayDir: AbsoluteFilePath } | undefined> {
+    const langDir = path.join(translationsRootDir, lang) as AbsoluteFilePath;
+    const directDocsYmlPath = path.join(langDir, "docs.yml") as AbsoluteFilePath;
+    if (await doesPathExist(directDocsYmlPath)) {
+        return { overlayDocsYmlPath: directDocsYmlPath, overlayDir: langDir };
+    }
+
+    const legacyFernDir = path.join(langDir, "fern") as AbsoluteFilePath;
+    const legacyDocsYmlPath = path.join(legacyFernDir, "docs.yml") as AbsoluteFilePath;
+    if (await doesPathExist(legacyDocsYmlPath)) {
+        return { overlayDocsYmlPath: legacyDocsYmlPath, overlayDir: legacyFernDir };
+    }
+
+    return undefined;
+}
+
 function extractString(obj: unknown, key: string): string | undefined {
     if (isPlainObject(obj)) {
         const value = (obj as Record<string, unknown>)[key];
@@ -2133,7 +2169,7 @@ function extractString(obj: unknown, key: string): string | undefined {
  */
 async function parseNavigationOverlayFromDocsYml({
     docsYmlContent,
-    langFernDir,
+    langFernDir: overlayDir,
     context
 }: {
     docsYmlContent: Record<string, unknown>;
@@ -2189,8 +2225,8 @@ async function parseNavigationOverlayFromDocsYml({
             // These are stored per-product to avoid collision when multiple products share tab IDs
             if (typeof productObj.path === "string") {
                 // Validate path to prevent path traversal attacks
-                const resolvedNavFilePath = path.resolve(langFernDir, productObj.path) as AbsoluteFilePath;
-                if (!resolvedNavFilePath.startsWith(langFernDir)) {
+                const resolvedNavFilePath = path.resolve(overlayDir, productObj.path) as AbsoluteFilePath;
+                if (!resolvedNavFilePath.startsWith(overlayDir)) {
                     context.logger.warn(
                         `Invalid path in product overlay: "${productObj.path}" escapes the translations directory. Skipping.`
                     );

--- a/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
@@ -539,7 +539,8 @@ export interface ParsedLibraryConfiguration {
 
 /**
  * Represents a navigation overlay for a single locale, extracted from
- * `translations/<lang>/fern/docs.yml` and any referenced product/version YAML files.
+ * `translations/<lang>/docs.yml` (or, for backwards compatibility,
+ * `translations/<lang>/fern/docs.yml`) and any referenced product/version YAML files.
  *
  * These overlays contain only the translatable fields (display-name, title, subtitle,
  * announcement message) keyed by the identifiers used in the source YAML (tab IDs,

--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -137,7 +137,7 @@ export interface PreviewDocsResult {
      */
     translationPages: Record<string, Record<RelativeFilePath, string>> | undefined;
     /**
-     * Per-locale translated navigation overlays from translations/<lang>/fern/ YAML files.
+     * Per-locale translated navigation overlays from translations/<lang>/ YAML files.
      * Key is locale, value is a parsed overlay with translated display-names, titles, etc.
      */
     translationNavigationOverlays: Record<string, TranslationNavigationOverlay> | undefined;

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -273,7 +273,8 @@ export class DocsDefinitionResolver {
 
     /**
      * Returns per-locale translated navigation overlays loaded from
-     * `translations/<lang>/fern/docs.yml` and referenced nav YAML files.
+     * `translations/<lang>/docs.yml` (or `translations/<lang>/fern/docs.yml` for
+     * backwards compatibility) and referenced nav YAML files.
      * Must be called after `resolve()`.
      */
     public getTranslationNavigationOverlays():

--- a/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
+++ b/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
@@ -6,7 +6,8 @@ import { FernNavigation } from "@fern-api/fdr-sdk";
  *
  * This walks the navigation tree (as a plain object) and overrides `title`,
  * `subtitle`, and `announcement` fields based on the overlay data parsed from
- * `translations/<lang>/fern/docs.yml` and nav YAML files.
+ * `translations/<lang>/docs.yml` (or `translations/<lang>/fern/docs.yml` for
+ * backwards compatibility) and nav YAML files.
  *
  * Matching strategy:
  * - Products: matched positionally against the overlay's products array


### PR DESCRIPTION
## Summary

- Translation overlays for `docs.yml` are now read directly from `translations/<locale>/docs.yml`, removing the requirement for an extra nested `fern/` folder under each locale.
- For backwards compatibility with projects that already have the nested layout, `translations/<locale>/fern/docs.yml` is still picked up as a fallback when no canonical `docs.yml` is present.
- Product nav-file paths referenced from the overlay (`products[].path`) now resolve relative to wherever the overlay `docs.yml` was found, so both layouts keep working.

## Test plan

- [x] `pnpm turbo run compile --filter @fern-api/configuration-loader --filter @fern-api/configuration --filter @fern-api/docs-resolver --filter @fern-api/docs-preview`
- [x] `pnpm turbo run test --filter @fern-api/configuration-loader` — 244 passed (includes 4 new cases for the canonical location, the legacy fallback, the canonical-wins-when-both-exist case, and product nav-file resolution).
- [x] `pnpm turbo run test --filter @fern-api/docs-resolver` — 44 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)