### PR TITLE
chore(cli): bump @fern-api/fdr-sdk to 1.2.0-1d73d2e141

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
       "minimatch": ">=10.2.3",
       "qs": "6.15.0",
       "url-join": "^4.0.1",
-      "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+      "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
       "form-data": "^4.0.4",
       "@fern-api/ui-core-utils": "0.145.12-b50d999d1",
       "vite": "^7.3.2",

--- a/packages/cli/api-importers/graphql/package.json
+++ b/packages/cli/api-importers/graphql/package.json
@@ -31,7 +31,7 @@
     "test:update": "vitest --run -u --passWithNoTests"
   },
   "dependencies": {
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/task-context": "workspace:*",
     "graphql": "catalog:"

--- a/packages/cli/cli/changes/unreleased/bump-fdr-sdk-1.2.0.yml
+++ b/packages/cli/cli/changes/unreleased/bump-fdr-sdk-1.2.0.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump `@fern-api/fdr-sdk` to `1.2.0-1d73d2e141` to pick up the first-class
+    `Alpha`, `Preview`, and `Legacy` availability values published from the
+    `fdr@1.2.0` tag.
+  type: chore

--- a/packages/cli/cli/package.json
+++ b/packages/cli/cli/package.json
@@ -68,7 +68,7 @@
     "@fern-api/docs-preview": "workspace:*",
     "@fern-api/docs-resolver": "workspace:*",
     "@fern-api/docs-validator": "workspace:*",
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/fern-definition-formatter": "workspace:*",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/fern-definition-validator": "workspace:*",

--- a/packages/cli/configuration-loader/package.json
+++ b/packages/cli/configuration-loader/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/github": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",

--- a/packages/cli/configuration/package.json
+++ b/packages/cli/configuration/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/path-utils": "workspace:*",
     "@fern-fern/fiddle-sdk": "catalog:",

--- a/packages/cli/docs-importers/commons/package.json
+++ b/packages/cli/docs-importers/commons/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/configuration": "workspace:*",
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/task-context": "workspace:*",
     "js-yaml": "catalog:"

--- a/packages/cli/docs-importers/mintlify/package.json
+++ b/packages/cli/docs-importers/mintlify/package.json
@@ -35,7 +35,7 @@
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-importer-commons": "workspace:*",
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/task-context": "workspace:*",

--- a/packages/cli/docs-importers/readme/package.json
+++ b/packages/cli/docs-importers/readme/package.json
@@ -35,7 +35,7 @@
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-importer-commons": "workspace:*",
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/task-context": "workspace:*",

--- a/packages/cli/docs-markdown-utils/package.json
+++ b/packages/cli/docs-markdown-utils/package.json
@@ -32,7 +32,7 @@
     "test:update": "vitest --run -u"
   },
   "dependencies": {
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/task-context": "workspace:*",
     "estree-walker": "catalog:",

--- a/packages/cli/docs-preview/package.json
+++ b/packages/cli/docs-preview/package.json
@@ -35,7 +35,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-markdown-utils": "workspace:*",
     "@fern-api/docs-resolver": "workspace:*",
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/ir-sdk": "workspace:*",
     "@fern-api/ir-utils": "workspace:*",

--- a/packages/cli/ete-tests/package.json
+++ b/packages/cli/ete-tests/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@fern-api/configuration": "workspace:*",
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/lazy-fern-workspace": "workspace:*",
     "@fern-api/logger": "workspace:*",

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
@@ -42,7 +42,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-resolver": "workspace:*",
     "@fern-api/fai-sdk": "catalog:",
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/ir-generator": "workspace:*",
     "@fern-api/ir-migrations": "workspace:*",

--- a/packages/cli/register/package.json
+++ b/packages/cli/register/package.json
@@ -38,7 +38,7 @@
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/ir-generator": "workspace:*",
     "@fern-api/ir-sdk": "workspace:*",

--- a/packages/cli/workspace/browser-compatible-fern-workspace/package.json
+++ b/packages/cli/workspace/browser-compatible-fern-workspace/package.json
@@ -37,7 +37,7 @@
     "@fern-api/asyncapi-to-ir": "workspace:*",
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/ir-sdk": "workspace:*",
     "@fern-api/openapi-ir": "workspace:*",
     "@fern-api/openapi-ir-parser": "workspace:*",

--- a/packages/cli/workspace/lazy-fern-workspace/package.json
+++ b/packages/cli/workspace/lazy-fern-workspace/package.json
@@ -41,7 +41,7 @@
     "@fern-api/conjure-to-fern": "workspace:*",
     "@fern-api/core": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/graphql-to-fdr": "workspace:*",

--- a/packages/cli/yaml/docs-validator/package.json
+++ b/packages/cli/yaml/docs-validator/package.json
@@ -40,7 +40,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-markdown-utils": "workspace:*",
     "@fern-api/docs-resolver": "workspace:*",
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/ir-generator": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-api/fdr-sdk": "1.1.28-f4f0966d2e",
+    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
     "@fern-api/venus-api-sdk": "catalog:",
     "@fern-fern/fdr-test-sdk": "catalog:",
     "@fern-fern/fiddle-sdk": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,7 +594,7 @@ overrides:
   minimatch: '>=10.2.3'
   qs: 6.15.0
   url-join: ^4.0.1
-  '@fern-api/fdr-sdk': 1.1.28-f4f0966d2e
+  '@fern-api/fdr-sdk': 1.2.0-1d73d2e141
   form-data: ^4.0.4
   '@fern-api/ui-core-utils': 0.145.12-b50d999d1
   vite: ^7.3.2
@@ -3844,8 +3844,8 @@ importers:
   packages/cli/api-importers/graphql:
     dependencies:
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -4335,8 +4335,8 @@ importers:
         specifier: workspace:*
         version: link:../yaml/docs-validator
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-formatter':
         specifier: workspace:*
         version: link:../fern-definition/formatter
@@ -4972,8 +4972,8 @@ importers:
         specifier: workspace:*
         version: link:../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../fern-definition/schema
@@ -5009,8 +5009,8 @@ importers:
         specifier: workspace:*
         version: link:../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5088,8 +5088,8 @@ importers:
         specifier: workspace:*
         version: link:../../configuration
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -5128,8 +5128,8 @@ importers:
         specifier: workspace:*
         version: link:../commons
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -5168,8 +5168,8 @@ importers:
         specifier: workspace:*
         version: link:../commons
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -5235,8 +5235,8 @@ importers:
   packages/cli/docs-markdown-utils:
     dependencies:
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5323,8 +5323,8 @@ importers:
         specifier: workspace:*
         version: link:../docs-resolver
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5438,8 +5438,8 @@ importers:
         specifier: workspace:*
         version: link:../docs-markdown-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5541,8 +5541,8 @@ importers:
         specifier: workspace:*
         version: link:../configuration
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -6243,8 +6243,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.6-2ee1b7e28
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../../commons/fs-utils
@@ -6456,8 +6456,8 @@ importers:
   packages/cli/library-docs-generator:
     dependencies:
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/task-context':
         specifier: workspace:*
         version: link:../task-context
@@ -6690,8 +6690,8 @@ importers:
         specifier: workspace:*
         version: link:../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -6886,8 +6886,8 @@ importers:
         specifier: workspace:*
         version: link:../../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../../ir-sdk
@@ -6971,8 +6971,8 @@ importers:
         specifier: workspace:*
         version: link:../../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../../fern-definition/schema
@@ -7211,8 +7211,8 @@ importers:
         specifier: workspace:*
         version: link:../../docs-resolver
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../../fern-definition/schema
@@ -7844,8 +7844,8 @@ importers:
   packages/core:
     dependencies:
       '@fern-api/fdr-sdk':
-        specifier: 1.1.28-f4f0966d2e
-        version: 1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.0-1d73d2e141
+        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
         version: 0.22.34
@@ -9405,8 +9405,8 @@ packages:
     resolution: {integrity: sha512-3qhAAuc4ZJWLaFtyZzaYXfF9OQ5iviNrvLDXtjKScKUNS134fR3v3c3xedCidTq5KedapuBECziUaOmmd6KXVA==}
     engines: {node: '>=18.0.0'}
 
-  '@fern-api/fdr-sdk@1.1.28-f4f0966d2e':
-    resolution: {integrity: sha512-0w5/vtiwl+NvuRNwi7zCMYRAa2tqQUcMMoLl2bZ2AyekDqRYnjBMZlHNaQRVRJg5BPmz26qBVxnOkSymHESDKA==}
+  '@fern-api/fdr-sdk@1.2.0-1d73d2e141':
+    resolution: {integrity: sha512-MEFE1wOThaUz9IK3bgIkTAQKvLJgt8ccHvXehK9HIvBvxl6EdHNrXrZAlFS5TxLd9yd1AtM9M8LmzzMIzoHfGQ==}
 
   '@fern-api/generator-cli@0.9.22':
     resolution: {integrity: sha512-War2x7+HMAl8TzferxbIRfp1zgQ5OMdoZW/FsD2H/Ep7t0SWLBDcAm+x7s+mhnwEYYXe9VSdA2+aNZC3pwRalA==}
@@ -16415,7 +16415,7 @@ snapshots:
 
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28': {}
 
-  '@fern-api/fdr-sdk@1.1.28-f4f0966d2e(@opentelemetry/api@1.9.1)(typescript@5.9.3)':
+  '@fern-api/fdr-sdk@1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)':
     dependencies:
       '@fern-api/ui-core-utils': 0.145.12-b50d999d1
       '@orpc/client': 1.13.9(@opentelemetry/api@1.9.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,7 +59,7 @@ catalog:
   "@bufbuild/protobuf": ^2.2.5
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
-  "@fern-api/fdr-sdk": 1.1.28-f4f0966d2e
+  "@fern-api/fdr-sdk": 1.2.0-1d73d2e141
   "@fern-api/generator-cli": 0.9.22
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34


### PR DESCRIPTION
## Description

Bumps `@fern-api/fdr-sdk` from `1.1.28-f4f0966d2e` → `1.2.0-1d73d2e141` to pick up the first-class `Alpha`, `Preview`, `Legacy` availability values published from the [`fdr@1.2.0` tag](https://github.com/fern-api/fern-platform/releases/tag/fdr@1.2.0) on `fern-api/fern-platform`.

This is the follow-up to the FDR SDK bump in #15320, which had to use a prerelease snapshot because `1.2.0` was not yet published when that PR landed. The CLI's IR-to-FDR converter at `packages/cli/register/src/ir-to-fdr-converter/convertPackage.ts` already maps `IR.AvailabilityStatus.Alpha/Preview/Legacy` → `FdrCjsSdk.Availability.Alpha/Preview/Legacy` directly (no temp fallbacks), so the only change here is the version bump.

> [!NOTE]
> The published version is `1.2.0-1d73d2e141`, not a clean `1.2.0`. The fern-platform `Publish FDR SDKs` workflow always appends `-<git describe>` via `scripts/fdr-version.sh`, so every fdr-sdk version on npm has a hash suffix. The `npm dist-tag latest` for `@fern-api/fdr-sdk` points to `1.2.0-1d73d2e141`, confirming this is the canonical release for the `fdr@1.2.0` tag.

## Changes Made

- 17 `package.json` files: `@fern-api/fdr-sdk` pinned `1.1.28-f4f0966d2e` → `1.2.0-1d73d2e141`
- `pnpm-workspace.yaml` catalog entry updated to match
- `pnpm-lock.yaml` regenerated via `pnpm install`
- Changelog entry added at `packages/cli/cli/changes/unreleased/bump-fdr-sdk-1.2.0.yml` (`type: chore`)

## Testing

- [x] `pnpm install` resolves cleanly (downloads `@fern-api/fdr-sdk@1.2.0-1d73d2e141` from npm)
- [x] `pnpm turbo run compile --filter=@fern-api/register` passes (36 packages compiled, no type errors)
- [ ] Waiting on full CI

Link to Devin session: https://app.devin.ai/sessions/dfd46458269a401d82862980e905e9a2
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
