### PR TITLE
feat(cli): allow per-locale navbar-links overrides in translation overlays

### DIFF
--- a/packages/cli/cli/changes/unreleased/feat-translation-navbar-links-override.yml
+++ b/packages/cli/cli/changes/unreleased/feat-translation-navbar-links-override.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Translation overlays can now override navbar links (CTAs) per locale. Set `navbar-links:`
+    inside `translations/<locale>/docs.yml` and the per-locale FDR upload will use those
+    instead of the docs-level navbar-links. Local icon files referenced from the overlay
+    are uploaded and resolved alongside the rest of the docs assets.
+  type: feat

--- a/packages/cli/configuration-loader/src/docs-yml/__test__/translationsDocsConfiguration.test.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/__test__/translationsDocsConfiguration.test.ts
@@ -418,4 +418,66 @@ describe("parseDocsConfiguration — translation navbar-links overrides", () => 
         expect(navbarLinks?.[0]).toMatchObject({ type: "filled", text: "Valide" });
         expect(warnings.some((w) => w.includes("Invalid navbar-link"))).toBe(true);
     });
+
+    it("should treat an empty navbar-links list as a per-locale opt-out (not inherit)", async () => {
+        const fernDir = tmpDir as AbsoluteFilePath;
+        const configPath = path.join(tmpDir, "docs.yml") as AbsoluteFilePath;
+        await writeFile(configPath, "");
+
+        const frDir = path.join(tmpDir, "translations", "fr");
+        await mkdir(frDir, { recursive: true });
+        await writeFile(path.join(frDir, "docs.yml"), "navbar-links: []\n");
+
+        const config = makeMinimalRawConfig({
+            translations: [{ lang: "en", default: true }, { lang: "fr" }]
+        });
+
+        const parsed = await parseDocsConfiguration({
+            rawDocsConfiguration: config,
+            absolutePathToFernFolder: fernDir,
+            absoluteFilepathToDocsConfig: configPath,
+            context: createMockTaskContext()
+        });
+
+        const navbarLinks = parsed.translationNavigationOverlays?.["fr"]?.navbarLinks;
+        expect(navbarLinks).toEqual([]);
+    });
+
+    it("should still produce an override (empty list) when every navbar-link entry is invalid", async () => {
+        const fernDir = tmpDir as AbsoluteFilePath;
+        const configPath = path.join(tmpDir, "docs.yml") as AbsoluteFilePath;
+        await writeFile(configPath, "");
+
+        const frDir = path.join(tmpDir, "translations", "fr");
+        await mkdir(frDir, { recursive: true });
+        await writeFile(
+            path.join(frDir, "docs.yml"),
+            ["navbar-links:", "  - type: not-a-real-type", "    text: Invalide"].join("\n") + "\n"
+        );
+
+        const config = makeMinimalRawConfig({
+            translations: [{ lang: "en", default: true }, { lang: "fr" }]
+        });
+
+        const warnings: string[] = [];
+        const mockContext = createMockTaskContext({
+            logger: {
+                warn: (msg: string) => warnings.push(msg),
+                info: () => undefined,
+                debug: () => undefined,
+                error: () => undefined
+            } as never
+        });
+
+        const parsed = await parseDocsConfiguration({
+            rawDocsConfiguration: config,
+            absolutePathToFernFolder: fernDir,
+            absoluteFilepathToDocsConfig: configPath,
+            context: mockContext
+        });
+
+        const navbarLinks = parsed.translationNavigationOverlays?.["fr"]?.navbarLinks;
+        expect(navbarLinks).toEqual([]);
+        expect(warnings.some((w) => w.includes("Invalid navbar-link"))).toBe(true);
+    });
 });

--- a/packages/cli/configuration-loader/src/docs-yml/__test__/translationsDocsConfiguration.test.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/__test__/translationsDocsConfiguration.test.ts
@@ -301,3 +301,121 @@ describe("parseDocsConfiguration — translation navigation overlay docs.yml loc
         expect(productOverlay?.tabs?.["guides"]?.displayName).toBe("Guides");
     });
 });
+
+describe("parseDocsConfiguration — translation navbar-links overrides", () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await mkdtemp(path.join(os.tmpdir(), "fern-translations-navbar-test-"));
+    });
+
+    afterEach(async () => {
+        await rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it("should parse navbar-links from a translation overlay docs.yml", async () => {
+        const fernDir = tmpDir as AbsoluteFilePath;
+        const configPath = path.join(tmpDir, "docs.yml") as AbsoluteFilePath;
+        await writeFile(configPath, "");
+
+        const frDir = path.join(tmpDir, "translations", "fr");
+        await mkdir(frDir, { recursive: true });
+        await writeFile(
+            path.join(frDir, "docs.yml"),
+            [
+                "navbar-links:",
+                "  - type: filled",
+                "    text: Commencer",
+                "    href: https://example.com/fr/start",
+                "  - type: github",
+                "    value: https://github.com/example/repo"
+            ].join("\n") + "\n"
+        );
+
+        const config = makeMinimalRawConfig({
+            translations: [{ lang: "en", default: true }, { lang: "fr" }]
+        });
+
+        const parsed = await parseDocsConfiguration({
+            rawDocsConfiguration: config,
+            absolutePathToFernFolder: fernDir,
+            absoluteFilepathToDocsConfig: configPath,
+            context: createMockTaskContext()
+        });
+
+        const navbarLinks = parsed.translationNavigationOverlays?.["fr"]?.navbarLinks;
+        expect(navbarLinks).toBeDefined();
+        expect(navbarLinks).toHaveLength(2);
+        expect(navbarLinks?.[0]).toMatchObject({ type: "filled", text: "Commencer" });
+        expect(navbarLinks?.[1]).toMatchObject({ type: "github" });
+    });
+
+    it("should leave navbarLinks undefined when overlay does not specify navbar-links", async () => {
+        const fernDir = tmpDir as AbsoluteFilePath;
+        const configPath = path.join(tmpDir, "docs.yml") as AbsoluteFilePath;
+        await writeFile(configPath, "");
+
+        const frDir = path.join(tmpDir, "translations", "fr");
+        await mkdir(frDir, { recursive: true });
+        await writeFile(path.join(frDir, "docs.yml"), "announcement:\n  message: Bienvenue\n");
+
+        const config = makeMinimalRawConfig({
+            translations: [{ lang: "en", default: true }, { lang: "fr" }]
+        });
+
+        const parsed = await parseDocsConfiguration({
+            rawDocsConfiguration: config,
+            absolutePathToFernFolder: fernDir,
+            absoluteFilepathToDocsConfig: configPath,
+            context: createMockTaskContext()
+        });
+
+        expect(parsed.translationNavigationOverlays?.["fr"]?.navbarLinks).toBeUndefined();
+    });
+
+    it("should drop invalid navbar-link entries with a warning but keep valid ones", async () => {
+        const fernDir = tmpDir as AbsoluteFilePath;
+        const configPath = path.join(tmpDir, "docs.yml") as AbsoluteFilePath;
+        await writeFile(configPath, "");
+
+        const frDir = path.join(tmpDir, "translations", "fr");
+        await mkdir(frDir, { recursive: true });
+        await writeFile(
+            path.join(frDir, "docs.yml"),
+            [
+                "navbar-links:",
+                "  - type: filled",
+                "    text: Valide",
+                "    href: https://example.com/fr",
+                "  - type: not-a-real-type",
+                "    text: Invalide"
+            ].join("\n") + "\n"
+        );
+
+        const config = makeMinimalRawConfig({
+            translations: [{ lang: "en", default: true }, { lang: "fr" }]
+        });
+
+        const warnings: string[] = [];
+        const mockContext = createMockTaskContext({
+            logger: {
+                warn: (msg: string) => warnings.push(msg),
+                info: () => undefined,
+                debug: () => undefined,
+                error: () => undefined
+            } as never
+        });
+
+        const parsed = await parseDocsConfiguration({
+            rawDocsConfiguration: config,
+            absolutePathToFernFolder: fernDir,
+            absoluteFilepathToDocsConfig: configPath,
+            context: mockContext
+        });
+
+        const navbarLinks = parsed.translationNavigationOverlays?.["fr"]?.navbarLinks;
+        expect(navbarLinks).toHaveLength(1);
+        expect(navbarLinks?.[0]).toMatchObject({ type: "filled", text: "Valide" });
+        expect(warnings.some((w) => w.includes("Invalid navbar-link"))).toBe(true);
+    });
+});

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -2170,7 +2170,10 @@ function extractString(obj: unknown, key: string): string | undefined {
 /**
  * Validates each entry of a translation overlay's `navbar-links` array against the
  * docs.yml NavbarLink schema. Invalid entries are dropped with a warning so a single
- * malformed link does not discard the whole list.
+ * malformed link does not discard the whole list. The presence of the field — even
+ * when it parses to an empty list — is preserved so the caller can distinguish an
+ * intentional override (including the empty `navbar-links: []` opt-out) from an
+ * absent field.
  */
 async function validateOverlayNavbarLinks({
     rawNavbarLinks,
@@ -2180,7 +2183,7 @@ async function validateOverlayNavbarLinks({
     rawNavbarLinks: unknown[];
     overlayDocsYmlPath: AbsoluteFilePath;
     context: TaskContext;
-}): Promise<docsYml.RawSchemas.NavbarLink[] | undefined> {
+}): Promise<docsYml.RawSchemas.NavbarLink[]> {
     const result: docsYml.RawSchemas.NavbarLink[] = [];
     for (const [index, raw] of rawNavbarLinks.entries()) {
         try {
@@ -2192,7 +2195,7 @@ async function validateOverlayNavbarLinks({
             );
         }
     }
-    return result.length > 0 ? result : undefined;
+    return result;
 }
 
 /**
@@ -2228,7 +2231,8 @@ async function parseNavigationOverlayFromDocsYml({
     }
 
     // Parse navbar-links (CTAs). When present, these replace the docs-level
-    // navbar-links in the FDR upload for this locale.
+    // navbar-links in the FDR upload for this locale — including the empty
+    // case (`navbar-links: []`), which is a per-locale opt-out of CTAs.
     const rawNavbarLinks = docsYmlContent["navbar-links"];
     if (Array.isArray(rawNavbarLinks)) {
         const validatedNavbarLinks = await validateOverlayNavbarLinks({
@@ -2236,10 +2240,10 @@ async function parseNavigationOverlayFromDocsYml({
             overlayDocsYmlPath,
             context
         });
-        if (validatedNavbarLinks != null) {
-            overlay.navbarLinks = convertNavbarLinks(validatedNavbarLinks, overlayDocsYmlPath);
-        }
+        overlay.navbarLinks = convertNavbarLinks(validatedNavbarLinks, overlayDocsYmlPath) ?? [];
     }
+    // If `navbar-links` is absent, leave `overlay.navbarLinks` undefined so the
+    // docs-level CTAs are inherited.
 
     // Parse top-level tabs
     if (isPlainObject(docsYmlContent.tabs)) {

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -2106,6 +2106,7 @@ async function loadTranslationNavigationOverlays({
                 const overlay = await parseNavigationOverlayFromDocsYml({
                     docsYmlContent: overlayContent as Record<string, unknown>,
                     langFernDir: overlayDir,
+                    overlayDocsYmlPath,
                     context
                 });
 
@@ -2167,16 +2168,46 @@ function extractString(obj: unknown, key: string): string | undefined {
 }
 
 /**
+ * Validates each entry of a translation overlay's `navbar-links` array against the
+ * docs.yml NavbarLink schema. Invalid entries are dropped with a warning so a single
+ * malformed link does not discard the whole list.
+ */
+async function validateOverlayNavbarLinks({
+    rawNavbarLinks,
+    overlayDocsYmlPath,
+    context
+}: {
+    rawNavbarLinks: unknown[];
+    overlayDocsYmlPath: AbsoluteFilePath;
+    context: TaskContext;
+}): Promise<docsYml.RawSchemas.NavbarLink[] | undefined> {
+    const result: docsYml.RawSchemas.NavbarLink[] = [];
+    for (const [index, raw] of rawNavbarLinks.entries()) {
+        try {
+            const parsed = await docsYml.RawSchemas.Serializer.NavbarLink.parseOrThrow(raw);
+            result.push(parsed);
+        } catch (error) {
+            context.logger.warn(
+                `Invalid navbar-link at index ${index} in "${overlayDocsYmlPath}": ${String(error)}. Skipping this entry.`
+            );
+        }
+    }
+    return result.length > 0 ? result : undefined;
+}
+
+/**
  * Parses a translated `docs.yml` overlay and any referenced nav YAML files
  * to produce a `TranslationNavigationOverlay`.
  */
 async function parseNavigationOverlayFromDocsYml({
     docsYmlContent,
     langFernDir: overlayDir,
+    overlayDocsYmlPath,
     context
 }: {
     docsYmlContent: Record<string, unknown>;
     langFernDir: AbsoluteFilePath;
+    overlayDocsYmlPath: AbsoluteFilePath;
     context: TaskContext;
 }): Promise<docsYml.TranslationNavigationOverlay> {
     const overlay: docsYml.TranslationNavigationOverlay = {
@@ -2184,7 +2215,8 @@ async function parseNavigationOverlayFromDocsYml({
         products: undefined,
         versions: undefined,
         announcement: undefined,
-        navigation: undefined
+        navigation: undefined,
+        navbarLinks: undefined
     };
 
     // Parse announcement
@@ -2192,6 +2224,20 @@ async function parseNavigationOverlayFromDocsYml({
         const message = extractString(docsYmlContent.announcement, "message");
         if (message != null) {
             overlay.announcement = { message };
+        }
+    }
+
+    // Parse navbar-links (CTAs). When present, these replace the docs-level
+    // navbar-links in the FDR upload for this locale.
+    const rawNavbarLinks = docsYmlContent["navbar-links"];
+    if (Array.isArray(rawNavbarLinks)) {
+        const validatedNavbarLinks = await validateOverlayNavbarLinks({
+            rawNavbarLinks,
+            overlayDocsYmlPath,
+            context
+        });
+        if (validatedNavbarLinks != null) {
+            overlay.navbarLinks = convertNavbarLinks(validatedNavbarLinks, overlayDocsYmlPath);
         }
     }
 

--- a/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
@@ -558,6 +558,11 @@ export interface TranslationNavigationOverlay {
     announcement: AnnouncementOverlay | undefined;
     /** Translated navigation items (sections, pages), from the navigation YAML */
     navigation: NavigationItemOverlay[] | undefined;
+    /**
+     * Translated navbar links (CTAs). When present, these replace the docs-level
+     * navbar links in the FDR upload for this locale.
+     */
+    navbarLinks: CjsFdrSdk.docs.v1.commons.NavbarLink[] | undefined;
 }
 
 export interface TabOverlay {

--- a/packages/cli/docs-preview/src/runPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runPreviewServer.ts
@@ -212,9 +212,13 @@ export async function runPreviewServer({
                 // Apply navigation overlay (translated display-names, titles, etc.)
                 const localeNavOverlay = translationNavigationOverlays?.[locale];
                 let translatedAnnouncement = docsDefinition.config.announcement;
+                let translatedNavbarLinks = docsDefinition.config.navbarLinks;
                 if (localeNavOverlay != null) {
                     updatedRoot = applyTranslatedNavigationOverlays(updatedRoot, localeNavOverlay);
                     translatedAnnouncement = getTranslatedAnnouncement(localeNavOverlay) ?? translatedAnnouncement;
+                    if (localeNavOverlay.navbarLinks != null) {
+                        translatedNavbarLinks = localeNavOverlay.navbarLinks;
+                    }
                 }
 
                 const translatedDefinition: DocsV1Read.DocsDefinition = {
@@ -223,7 +227,8 @@ export async function runPreviewServer({
                     config: {
                         ...docsDefinition.config,
                         root: updatedRoot,
-                        announcement: translatedAnnouncement
+                        announcement: translatedAnnouncement,
+                        navbarLinks: translatedNavbarLinks
                     }
                 };
 

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -509,6 +509,10 @@ export class DocsDefinitionResolver {
             this.collectedFileIds.set(uploadedFile.absoluteFilePath, uploadedFile.fileId);
         });
 
+        // Resolve any AbsoluteFilePath icons on translation overlay navbar-links to their
+        // uploaded file IDs so the per-locale navbarLinks land in FDR with valid icon refs.
+        this.resolveTranslationOverlayNavbarLinkIcons();
+
         // store root here so we only process once
         this.taskContext.logger.debug("Building navigation tree...");
         const rootStart = performance.now();
@@ -2195,6 +2199,46 @@ export class DocsDefinitionResolver {
         }
 
         return iconPath as string;
+    }
+
+    /**
+     * Walks each translation overlay's navbar-links and rewrites any
+     * AbsoluteFilePath icons to `file:<fileId>` references using the icons
+     * we just uploaded. Mirrors the per-link transform applied to the
+     * docs-level navbar-links in `toDocsConfig`.
+     */
+    private resolveTranslationOverlayNavbarLinkIcons(): void {
+        const overlays = this.parsedDocsConfig.translationNavigationOverlays;
+        if (overlays == null) {
+            return;
+        }
+        for (const overlay of Object.values(overlays)) {
+            if (overlay.navbarLinks == null) {
+                continue;
+            }
+            overlay.navbarLinks = overlay.navbarLinks.map((navbarLink) => {
+                if (navbarLink.type === "github") {
+                    return navbarLink;
+                }
+                if (navbarLink.type === "dropdown") {
+                    return {
+                        ...navbarLink,
+                        icon: this.resolveIconFileId(navbarLink.icon),
+                        rightIcon: this.resolveIconFileId(navbarLink.rightIcon),
+                        links: navbarLink.links.map((link) => ({
+                            ...link,
+                            icon: this.resolveIconFileId(link.icon),
+                            rightIcon: this.resolveIconFileId(link.rightIcon)
+                        }))
+                    };
+                }
+                return {
+                    ...navbarLink,
+                    icon: this.resolveIconFileId(navbarLink.icon),
+                    rightIcon: this.resolveIconFileId(navbarLink.rightIcon)
+                };
+            });
+        }
     }
 
     private convertPageActions(): DocsV1Write.PageActionsConfig | undefined {

--- a/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
@@ -14,7 +14,8 @@ function emptyOverlay(): docsYml.TranslationNavigationOverlay {
         products: undefined,
         versions: undefined,
         announcement: undefined,
-        navigation: undefined
+        navigation: undefined,
+        navbarLinks: undefined
     };
 }
 

--- a/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
+++ b/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
@@ -81,7 +81,8 @@ function applyChildOverlays(
                     products: undefined,
                     versions: overlay.versions,
                     announcement: productOverlay.announcement ?? overlay.announcement,
-                    navigation: productOverlay.navigation ?? overlay.navigation
+                    navigation: productOverlay.navigation ?? overlay.navigation,
+                    navbarLinks: overlay.navbarLinks
                 };
                 const walked = walkAndApply(child, scopedOverlay) as Record<string, unknown>;
                 return applyProductOverlayToNode(walked, productOverlay);
@@ -285,7 +286,8 @@ function applyTabOverlayToNode(node: Record<string, unknown>, overlay: docsYml.T
                 products: undefined,
                 versions: undefined,
                 announcement: undefined,
-                navigation: tabNavOverlay.layout
+                navigation: tabNavOverlay.layout,
+                navbarLinks: undefined
             };
             return walkAndApply(node, scopedOverlay);
         }

--- a/packages/cli/docs-resolver/src/utils/getImageFilepathsToUpload.ts
+++ b/packages/cli/docs-resolver/src/utils/getImageFilepathsToUpload.ts
@@ -179,7 +179,61 @@ export async function collectFilesFromDocsConfig({
         );
     }
 
+    /* per-locale translation overlay navbar links */
+    if (parsedDocsConfig.translationNavigationOverlays != null) {
+        for (const overlay of Object.values(parsedDocsConfig.translationNavigationOverlays)) {
+            await collectIconsFromNavbarLinks({
+                navbarLinks: overlay.navbarLinks,
+                filepaths
+            });
+        }
+    }
+
     return filepaths;
+}
+
+async function collectIconsFromNavbarLinks({
+    navbarLinks,
+    filepaths
+}: {
+    navbarLinks: docsYml.TranslationNavigationOverlay["navbarLinks"];
+    filepaths: Set<AbsoluteFilePath>;
+}): Promise<void> {
+    if (navbarLinks == null) {
+        return;
+    }
+    await Promise.all(
+        navbarLinks.map(async (link) => {
+            if (link.type === "github") {
+                return;
+            }
+            if (link.type === "dropdown") {
+                await Promise.all(
+                    link.links.map(async (nestedLink) => {
+                        if (nestedLink.icon != null) {
+                            await addIconToFilepaths({ iconPath: nestedLink.icon, filepaths });
+                        }
+                        if (nestedLink.rightIcon != null) {
+                            await addIconToFilepaths({ iconPath: nestedLink.rightIcon, filepaths });
+                        }
+                    })
+                );
+                if (link.icon != null) {
+                    await addIconToFilepaths({ iconPath: link.icon, filepaths });
+                }
+                if (link.rightIcon != null) {
+                    await addIconToFilepaths({ iconPath: link.rightIcon, filepaths });
+                }
+                return;
+            }
+            if (link.icon != null) {
+                await addIconToFilepaths({ iconPath: link.icon, filepaths });
+            }
+            if (link.rightIcon != null) {
+                await addIconToFilepaths({ iconPath: link.rightIcon, filepaths });
+            }
+        })
+    );
 }
 
 async function collectIconsFromNavigation({

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -728,10 +728,14 @@ export async function publishDocs({
                         // Apply navigation overlay (translated display-names, titles, etc.)
                         const localeNavOverlay = translationNavigationOverlays?.[locale];
                         let translatedAnnouncement = docsDefinition.config.announcement;
+                        let translatedNavbarLinks = docsDefinition.config.navbarLinks;
                         if (localeNavOverlay != null) {
                             updatedRoot = applyTranslatedNavigationOverlays(updatedRoot, localeNavOverlay);
                             translatedAnnouncement =
                                 getTranslatedAnnouncement(localeNavOverlay) ?? translatedAnnouncement;
+                            if (localeNavOverlay.navbarLinks != null) {
+                                translatedNavbarLinks = localeNavOverlay.navbarLinks;
+                            }
                         }
 
                         const translatedDefinition: DocsDefinition = {
@@ -740,7 +744,8 @@ export async function publishDocs({
                             config: {
                                 ...docsDefinition.config,
                                 root: updatedRoot,
-                                announcement: translatedAnnouncement
+                                announcement: translatedAnnouncement,
+                                navbarLinks: translatedNavbarLinks
                             }
                         };
                         const pageCount = Object.keys(localePages).length;


### PR DESCRIPTION
## Summary

- Adds a `navbar-links:` field to translation overlay `docs.yml` (`translations/<locale>/docs.yml`).
- When present, the per-locale FDR upload uses those navbar-links instead of the docs-level ones, so different languages can show different CTAs.
- Local icon files referenced from overlay navbar-links are collected into the upload set and rewritten to `file:<fileId>` references after upload, mirroring the existing docs-level navbar-link icon handling.
- Invalid navbar-link entries in an overlay are skipped with a warning rather than discarding the whole list.

## How it works

1. `parseNavigationOverlayFromDocsYml` validates each overlay `navbar-links` entry against the existing `NavbarLink` schema and runs valid entries through `convertNavbarLinks`, storing them on the overlay (`packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts`).
2. `getImageFilepathsToUpload` walks per-locale overlay navbar-links and adds their icon paths to the upload set (`packages/cli/docs-resolver/src/utils/getImageFilepathsToUpload.ts`).
3. After upload, `DocsDefinitionResolver.resolveTranslationOverlayNavbarLinkIcons` rewrites overlay icons to `file:<fileId>` references using the same logic as the docs-level navbarLinks (`packages/cli/docs-resolver/src/DocsDefinitionResolver.ts`).
4. `publishDocs.ts` and `runPreviewServer.ts` swap `config.navbarLinks` for the locale-specific list when building the translated `DocsDefinition`.

## Test plan

- [x] `pnpm turbo run compile --filter @fern-api/configuration --filter @fern-api/configuration-loader --filter @fern-api/docs-resolver --filter @fern-api/docs-preview --filter @fern-api/remote-workspace-runner`
- [x] `pnpm turbo run test --filter @fern-api/configuration-loader` — 247 passed (3 new cases: parse navbar-links, leave undefined when not specified, drop invalid entries with warning).
- [x] `pnpm turbo run test --filter @fern-api/docs-resolver` — 44 passed (existing).
- [x] `pnpm turbo run test --filter @fern-api/docs-preview` — 57 passed (existing).
- [ ] End-to-end: publish a docs site with a `fr` translation overlay containing `navbar-links` and verify the FDR upload for the `fr` locale carries those CTAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)