### PR TITLE
chore(python): bump @fern-api/generator-cli to 0.9.22

### DIFF
--- a/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.22.yml
+++ b/generators/python/sdk/changes/unreleased/bump-generator-cli-0.9.22.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump @fern-api/generator-cli to 0.9.22. Picks up replay 0.14.1 fix for
+    consolidating duplicate-content patches to prevent next-regen corruption.
+  type: fix


### PR DESCRIPTION
## Description

Triggers a new Python SDK generator release that picks up generator-cli 0.9.22 (replay 0.14.1 — fix for consolidating duplicate-content patches to prevent next-regen corruption).

## Changes Made

- Added unreleased changelog entry for Python SDK generator to trigger a new release with generator-cli 0.9.22

## Testing

- [ ] CI validates changelog format

Link to Devin session: https://app.devin.ai/sessions/7e1f232131034d6ab0b94f05d4c0310a
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
