### PR TITLE
chore(deps): bump @fern-api/replay to 0.14.1 in generator-cli

### DIFF
--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -39,7 +39,7 @@
     "@fern-api/cli-ai": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
-    "@fern-api/replay": "0.14.0",
+    "@fern-api/replay": "0.14.1",
     "@fern-api/task-context": "workspace:*",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,15 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Bump `@fern-api/replay` from 0.14.0 to 0.14.1. Picks up fix for
+        consolidating duplicate-content patches to prevent next-regen
+        corruption.
+      type: fix
+  createdAt: "2026-04-30"
+  version: 0.9.22
+
+- changelogEntry:
+    - summary: |
         Bump `@fern-api/replay` from 0.13.0 to 0.14.0. Picks up fixes for
         silent customization loss across apply and resolve paths (FER-9983),
         per-patch-region diff to prevent silent customization loss, and

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7881,8 +7881,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/logging-execa
       '@fern-api/replay':
-        specifier: 0.14.0
-        version: 0.14.0
+        specifier: 0.14.1
+        version: 0.14.1
       '@fern-api/task-context':
         specifier: workspace:*
         version: link:../cli/task-context
@@ -9408,6 +9408,11 @@ packages:
 
   '@fern-api/replay@0.14.0':
     resolution: {integrity: sha512-Sps+V/hb3T3XSR9Qsi2Zp19biHRdvOcyxBjV/CZnOGgeDYPz37TuG9OZdAKuW2DsXjcCAvDjsvU3TQDeHjzD5w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@fern-api/replay@0.14.1':
+    resolution: {integrity: sha512-OBuBJb7HWMkWjhKpd91NW5pfPtpzvAEvkkFPVtN70K9uLPoc8CQm0j/asaEaOjH/tm7cXDAEQZj4Ekn1Rj+XNw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16444,6 +16449,15 @@ snapshots:
       - supports-color
 
   '@fern-api/replay@0.14.0':
+    dependencies:
+      minimatch: 10.2.5
+      node-diff3: 3.2.0
+      simple-git: 3.35.2
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@fern-api/replay@0.14.1':
     dependencies:
       minimatch: 10.2.5
       node-diff3: 3.2.0


### PR DESCRIPTION
## Description

Bumps `@fern-api/replay` from 0.14.0 to 0.14.1 in `packages/generator-cli`. This triggers a new generator-cli release (0.9.22).

## Changes Made

- Updated `@fern-api/replay` dependency from `0.14.0` to `0.14.1` in `packages/generator-cli/package.json`
- Added `versions.yml` entry for generator-cli `0.9.22` with changelog

### Replay 0.14.1 changelog:
- fix(replay): consolidate duplicate-content patches to prevent next-regen corruption

## Testing

- [x] `pnpm install` passes
- [ ] CI validates

Link to Devin session: https://app.devin.ai/sessions/7e1f232131034d6ab0b94f05d4c0310a
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
