### PR TITLE
fix(python): respect smart-casing config from generators.yml

### DIFF
--- a/generators/python-v2/base/src/context/AbstractPythonGeneratorContext.ts
+++ b/generators/python-v2/base/src/context/AbstractPythonGeneratorContext.ts
@@ -11,17 +11,6 @@ import { BasePythonCustomConfigSchema } from "../custom-config/BasePythonCustomC
 import { PythonProject } from "../project/index.js";
 import { PythonTypeMapper } from "./PythonTypeMapper.js";
 
-/**
- * Default smart-casing case converter. Used as a fallback for callers that don't have access
- * to a generator context (e.g. utilities). Most callers should use `context.caseConverter`,
- * which respects the customer's `smart-casing` config from generators.yml.
- */
-export const PYTHON_CASE_CONVERTER = new CaseConverter({
-    generationLanguage: "python",
-    keywords: undefined,
-    smartCasing: true
-});
-
 export abstract class AbstractPythonGeneratorContext<
     CustomConfig extends BasePythonCustomConfigSchema
 > extends AbstractGeneratorContext {
@@ -30,8 +19,8 @@ export abstract class AbstractPythonGeneratorContext<
     public readonly project: PythonProject;
     /**
      * Case converter configured from the IR's casingsConfig (driven by the customer's
-     * `smart-casing` flag in generators.yml). Use this instead of PYTHON_CASE_CONVERTER
-     * so generated names match the IR's pre-computed snake_case values.
+     * `smart-casing` flag in generators.yml). Generated names must use this so they
+     * match the IR server's pre-computed snake_case values.
      */
     public readonly caseConverter: CaseConverter;
 

--- a/generators/python-v2/base/src/context/AbstractPythonGeneratorContext.ts
+++ b/generators/python-v2/base/src/context/AbstractPythonGeneratorContext.ts
@@ -11,6 +11,11 @@ import { BasePythonCustomConfigSchema } from "../custom-config/BasePythonCustomC
 import { PythonProject } from "../project/index.js";
 import { PythonTypeMapper } from "./PythonTypeMapper.js";
 
+/**
+ * Default smart-casing case converter. Used as a fallback for callers that don't have access
+ * to a generator context (e.g. utilities). Most callers should use `context.caseConverter`,
+ * which respects the customer's `smart-casing` config from generators.yml.
+ */
 export const PYTHON_CASE_CONVERTER = new CaseConverter({
     generationLanguage: "python",
     keywords: undefined,
@@ -23,6 +28,12 @@ export abstract class AbstractPythonGeneratorContext<
     private packageName: string;
     public readonly pythonTypeMapper: PythonTypeMapper;
     public readonly project: PythonProject;
+    /**
+     * Case converter configured from the IR's casingsConfig (driven by the customer's
+     * `smart-casing` flag in generators.yml). Use this instead of PYTHON_CASE_CONVERTER
+     * so generated names match the IR's pre-computed snake_case values.
+     */
+    public readonly caseConverter: CaseConverter;
 
     public constructor(
         public readonly ir: FernIr.IntermediateRepresentation,
@@ -31,9 +42,12 @@ export abstract class AbstractPythonGeneratorContext<
         public readonly generatorNotificationService: GeneratorNotificationService
     ) {
         super(config, generatorNotificationService);
-        this.packageName = snakeCase(
-            `${this.config.organization}_${PYTHON_CASE_CONVERTER.snakeUnsafe(this.ir.apiName)}`
-        );
+        this.caseConverter = new CaseConverter({
+            generationLanguage: "python",
+            keywords: undefined,
+            smartCasing: this.ir.casingsConfig?.smartCasing ?? true
+        });
+        this.packageName = snakeCase(`${this.config.organization}_${this.caseConverter.snakeUnsafe(this.ir.apiName)}`);
         this.pythonTypeMapper = new PythonTypeMapper(this);
         this.project = new PythonProject({ context: this });
     }
@@ -60,15 +74,15 @@ export abstract class AbstractPythonGeneratorContext<
     }
 
     public getClassName(name: FernIr.NameOrString): string {
-        return PYTHON_CASE_CONVERTER.pascalSafe(name);
+        return this.caseConverter.pascalSafe(name);
     }
 
     public getPascalCaseSafeName(name: FernIr.NameOrString): string {
-        return PYTHON_CASE_CONVERTER.pascalSafe(name);
+        return this.caseConverter.pascalSafe(name);
     }
 
     public getSnakeCaseSafeName(name: FernIr.NameOrString): string {
-        return PYTHON_CASE_CONVERTER.snakeSafe(name);
+        return this.caseConverter.snakeSafe(name);
     }
 
     public getModulePathForId(typeId: string): string[] {

--- a/generators/python-v2/base/src/context/index.ts
+++ b/generators/python-v2/base/src/context/index.ts
@@ -1,2 +1,2 @@
-export { AbstractPythonGeneratorContext, PYTHON_CASE_CONVERTER } from "./AbstractPythonGeneratorContext.js";
+export { AbstractPythonGeneratorContext } from "./AbstractPythonGeneratorContext.js";
 export { PythonTypeMapper } from "./PythonTypeMapper.js";

--- a/generators/python-v2/pydantic-model/src/v2/EnumGenerator.ts
+++ b/generators/python-v2/pydantic-model/src/v2/EnumGenerator.ts
@@ -1,7 +1,7 @@
 import { getNameFromWireValue, getWireValue } from "@fern-api/base-generator";
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import { python } from "@fern-api/python-ast";
-import { PYTHON_CASE_CONVERTER as caseConverter, WriteablePythonFile } from "@fern-api/python-base";
+import { WriteablePythonFile } from "@fern-api/python-base";
 import { FernIr } from "@fern-fern/ir-sdk";
 
 import { PydanticModelGeneratorContext } from "../ModelGeneratorContext.js";
@@ -26,7 +26,7 @@ export class EnumGenerator {
 
         // Add enum members
         for (const enumValue of this.enumDeclaration.values) {
-            const memberName = caseConverter.screamingSnakeSafe(getNameFromWireValue(enumValue.name));
+            const memberName = this.context.caseConverter.screamingSnakeSafe(getNameFromWireValue(enumValue.name));
             const wireValue = this.escapeStringForPython(getWireValue(enumValue.name));
 
             enumClass.addField(
@@ -66,7 +66,7 @@ export class EnumGenerator {
                     type: undefined
                 }),
                 ...this.enumDeclaration.values.map((enumValue) => {
-                    const parameterName = caseConverter.snakeSafe(getNameFromWireValue(enumValue.name));
+                    const parameterName = this.context.caseConverter.snakeSafe(getNameFromWireValue(enumValue.name));
                     return python.parameter({
                         name: parameterName,
                         type: python.Type.reference(
@@ -87,8 +87,8 @@ export class EnumGenerator {
         // Add if statements for each enum value
         for (const enumValue of this.enumDeclaration.values) {
             const enumName = getNameFromWireValue(enumValue.name);
-            const memberName = caseConverter.screamingSnakeSafe(enumName);
-            const parameterName = caseConverter.snakeSafe(enumName);
+            const memberName = this.context.caseConverter.screamingSnakeSafe(enumName);
+            const parameterName = this.context.caseConverter.snakeSafe(enumName);
 
             visitMethod.addStatement(
                 python.codeBlock((writer) => {

--- a/generators/python-v2/pydantic-model/src/v2/WrappedAliasGenerator.ts
+++ b/generators/python-v2/pydantic-model/src/v2/WrappedAliasGenerator.ts
@@ -1,7 +1,7 @@
 import { assertNever } from "@fern-api/core-utils";
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import { python } from "@fern-api/python-ast";
-import { PYTHON_CASE_CONVERTER as caseConverter, core, dt, pydantic, WriteablePythonFile } from "@fern-api/python-base";
+import { core, dt, pydantic, WriteablePythonFile } from "@fern-api/python-base";
 import { FernIr } from "@fern-fern/ir-sdk";
 
 import { PydanticModelGeneratorContext } from "../ModelGeneratorContext.js";
@@ -110,7 +110,7 @@ export class WrappedAliasGenerator {
                     literal: () => "get_as_string",
                     _other: () => "get_value"
                 }),
-            named: (typeName) => "get_as_" + caseConverter.snakeUnsafe(typeName.name),
+            named: (typeName) => "get_as_" + this.context.caseConverter.snakeUnsafe(typeName.name),
             primitive: (primitive) => {
                 if (primitive.v2 != null) {
                     return primitive.v2?._visit({
@@ -205,7 +205,7 @@ export class WrappedAliasGenerator {
                     literal: () => "from_string",
                     _other: () => "from_value"
                 }),
-            named: (typeName) => "from_" + caseConverter.snakeUnsafe(typeName.name),
+            named: (typeName) => "from_" + this.context.caseConverter.snakeUnsafe(typeName.name),
             primitive: (primitive) => {
                 if (primitive.v2 != null) {
                     return primitive.v2?._visit({

--- a/generators/python-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/python-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -1,5 +1,4 @@
 import { AbstractReadmeSnippetBuilder, GeneratorError, getNameFromWireValue } from "@fern-api/base-generator";
-import { PYTHON_CASE_CONVERTER as caseConverter } from "@fern-api/python-base";
 import { FernGeneratorCli } from "@fern-fern/generator-cli-sdk";
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { FernIr } from "@fern-fern/ir-sdk";
@@ -293,21 +292,21 @@ asyncio.run(main())`
             switch (scheme.type) {
                 case "bearer":
                     args.push(
-                        `    ${caseConverter.snakeUnsafe(scheme.token)}="${scheme.tokenPlaceholder ?? `YOUR_${caseConverter.screamingSnakeUnsafe(scheme.token)}`}",`
+                        `    ${this.context.caseConverter.snakeUnsafe(scheme.token)}="${scheme.tokenPlaceholder ?? `YOUR_${this.context.caseConverter.screamingSnakeUnsafe(scheme.token)}`}",`
                     );
                     break;
                 case "basic":
                     args.push(
-                        `    ${caseConverter.snakeUnsafe(scheme.username)}="${scheme.usernamePlaceholder ?? `YOUR_${caseConverter.screamingSnakeUnsafe(scheme.username)}`}",`
+                        `    ${this.context.caseConverter.snakeUnsafe(scheme.username)}="${scheme.usernamePlaceholder ?? `YOUR_${this.context.caseConverter.screamingSnakeUnsafe(scheme.username)}`}",`
                     );
                     args.push(
-                        `    ${caseConverter.snakeUnsafe(scheme.password)}="${scheme.passwordPlaceholder ?? `YOUR_${caseConverter.screamingSnakeUnsafe(scheme.password)}`}",`
+                        `    ${this.context.caseConverter.snakeUnsafe(scheme.password)}="${scheme.passwordPlaceholder ?? `YOUR_${this.context.caseConverter.screamingSnakeUnsafe(scheme.password)}`}",`
                     );
                     break;
                 case "header": {
                     const schemeName = getNameFromWireValue(scheme.name);
-                    const headerName = caseConverter.snakeUnsafe(schemeName);
-                    const headerScreaming = caseConverter.screamingSnakeUnsafe(schemeName);
+                    const headerName = this.context.caseConverter.snakeUnsafe(schemeName);
+                    const headerScreaming = this.context.caseConverter.screamingSnakeUnsafe(schemeName);
                     args.push(`    ${headerName}="${scheme.headerPlaceholder ?? `YOUR_${headerScreaming}`}",`);
                     break;
                 }
@@ -491,7 +490,7 @@ print(response.data)  # access the underlying object`
         }
 
         const { subpackage, channel } = websocketInfo;
-        const subpackageName = caseConverter.snakeSafe(subpackage.name);
+        const subpackageName = this.context.caseConverter.snakeSafe(subpackage.name);
         // connectMethodName may not exist on older IR SDK versions
         const connectMethodName = (channel as unknown as { connectMethodName?: string }).connectMethodName;
         const connectMethodNameSnakeCase = this.toSnakeCase(connectMethodName ?? "connect");
@@ -675,7 +674,7 @@ ${constructorArg}
         const envClassName = `${this.clientClassName}Environment`;
         const importLine = `from ${this.packageName}.environment import ${envClassName}`;
 
-        const firstEnvName = resolveDefaultEnvironmentName(envConfig);
+        const firstEnvName = resolveDefaultEnvironmentName(this.context, envConfig);
 
         if (firstEnvName == null) {
             return undefined;
@@ -708,14 +707,18 @@ ${constructorArg}
     }
 
     private getEndpointAccessPath(endpoint: EndpointWithFilepath): string {
-        const clientAccessParts = endpoint.fernFilepath.allParts.map((part) => caseConverter.snakeSafe(part));
-        const methodName = caseConverter.snakeUnsafe(endpoint.endpoint.name);
+        const clientAccessParts = endpoint.fernFilepath.allParts.map((part) =>
+            this.context.caseConverter.snakeSafe(part)
+        );
+        const methodName = this.context.caseConverter.snakeUnsafe(endpoint.endpoint.name);
         return clientAccessParts.length > 0 ? `${clientAccessParts.join(".")}.${methodName}` : methodName;
     }
 
     private getRawResponseMethodCall(endpoint: EndpointWithFilepath): string {
-        const clientAccessParts = endpoint.fernFilepath.allParts.map((part) => caseConverter.snakeSafe(part));
-        const methodName = caseConverter.snakeUnsafe(endpoint.endpoint.name);
+        const clientAccessParts = endpoint.fernFilepath.allParts.map((part) =>
+            this.context.caseConverter.snakeSafe(part)
+        );
+        const methodName = this.context.caseConverter.snakeUnsafe(endpoint.endpoint.name);
         if (clientAccessParts.length > 0) {
             return `client.${clientAccessParts.join(".")}.with_raw_response.${methodName}`;
         }

--- a/generators/python-v2/sdk/src/reference/buildReference.ts
+++ b/generators/python-v2/sdk/src/reference/buildReference.ts
@@ -1,5 +1,4 @@
 import { getNameFromWireValue, ReferenceConfigBuilder } from "@fern-api/base-generator";
-import { PYTHON_CASE_CONVERTER as caseConverter } from "@fern-api/python-base";
 import { FernGeneratorCli } from "@fern-fern/generator-cli-sdk";
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { FernIr } from "@fern-fern/ir-sdk";
@@ -20,7 +19,7 @@ export function buildReference({
     serviceEntries.forEach(([serviceId, service]) => {
         const section = isRootServiceId({ context, serviceId })
             ? builder.addRootSection()
-            : builder.addSection({ title: getSectionTitle({ service }) });
+            : builder.addSection({ title: getSectionTitle({ context, service }) });
         const endpoints = getEndpointReferencesForService({ context, service, endpointSnippets: snippetsByEndpointId });
         for (const endpoint of endpoints) {
             section.addEndpoint(endpoint);
@@ -88,11 +87,11 @@ function getEndpointReference({
     endpoint: FernIr.HttpEndpoint;
     endpointSnippets: Record<string, string>;
 }): FernGeneratorCli.EndpointReference | undefined {
-    const methodName = caseConverter.snakeUnsafe(endpoint.name);
-    const accessPath = getAccessFromRootClient({ service });
-    const parameters = getEndpointParameters({ endpoint });
+    const methodName = context.caseConverter.snakeUnsafe(endpoint.name);
+    const accessPath = getAccessFromRootClient({ context, service });
+    const parameters = getEndpointParameters({ context, endpoint });
     const sourceFilePath = getSourceFilePath({ context, service });
-    const returnTypeStr = getReturnTypeString({ endpoint });
+    const returnTypeStr = getReturnTypeString({ context, endpoint });
 
     // Use prerendered snippet if available, otherwise fallback to abbreviated form
     let snippet = endpointSnippets[endpoint.id] ?? `${accessPath}.${methodName}(${parameters.length > 0 ? "..." : ""})`;
@@ -132,19 +131,31 @@ function getEndpointReference({
     };
 }
 
-function getAccessFromRootClient({ service }: { service: FernIr.HttpService }): string {
+function getAccessFromRootClient({
+    context,
+    service
+}: {
+    context: SdkGeneratorContext;
+    service: FernIr.HttpService;
+}): string {
     const clientVariableName = "client";
-    const servicePath = service.name.fernFilepath.allParts.map((part) => caseConverter.snakeSafe(part));
+    const servicePath = service.name.fernFilepath.allParts.map((part) => context.caseConverter.snakeSafe(part));
     return servicePath.length > 0 ? `${clientVariableName}.${servicePath.join(".")}` : clientVariableName;
 }
 
-function getEndpointParameters({ endpoint }: { endpoint: FernIr.HttpEndpoint }): FernGeneratorCli.ParameterReference[] {
+function getEndpointParameters({
+    context,
+    endpoint
+}: {
+    context: SdkGeneratorContext;
+    endpoint: FernIr.HttpEndpoint;
+}): FernGeneratorCli.ParameterReference[] {
     const parameters: FernGeneratorCli.ParameterReference[] = [];
 
     endpoint.allPathParameters.forEach((pathParam) => {
         parameters.push({
-            name: caseConverter.snakeUnsafe(pathParam.name),
-            type: getTypeString(pathParam.valueType),
+            name: context.caseConverter.snakeUnsafe(pathParam.name),
+            type: getTypeString(context, pathParam.valueType),
             description: pathParam.docs,
             required: !isTypeOptional(pathParam.valueType)
         });
@@ -155,15 +166,15 @@ function getEndpointParameters({ endpoint }: { endpoint: FernIr.HttpEndpoint }):
         let type: string;
         if (queryParam.allowMultiple) {
             const baseType = isOptional
-                ? unwrapOptionalType(queryParam.valueType)
-                : getTypeString(queryParam.valueType);
+                ? unwrapOptionalType(context, queryParam.valueType)
+                : getTypeString(context, queryParam.valueType);
             const unionType = `typing.Union[${baseType}, typing.Sequence[${baseType}]]`;
             type = isOptional ? wrapOptional(unionType) : unionType;
         } else {
-            type = getTypeString(queryParam.valueType);
+            type = getTypeString(context, queryParam.valueType);
         }
         parameters.push({
-            name: caseConverter.snakeUnsafe(getNameFromWireValue(queryParam.name)),
+            name: context.caseConverter.snakeUnsafe(getNameFromWireValue(queryParam.name)),
             type,
             description: queryParam.docs,
             required: !isOptional
@@ -172,8 +183,8 @@ function getEndpointParameters({ endpoint }: { endpoint: FernIr.HttpEndpoint }):
 
     endpoint.headers.forEach((header) => {
         parameters.push({
-            name: caseConverter.snakeUnsafe(getNameFromWireValue(header.name)),
-            type: getTypeString(header.valueType),
+            name: context.caseConverter.snakeUnsafe(getNameFromWireValue(header.name)),
+            type: getTypeString(context, header.valueType),
             description: header.docs,
             required: !isTypeOptional(header.valueType)
         });
@@ -184,8 +195,8 @@ function getEndpointParameters({ endpoint }: { endpoint: FernIr.HttpEndpoint }):
         if (endpoint.requestBody.extendedProperties != null) {
             endpoint.requestBody.extendedProperties.forEach((property) => {
                 parameters.push({
-                    name: caseConverter.snakeUnsafe(getNameFromWireValue(property.name)),
-                    type: getTypeString(property.valueType),
+                    name: context.caseConverter.snakeUnsafe(getNameFromWireValue(property.name)),
+                    type: getTypeString(context, property.valueType),
                     description: property.docs,
                     required: !isTypeOptional(property.valueType)
                 });
@@ -193,8 +204,8 @@ function getEndpointParameters({ endpoint }: { endpoint: FernIr.HttpEndpoint }):
         }
         endpoint.requestBody.properties.forEach((property) => {
             parameters.push({
-                name: caseConverter.snakeUnsafe(getNameFromWireValue(property.name)),
-                type: getTypeString(property.valueType),
+                name: context.caseConverter.snakeUnsafe(getNameFromWireValue(property.name)),
+                type: getTypeString(context, property.valueType),
                 description: property.docs,
                 required: !isTypeOptional(property.valueType)
             });
@@ -202,7 +213,7 @@ function getEndpointParameters({ endpoint }: { endpoint: FernIr.HttpEndpoint }):
     } else if (endpoint.requestBody != null && endpoint.requestBody.type === "reference") {
         parameters.push({
             name: "request",
-            type: getTypeString(endpoint.requestBody.requestBodyType),
+            type: getTypeString(context, endpoint.requestBody.requestBodyType),
             description: endpoint.requestBody.docs,
             required: !isTypeOptional(endpoint.requestBody.requestBodyType)
         });
@@ -214,15 +225,15 @@ function getEndpointParameters({ endpoint }: { endpoint: FernIr.HttpEndpoint }):
                 const fileType = fileProperty.type === "fileArray" ? "typing.List[core.File]" : "core.File";
                 const type = isOptional ? `typing.Optional[${fileType}]` : fileType;
                 parameters.push({
-                    name: caseConverter.snakeUnsafe(getNameFromWireValue(fileProperty.key)),
+                    name: context.caseConverter.snakeUnsafe(getNameFromWireValue(fileProperty.key)),
                     type,
                     description: fileProperty.docs,
                     required: !isOptional
                 });
             } else if (property.type === "bodyProperty") {
                 parameters.push({
-                    name: caseConverter.snakeUnsafe(getNameFromWireValue(property.name)),
-                    type: getTypeString(property.valueType),
+                    name: context.caseConverter.snakeUnsafe(getNameFromWireValue(property.name)),
+                    type: getTypeString(context, property.valueType),
                     description: property.docs,
                     required: !isTypeOptional(property.valueType)
                 });
@@ -253,7 +264,7 @@ function getEndpointParameters({ endpoint }: { endpoint: FernIr.HttpEndpoint }):
     return parameters;
 }
 
-function getTypeString(typeReference: FernIr.TypeReference): string {
+function getTypeString(context: SdkGeneratorContext, typeReference: FernIr.TypeReference): string {
     switch (typeReference.type) {
         case "primitive": {
             const primitiveType = typeReference.primitive.v1;
@@ -288,15 +299,15 @@ function getTypeString(typeReference: FernIr.TypeReference): string {
         case "container": {
             switch (typeReference.container.type) {
                 case "list":
-                    return `typing.List[${getTypeString(typeReference.container.list)}]`;
+                    return `typing.List[${getTypeString(context, typeReference.container.list)}]`;
                 case "set":
-                    return `typing.Set[${getTypeString(typeReference.container.set)}]`;
+                    return `typing.Set[${getTypeString(context, typeReference.container.set)}]`;
                 case "map":
-                    return `typing.Dict[${getTypeString(typeReference.container.keyType)}, ${getTypeString(typeReference.container.valueType)}]`;
+                    return `typing.Dict[${getTypeString(context, typeReference.container.keyType)}, ${getTypeString(context, typeReference.container.valueType)}]`;
                 case "optional":
-                    return wrapOptional(getTypeString(typeReference.container.optional));
+                    return wrapOptional(getTypeString(context, typeReference.container.optional));
                 case "nullable":
-                    return wrapOptional(getTypeString(typeReference.container.nullable));
+                    return wrapOptional(getTypeString(context, typeReference.container.nullable));
                 case "literal":
                     return "typing.Literal";
                 default:
@@ -304,7 +315,7 @@ function getTypeString(typeReference: FernIr.TypeReference): string {
             }
         }
         case "named":
-            return caseConverter.pascalUnsafe(typeReference.name);
+            return context.caseConverter.pascalUnsafe(typeReference.name);
         case "unknown":
             return "typing.Any";
         default:
@@ -320,14 +331,20 @@ function getSourceFilePath({
     service: FernIr.HttpService;
 }): string | undefined {
     const modulePath = context.getModulePath().replace(/-/g, "_");
-    const pathParts = service.name.fernFilepath.allParts.map((part) => caseConverter.snakeSafe(part));
+    const pathParts = service.name.fernFilepath.allParts.map((part) => context.caseConverter.snakeSafe(part));
     if (pathParts.length === 0) {
         return `src/${modulePath}/client.py`;
     }
     return `src/${modulePath}/${pathParts.join("/")}/client.py`;
 }
 
-function getReturnTypeString({ endpoint }: { endpoint: FernIr.HttpEndpoint }): string | undefined {
+function getReturnTypeString({
+    context,
+    endpoint
+}: {
+    context: SdkGeneratorContext;
+    endpoint: FernIr.HttpEndpoint;
+}): string | undefined {
     const responseBody = endpoint.response?.body;
     if (responseBody == null) {
         return undefined;
@@ -335,7 +352,7 @@ function getReturnTypeString({ endpoint }: { endpoint: FernIr.HttpEndpoint }): s
     switch (responseBody.type) {
         case "json": {
             const responseBodyType = responseBody.value.responseBodyType;
-            return getTypeString(responseBodyType);
+            return getTypeString(context, responseBodyType);
         }
         case "streaming":
             return "typing.Iterator[bytes]";
@@ -360,10 +377,10 @@ function isRootServiceId({
     return context.ir.rootPackage.service === serviceId;
 }
 
-function getSectionTitle({ service }: { service: FernIr.HttpService }): string {
+function getSectionTitle({ context, service }: { context: SdkGeneratorContext; service: FernIr.HttpService }): string {
     return (
         service.displayName ??
-        service.name.fernFilepath.allParts.map((part) => caseConverter.pascalSafe(part)).join(" ")
+        service.name.fernFilepath.allParts.map((part) => context.caseConverter.pascalSafe(part)).join(" ")
     );
 }
 
@@ -374,16 +391,16 @@ function isTypeOptional(typeReference: FernIr.TypeReference): boolean {
     return false;
 }
 
-function unwrapOptionalType(typeReference: FernIr.TypeReference): string {
+function unwrapOptionalType(context: SdkGeneratorContext, typeReference: FernIr.TypeReference): string {
     if (typeReference.type === "container") {
         if (typeReference.container.type === "optional") {
-            return getTypeString(typeReference.container.optional);
+            return getTypeString(context, typeReference.container.optional);
         }
         if (typeReference.container.type === "nullable") {
-            return getTypeString(typeReference.container.nullable);
+            return getTypeString(context, typeReference.container.nullable);
         }
     }
-    return getTypeString(typeReference);
+    return getTypeString(context, typeReference);
 }
 
 function wrapOptional(typeStr: string): string {
@@ -490,7 +507,7 @@ function getEnvironmentInfo({
     const packageName = context.getModulePath();
     const importLine = `from ${packageName}.environment import ${envClassName}`;
 
-    const firstEnvName = resolveDefaultEnvironmentName(envConfig);
+    const firstEnvName = resolveDefaultEnvironmentName(context, envConfig);
 
     if (firstEnvName == null) {
         return undefined;
@@ -504,7 +521,10 @@ function getEnvironmentInfo({
  * Resolves the default (or first) environment name as SCREAMING_SNAKE_CASE.
  * Works for both singleBaseUrl and multipleBaseUrls environment types.
  */
-export function resolveDefaultEnvironmentName(envConfig: FernIr.EnvironmentsConfig): string | undefined {
+export function resolveDefaultEnvironmentName(
+    context: SdkGeneratorContext,
+    envConfig: FernIr.EnvironmentsConfig
+): string | undefined {
     const envs =
         envConfig.environments.type === "singleBaseUrl" || envConfig.environments.type === "multipleBaseUrls"
             ? envConfig.environments.environments
@@ -516,11 +536,11 @@ export function resolveDefaultEnvironmentName(envConfig: FernIr.EnvironmentsConf
     if (defaultEnvId != null) {
         const defaultEnv = envs.find((e) => e.id === defaultEnvId);
         if (defaultEnv?.name != null) {
-            return caseConverter.screamingSnakeUnsafe(defaultEnv.name);
+            return context.caseConverter.screamingSnakeUnsafe(defaultEnv.name);
         }
     }
     if (envs.length > 0 && envs[0] != null) {
-        return caseConverter.screamingSnakeUnsafe(envs[0].name);
+        return context.caseConverter.screamingSnakeUnsafe(envs[0].name);
     }
     return undefined;
 }

--- a/generators/python-v2/sdk/src/reference/buildReference.ts
+++ b/generators/python-v2/sdk/src/reference/buildReference.ts
@@ -392,13 +392,14 @@ function isTypeOptional(typeReference: FernIr.TypeReference): boolean {
 }
 
 function unwrapOptionalType(context: SdkGeneratorContext, typeReference: FernIr.TypeReference): string {
-    if (typeReference.type === "container") {
-        if (typeReference.container.type === "optional") {
-            return getTypeString(context, typeReference.container.optional);
-        }
-        if (typeReference.container.type === "nullable") {
-            return getTypeString(context, typeReference.container.nullable);
-        }
+    if (typeReference.type !== "container") {
+        return getTypeString(context, typeReference);
+    }
+    if (typeReference.container.type === "optional") {
+        return getTypeString(context, typeReference.container.optional);
+    }
+    if (typeReference.container.type === "nullable") {
+        return getTypeString(context, typeReference.container.nullable);
     }
     return getTypeString(context, typeReference);
 }

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -4,7 +4,7 @@ import { FernIr as DynamicFernIr } from "@fern-api/dynamic-ir-sdk";
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import { WireMockMapping } from "@fern-api/mock-utils";
 import { python } from "@fern-api/python-ast";
-import { PYTHON_CASE_CONVERTER as caseConverter, WriteablePythonFile } from "@fern-api/python-base";
+import { WriteablePythonFile } from "@fern-api/python-base";
 import { DynamicSnippetsGenerator } from "@fern-api/python-dynamic-snippets";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
@@ -351,12 +351,14 @@ export class WireTestGenerator {
 
             // Exclusions use definition-level identifiers in the form "<service_path>.<endpoint_name>"
             // or "<service_path>.*" to exclude an entire service.
-            const servicePathParts = service.name.fernFilepath.allParts.map((part) => caseConverter.snakeSafe(part));
+            const servicePathParts = service.name.fernFilepath.allParts.map((part) =>
+                this.context.caseConverter.snakeSafe(part)
+            );
             const servicePath = servicePathParts.join(".");
             const selector =
                 servicePath.length > 0
-                    ? `${servicePath}.${caseConverter.snakeSafe(endpoint.name)}`
-                    : caseConverter.snakeSafe(endpoint.name);
+                    ? `${servicePath}.${this.context.caseConverter.snakeSafe(endpoint.name)}`
+                    : this.context.caseConverter.snakeSafe(endpoint.name);
             const excluded = this.context.customConfig.wire_tests?.exclusions ?? [];
             if (
                 excluded.includes(selector) ||
@@ -514,8 +516,10 @@ export class WireTestGenerator {
         endpoint: FernIr.HttpEndpoint,
         exampleIndex: number
     ): string {
-        const servicePathParts = service.name.fernFilepath.allParts.map((part) => caseConverter.snakeSafe(part));
-        const endpointName = caseConverter.snakeSafe(endpoint.name);
+        const servicePathParts = service.name.fernFilepath.allParts.map((part) =>
+            this.context.caseConverter.snakeSafe(part)
+        );
+        const endpointName = this.context.caseConverter.snakeSafe(endpoint.name);
 
         const segments: string[] = [];
         if (servicePathParts.length > 0) {
@@ -716,7 +720,7 @@ export class WireTestGenerator {
     // =============================================================================
 
     private getTestFunctionName(serviceName: string, endpoint: FernIr.HttpEndpoint): string {
-        const endpointName = caseConverter.snakeSafe(endpoint.name);
+        const endpointName = this.context.caseConverter.snakeSafe(endpoint.name);
         return `test_${serviceName}_${endpointName}`;
     }
 
@@ -825,6 +829,6 @@ export class WireTestGenerator {
     }
 
     private getFormattedServiceName(service: FernIr.HttpService): string {
-        return service.name.fernFilepath.allParts.map((part) => caseConverter.camelUnsafe(part)).join("_");
+        return service.name.fernFilepath.allParts.map((part) => this.context.caseConverter.camelUnsafe(part)).join("_");
     }
 }

--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -2,7 +2,6 @@ import { File, getNameFromWireValue, getWireValue } from "@fern-api/base-generat
 import { assertNever } from "@fern-api/core-utils";
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import { isEqualToMatcher, WireMock, WireMockStubMapping } from "@fern-api/mock-utils";
-import { PYTHON_CASE_CONVERTER as caseConverter } from "@fern-api/python-base";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 
@@ -598,7 +597,7 @@ def pytest_unconfigure(config: pytest.Config) -> None:
 
             // Build kwargs for all base URLs using dynamic base_url variable
             const baseUrlKwargsDynamic = envConfig.baseUrls
-                .map((baseUrl) => `${caseConverter.snakeSafe(baseUrl.name)}=base_url`)
+                .map((baseUrl) => `${this.context.caseConverter.snakeSafe(baseUrl.name)}=base_url`)
                 .join(", ");
 
             return {
@@ -635,7 +634,7 @@ def pytest_unconfigure(config: pytest.Config) -> None:
         // Process global headers that might require values
         if (this.ir.headers) {
             for (const header of this.ir.headers) {
-                const paramName = caseConverter.snakeSafe(getNameFromWireValue(header.name));
+                const paramName = this.context.caseConverter.snakeSafe(getNameFromWireValue(header.name));
                 // Only add if not already added by auth schemes
                 if (!params.some((p) => p.startsWith(`        ${paramName}=`))) {
                     params.push(`        ${paramName}="test_${paramName}",`);
@@ -655,24 +654,24 @@ def pytest_unconfigure(config: pytest.Config) -> None:
         switch (scheme.type) {
             case "bearer":
                 // Bearer auth uses a token parameter
-                params.push(`        ${caseConverter.snakeSafe(scheme.token)}="test_token",`);
+                params.push(`        ${this.context.caseConverter.snakeSafe(scheme.token)}="test_token",`);
                 break;
 
             case "basic":
                 // Basic auth uses username and password parameters (skip omitted fields).
                 // Values must use hyphens ("test-username") to match mock-utils WireMock stubs.
                 if (!scheme.usernameOmit) {
-                    params.push(`        ${caseConverter.snakeSafe(scheme.username)}="test-username",`);
+                    params.push(`        ${this.context.caseConverter.snakeSafe(scheme.username)}="test-username",`);
                 }
                 if (!scheme.passwordOmit) {
-                    params.push(`        ${caseConverter.snakeSafe(scheme.password)}="test-password",`);
+                    params.push(`        ${this.context.caseConverter.snakeSafe(scheme.password)}="test-password",`);
                 }
                 break;
 
             case "header":
                 // Header auth uses a custom header parameter
                 params.push(
-                    `        ${caseConverter.snakeSafe(getNameFromWireValue(scheme.name))}="test_${caseConverter.snakeSafe(getNameFromWireValue(scheme.name))}",`
+                    `        ${this.context.caseConverter.snakeSafe(getNameFromWireValue(scheme.name))}="test_${this.context.caseConverter.snakeSafe(getNameFromWireValue(scheme.name))}",`
                 );
                 break;
 

--- a/generators/python/sdk/changes/unreleased/respect-smart-casing-config.yml
+++ b/generators/python/sdk/changes/unreleased/respect-smart-casing-config.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Respect the customer's `smart-casing` flag from `generators.yml` when computing
+    Python identifiers from compressed v66 IR strings. Previously the v1 Python
+    generator's `_smart_snake` and v2's `PYTHON_CASE_CONVERTER` were both hardcoded
+    with `smartCasing: true`, causing names produced by the generator to diverge
+    from the IR's pre-computed `snake_case` values when the customer set
+    `smart-casing: false`. This manifested as wire-test method calls and Pydantic
+    field aliases that did not exist on the generated client (e.g. test calling
+    `set_fcmv_1_provider()` while the client method was named `set_fcmv1provider`).
+
+    `_smart_snake` and the v2 `caseConverter` now read `casingsConfig.smartCasing`
+    from the IR and switch between smart-casing semantics (default) and plain
+    lodash semantics (`smart-casing: false`). No effect for customers who use
+    the default; fixes generation for customers like auth0 that opt out.
+  type: fix

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -10,6 +10,7 @@ from .publisher import Publisher
 from fern_python.codegen.project import Project, ProjectConfig
 from fern_python.external_dependencies.ruff import RUFF_DEPENDENCY
 from fern_python.generator_exec_wrapper import GeneratorExecWrapper
+from fern_python.utils import configure_smart_casing
 from fern_python.version import GithubCIPythonVersionResolver, PythonVersion, get_minimum_compatible_version
 
 import fern.ir.resources as ir_types
@@ -35,6 +36,12 @@ class AbstractGenerator(ABC):
         ir: ir_types.IntermediateRepresentation,
         generator_config: GeneratorConfig,
     ) -> None:
+        # Configure smart-casing from the IR's casingsConfig (driven by the customer's
+        # `smart-casing` flag in generators.yml). Must run before any name resolution
+        # so _smart_snake matches the IR server's pre-computed snake_case values.
+        smart_casing = ir.casings_config.smart_casing if ir.casings_config is not None else True
+        configure_smart_casing(smart_casing)
+
         project_config = generator_config.output.mode.visit(
             download_files=lambda: None,
             publish=lambda publish: ProjectConfig(

--- a/generators/python/src/fern_python/utils/__init__.py
+++ b/generators/python/src/fern_python/utils/__init__.py
@@ -1,4 +1,11 @@
-from .name_resolver import get_name_from_wire_value, get_original_name, get_wire_value, resolve_name, resolve_wire_name
+from .name_resolver import (
+    configure_smart_casing,
+    get_name_from_wire_value,
+    get_original_name,
+    get_wire_value,
+    resolve_name,
+    resolve_wire_name,
+)
 from .pascal_case import pascal_case
 from .snake_case import snake_case
 
@@ -13,6 +20,7 @@ def __getattr__(name: str) -> object:  # type: ignore[return]
 
 __all__ = [
     "build_snippet_writer",
+    "configure_smart_casing",
     "get_name_from_wire_value",
     "get_original_name",
     "get_wire_value",

--- a/generators/python/src/fern_python/utils/name_resolver.py
+++ b/generators/python/src/fern_python/utils/name_resolver.py
@@ -29,6 +29,8 @@ def configure_smart_casing(enabled: bool) -> None:
     """Set whether _smart_snake uses smartCasing semantics. Must be called before
     any name resolution (cache is cleared to invalidate any pre-flag results)."""
     global _smart_casing_enabled
+    if _smart_casing_enabled == enabled:
+        return
     _smart_casing_enabled = enabled
     _resolve_string_name.cache_clear()
 

--- a/generators/python/src/fern_python/utils/name_resolver.py
+++ b/generators/python/src/fern_python/utils/name_resolver.py
@@ -18,6 +18,20 @@ import fern.ir.resources as ir_types
 
 _DIGIT_SPLIT = re.compile(r"(\d+)")
 
+# Mirrors @fern-api/casings-generator's `smartCasing` config from the customer's
+# generators.yml (`smart-casing: true|false`). The IR pre-computes Name.snake_case
+# using this flag; recomputed names from compressed v66 strings must use the same
+# semantics or v1's output diverges from the IR's pre-computed values (and from v2).
+_smart_casing_enabled = True
+
+
+def configure_smart_casing(enabled: bool) -> None:
+    """Set whether _smart_snake uses smartCasing semantics. Must be called before
+    any name resolution (cache is cleared to invalidate any pre-flag results)."""
+    global _smart_casing_enabled
+    _smart_casing_enabled = enabled
+    _resolve_string_name.cache_clear()
+
 
 def _to_camel(s: str) -> str:
     snake = to_snake(s)
@@ -28,13 +42,19 @@ def _to_camel(s: str) -> str:
 
 
 def _smart_snake(s: str) -> str:
-    """Smart-casing snake_case matching @fern-api/casings-generator.
+    """Snake_case matching @fern-api/casings-generator's snakeCase output.
 
-    Treats digits adjacent to letters as part of the same word so
-    ``3d`` stays ``3d`` instead of becoming ``3_d``. Mirrors:
+    When smartCasing is enabled (the default), digits adjacent to letters stay
+    attached so ``3d`` -> ``3d`` and ``base64`` -> ``base64``. Mirrors:
 
         n.split(" ").map(part => part.split(/(\\d+)/).map(snakeCase).join("")).join("_")
+
+    When smartCasing is disabled (``smart-casing: false`` in generators.yml), every
+    digit run is treated as a separate word, matching plain lodash ``snakeCase``:
+    ``setFcmv1Provider`` -> ``set_fcmv_1_provider``, ``auth0_mapping`` -> ``auth_0_mapping``.
     """
+    if not _smart_casing_enabled:
+        return "_".join(to_snake(part) for part in s.split(" "))
     return "_".join("".join(to_snake(sub) for sub in _DIGIT_SPLIT.split(part)) for part in s.split(" "))
 
 

--- a/generators/python/tests/utils/casing/test_smart_casing.py
+++ b/generators/python/tests/utils/casing/test_smart_casing.py
@@ -1,0 +1,97 @@
+"""Tests for the smart-casing dispatch in name_resolver.
+
+Mirrors @fern-api/casings-generator's `smartCasing` flag from generators.yml.
+When `smart-casing: true` (the default), digits adjacent to letters stay attached
+(`base64` -> `base64`). When `smart-casing: false`, every digit run is a word
+boundary, matching plain lodash `snakeCase` (`base64` -> `base_64`,
+`setFcmv1Provider` -> `set_fcmv_1_provider`).
+"""
+
+import pytest
+
+from fern_python.utils import configure_smart_casing
+from fern_python.utils.name_resolver import _resolve_string_name, _smart_snake
+
+
+@pytest.fixture(autouse=True)
+def reset_smart_casing():
+    """Restore the default (smartCasing=True) between tests so module state
+    doesn't leak across test order."""
+    configure_smart_casing(True)
+    yield
+    configure_smart_casing(True)
+
+
+class TestSmartCasingTrue:
+    """Default behavior: digit suffixes attach (`base64`, `applicationV1`, `v2`)."""
+
+    def test_digit_suffixes_attach(self) -> None:
+        assert _smart_snake("base64") == "base64"
+        assert _smart_snake("utf8") == "utf8"
+        assert _smart_snake("sha256") == "sha256"
+
+    def test_camelcase_with_trailing_digit_keeps_digit_attached(self) -> None:
+        assert _smart_snake("applicationV1") == "application_v1"
+
+    def test_short_digit_prefixed_identifier(self) -> None:
+        assert _smart_snake("3d") == "3d"
+        assert _smart_snake("2fa") == "2fa"
+
+    def test_digit_in_middle_of_camelcase(self) -> None:
+        # Documented smartCasing limitation — digit between camelCase words
+        # collapses to no separator. This matches the canonical TS smartSnakeFn.
+        assert _smart_snake("setFcmv1Provider") == "set_fcmv1provider"
+        assert _smart_snake("auth0Mapping") == "auth0mapping"
+
+
+class TestSmartCasingFalse:
+    """smart-casing: false (e.g. auth0 generators.yml): digit runs are word boundaries."""
+
+    def setup_method(self) -> None:
+        configure_smart_casing(False)
+
+    def test_digit_suffixes_separate(self) -> None:
+        assert _smart_snake("base64") == "base_64"
+        assert _smart_snake("utf8") == "utf_8"
+
+    def test_digit_in_camelcase_separates(self) -> None:
+        # The auth0 case that motivated this flag.
+        assert _smart_snake("setFcmv1Provider") == "set_fcmv_1_provider"
+        assert _smart_snake("updateFcmv1Provider") == "update_fcmv_1_provider"
+
+    def test_digit_in_snake_case_preserves_separators(self) -> None:
+        assert _smart_snake("auth0_mapping") == "auth_0_mapping"
+        assert _smart_snake("auth0Mapping") == "auth_0_mapping"
+
+    def test_multiple_digit_runs(self) -> None:
+        assert _smart_snake("org.iso.18013.5.1") == "org_iso_18013_5_1"
+        assert _smart_snake("org_iso_18013_5_1") == "org_iso_18013_5_1"
+
+
+class TestConfigureSmartCasing:
+    def test_toggling_clears_resolve_cache(self) -> None:
+        configure_smart_casing(True)
+        smart = _resolve_string_name("setFcmv1Provider")
+        assert smart.snake_case.safe_name == "set_fcmv1provider"
+
+        configure_smart_casing(False)
+        plain = _resolve_string_name("setFcmv1Provider")
+        assert plain.snake_case.safe_name == "set_fcmv_1_provider"
+        assert plain is not smart
+
+    def test_no_op_configure_preserves_cache(self) -> None:
+        configure_smart_casing(True)
+        first = _resolve_string_name("setFcmv1Provider")
+        configure_smart_casing(True)
+        second = _resolve_string_name("setFcmv1Provider")
+        assert first is second
+
+    def test_digit_prefixed_identifier_remains_safe_under_both_modes(self) -> None:
+        # Field "3d" is the original reserved-keywords seed case: must produce
+        # a valid Python identifier (sanitized to f_3d downstream) regardless
+        # of smart-casing. With smartCasing it goes 3d -> _3d -> f_3d; without
+        # it goes 3_d -> _3_d -> f_3_d. Both are valid.
+        configure_smart_casing(True)
+        assert _resolve_string_name("3d").snake_case.safe_name == "_3d"
+        configure_smart_casing(False)
+        assert _resolve_string_name("3d").snake_case.safe_name == "_3_d"

--- a/generators/python/tests/utils/casing/test_smart_casing.py
+++ b/generators/python/tests/utils/casing/test_smart_casing.py
@@ -7,6 +7,8 @@ boundary, matching plain lodash `snakeCase` (`base64` -> `base_64`,
 `setFcmv1Provider` -> `set_fcmv_1_provider`).
 """
 
+from typing import Iterator
+
 import pytest
 
 from fern_python.utils import configure_smart_casing
@@ -14,7 +16,7 @@ from fern_python.utils.name_resolver import _resolve_string_name, _smart_snake
 
 
 @pytest.fixture(autouse=True)
-def reset_smart_casing():
+def reset_smart_casing() -> Iterator[None]:
     """Restore the default (smartCasing=True) between tests so module state
     doesn't leak across test order."""
     configure_smart_casing(True)


### PR DESCRIPTION
## Summary

The Python generator (v1 and v2) was hardcoded with \`smartCasing: true\`, ignoring the \`smart-casing\` flag from \`generators.yml\`. When customers opt out (\`smart-casing: false\`), the IR pre-computes \`Name.snake_case\` with plain lodash semantics, but the generator recomputes compressed v66 strings with smart-casing — producing names that don't match what the IR (and v2 wire tests) expect.

This PR plumbs \`ir.casingsConfig.smartCasing\` through to:
1. v1's \`_smart_snake\` (via a module-level flag set at generator startup)
2. v2's \`PYTHON_CASE_CONVERTER\` (now per-context, constructed from the IR)

## Example

Auth0's \`generators.yml\`:

\`\`\`yaml
python-sdk:
  generators:
    - name: fernapi/fern-python-sdk
      smart-casing: false
\`\`\`

## Why this is the right fix

The IR explicitly carries \`casingsConfig.smartCasing\` so consumers can reconstruct the correct CasingsGenerator. The Python generator just wasn't reading it. For customers with the default \`smart-casing: true\`, behavior is unchanged. Only customers who opt out (currently the failure mode) see the fix take effect.

## Test plan

- [x] Auth0 SDK regenerated locally — method names, Pydantic field names, and wire test method calls all match
- [x] Python-v2 packages compile cleanly (\`pnpm turbo run compile\`)
- [ ] Seed CI green (verifies non-auth0 customers with default smart-casing are unaffected)
- [ ] Reserved-keywords seed fixture still produces \`f_3d\` (default \`smart-casing: true\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)