### PR TITLE
fix(cli): improve error message for EACCES on fern login token write

### DIFF
--- a/packages/cli/auth/src/persistence/storeToken.ts
+++ b/packages/cli/auth/src/persistence/storeToken.ts
@@ -5,6 +5,22 @@ import { getPathToTokenFile } from "./getPathToTokenFile.js";
 
 export async function storeToken(token: string): Promise<void> {
     const pathToTokenFile = getPathToTokenFile();
-    await mkdir(path.dirname(pathToTokenFile), { recursive: true });
-    await writeFile(pathToTokenFile, token);
+    const dir = path.dirname(pathToTokenFile);
+    try {
+        await mkdir(dir, { recursive: true });
+        await writeFile(pathToTokenFile, token);
+    } catch (error) {
+        if (isErrnoException(error) && (error.code === "EACCES" || error.code === "EPERM")) {
+            throw new Error(
+                `Permission denied writing to ${pathToTokenFile}.\n` +
+                    `The directory ${dir} may be owned by another user (e.g. root).\n` +
+                    `To fix, run: sudo chown -R $(whoami) ${dir}`
+            );
+        }
+        throw error;
+    }
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+    return error instanceof Error && "code" in error;
 }

--- a/packages/cli/cli/changes/unreleased/fix-login-eacces-error-message.yml
+++ b/packages/cli/cli/changes/unreleased/fix-login-eacces-error-message.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Improve error message when `fern login` fails with a permission error writing
+    to `~/.fern/token`. The CLI now suggests the fix command (`sudo chown -R $(whoami) ~/.fern`).
+  type: fix


### PR DESCRIPTION
## Description

A user ran `fern login` and received `EACCES: permission denied, open '/Users/<user>/.fern/token'` with no guidance on how to fix it. This happens when the `~/.fern` directory is owned by root (e.g., from a previous `sudo` install).

## Changes Made
- Wrapped the `mkdir`/`writeFile` calls in `storeToken()` with a try/catch that detects `EACCES` and `EPERM` errors
- The new error message tells the user exactly what failed and how to fix it: `sudo chown -R $(whoami) ~/.fern`

## Testing
- [x] Lint passes (`pnpm check`)
- [x] Manual code review of the change

Link to Devin session: https://app.devin.ai/sessions/898c7969fb2d4d48bf1273e1dfbc7d74
Requested by: @jon-fern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
