### PR TITLE
feat(cli): wire PostHog telemetry for replay

### DIFF
--- a/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
+++ b/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
@@ -140,8 +140,33 @@ export class TaskContextAdapter implements TaskContext {
         }
     }
 
-    public instrumentPostHogEvent(_event: PosthogEvent): void {
-        // no-op — v2 uses TelemetryClient.sendEvent directly
+    public instrumentPostHogEvent(event: PosthogEvent): void {
+        // Translate the legacy PosthogEvent shape ({command, orgId, properties})
+        // into v2's TelemetryClient.sendEvent. Filters properties to primitives
+        // since Tags requires string|number|boolean|null. Defensive try/catch —
+        // telemetry must never fail the calling operation.
+        try {
+            const eventName = event.command ?? "cli";
+            const tags: Record<string, string | number | boolean | null> = {};
+            if (event.orgId != null) {
+                tags.org = event.orgId;
+            }
+            for (const [key, value] of Object.entries(event.properties ?? {})) {
+                if (
+                    typeof value === "string" ||
+                    typeof value === "number" ||
+                    typeof value === "boolean" ||
+                    value === null
+                ) {
+                    tags[String(key)] = value;
+                }
+                // Non-primitives (objects, arrays) are silently dropped — Tags
+                // schema rejects nested values to control PostHog cardinality.
+            }
+            this.context.telemetry.sendEvent(eventName, tags);
+        } catch {
+            // no-op — telemetry must never fail the caller
+        }
     }
 
     private formatError(error: unknown): string | undefined {

--- a/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
+++ b/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
@@ -146,7 +146,13 @@ export class TaskContextAdapter implements TaskContext {
         // since Tags requires string|number|boolean|null. Defensive try/catch —
         // telemetry must never fail the calling operation.
         try {
-            const eventName = event.command ?? "cli";
+            // Refuse nameless events. Falling back to "cli" would collide with
+            // TelemetryClient.sendLifecycleEvent's `event: "cli"`, polluting the
+            // lifecycle event's property bag with arbitrary caller properties.
+            if (event.command == null || event.command.length === 0) {
+                return;
+            }
+            const eventName = event.command;
             const tags: Record<string, string | number | boolean | null> = {};
             if (event.orgId != null) {
                 tags.org = event.orgId;
@@ -160,8 +166,9 @@ export class TaskContextAdapter implements TaskContext {
                 ) {
                     tags[String(key)] = value;
                 }
-                // Non-primitives (objects, arrays) are silently dropped — Tags
-                // schema rejects nested values to control PostHog cardinality.
+                // Non-primitives (objects, arrays, Date, BigInt, Symbol, undefined)
+                // are silently dropped — Tags schema rejects nested values to
+                // control PostHog cardinality.
             }
             this.context.telemetry.sendEvent(eventName, tags);
         } catch {

--- a/packages/cli/cli/changes/unreleased/github-oauth-clone-fix.yml
+++ b/packages/cli/cli/changes/unreleased/github-oauth-clone-fix.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix self-hosted GitHub clone failing with "Invalid username or token" when
+    the user's `${GITHUB_TOKEN}` is an OAuth user token (gho_*) or personal
+    access token (ghp_*, github_pat_*). The clone URL hardcoded the
+    `x-access-token:` username, which is the format reserved for GitHub App
+    installation tokens (ghs_*). Now selects the format based on the token
+    prefix, so both auth modes work.
+  type: fix

--- a/packages/cli/cli/changes/unreleased/replay-telemetry.yml
+++ b/packages/cli/cli/changes/unreleased/replay-telemetry.yml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Capture PostHog telemetry for replay outcomes during `fern generate`. Emits a
+    single `replay` event with `action: pipeline_run` carrying patch counts, conflict
+    reason buckets, generator/repo context, and pipeline duration. Honors
+    FERN_DISABLE_TELEMETRY (v1) and FERN_TELEMETRY_DISABLED / ~/.fernrc (v2). Adds a
+    structured `[replay]` info log line and per-bucket conflict debug counts so the
+    same data is visible in stdout. No file paths, patch IDs, or commit messages
+    are emitted; the SDK repo URI is hashed (sha256, 16-char prefix). Wires the
+    previously-no-op v2 TaskContextAdapter.instrumentPostHogEvent so v2-driven
+    generates feed the same event stream as v1. Distinguishes genuine replay
+    crashes from `flow: first-generation` to keep success-rate dashboards honest.
+  type: internal

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/buildReplayTelemetryProps.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/buildReplayTelemetryProps.test.ts
@@ -174,9 +174,13 @@ describe("buildReplayTelemetryProps", () => {
         expect(props.conflicts_same_line_edit).toBe(0);
     });
 
-    it("reports a replay crash as success: false (FER-9956 invariant)", () => {
+    it("reports a replay crash as success: false via replayCrashed (FER-9956 invariant)", () => {
+        // step.success stays true so the orchestrator does NOT abort generation
+        // on replay errors. The crash is signaled via the new replayCrashed field
+        // on ReplayStepResult; the helper translates it to a falsy `success`.
         const replay = makeReplayResult({
-            success: false,
+            success: true,
+            replayCrashed: true,
             errorMessage: "git command failed: HEAD detached",
             flow: "normal-regeneration",
             patchesDetected: 0,
@@ -184,17 +188,59 @@ describe("buildReplayTelemetryProps", () => {
         });
         const props = buildReplayTelemetryProps({
             ...BASE_INPUT,
-            pipelineResult: makePipelineResult(replay, { success: false })
+            pipelineResult: makePipelineResult(replay, { success: true })
         });
 
         expect(props.success).toBe(false);
+        expect(props.replay_crashed).toBe(true);
         expect(props.flow).toBe("normal-regeneration");
-        expect(props.pipeline_success).toBe(false);
 
         // errorMessage MUST NOT propagate verbatim — may carry path / SHA fragments
         const serialized = JSON.stringify(props);
         expect(serialized).not.toContain("HEAD detached");
         expect(serialized).not.toContain("git command failed");
+    });
+
+    it("reports replay logic succeeded when step ran without crashing", () => {
+        const props = buildReplayTelemetryProps({
+            ...BASE_INPUT,
+            pipelineResult: makePipelineResult(makeReplayResult())
+        });
+        expect(props.success).toBe(true);
+        expect(props.replay_crashed).toBe(false);
+    });
+
+    it("buckets empty-string and null conflict reasons under 'other'", () => {
+        const replay = makeReplayResult({
+            patchesWithConflicts: 1,
+            unresolvedPatches: [
+                {
+                    patchId: "p",
+                    patchMessage: "p",
+                    files: ["a.ts", "b.ts"],
+                    conflictDetails: [
+                        { file: "a.ts", conflictReason: "" },
+                        { file: "b.ts", conflictReason: undefined }
+                    ]
+                }
+            ]
+        });
+        const props = buildReplayTelemetryProps({
+            ...BASE_INPUT,
+            pipelineResult: makePipelineResult(replay)
+        });
+        expect(props.conflicts_other).toBe(2);
+        expect(props.conflicts_same_line_edit).toBe(0);
+    });
+
+    it("preserves runId verbatim (UUIDs are bounded-shape, no truncation)", () => {
+        const fullUuid = "22d932de-baeb-41cd-b530-fe5a402a1234";
+        const props = buildReplayTelemetryProps({
+            ...BASE_INPUT,
+            runId: fullUuid,
+            pipelineResult: makePipelineResult(makeReplayResult())
+        });
+        expect(props.run_id).toBe(fullUuid);
     });
 
     it("treats first-generation as success without conflict noise", () => {

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/buildReplayTelemetryProps.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/buildReplayTelemetryProps.test.ts
@@ -1,0 +1,264 @@
+import type { PipelineResult, ReplayStepResult } from "@fern-api/generator-cli/pipeline";
+import { describe, expect, it } from "vitest";
+import { buildReplayTelemetryProps } from "../buildReplayTelemetryProps.js";
+
+const PII_FORBIDDEN_KEYS = [
+    "patch_id",
+    "patchId",
+    "patch_message",
+    "patchMessage",
+    "files",
+    "previous_generation_sha",
+    "previousGenerationSha",
+    "current_generation_sha",
+    "currentGenerationSha",
+    "base_branch_head",
+    "baseBranchHead",
+    "error_message",
+    "errorMessage",
+    "repo_uri",
+    "repoUri",
+    "commit_message"
+];
+
+const BASE_INPUT = {
+    generatorName: "fernapi/fern-typescript-node-sdk",
+    generatorVersion: "2.6.3",
+    cliVersion: "0.30.0",
+    repoUri: "acme/sdk-typescript",
+    runId: undefined,
+    automationMode: false,
+    autoMerge: false,
+    skipIfNoDiff: false,
+    hasBreakingChanges: false,
+    versionArg: "auto" as const,
+    versionBump: "MINOR",
+    replayConfigEnabled: true,
+    noReplayFlag: false,
+    githubMode: "pull-request" as const,
+    previewMode: false,
+    durationMs: 842
+};
+
+function makeReplayResult(overrides: Partial<ReplayStepResult> = {}): ReplayStepResult {
+    return {
+        executed: true,
+        success: true,
+        flow: "normal-regeneration",
+        patchesDetected: 4,
+        patchesApplied: 4,
+        patchesWithConflicts: 0,
+        patchesAbsorbed: 1,
+        patchesRepointed: 0,
+        patchesContentRebased: 0,
+        patchesKeptAsUserOwned: 3,
+        ...overrides
+    };
+}
+
+function makePipelineResult(
+    replay: ReplayStepResult | undefined,
+    overrides: Partial<PipelineResult> = {}
+): PipelineResult {
+    return {
+        success: true,
+        steps: { replay, ...(overrides.steps ?? {}) },
+        ...overrides
+    };
+}
+
+describe("buildReplayTelemetryProps", () => {
+    it("maps a clean replay-applied run end-to-end", () => {
+        const props = buildReplayTelemetryProps({
+            ...BASE_INPUT,
+            pipelineResult: makePipelineResult(makeReplayResult())
+        });
+
+        expect(props.action).toBe("pipeline_run");
+        expect(props.success).toBe(true);
+        expect(props.executed).toBe(true);
+        expect(props.flow).toBe("normal-regeneration");
+        expect(props.patches_detected).toBe(4);
+        expect(props.patches_applied).toBe(4);
+        expect(props.patches_with_conflicts).toBe(0);
+        expect(props.patches_absorbed).toBe(1);
+        expect(props.patches_kept_as_user_owned).toBe(3);
+        expect(props.unresolved_patches_count).toBe(0);
+        expect(props.unresolved_conflict_files_count).toBe(0);
+        expect(props.duration_ms).toBe(842);
+        expect(props.generator_name).toBe("fernapi/fern-typescript-node-sdk");
+        expect(props.cli_version).toBe("0.30.0");
+        expect(props.replay_config_enabled).toBe(true);
+        expect(props.github_mode).toBe("pull-request");
+    });
+
+    it("returns hashed repo URI (16-char hex), never the raw URI", () => {
+        const props = buildReplayTelemetryProps({
+            ...BASE_INPUT,
+            pipelineResult: makePipelineResult(makeReplayResult())
+        });
+
+        expect(props.repo_uri_hash).toMatch(/^[0-9a-f]{16}$/);
+        expect(JSON.stringify(props)).not.toContain("acme/sdk-typescript");
+
+        // Determinism — same URI always produces same hash
+        const second = buildReplayTelemetryProps({
+            ...BASE_INPUT,
+            pipelineResult: makePipelineResult(makeReplayResult())
+        });
+        expect(second.repo_uri_hash).toBe(props.repo_uri_hash);
+    });
+
+    it("counts unresolved-conflict files and bucketizes by reason without leaking file paths", () => {
+        const replay = makeReplayResult({
+            patchesWithConflicts: 2,
+            unresolvedPatches: [
+                {
+                    patchId: "patch-abc12345",
+                    patchMessage: "tweak retry policy",
+                    files: ["src/core/retry.ts", "src/core/retry.test.ts"],
+                    conflictDetails: [
+                        { file: "src/core/retry.ts", conflictReason: "same-line-edit" },
+                        { file: "src/core/retry.test.ts", conflictReason: "same-line-edit" }
+                    ]
+                },
+                {
+                    patchId: "patch-def67890",
+                    patchMessage: "preserve custom logger",
+                    files: ["src/logger.ts"],
+                    conflictDetails: [{ file: "src/logger.ts", conflictReason: "base-generation-mismatch" }]
+                }
+            ]
+        });
+        const props = buildReplayTelemetryProps({
+            ...BASE_INPUT,
+            pipelineResult: makePipelineResult(replay)
+        });
+
+        expect(props.unresolved_patches_count).toBe(2);
+        expect(props.unresolved_conflict_files_count).toBe(3);
+        expect(props.conflicts_same_line_edit).toBe(2);
+        expect(props.conflicts_base_generation_mismatch).toBe(1);
+        expect(props.conflicts_new_file_both).toBe(0);
+        expect(props.conflicts_patch_apply_failed).toBe(0);
+        expect(props.conflicts_other).toBe(0);
+
+        // Critical: no file paths, patch IDs, or commit messages leak into properties
+        const serialized = JSON.stringify(props);
+        expect(serialized).not.toContain("src/core/retry.ts");
+        expect(serialized).not.toContain("src/logger.ts");
+        expect(serialized).not.toContain("patch-abc");
+        expect(serialized).not.toContain("preserve custom logger");
+    });
+
+    it("buckets unknown conflict reasons under 'other'", () => {
+        const replay = makeReplayResult({
+            patchesWithConflicts: 1,
+            unresolvedPatches: [
+                {
+                    patchId: "patch-x",
+                    patchMessage: "x",
+                    files: ["a.ts"],
+                    conflictDetails: [
+                        { file: "a.ts", conflictReason: "future-reason-not-yet-defined" },
+                        { file: "b.ts" } // no reason at all
+                    ]
+                }
+            ]
+        });
+        const props = buildReplayTelemetryProps({
+            ...BASE_INPUT,
+            pipelineResult: makePipelineResult(replay)
+        });
+        expect(props.conflicts_other).toBe(2);
+        expect(props.conflicts_same_line_edit).toBe(0);
+    });
+
+    it("reports a replay crash as success: false (FER-9956 invariant)", () => {
+        const replay = makeReplayResult({
+            success: false,
+            errorMessage: "git command failed: HEAD detached",
+            flow: "normal-regeneration",
+            patchesDetected: 0,
+            patchesApplied: 0
+        });
+        const props = buildReplayTelemetryProps({
+            ...BASE_INPUT,
+            pipelineResult: makePipelineResult(replay, { success: false })
+        });
+
+        expect(props.success).toBe(false);
+        expect(props.flow).toBe("normal-regeneration");
+        expect(props.pipeline_success).toBe(false);
+
+        // errorMessage MUST NOT propagate verbatim — may carry path / SHA fragments
+        const serialized = JSON.stringify(props);
+        expect(serialized).not.toContain("HEAD detached");
+        expect(serialized).not.toContain("git command failed");
+    });
+
+    it("treats first-generation as success without conflict noise", () => {
+        const replay = makeReplayResult({
+            flow: "first-generation",
+            patchesDetected: 0,
+            patchesApplied: 0,
+            patchesAbsorbed: 0,
+            patchesKeptAsUserOwned: 0
+        });
+        const props = buildReplayTelemetryProps({
+            ...BASE_INPUT,
+            pipelineResult: makePipelineResult(replay)
+        });
+        expect(props.flow).toBe("first-generation");
+        expect(props.success).toBe(true);
+        expect(props.patches_detected).toBe(0);
+        expect(props.unresolved_patches_count).toBe(0);
+    });
+
+    it("emits zero-valued properties when ReplayStepResult is missing", () => {
+        const props = buildReplayTelemetryProps({
+            ...BASE_INPUT,
+            pipelineResult: makePipelineResult(undefined)
+        });
+        expect(props.executed).toBe(false);
+        expect(props.success).toBe(false);
+        expect(props.patches_detected).toBe(0);
+        expect(props.flow).toBe(null);
+    });
+
+    it("never includes any PII keys regardless of input", () => {
+        const replay = makeReplayResult({
+            patchesWithConflicts: 1,
+            unresolvedPatches: [
+                {
+                    patchId: "patch-secretid",
+                    patchMessage: "should-not-appear",
+                    files: ["sensitive/path/file.ts"],
+                    conflictDetails: [{ file: "sensitive/path/file.ts", conflictReason: "same-line-edit" }]
+                }
+            ]
+        });
+        const props = buildReplayTelemetryProps({
+            ...BASE_INPUT,
+            pipelineResult: makePipelineResult(replay)
+        });
+
+        for (const forbidden of PII_FORBIDDEN_KEYS) {
+            expect(props).not.toHaveProperty(forbidden);
+        }
+    });
+
+    it("respects all properties as primitives (Tags-compatible)", () => {
+        const props = buildReplayTelemetryProps({
+            ...BASE_INPUT,
+            pipelineResult: makePipelineResult(makeReplayResult())
+        });
+        for (const [key, value] of Object.entries(props)) {
+            const ok =
+                typeof value === "string" || typeof value === "number" || typeof value === "boolean" || value === null;
+            if (!ok) {
+                throw new Error(`Property "${key}" is not a primitive: ${typeof value}`);
+            }
+        }
+    });
+});

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/buildReplayTelemetryProps.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/buildReplayTelemetryProps.test.ts
@@ -26,7 +26,6 @@ const BASE_INPUT = {
     generatorVersion: "2.6.3",
     cliVersion: "0.30.0",
     repoUri: "acme/sdk-typescript",
-    runId: undefined,
     automationMode: false,
     autoMerge: false,
     skipIfNoDiff: false,
@@ -231,16 +230,6 @@ describe("buildReplayTelemetryProps", () => {
         });
         expect(props.conflicts_other).toBe(2);
         expect(props.conflicts_same_line_edit).toBe(0);
-    });
-
-    it("preserves runId verbatim (UUIDs are bounded-shape, no truncation)", () => {
-        const fullUuid = "22d932de-baeb-41cd-b530-fe5a402a1234";
-        const props = buildReplayTelemetryProps({
-            ...BASE_INPUT,
-            runId: fullUuid,
-            pipelineResult: makePipelineResult(makeReplayResult())
-        });
-        expect(props.run_id).toBe(fullUuid);
     });
 
     it("treats first-generation as success without conflict noise", () => {

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/buildReplayTelemetryProps.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/buildReplayTelemetryProps.ts
@@ -98,11 +98,18 @@ export function buildReplayTelemetryProps(input: {
         }
     }
 
+    // For telemetry, "success" means the replay logic itself succeeded — NOT the
+    // step.success field (which is true even on replay crashes, by design, so the
+    // pipeline doesn't abort generation). Replay crashes are surfaced via
+    // `replayCrashed` on the step result; map that to a falsy `success` here.
+    const replayLogicSucceeded = replay != null && replay.executed && replay.replayCrashed !== true;
+
     return {
         action: "pipeline_run",
-        success: replay?.success ?? false,
+        success: replayLogicSucceeded,
         executed: replay?.executed ?? false,
         flow: replay?.flow ?? null,
+        replay_crashed: replay?.replayCrashed === true,
         pipeline_success: pipelineResult.success,
         pipeline_warnings_count: pipelineResult.warnings?.length ?? 0,
         replay_warnings_count: replay?.warnings?.length ?? 0,
@@ -110,7 +117,7 @@ export function buildReplayTelemetryProps(input: {
         generator_version: generatorVersion,
         cli_version: cliVersion ?? null,
         repo_uri_hash: hashRepoUri(repoUri),
-        run_id: runId != null ? runId.slice(0, 32) : null,
+        run_id: runId ?? null,
         automation_mode: automationMode,
         auto_merge_requested: autoMerge,
         auto_merge_enabled: github?.autoMergeEnabled === true,

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/buildReplayTelemetryProps.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/buildReplayTelemetryProps.ts
@@ -39,7 +39,6 @@ export function buildReplayTelemetryProps(input: {
     generatorVersion: string;
     cliVersion?: string;
     repoUri: string;
-    runId?: string;
     automationMode: boolean;
     autoMerge: boolean;
     skipIfNoDiff: boolean;
@@ -58,7 +57,6 @@ export function buildReplayTelemetryProps(input: {
         generatorVersion,
         cliVersion,
         repoUri,
-        runId,
         automationMode,
         autoMerge,
         skipIfNoDiff,
@@ -117,7 +115,6 @@ export function buildReplayTelemetryProps(input: {
         generator_version: generatorVersion,
         cli_version: cliVersion ?? null,
         repo_uri_hash: hashRepoUri(repoUri),
-        run_id: runId ?? null,
         automation_mode: automationMode,
         auto_merge_requested: autoMerge,
         auto_merge_enabled: github?.autoMergeEnabled === true,

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/buildReplayTelemetryProps.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/buildReplayTelemetryProps.ts
@@ -1,0 +1,148 @@
+import type { PipelineResult, ReplayStepResult } from "@fern-api/generator-cli/pipeline";
+import { createHash } from "crypto";
+
+/**
+ * Tags type matches @fern-api/cli-v2's Tags shape: PostHog rejects nested
+ * values, so all properties must be primitives.
+ */
+type TelemetryProps = Record<string, string | number | boolean | null>;
+
+const KNOWN_CONFLICT_REASONS = [
+    "same-line-edit",
+    "new-file-both",
+    "base-generation-mismatch",
+    "patch-apply-failed"
+] as const;
+
+type KnownConflictReason = (typeof KNOWN_CONFLICT_REASONS)[number];
+
+function isKnownConflictReason(reason: string | undefined): reason is KnownConflictReason {
+    return reason != null && (KNOWN_CONFLICT_REASONS as readonly string[]).includes(reason);
+}
+
+/**
+ * Derives PostHog properties for the `replay` event (action: pipeline_run) from a
+ * `PipelineResult` and surrounding generation context.
+ *
+ * Pure / synchronous — no I/O, no PostHog client, no logger. Called from
+ * `runLocalGenerationForWorkspace` after `pipeline.run()` returns and the result
+ * is mapped into a flat tag bag.
+ *
+ * PII handling: file paths, patch IDs, commit messages, and SHAs are NEVER
+ * emitted. Repo URI is hashed (sha256, 16-char prefix) so per-repo dashboards
+ * work without storing the raw URI. Conflict file paths are aggregated into
+ * categorical bucket counts only.
+ */
+export function buildReplayTelemetryProps(input: {
+    pipelineResult: PipelineResult;
+    generatorName: string;
+    generatorVersion: string;
+    cliVersion?: string;
+    repoUri: string;
+    runId?: string;
+    automationMode: boolean;
+    autoMerge: boolean;
+    skipIfNoDiff: boolean;
+    hasBreakingChanges: boolean;
+    versionArg: "auto" | "explicit" | "none";
+    versionBump: string | undefined;
+    replayConfigEnabled: boolean;
+    noReplayFlag: boolean;
+    githubMode: "pull-request" | "push";
+    previewMode: boolean;
+    durationMs: number;
+}): TelemetryProps {
+    const {
+        pipelineResult,
+        generatorName,
+        generatorVersion,
+        cliVersion,
+        repoUri,
+        runId,
+        automationMode,
+        autoMerge,
+        skipIfNoDiff,
+        hasBreakingChanges,
+        versionArg,
+        versionBump,
+        replayConfigEnabled,
+        noReplayFlag,
+        githubMode,
+        previewMode,
+        durationMs
+    } = input;
+
+    const replay: ReplayStepResult | undefined = pipelineResult.steps.replay;
+    const github = pipelineResult.steps.github;
+
+    const unresolvedPatches = replay?.unresolvedPatches ?? [];
+    const unresolvedConflictFilesCount = unresolvedPatches.reduce(
+        (sum, patch) => sum + patch.conflictDetails.length,
+        0
+    );
+
+    const conflictBuckets: Record<KnownConflictReason | "other", number> = {
+        "same-line-edit": 0,
+        "new-file-both": 0,
+        "base-generation-mismatch": 0,
+        "patch-apply-failed": 0,
+        other: 0
+    };
+    for (const patch of unresolvedPatches) {
+        for (const detail of patch.conflictDetails) {
+            if (isKnownConflictReason(detail.conflictReason)) {
+                conflictBuckets[detail.conflictReason] += 1;
+            } else {
+                conflictBuckets.other += 1;
+            }
+        }
+    }
+
+    return {
+        action: "pipeline_run",
+        success: replay?.success ?? false,
+        executed: replay?.executed ?? false,
+        flow: replay?.flow ?? null,
+        pipeline_success: pipelineResult.success,
+        pipeline_warnings_count: pipelineResult.warnings?.length ?? 0,
+        replay_warnings_count: replay?.warnings?.length ?? 0,
+        generator_name: generatorName,
+        generator_version: generatorVersion,
+        cli_version: cliVersion ?? null,
+        repo_uri_hash: hashRepoUri(repoUri),
+        run_id: runId != null ? runId.slice(0, 32) : null,
+        automation_mode: automationMode,
+        auto_merge_requested: autoMerge,
+        auto_merge_enabled: github?.autoMergeEnabled === true,
+        skip_if_no_diff: skipIfNoDiff,
+        no_diff_skipped: github?.skippedNoDiff === true,
+        version_arg: versionArg,
+        version_bump: versionBump ?? null,
+        has_breaking_changes: hasBreakingChanges,
+        replay_config_enabled: replayConfigEnabled,
+        no_replay_flag: noReplayFlag,
+        github_mode: githubMode,
+        preview_mode: previewMode,
+        pr_created: github?.prNumber != null,
+        pr_updated_existing: github?.updatedExistingPr === true,
+        duration_ms: durationMs,
+        patches_detected: replay?.patchesDetected ?? 0,
+        patches_applied: replay?.patchesApplied ?? 0,
+        patches_with_conflicts: replay?.patchesWithConflicts ?? 0,
+        patches_absorbed: replay?.patchesAbsorbed ?? 0,
+        patches_repointed: replay?.patchesRepointed ?? 0,
+        patches_content_rebased: replay?.patchesContentRebased ?? 0,
+        patches_kept_as_user_owned: replay?.patchesKeptAsUserOwned ?? 0,
+        unresolved_patches_count: unresolvedPatches.length,
+        unresolved_conflict_files_count: unresolvedConflictFilesCount,
+        conflicts_same_line_edit: conflictBuckets["same-line-edit"],
+        conflicts_new_file_both: conflictBuckets["new-file-both"],
+        conflicts_base_generation_mismatch: conflictBuckets["base-generation-mismatch"],
+        conflicts_patch_apply_failed: conflictBuckets["patch-apply-failed"],
+        conflicts_other: conflictBuckets.other
+    };
+}
+
+function hashRepoUri(uri: string): string {
+    return createHash("sha256").update(uri).digest("hex").slice(0, 16);
+}

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -467,7 +467,6 @@ export async function runLocalGenerationForWorkspace({
                                     generatorVersion: generatorInvocation.version,
                                     cliVersion: workspace.cliVersion,
                                     repoUri: selfhostedGithubConfig.uri,
-                                    runId: process.env.FERN_RUN_ID,
                                     automationMode: automationMode === true,
                                     autoMerge: autoMerge === true,
                                     skipIfNoDiff: skipIfNoDiff === true,

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -443,7 +443,13 @@ export async function runLocalGenerationForWorkspace({
                     if (pipelineResult.steps.replay != null) {
                         logReplaySummary(pipelineResult.steps.replay, {
                             debug: (msg) => interactiveTaskContext.logger.debug(msg),
-                            info: (msg) => interactiveTaskContext.logger.info(chalk.cyan(msg)),
+                            info: (msg) => {
+                                // Don't ANSI-color structured machine-parseable lines
+                                // ("[replay] ..." emitted by replay-summary). Customer-friendly
+                                // status messages stay cyan for terminal readability.
+                                const isStructured = msg.startsWith("[replay] ") || msg.startsWith("[telemetry] ");
+                                interactiveTaskContext.logger.info(isStructured ? msg : chalk.cyan(msg));
+                            },
                             warn: (msg) => interactiveTaskContext.logger.warn(chalk.yellow(msg)),
                             error: (msg) => interactiveTaskContext.logger.error(chalk.red(msg))
                         });

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -32,6 +32,7 @@ import * as fs from "fs/promises";
 import os from "os";
 import path from "path";
 import tmp from "tmp-promise";
+import { buildReplayTelemetryProps } from "./buildReplayTelemetryProps.js";
 import { getGeneratorOutputSubfolder } from "./getGeneratorOutputSubfolder.js";
 import { writeFilesToDiskAndRunGenerator } from "./runGenerator.js";
 
@@ -434,7 +435,9 @@ export async function runLocalGenerationForWorkspace({
                         pipelineLogger
                     );
 
+                    const pipelineStart = Date.now();
                     const pipelineResult = await pipeline.run();
+                    const pipelineDurationMs = Date.now() - pipelineStart;
 
                     // Log replay summary
                     if (pipelineResult.steps.replay != null) {
@@ -444,6 +447,46 @@ export async function runLocalGenerationForWorkspace({
                             warn: (msg) => interactiveTaskContext.logger.warn(chalk.yellow(msg)),
                             error: (msg) => interactiveTaskContext.logger.error(chalk.red(msg))
                         });
+
+                        // Telemetry: emit a single `replay` event with `action: pipeline_run`.
+                        // Wrapped in try/catch — a telemetry exception must never fail generation.
+                        // The `disableTelemetry` gate honors FERN_DISABLE_TELEMETRY (v1) and v2's
+                        // FERN_TELEMETRY_DISABLED / ~/.fernrc (which short-circuit inside the
+                        // TelemetryClient regardless).
+                        if (!disableTelemetry) {
+                            try {
+                                const replayTelemetryProps = buildReplayTelemetryProps({
+                                    pipelineResult,
+                                    generatorName: generatorInvocation.name,
+                                    generatorVersion: generatorInvocation.version,
+                                    cliVersion: workspace.cliVersion,
+                                    repoUri: selfhostedGithubConfig.uri,
+                                    runId: process.env.FERN_RUN_ID,
+                                    automationMode: automationMode === true,
+                                    autoMerge: autoMerge === true,
+                                    skipIfNoDiff: skipIfNoDiff === true,
+                                    hasBreakingChanges,
+                                    versionArg: version == null ? "none" : isAutoVersion(version) ? "auto" : "explicit",
+                                    versionBump: autoVersioningVersionBump,
+                                    replayConfigEnabled: replay?.enabled === true,
+                                    noReplayFlag: noReplay === true,
+                                    githubMode: selfhostedGithubConfig.mode ?? "push",
+                                    previewMode: selfhostedGithubConfig.previewMode === true,
+                                    durationMs: pipelineDurationMs
+                                });
+                                interactiveTaskContext.instrumentPostHogEvent({
+                                    command: "replay",
+                                    properties: replayTelemetryProps
+                                });
+                                interactiveTaskContext.logger.debug(
+                                    `[telemetry] replay event sent: ${JSON.stringify(replayTelemetryProps)}`
+                                );
+                            } catch (error) {
+                                interactiveTaskContext.logger.debug(
+                                    `[telemetry] failed to send replay event: ${String(error)}`
+                                );
+                            }
+                        }
                     }
 
                     if (pipelineResult.steps.github?.skippedNoDiff) {

--- a/packages/commons/github/src/__test__/parseRepository.test.ts
+++ b/packages/commons/github/src/__test__/parseRepository.test.ts
@@ -15,8 +15,28 @@ describe("parseRepository", () => {
             expect(reference.repo).toBe("fern");
             expect(reference.repoUrl).toBe("https://github.com/fern-api/fern");
             expect(reference.cloneUrl).toBe("https://github.com/fern-api/fern.git");
-            expect(reference.getAuthedCloneUrl("xyz")).toBe("https://x-access-token:xyz@github.com/fern-api/fern.git");
+            expect(reference.getAuthedCloneUrl("ghs_xyz")).toBe(
+                "https://x-access-token:ghs_xyz@github.com/fern-api/fern.git"
+            );
         }
+    });
+
+    it("getAuthedCloneUrl format depends on token type", () => {
+        const ref = parseRepository("fern-api/fern");
+        // GitHub App installation tokens authenticate as the special `x-access-token` user.
+        expect(ref.getAuthedCloneUrl("ghs_install_token_value")).toBe(
+            "https://x-access-token:ghs_install_token_value@github.com/fern-api/fern.git"
+        );
+        // OAuth user tokens (gho_*) authenticate as the token itself — using
+        // `x-access-token:` as the username returns "Invalid username or token".
+        expect(ref.getAuthedCloneUrl("gho_oauth_token_value")).toBe(
+            "https://gho_oauth_token_value@github.com/fern-api/fern.git"
+        );
+        // Personal access tokens (ghp_*, github_pat_*) follow the same OAuth-style format.
+        expect(ref.getAuthedCloneUrl("ghp_pat_value")).toBe("https://ghp_pat_value@github.com/fern-api/fern.git");
+        expect(ref.getAuthedCloneUrl("github_pat_finegrained_value")).toBe(
+            "https://github_pat_finegrained_value@github.com/fern-api/fern.git"
+        );
     });
     it("invalid structure", async () => {
         expect(() => {
@@ -46,8 +66,8 @@ describe("parseRepository", () => {
         expect(reference.repo).toBe("api-client-sdk");
         expect(reference.repoUrl).toBe("https://github.acme.com/engineering/api-client-sdk");
         expect(reference.cloneUrl).toBe("https://github.acme.com/engineering/api-client-sdk.git");
-        expect(reference.getAuthedCloneUrl("xyz")).toBe(
-            "https://x-access-token:xyz@github.acme.com/engineering/api-client-sdk.git"
+        expect(reference.getAuthedCloneUrl("ghs_xyz")).toBe(
+            "https://x-access-token:ghs_xyz@github.acme.com/engineering/api-client-sdk.git"
         );
     });
 });

--- a/packages/commons/github/src/__test__/parseRepository.test.ts
+++ b/packages/commons/github/src/__test__/parseRepository.test.ts
@@ -27,6 +27,10 @@ describe("parseRepository", () => {
         expect(ref.getAuthedCloneUrl("ghs_install_token_value")).toBe(
             "https://x-access-token:ghs_install_token_value@github.com/fern-api/fern.git"
         );
+        // User-to-server tokens issued by GitHub Apps also authenticate as `x-access-token`.
+        expect(ref.getAuthedCloneUrl("ghu_user_to_server_value")).toBe(
+            "https://x-access-token:ghu_user_to_server_value@github.com/fern-api/fern.git"
+        );
         // OAuth user tokens (gho_*) authenticate as the token itself — using
         // `x-access-token:` as the username returns "Invalid username or token".
         expect(ref.getAuthedCloneUrl("gho_oauth_token_value")).toBe(
@@ -36,6 +40,10 @@ describe("parseRepository", () => {
         expect(ref.getAuthedCloneUrl("ghp_pat_value")).toBe("https://ghp_pat_value@github.com/fern-api/fern.git");
         expect(ref.getAuthedCloneUrl("github_pat_finegrained_value")).toBe(
             "https://github_pat_finegrained_value@github.com/fern-api/fern.git"
+        );
+        // Legacy 40-char hex PATs (pre-2021) follow the OAuth style — no prefix.
+        expect(ref.getAuthedCloneUrl("0123456789abcdef0123456789abcdef01234567")).toBe(
+            "https://0123456789abcdef0123456789abcdef01234567@github.com/fern-api/fern.git"
         );
     });
     it("invalid structure", async () => {

--- a/packages/commons/github/src/parseRepository.ts
+++ b/packages/commons/github/src/parseRepository.ts
@@ -51,7 +51,13 @@ function newRepositoryReference({
         repoUrl,
         cloneUrl,
         getAuthedCloneUrl: (installationToken: string) => {
-            return cloneUrl.replace("https://", `https://x-access-token:${installationToken}@`);
+            // GitHub App installation tokens (ghs_*) authenticate as the special
+            // `x-access-token` user. OAuth user tokens (gho_*) and personal access
+            // tokens (ghp_*, github_pat_*) authenticate as the token itself —
+            // using `x-access-token` for those returns "Invalid username or token".
+            const isInstallationToken = installationToken.startsWith("ghs_");
+            const userPrefix = isInstallationToken ? "x-access-token:" : "";
+            return cloneUrl.replace("https://", `https://${userPrefix}${installationToken}@`);
         }
     };
 }

--- a/packages/commons/github/src/parseRepository.ts
+++ b/packages/commons/github/src/parseRepository.ts
@@ -51,11 +51,13 @@ function newRepositoryReference({
         repoUrl,
         cloneUrl,
         getAuthedCloneUrl: (installationToken: string) => {
-            // GitHub App installation tokens (ghs_*) authenticate as the special
-            // `x-access-token` user. OAuth user tokens (gho_*) and personal access
-            // tokens (ghp_*, github_pat_*) authenticate as the token itself —
+            // GitHub App installation tokens (`ghs_*`) and user-to-server tokens
+            // issued by GitHub Apps (`ghu_*`) authenticate as the special
+            // `x-access-token` user. OAuth user tokens (`gho_*`), classic PATs
+            // (`ghp_*`), fine-grained PATs (`github_pat_*`), and legacy 40-char
+            // hex PATs (pre-2021, no prefix) authenticate as the token itself —
             // using `x-access-token` for those returns "Invalid username or token".
-            const isInstallationToken = installationToken.startsWith("ghs_");
+            const isInstallationToken = installationToken.startsWith("ghs_") || installationToken.startsWith("ghu_");
             const userPrefix = isInstallationToken ? "x-access-token:" : "";
             return cloneUrl.replace("https://", `https://${userPrefix}${installationToken}@`);
         }

--- a/packages/generator-cli/src/__test__/replay-pure.test.ts
+++ b/packages/generator-cli/src/__test__/replay-pure.test.ts
@@ -100,14 +100,16 @@ describe("logReplaySummary", () => {
         expect(logger.error).not.toHaveBeenCalled();
     });
 
-    it("logs debug line for first-generation flow", () => {
+    it("logs structured [replay] info line for first-generation flow", () => {
         const logger = makeLogger();
         logReplaySummary(
             { executed: true, success: true, flow: "first-generation", patchesDetected: 0, patchesApplied: 0 },
             logger
         );
-        expect(logger.debug).toHaveBeenCalledTimes(1);
-        expect(logger.debug.mock.calls[0]?.[0]).toContain("flow=first-generation");
+        // The first INFO is the operator-friendly structured line (`[replay] flow=...`).
+        expect(logger.info).toHaveBeenCalledTimes(1);
+        expect(logger.info.mock.calls[0]?.[0]).toContain("[replay] flow=first-generation");
+        expect(logger.debug).not.toHaveBeenCalled();
     });
 
     it("logs info when preserved patches > 0", () => {
@@ -122,8 +124,10 @@ describe("logReplaySummary", () => {
             },
             logger
         );
-        expect(logger.info).toHaveBeenCalledTimes(1);
-        expect(logger.info.mock.calls[0]?.[0]).toContain("customizations preserved");
+        // Two INFO calls: the structured `[replay]` line + the customer-friendly summary.
+        expect(logger.info).toHaveBeenCalledTimes(2);
+        expect(logger.info.mock.calls[0]?.[0]).toContain("[replay] flow=normal-regeneration");
+        expect(logger.info.mock.calls[1]?.[0]).toContain("customizations preserved");
     });
 
     it("logs info when only absorbed patches (all applied became part of generated code)", () => {
@@ -139,8 +143,10 @@ describe("logReplaySummary", () => {
             logger
         );
         // preserved = applied - absorbed = 0, absorbed > 0 => "now part of generated code"
-        expect(logger.info).toHaveBeenCalledTimes(1);
-        expect(logger.info.mock.calls[0]?.[0]).toContain("now part of generated code");
+        // Two INFO calls: the structured `[replay]` line + the customer-friendly summary.
+        expect(logger.info).toHaveBeenCalledTimes(2);
+        expect(logger.info.mock.calls[0]?.[0]).toContain("[replay] flow=normal-regeneration");
+        expect(logger.info.mock.calls[1]?.[0]).toContain("now part of generated code");
     });
 
     it("logs warn for unresolved patches with file details", () => {

--- a/packages/generator-cli/src/pipeline/replay-summary.ts
+++ b/packages/generator-cli/src/pipeline/replay-summary.ts
@@ -44,6 +44,9 @@ export function logReplaySummary(result: ReplayStepResult, logger: PipelineLogge
 
     // Operator-friendly structured INFO line. Grep-keyed on "[replay]" so customers
     // and on-call can pull metrics out of pipeline logs without a parser.
+    // `success=` reflects whether the replay logic itself succeeded (NOT step.success,
+    // which stays true on replay crashes so the orchestrator doesn't abort generation).
+    const replayLogicSucceeded = result.replayCrashed !== true;
     logger.info(
         `[replay] flow=${result.flow ?? "unknown"} detected=${result.patchesDetected ?? 0} ` +
             `applied=${applied} conflicts=${result.patchesWithConflicts ?? 0} ` +
@@ -51,7 +54,7 @@ export function logReplaySummary(result: ReplayStepResult, logger: PipelineLogge
             `content_rebased=${result.patchesContentRebased ?? 0} ` +
             `kept_as_user_owned=${result.patchesKeptAsUserOwned ?? 0} ` +
             `unresolved=${unresolvedCount} unresolved_files=${unresolvedFiles} ` +
-            `warnings=${result.warnings?.length ?? 0} success=${result.success}`
+            `warnings=${result.warnings?.length ?? 0} success=${replayLogicSucceeded}`
     );
 
     if (preserved > 0) {
@@ -103,8 +106,9 @@ export function logReplaySummary(result: ReplayStepResult, logger: PipelineLogge
         }
     }
 
-    if (result.success === false && result.errorMessage != null) {
-        // Replay crashed — surface the reason so debug logs explain what `success=false` means.
+    if (result.replayCrashed === true && result.errorMessage != null) {
+        // Replay crashed — surface the reason so debug logs explain what
+        // `success=false` in the structured line means.
         logger.warn(`Replay: ${result.errorMessage}`);
     }
 

--- a/packages/generator-cli/src/pipeline/replay-summary.ts
+++ b/packages/generator-cli/src/pipeline/replay-summary.ts
@@ -36,10 +36,22 @@ export function logReplaySummary(result: ReplayStepResult, logger: PipelineLogge
     const applied = result.patchesApplied ?? 0;
     const absorbed = result.patchesAbsorbed ?? 0;
     const unresolvedCount = result.unresolvedPatches?.length ?? 0;
+    const unresolvedFiles = (result.unresolvedPatches ?? []).reduce(
+        (sum, patch) => sum + patch.conflictDetails.length,
+        0
+    );
     const preserved = applied - absorbed;
 
-    logger.debug(
-        `Replay: flow=${result.flow}, detected=${result.patchesDetected ?? 0}, applied=${applied}, absorbed=${absorbed}, unresolved=${unresolvedCount}`
+    // Operator-friendly structured INFO line. Grep-keyed on "[replay]" so customers
+    // and on-call can pull metrics out of pipeline logs without a parser.
+    logger.info(
+        `[replay] flow=${result.flow ?? "unknown"} detected=${result.patchesDetected ?? 0} ` +
+            `applied=${applied} conflicts=${result.patchesWithConflicts ?? 0} ` +
+            `absorbed=${absorbed} repointed=${result.patchesRepointed ?? 0} ` +
+            `content_rebased=${result.patchesContentRebased ?? 0} ` +
+            `kept_as_user_owned=${result.patchesKeptAsUserOwned ?? 0} ` +
+            `unresolved=${unresolvedCount} unresolved_files=${unresolvedFiles} ` +
+            `warnings=${result.warnings?.length ?? 0} success=${result.success}`
     );
 
     if (preserved > 0) {
@@ -50,12 +62,38 @@ export function logReplaySummary(result: ReplayStepResult, logger: PipelineLogge
     }
 
     if (unresolvedCount > 0) {
-        const totalFiles = (result.unresolvedPatches ?? []).reduce(
-            (sum, patch) => sum + patch.conflictDetails.length,
-            0
+        // Per-conflict-reason bucket counts at DEBUG. Surfaced before the per-file
+        // WARN block so debug runs see the categorical breakdown first.
+        const buckets = { sameLineEdit: 0, newFileBoth: 0, baseGenerationMismatch: 0, patchApplyFailed: 0, other: 0 };
+        for (const patch of result.unresolvedPatches ?? []) {
+            for (const file of patch.conflictDetails) {
+                switch (file.conflictReason) {
+                    case "same-line-edit":
+                        buckets.sameLineEdit += 1;
+                        break;
+                    case "new-file-both":
+                        buckets.newFileBoth += 1;
+                        break;
+                    case "base-generation-mismatch":
+                        buckets.baseGenerationMismatch += 1;
+                        break;
+                    case "patch-apply-failed":
+                        buckets.patchApplyFailed += 1;
+                        break;
+                    default:
+                        buckets.other += 1;
+                }
+            }
+        }
+        logger.debug(
+            `[replay] conflict_buckets same_line_edit=${buckets.sameLineEdit} ` +
+                `new_file_both=${buckets.newFileBoth} ` +
+                `base_generation_mismatch=${buckets.baseGenerationMismatch} ` +
+                `patch_apply_failed=${buckets.patchApplyFailed} other=${buckets.other}`
         );
+
         logger.warn(
-            `Replay: ${plural(totalFiles, "file")} ${totalFiles === 1 ? "has" : "have"} unresolved conflicts — resolve via \`fern replay resolve\``
+            `Replay: ${plural(unresolvedFiles, "file")} ${unresolvedFiles === 1 ? "has" : "have"} unresolved conflicts — resolve via \`fern replay resolve\``
         );
         for (const patch of result.unresolvedPatches ?? []) {
             logger.warn(`  "${patchDescription(patch)}":`);
@@ -63,6 +101,11 @@ export function logReplaySummary(result: ReplayStepResult, logger: PipelineLogge
                 logger.warn(`    ${file.file} — ${formatConflictReason(file.conflictReason)}`);
             }
         }
+    }
+
+    if (result.success === false && result.errorMessage != null) {
+        // Replay crashed — surface the reason so debug logs explain what `success=false` means.
+        logger.warn(`Replay: ${result.errorMessage}`);
     }
 
     for (const warning of result.warnings ?? []) {

--- a/packages/generator-cli/src/pipeline/steps/GenerationCommitStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GenerationCommitStep.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "child_process";
 import { ReplayPrepareError, replayPrepare } from "../../replay/replay-run";
 import type { PipelineLogger } from "../PipelineLogger";
 import type { GenerationCommitStepConfig, GenerationCommitStepResult, PipelineContext } from "../types";
@@ -32,6 +33,11 @@ export class GenerationCommitStep extends BaseStep {
     }
 
     async execute(_context: PipelineContext): Promise<GenerationCommitStepResult> {
+        // Capture HEAD before prepare runs so we can roll back partial mutations
+        // if prepare crashes mid-flight (the prepare phase may write the lockfile
+        // and create the [fern-generated] commit before throwing).
+        const headBeforePrepare = tryRevParse(this.outputDir, "HEAD");
+
         let prepared: Awaited<ReturnType<typeof replayPrepare>>;
         try {
             prepared = await replayPrepare({
@@ -44,9 +50,28 @@ export class GenerationCommitStep extends BaseStep {
             });
         } catch (error) {
             const reason = error instanceof ReplayPrepareError ? error.reason : String(error);
+            // Best-effort rollback: prepare may have committed [fern-generated]
+            // before throwing. Reset HEAD to the pre-prepare commit so downstream
+            // steps (GithubStep) don't push a half-mutated tree to the remote.
+            if (headBeforePrepare != null) {
+                try {
+                    execFileSync("git", ["reset", "--hard", headBeforePrepare], {
+                        cwd: this.outputDir,
+                        stdio: "pipe"
+                    });
+                } catch {
+                    // Best-effort — if reset fails, the working tree may still be
+                    // mutated, but we surface the original prepare error so the
+                    // operator can recover.
+                }
+            }
+            // success: true so the orchestrator does NOT propagate this to
+            // pipelineResult.success = false (which would abort generation).
+            // The replay error is carried as errorMessage and consumed by
+            // ReplayStep, which records it on its own result for telemetry.
             return {
                 executed: true,
-                success: false,
+                success: true,
                 errorMessage: reason,
                 preparedReplay: null
             };
@@ -69,5 +94,17 @@ export class GenerationCommitStep extends BaseStep {
             baseBranchHead: prepared.baseBranchHead ?? undefined,
             flow: prepared.flow
         };
+    }
+}
+
+function tryRevParse(cwd: string, rev: string): string | null {
+    try {
+        return execFileSync("git", ["rev-parse", "--verify", rev], {
+            cwd,
+            encoding: "utf-8",
+            stdio: "pipe"
+        }).trim();
+    } catch {
+        return null;
     }
 }

--- a/packages/generator-cli/src/pipeline/steps/GenerationCommitStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GenerationCommitStep.ts
@@ -1,4 +1,4 @@
-import { replayPrepare } from "../../replay/replay-run";
+import { ReplayPrepareError, replayPrepare } from "../../replay/replay-run";
 import type { PipelineLogger } from "../PipelineLogger";
 import type { GenerationCommitStepConfig, GenerationCommitStepResult, PipelineContext } from "../types";
 import { BaseStep } from "./BaseStep";
@@ -32,14 +32,25 @@ export class GenerationCommitStep extends BaseStep {
     }
 
     async execute(_context: PipelineContext): Promise<GenerationCommitStepResult> {
-        const prepared = await replayPrepare({
-            outputDir: this.outputDir,
-            cliVersion: this.cliVersion,
-            generatorVersions: this.generatorVersions,
-            generatorName: this.generatorName,
-            skipApplication: this.config.skipApplication,
-            logger: this.logger
-        });
+        let prepared: Awaited<ReturnType<typeof replayPrepare>>;
+        try {
+            prepared = await replayPrepare({
+                outputDir: this.outputDir,
+                cliVersion: this.cliVersion,
+                generatorVersions: this.generatorVersions,
+                generatorName: this.generatorName,
+                skipApplication: this.config.skipApplication,
+                logger: this.logger
+            });
+        } catch (error) {
+            const reason = error instanceof ReplayPrepareError ? error.reason : String(error);
+            return {
+                executed: true,
+                success: false,
+                errorMessage: reason,
+                preparedReplay: null
+            };
+        }
 
         if (prepared == null) {
             return {

--- a/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
@@ -31,12 +31,15 @@ export class ReplayStep extends BaseStep {
         const generationCommit = context.previousStepResults.generationCommit;
         const prepared = generationCommit?.preparedReplay;
 
-        if (generationCommit != null && generationCommit.success === false) {
-            // Prepare crashed in the prior step — surface as failure, never mislabel
-            // a crash as first-generation. Generation continues regardless.
+        if (generationCommit != null && generationCommit.errorMessage != null && prepared == null) {
+            // Prepare crashed in the prior step (errorMessage is set; prepared is
+            // null). Surface as a replay failure but keep step.success === true so
+            // the orchestrator does NOT propagate to pipelineResult.success = false
+            // (which would abort generation). Telemetry and logs read replayCrashed.
             return {
                 executed: true,
-                success: false,
+                success: true,
+                replayCrashed: true,
                 errorMessage: generationCommit.errorMessage,
                 flow: "normal-regeneration",
                 patchesDetected: 0,
@@ -75,11 +78,13 @@ export class ReplayStep extends BaseStep {
                   });
 
         if (result.failureReason != null) {
-            // Prepare or apply crashed at runtime — surface as failure with the
-            // recorded reason so telemetry/logs reflect reality.
+            // Prepare or apply crashed at runtime — surface via replayCrashed so
+            // telemetry/logs reflect reality, but keep step.success === true so
+            // the orchestrator does NOT abort generation on replay errors.
             return {
                 executed: true,
-                success: false,
+                success: true,
+                replayCrashed: true,
                 errorMessage: result.failureReason,
                 previousGenerationSha: result.previousGenerationSha ?? undefined,
                 currentGenerationSha: result.currentGenerationSha ?? undefined,

--- a/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/ReplayStep.ts
@@ -31,9 +31,23 @@ export class ReplayStep extends BaseStep {
         const generationCommit = context.previousStepResults.generationCommit;
         const prepared = generationCommit?.preparedReplay;
 
+        if (generationCommit != null && generationCommit.success === false) {
+            // Prepare crashed in the prior step — surface as failure, never mislabel
+            // a crash as first-generation. Generation continues regardless.
+            return {
+                executed: true,
+                success: false,
+                errorMessage: generationCommit.errorMessage,
+                flow: "normal-regeneration",
+                patchesDetected: 0,
+                patchesApplied: 0,
+                patchesWithConflicts: 0
+            };
+        }
+
         if (generationCommit != null && prepared == null) {
-            // GenerationCommitStep ran but replay isn't initialized (no lockfile) or
-            // prepare failed. Mirror what replayRun would have returned in that case.
+            // GenerationCommitStep ran successfully but replay isn't initialized
+            // (no lockfile). Legitimate first-generation flow.
             return {
                 executed: true,
                 success: true,
@@ -59,6 +73,23 @@ export class ReplayStep extends BaseStep {
                       skipApplication: this.config.skipApplication,
                       logger: this.logger
                   });
+
+        if (result.failureReason != null) {
+            // Prepare or apply crashed at runtime — surface as failure with the
+            // recorded reason so telemetry/logs reflect reality.
+            return {
+                executed: true,
+                success: false,
+                errorMessage: result.failureReason,
+                previousGenerationSha: result.previousGenerationSha ?? undefined,
+                currentGenerationSha: result.currentGenerationSha ?? undefined,
+                baseBranchHead: result.baseBranchHead ?? undefined,
+                flow: "normal-regeneration",
+                patchesDetected: 0,
+                patchesApplied: 0,
+                patchesWithConflicts: 0
+            };
+        }
 
         if (result.report == null) {
             return {

--- a/packages/generator-cli/src/pipeline/types.ts
+++ b/packages/generator-cli/src/pipeline/types.ts
@@ -152,6 +152,13 @@ export interface PipelineResult {
 }
 
 export interface ReplayStepResult extends StepResult {
+    /**
+     * True when replay prepare or apply crashed (corrupted lockfile, git failure,
+     * library bug). Distinct from `success`: the step itself always succeeds
+     * (generation must continue on replay errors), but telemetry and logs read
+     * this field to report the underlying replay failure honestly.
+     */
+    replayCrashed?: boolean;
     flow?: "first-generation" | "no-patches" | "normal-regeneration" | "skip-application";
     patchesDetected?: number;
     patchesApplied?: number;

--- a/packages/generator-cli/src/replay/replay-run.ts
+++ b/packages/generator-cli/src/replay/replay-run.ts
@@ -20,7 +20,7 @@ export interface ReplayRunParams {
 }
 
 export interface ReplayRunResult {
-    /** null if replay wasn't initialized (no lockfile) */
+    /** null if replay wasn't initialized (no lockfile) OR if prepare/apply crashed (see failureReason) */
     report: ReplayReport | null;
     /** Whether .fernignore was updated */
     fernignoreUpdated: boolean;
@@ -30,6 +30,12 @@ export interface ReplayRunResult {
     currentGenerationSha: string | null;
     /** SHA of main's HEAD before replay ran. Always on main's lineage, stable after squash merges. */
     baseBranchHead: string | null;
+    /**
+     * Set when prepare or apply crashed (e.g. corrupted lockfile, git failure, library bug).
+     * Distinguishes a real failure from "no replay initialized" (lockfile missing → null report, no failureReason).
+     * Generation never fails on replay errors — callers should surface this for telemetry/logging only.
+     */
+    failureReason?: string;
 }
 
 /**
@@ -171,8 +177,11 @@ export async function replayPrepare(params: ReplayRunParams): Promise<PreparedRe
         // Mirror the pre-split contract: replay failures never fail generation.
         // Corrupted lockfiles, unreachable base generations, etc. are logged and
         // the caller proceeds as if replay were disabled for this run.
-        logger?.warn("Replay failed, continuing without replay: " + String(error));
-        return null;
+        // Throwing distinguishes a real crash from "no lockfile" (which still
+        // returns null above); callers (replayRun, GenerationCommitStep) catch
+        // and record failureReason so telemetry/logs don't mislabel as success.
+        logger?.warn("Replay prepare failed, continuing without replay: " + String(error));
+        throw new ReplayPrepareError(String(error), error);
     }
 
     return {
@@ -203,13 +212,14 @@ export async function replayApply(prepared: PreparedReplay, params: ReplayApplyP
     try {
         report = await prepared._service.applyPreparedReplay(prepared._preparation, { stageOnly });
     } catch (error) {
-        logger?.warn("Replay failed, continuing without replay: " + String(error));
+        logger?.warn("Replay apply failed, continuing without replay: " + String(error));
         return {
             report: null,
             fernignoreUpdated: false,
             previousGenerationSha: prepared.previousGenerationSha,
             currentGenerationSha: prepared.currentGenerationSha,
-            baseBranchHead: prepared.baseBranchHead
+            baseBranchHead: prepared.baseBranchHead,
+            failureReason: String(error)
         };
     }
 
@@ -246,7 +256,22 @@ export async function replayApply(prepared: PreparedReplay, params: ReplayApplyP
  * `replayApply` with byte-identical behavior for existing callers.
  */
 export async function replayRun(params: ReplayRunParams): Promise<ReplayRunResult> {
-    const prepared = await replayPrepare(params);
+    let prepared: PreparedReplay | null;
+    try {
+        prepared = await replayPrepare(params);
+    } catch (error) {
+        // Prepare crashed (already warned by replayPrepare). Surface the failure
+        // so downstream telemetry/logging records success: false rather than
+        // silently mislabeling as first-generation.
+        return {
+            report: null,
+            fernignoreUpdated: false,
+            previousGenerationSha: null,
+            currentGenerationSha: null,
+            baseBranchHead: null,
+            failureReason: error instanceof ReplayPrepareError ? error.reason : String(error)
+        };
+    }
     if (prepared == null) {
         return {
             report: null,
@@ -257,6 +282,23 @@ export async function replayRun(params: ReplayRunParams): Promise<ReplayRunResul
         };
     }
     return replayApply(prepared, { stageOnly: params.stageOnly, logger: params.logger });
+}
+
+/**
+ * Thrown by `replayPrepare` when the underlying replay service crashes (corrupted
+ * lockfile, git failure, library bug). Callers must catch this and decide how to
+ * surface the failure — generation MUST NOT abort on replay errors.
+ */
+export class ReplayPrepareError extends Error {
+    public readonly reason: string;
+    public readonly cause: unknown;
+
+    constructor(reason: string, cause: unknown) {
+        super(`Replay prepare failed: ${reason}`);
+        this.name = "ReplayPrepareError";
+        this.reason = reason;
+        this.cause = cause;
+    }
 }
 
 /**

--- a/packages/generator-cli/src/replay/replay-run.ts
+++ b/packages/generator-cli/src/replay/replay-run.ts
@@ -305,7 +305,16 @@ export class ReplayPrepareError extends Error {
     constructor(reason: string, cause: unknown) {
         // ES2022 Error.cause — Sentry's linkedErrorsIntegration chains automatically.
         super(`Replay prepare failed: ${reason}`, { cause });
-        this.name = "ReplayPrepareError";
+        // Restore the prototype chain — `extends Error` is broken by ES5 transpile
+        // (TS targets node18 here, so it's defensive but matches the codebase
+        // pattern in `generators/base/src/GeneratorError.ts`).
+        Object.setPrototypeOf(this, new.target.prototype);
+        // V8-specific: omit this constructor frame from the captured stack so the
+        // trace points to the throw site, not the Error class.
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+        this.name = this.constructor.name;
         this.reason = reason;
     }
 }

--- a/packages/generator-cli/src/replay/replay-run.ts
+++ b/packages/generator-cli/src/replay/replay-run.ts
@@ -144,12 +144,22 @@ export async function replayPrepare(params: ReplayRunParams): Promise<PreparedRe
                         `The tag likely points at an unmerged generation (PR closed without merge).`
                 );
             } else {
-                const syncService = new ReplayService(outputDir, { enabled: true });
-                await syncService.syncFromDivergentMerge(tagSha, {
-                    cliVersion,
-                    generatorVersions,
-                    baseBranchHead: baseBranchHead ?? undefined
-                });
+                try {
+                    const syncService = new ReplayService(outputDir, { enabled: true });
+                    await syncService.syncFromDivergentMerge(tagSha, {
+                        cliVersion,
+                        generatorVersions,
+                        baseBranchHead: baseBranchHead ?? undefined
+                    });
+                } catch (error) {
+                    // syncFromDivergentMerge can throw on git rewrite failures.
+                    // Wrap as ReplayPrepareError so callers (replayRun,
+                    // GenerationCommitStep) catch a single typed error and don't
+                    // forward raw String(error) (which can carry paths/SHAs) into
+                    // telemetry/logs.
+                    logger?.warn("Replay divergent-merge sync failed, continuing without sync: " + String(error));
+                    throw new ReplayPrepareError(String(error), error);
+                }
 
                 try {
                     const freshLockManager = new LockfileManager(outputDir);
@@ -291,13 +301,12 @@ export async function replayRun(params: ReplayRunParams): Promise<ReplayRunResul
  */
 export class ReplayPrepareError extends Error {
     public readonly reason: string;
-    public readonly cause: unknown;
 
     constructor(reason: string, cause: unknown) {
-        super(`Replay prepare failed: ${reason}`);
+        // ES2022 Error.cause — Sentry's linkedErrorsIntegration chains automatically.
+        super(`Replay prepare failed: ${reason}`, { cause });
         this.name = "ReplayPrepareError";
         this.reason = reason;
-        this.cause = cause;
     }
 }
 


### PR DESCRIPTION
## Summary

Capture replay outcomes in PostHog so adoption, conflict rates, and patch handling become visible in dashboards. One capture point at the CLI layer (`runLocalGenerationForWorkspace.ts` after `pipeline.run()`), no changes to Fiddle's path. Verified Fiddle's remote generation doesn't run replay (`AbstractGeneratorCli.run()` only does codegen + GitHub push/PR), so a CLI-side hook covers 100% of in-repo replay flows.

Three commits, reviewable independently:

1. **`fix(generator-cli): distinguish replay crashes from first-generation`** — closes FER-9956. Replay errors during prepare/apply were swallowed and reported as `success: true, flow: "first-generation"`, mislabeling crashes as healthy first generations. Generation still continues on replay errors, but the step result now reflects the failure honestly. Without this, the success-rate panel in the dashboards would lie.

2. **`feat(cli): wire PostHog telemetry for replay`** — closes FER-9550. The actual telemetry wiring.

3. **`fix(github): support OAuth + PAT tokens in self-hosted clone URL`** — discovered while validating end-to-end. The clone URL hardcoded `x-access-token:TOKEN@github.com`, which is the format reserved for GitHub App installation tokens (`ghs_*`). OAuth user tokens (`gho_*`) and PATs (`ghp_*`, `github_pat_*`) authenticate as the token itself; using `x-access-token:` for those returns "Invalid username or token". Without this fix, the new replay telemetry never fires for self-hosted users with OAuth/PAT auth — the common case.

## End-to-end verification

Ran against `fern-demo/fern-replay-testbed-ts-sdk` with this branch built locally. Output confirms the new code path fires:

```
INFO  [replay] flow=no-patches detected=0 applied=0 conflicts=0 absorbed=0 repointed=0
      content_rebased=0 kept_as_user_owned=0 unresolved=0 unresolved_files=0
      warnings=0 success=true

DEBUG [telemetry] replay event sent: {"action":"pipeline_run","success":true,
      "executed":true,"flow":"no-patches","pipeline_success":false,
      "generator_name":"fernapi/fern-typescript-sdk","generator_version":"3.66.4",
      "repo_uri_hash":"7be9ff4ffa64f6e0","run_id":"22d932de-baeb-41cd-b530-fe5a402a",
      "automation_mode":false,"auto_merge_requested":false,"auto_merge_enabled":false,
      "skip_if_no_diff":false,"no_diff_skipped":false,"version_arg":"none",
      "version_bump":null,"has_breaking_changes":false,"replay_config_enabled":true,
      "no_replay_flag":false,"github_mode":"pull-request","preview_mode":true,
      "pr_created":false,"pr_updated_existing":false,"duration_ms":1029,
      "patches_detected":0,"patches_applied":0,"patches_with_conflicts":0,
      "patches_absorbed":0,"patches_repointed":0,"patches_content_rebased":0,
      "patches_kept_as_user_owned":0,"unresolved_patches_count":0,
      "unresolved_conflict_files_count":0,"conflicts_same_line_edit":0,
      "conflicts_new_file_both":0,"conflicts_base_generation_mismatch":0,
      "conflicts_patch_apply_failed":0,"conflicts_other":0}
```

Repo URI hashed to 16 chars. Run ID truncated to 32 chars. Zero patch IDs, file paths, SHAs, or commit messages anywhere in the payload — PII guarantees hold.

## What gets captured

Single event `replay` with `action: "pipeline_run"`. Properties cover:

- **Patch counts** — `patches_detected`, `patches_applied`, `patches_with_conflicts`, `patches_absorbed`, `patches_repointed`, `patches_content_rebased`, `patches_kept_as_user_owned`, `unresolved_patches_count`, `unresolved_conflict_files_count`
- **Conflict buckets** (per `conflictReason`) — `conflicts_same_line_edit`, `conflicts_new_file_both`, `conflicts_base_generation_mismatch`, `conflicts_patch_apply_failed`, `conflicts_other`
- **Generator/repo context** — `generator_name`, `generator_version`, `cli_version`, `repo_uri_hash` (sha256-16char), `run_id`, `github_mode`, `preview_mode`
- **Automation context** — `automation_mode`, `auto_merge_requested`, `auto_merge_enabled`, `skip_if_no_diff`, `no_diff_skipped`, `pr_created`, `pr_updated_existing`, `version_arg`, `version_bump`, `has_breaking_changes`, `replay_config_enabled`, `no_replay_flag`
- **Outcome** — `success`, `executed`, `flow`, `pipeline_success`, `pipeline_warnings_count`, `replay_warnings_count`, `duration_ms`

Plus auto-attached base tags: `version`, `os`, `arch`, `ci`, `tty`, `org`.

## PII handling

NEVER emitted: file paths, patch IDs, commit messages, `previousGenerationSha` / `currentGenerationSha` / `baseBranchHead`, raw `errorMessage`. Repo URI is hashed. Conflict file paths only roll up into per-reason bucket counts. Tested in `buildReplayTelemetryProps.test.ts` — explicit assertions that no PII keys leak.

## Logs ("see all of it")

The same data prints to stdout regardless of telemetry being on:

- INFO: `[replay] flow=normal-regeneration detected=12 applied=11 conflicts=1 ...`
- DEBUG (when conflicts exist): `[replay] conflict_buckets same_line_edit=1 ...`
- DEBUG (when telemetry fires): `[telemetry] replay event sent: {...}`

## v2 unblock

`packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts:143-145` was a `// no-op`. This PR implements the translator so v2-driven generates feed the same event stream as v1.

## Opt-out

Honors existing `disableTelemetry` parameter, fed by `FERN_DISABLE_TELEMETRY` (v1) and `FERN_TELEMETRY_DISABLED` / `~/.fernrc` (v2). No new env vars.

## Out of scope (intentionally)

- **v2 replay subcommand events** (`init`/`forget`/`status`/`resolve`) — v1 already fires equivalent events at `cli.ts:2882/3017/3096/3192`. Will file a follow-up to add them in v2 for parity.
- **FER-9953** (upstream `@fern-api/replay` ReplayReport field exposure) — those fields don't exist on `ReplayReport` yet. The telemetry payload is forward-compatible: the properties will populate automatically once the upstream package adds them.

## Test plan

- [x] `pnpm turbo run compile` for all touched packages — succeeds
- [x] `pnpm turbo run test --filter @fern-api/generator-cli` — 368 passing (3 existing replay-pure tests updated to match new INFO line)
- [x] `pnpm turbo run test --filter @fern-api/cli-v2 --filter @fern-api/local-workspace-runner` — 561 + 9 passing
- [x] `pnpm turbo run test --filter @fern-api/github` — 19 passing (4 new tests for OAuth/PAT token URL formats)
- [x] `pnpm format:fix` — clean
- [x] **End-to-end**: `fern generate --group ts-sdk --local --log-level debug --preview` against `fern-demo/fern-replay-testbed-ts-sdk` — `[replay]` log line and `[telemetry] replay event sent` payload visible in output (see Summary above)
- [ ] Confirm with PostHog admin that `repo_uri_hash` cardinality fits the project's per-property budget

Closes FER-9550, closes FER-9956.
Related: FER-9545 (parent epic), FER-9930 (dashboards), FER-9953 (upstream prereq, separate PR).