### PR TITLE
fix(php): emit required global headers as named constructor arguments

### DIFF
--- a/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -251,14 +251,20 @@ export class EndpointSnippetGenerator {
         }
 
         this.context.errors.scope(Scope.Headers);
+        const requiredGlobalHeaderArgs: NamedArgument[] = [];
+        if (this.context.ir.headers != null) {
+            requiredGlobalHeaderArgs.push(
+                ...this.getRequiredGlobalHeaderArgs({ headers: this.context.ir.headers, values: snippet.headers })
+            );
+        }
         if (this.context.ir.headers != null && snippet.headers != null) {
             optionArgs.push(
-                ...this.getConstructorHeaderArgs({ headers: this.context.ir.headers, values: snippet.headers })
+                ...this.getOptionalGlobalHeaderArgs({ headers: this.context.ir.headers, values: snippet.headers })
             );
         }
         this.context.errors.unscope();
 
-        const args: NamedArgument[] = [...authArgs];
+        const args: NamedArgument[] = [...requiredGlobalHeaderArgs, ...authArgs];
 
         if (environmentArg != null) {
             args.push(environmentArg);
@@ -664,7 +670,71 @@ export class EndpointSnippetGenerator {
         return [];
     }
 
-    private getConstructorHeaderArgs({
+    // NOTE: We intentionally avoid this.context.isOptional here because it treats
+    // named aliases to nullable types as optional, which would misclassify required
+    // headers with nullable alias types (they're still required constructor params).
+    private isHeaderTypeOptional(typeReference: FernIr.dynamic.TypeReference): boolean {
+        switch (typeReference.type) {
+            case "optional":
+                return true;
+            case "nullable":
+                return this.isHeaderTypeOptional(typeReference.value);
+            default:
+                return false;
+        }
+    }
+
+    private getRequiredGlobalHeaderArgs({
+        headers,
+        values
+    }: {
+        headers: FernIr.dynamic.NamedParameter[];
+        values: FernIr.dynamic.Values | undefined;
+    }): NamedArgument[] {
+        const args: NamedArgument[] = [];
+        for (const header of headers) {
+            if (this.isHeaderTypeOptional(header.typeReference)) {
+                continue;
+            }
+            const value = values?.[header.name.wireValue];
+            const arg = this.getRequiredGlobalHeaderValue({ header, value });
+            if (arg != null) {
+                args.push({
+                    name: this.context.getPropertyName(header.name.name),
+                    assignment: arg
+                });
+            }
+        }
+        return args;
+    }
+
+    private getRequiredGlobalHeaderValue({
+        header,
+        value
+    }: {
+        header: FernIr.dynamic.NamedParameter;
+        value: unknown;
+    }): php.TypeLiteral | undefined {
+        if (value !== undefined) {
+            const typeLiteral = this.context.dynamicTypeLiteralMapper.convert({
+                typeReference: header.typeReference,
+                value
+            });
+            if (php.TypeLiteral.isNop(typeLiteral)) {
+                return undefined;
+            }
+            return typeLiteral;
+        }
+        const placeholder = this.context.dynamicTypeLiteralMapper.generatePlaceholderValueForRequiredHeader({
+            typeReference: header.typeReference
+        });
+        if (php.TypeLiteral.isNop(placeholder)) {
+            return undefined;
+        }
+        return placeholder;
+    }
+
+    private getOptionalGlobalHeaderArgs({
         headers,
         values
     }: {
@@ -673,6 +743,9 @@ export class EndpointSnippetGenerator {
     }): php.ConstructorField[] {
         const args: php.ConstructorField[] = [];
         for (const header of headers) {
+            if (!this.isHeaderTypeOptional(header.typeReference)) {
+                continue;
+            }
             const value = values[header.name.wireValue];
             const arg = this.getConstructorHeaderArg({ header, value });
             if (arg != null) {

--- a/generators/php/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/php/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -635,10 +635,8 @@ namespace Example;
 use Acme\\AcmeClient;
 
 $client = new AcmeClient(
+    tenantId: 'my-tenant-id',
     token: '<YOUR_API_KEY>',
-    options: [
-        'tenantId' => 'my-tenant-id',
-    ],
 );
 $client->plantstore->list();
 "
@@ -653,10 +651,8 @@ use Acme\\AcmeClient;
 use Acme\\Plantstore\\Types\\CreatePlantRequest;
 
 $client = new AcmeClient(
+    tenantId: 'my-tenant-id',
     token: '<YOUR_API_KEY>',
-    options: [
-        'tenantId' => 'my-tenant-id',
-    ],
 );
 $client->plantstore->create(
     new CreatePlantRequest([

--- a/generators/php/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/php/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -386,6 +386,14 @@ export class DynamicTypeLiteralMapper {
         return this.context.isOptional(typeReference) || this.context.isNullable(typeReference);
     }
 
+    public generatePlaceholderValueForRequiredHeader({
+        typeReference
+    }: {
+        typeReference: FernIr.dynamic.TypeReference;
+    }): php.TypeLiteral {
+        return this.generatePlaceholderValue(typeReference);
+    }
+
     private generatePlaceholderValue(typeReference: FernIr.dynamic.TypeReference): php.TypeLiteral {
         switch (typeReference.type) {
             case "primitive":

--- a/generators/php/sdk/changes/unreleased/fix-snippet-required-global-headers.yml
+++ b/generators/php/sdk/changes/unreleased/fix-snippet-required-global-headers.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix dynamic snippet generator to emit required global headers as named
+    constructor arguments instead of inside the options array.
+  type: fix


### PR DESCRIPTION
## Summary
- Fix PHP dynamic snippet generator to emit required global headers as named constructor arguments instead of inside the `options` array
- Split `getConstructorHeaderArgs` into `getRequiredGlobalHeaderArgs` (positional) and `getOptionalGlobalHeaderArgs` (options array), using a dedicated `isHeaderTypeOptional` predicate that correctly handles nullable alias types
- Adds `generatePlaceholderValueForRequiredHeader` for fallback values when snippet data is missing

## Context
When the OpenAPI importer turns an `apiKey-in-header` security scheme into a required global header, the PHP SDK constructor takes that header as a required positional parameter (e.g. `string $authorization`). The snippet generator was placing these in the `options` array, producing constructor calls that omitted the required parameter — causing phpstan failures.

## Test plan
- [x] All 32 existing PHP dynamic snippet tests pass
- [x] Snapshot updated: `tenantId` moves from `options` array to named constructor arg
- [x] Adversarial review (2 rounds) — identified and fixed nullable-alias edge case
- [x] Independent cold review approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)