### PR TITLE
fix(swift): emit wire-test response bodies as raw multi-line string literals

### DIFF
--- a/generators/swift/codegen/src/ast/Expression.ts
+++ b/generators/swift/codegen/src/ast/Expression.ts
@@ -103,6 +103,11 @@ type StringLiteral = {
     escape?: boolean;
 };
 
+type RawMultiLineStringLiteral = {
+    type: "raw-multi-line-string-literal";
+    value: string;
+};
+
 type NumberLiteral = {
     type: "number-literal";
     value: number;
@@ -170,6 +175,7 @@ type InternalExpression =
     | ForceTry
     | Await
     | StringLiteral
+    | RawMultiLineStringLiteral
     | NumberLiteral
     | BoolLiteral
     | DateLiteral
@@ -320,6 +326,13 @@ export class Expression extends AstNode {
                         : `"${this.internalExpression.value}"`
                 );
                 break;
+            case "raw-multi-line-string-literal":
+                writer.write(`#"""`);
+                writer.newLine();
+                writer.write(this.internalExpression.value);
+                writer.newLine();
+                writer.write(`"""#`);
+                break;
             case "number-literal":
                 writer.write(this.internalExpression.value.toString());
                 break;
@@ -467,6 +480,19 @@ export class Expression extends AstNode {
 
     public static stringLiteral(value: string): Expression {
         return new this({ type: "string-literal", value });
+    }
+
+    /**
+     * Emits `value` as a Swift raw multi-line string literal (`#"""..."""#`).
+     * Inside a raw string literal, escape sequences such as `\n` are NOT
+     * interpreted by the Swift compiler -- they remain as literal
+     * backslash-n characters at runtime. Use this when `value` already
+     * contains escape sequences that must survive verbatim into the
+     * runtime `String` (e.g. JSON payloads where `\n` must reach the
+     * JSON parser as `\n`, not as a real newline).
+     */
+    public static rawMultiLineStringLiteral(value: string): Expression {
+        return new this({ type: "raw-multi-line-string-literal", value });
     }
 
     /**

--- a/generators/swift/codegen/src/ast/__test__/expression/expression.test.ts
+++ b/generators/swift/codegen/src/ast/__test__/expression/expression.test.ts
@@ -3,6 +3,18 @@ import { describe, expect, it } from "vitest";
 import { swift } from "../../../index.js";
 
 describe("Expression", () => {
+    describe("rawMultiLineStringLiteral", () => {
+        it("should preserve embedded escape sequences verbatim", () => {
+            const rawMultiLineStringLiteral = swift.Expression.rawMultiLineStringLiteral(
+                '{"calendar":"BEGIN:VEVENT\\nDTSTART:20260101"}'
+            );
+
+            expect(rawMultiLineStringLiteral.toString()).toBe(
+                '#"""\n{"calendar":"BEGIN:VEVENT\\nDTSTART:20260101"}\n"""#'
+            );
+        });
+    });
+
     describe("functionCall multiline vs single-line", () => {
         it("should write single-line function call with multiple arguments", () => {
             const functionCall = swift.Expression.functionCall({

--- a/generators/swift/sdk/changes/unreleased/fix-wire-test-raw-string-literal.yml
+++ b/generators/swift/sdk/changes/unreleased/fix-wire-test-raw-string-literal.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Use raw multi-line string literals (`#"""..."""#`) for wire-test response body stubs so that
+    escape sequences like `\n` in example values (e.g. iCalendar payloads) survive as literal
+    characters and produce valid JSON at runtime.
+  type: fix

--- a/generators/swift/sdk/src/generators/test/WireTestFunctionGenerator.ts
+++ b/generators/swift/sdk/src/generators/test/WireTestFunctionGenerator.ts
@@ -95,8 +95,10 @@ export class WireTestFunctionGenerator {
                                         arguments_: [
                                             swift.functionArgument({
                                                 value: swift.Expression.memberAccess({
-                                                    target: swift.Expression.stringLiteral(
-                                                        `""\n${typeof exampleTypeRef.jsonExample === "string" ? exampleTypeRef.jsonExample : JSON.stringify(exampleTypeRef.jsonExample, null, 2)}\n""`
+                                                    target: swift.Expression.rawMultiLineStringLiteral(
+                                                        typeof exampleTypeRef.jsonExample === "string"
+                                                            ? exampleTypeRef.jsonExample
+                                                            : JSON.stringify(exampleTypeRef.jsonExample, null, 2)
                                                     ),
                                                     memberName: "utf8"
                                                 })

--- a/seed/swift-sdk/accept-header/.fern/metadata.json
+++ b/seed/swift-sdk/accept-header/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/alias-extends/.fern/metadata.json
+++ b/seed/swift-sdk/alias-extends/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/alias/.fern/metadata.json
+++ b/seed/swift-sdk/alias/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/allof-inline/.fern/metadata.json
+++ b/seed/swift-sdk/allof-inline/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/allof/.fern/metadata.json
+++ b/seed/swift-sdk/allof/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/any-auth/.fern/metadata.json
+++ b/seed/swift-sdk/any-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/any-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/any-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,13 +7,13 @@ import AnyAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = AnyAuthClient(

--- a/seed/swift-sdk/any-auth/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/any-auth/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -7,7 +7,7 @@ import AnyAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -18,7 +18,7 @@ import AnyAuth
                     "name": "name"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = AnyAuthClient(
@@ -44,7 +44,7 @@ import AnyAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -55,7 +55,7 @@ import AnyAuth
                     "name": "name"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = AnyAuthClient(

--- a/seed/swift-sdk/api-wide-base-path/.fern/metadata.json
+++ b/seed/swift-sdk/api-wide-base-path/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/audiences/.fern/metadata.json
+++ b/seed/swift-sdk/audiences/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/audiences/Tests/Wire/Resources/FolderA/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/audiences/Tests/Wire/Resources/FolderA/Service/ServiceClientWireTests.swift
@@ -7,7 +7,7 @@ import Audiences
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "foo": {
                     "foo": {
@@ -15,7 +15,7 @@ import Audiences
                     }
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = AudiencesClient(

--- a/seed/swift-sdk/audiences/Tests/Wire/Resources/FolderD/Service/FolderDServiceClientWireTests.swift
+++ b/seed/swift-sdk/audiences/Tests/Wire/Resources/FolderD/Service/FolderDServiceClientWireTests.swift
@@ -7,11 +7,11 @@ import Audiences
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "foo": "foo"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = AudiencesClient(

--- a/seed/swift-sdk/audiences/Tests/Wire/Resources/Foo/FooClientWireTests.swift
+++ b/seed/swift-sdk/audiences/Tests/Wire/Resources/Foo/FooClientWireTests.swift
@@ -7,11 +7,11 @@ import Audiences
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "imported": "imported"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = AudiencesClient(

--- a/seed/swift-sdk/basic-auth-environment-variables/.fern/metadata.json
+++ b/seed/swift-sdk/basic-auth-environment-variables/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/basic-auth-environment-variables/Tests/Wire/Resources/BasicAuth/BasicAuthClientWireTests.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Tests/Wire/Resources/BasicAuth/BasicAuthClientWireTests.swift
@@ -7,9 +7,9 @@ import BasicAuthEnvironmentVariables
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = BasicAuthEnvironmentVariablesClient(
@@ -27,9 +27,9 @@ import BasicAuthEnvironmentVariables
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = BasicAuthEnvironmentVariablesClient(

--- a/seed/swift-sdk/basic-auth-pw-omitted/.fern/metadata.json
+++ b/seed/swift-sdk/basic-auth-pw-omitted/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/basic-auth-pw-omitted/Tests/Wire/Resources/BasicAuth/BasicAuthClientWireTests.swift
+++ b/seed/swift-sdk/basic-auth-pw-omitted/Tests/Wire/Resources/BasicAuth/BasicAuthClientWireTests.swift
@@ -7,9 +7,9 @@ import BasicAuthPwOmitted
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = BasicAuthPwOmittedClient(
@@ -27,9 +27,9 @@ import BasicAuthPwOmitted
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = BasicAuthPwOmittedClient(
@@ -47,9 +47,9 @@ import BasicAuthPwOmitted
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = BasicAuthPwOmittedClient(
@@ -72,9 +72,9 @@ import BasicAuthPwOmitted
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = BasicAuthPwOmittedClient(

--- a/seed/swift-sdk/basic-auth/.fern/metadata.json
+++ b/seed/swift-sdk/basic-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/basic-auth/Tests/Wire/Resources/BasicAuth/BasicAuthClient_WireTests.swift
+++ b/seed/swift-sdk/basic-auth/Tests/Wire/Resources/BasicAuth/BasicAuthClient_WireTests.swift
@@ -7,9 +7,9 @@ import BasicAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = BasicAuthClient(
@@ -27,9 +27,9 @@ import BasicAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = BasicAuthClient(
@@ -47,9 +47,9 @@ import BasicAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = BasicAuthClient(
@@ -72,9 +72,9 @@ import BasicAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = BasicAuthClient(

--- a/seed/swift-sdk/bearer-token-environment-variable/.fern/metadata.json
+++ b/seed/swift-sdk/bearer-token-environment-variable/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/bearer-token-environment-variable/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -7,9 +7,9 @@ import BearerTokenEnvironmentVariable
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = BearerTokenEnvironmentVariableClient(

--- a/seed/swift-sdk/bytes-download/.fern/metadata.json
+++ b/seed/swift-sdk/bytes-download/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/bytes-upload/.fern/metadata.json
+++ b/seed/swift-sdk/bytes-upload/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/circular-references-advanced/.fern/metadata.json
+++ b/seed/swift-sdk/circular-references-advanced/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/circular-references-extends/.fern/metadata.json
+++ b/seed/swift-sdk/circular-references-extends/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/circular-references/.fern/metadata.json
+++ b/seed/swift-sdk/circular-references/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/client-side-params/no-custom-config/.fern/metadata.json
+++ b/seed/swift-sdk/client-side-params/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/client-side-params/no-custom-config/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -7,7 +7,7 @@ import ClientSideParams
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -34,7 +34,7 @@ import ClientSideParams
                     }
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = ClientSideParamsClient(
@@ -89,7 +89,7 @@ import ClientSideParams
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
@@ -102,7 +102,7 @@ import ClientSideParams
                     }
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ClientSideParamsClient(
@@ -137,7 +137,7 @@ import ClientSideParams
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "results": [
                     {
@@ -168,7 +168,7 @@ import ClientSideParams
                   "total": 1,
                   "next_offset": 1
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ClientSideParamsClient(
@@ -230,7 +230,7 @@ import ClientSideParams
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "users": [
                     {
@@ -341,7 +341,7 @@ import ClientSideParams
                   "length": 1,
                   "total": 1
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ClientSideParamsClient(
@@ -485,7 +485,7 @@ import ClientSideParams
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "user_id": "user_id",
                   "email": "email",
@@ -537,7 +537,7 @@ import ClientSideParams
                   "given_name": "given_name",
                   "family_name": "family_name"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ClientSideParamsClient(
@@ -613,7 +613,7 @@ import ClientSideParams
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "user_id": "user_id",
                   "email": "email",
@@ -665,7 +665,7 @@ import ClientSideParams
                   "given_name": "given_name",
                   "family_name": "family_name"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ClientSideParamsClient(
@@ -757,7 +757,7 @@ import ClientSideParams
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "user_id": "user_id",
                   "email": "email",
@@ -809,7 +809,7 @@ import ClientSideParams
                   "given_name": "given_name",
                   "family_name": "family_name"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ClientSideParamsClient(
@@ -902,7 +902,7 @@ import ClientSideParams
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -955,7 +955,7 @@ import ClientSideParams
                     }
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = ClientSideParamsClient(
@@ -1036,7 +1036,7 @@ import ClientSideParams
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
@@ -1062,7 +1062,7 @@ import ClientSideParams
                     }
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ClientSideParamsClient(
@@ -1111,7 +1111,7 @@ import ClientSideParams
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "start": 1,
                   "limit": 1,
@@ -1270,7 +1270,7 @@ import ClientSideParams
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ClientSideParamsClient(
@@ -1485,7 +1485,7 @@ import ClientSideParams
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "client_id": "client_id",
                   "tenant": "tenant",
@@ -1561,7 +1561,7 @@ import ClientSideParams
                     }
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ClientSideParamsClient(

--- a/seed/swift-sdk/client-side-params/with-custom-config/.fern/metadata.json
+++ b/seed/swift-sdk/client-side-params/with-custom-config/.fern/metadata.json
@@ -7,8 +7,7 @@
     "clientClassName": "MyCustomClient"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/client-side-params/with-custom-config/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -7,7 +7,7 @@ import MyCustomModule
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -34,7 +34,7 @@ import MyCustomModule
                     }
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = MyCustomClient(
@@ -89,7 +89,7 @@ import MyCustomModule
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
@@ -102,7 +102,7 @@ import MyCustomModule
                     }
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = MyCustomClient(
@@ -137,7 +137,7 @@ import MyCustomModule
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "results": [
                     {
@@ -168,7 +168,7 @@ import MyCustomModule
                   "total": 1,
                   "next_offset": 1
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = MyCustomClient(
@@ -230,7 +230,7 @@ import MyCustomModule
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "users": [
                     {
@@ -341,7 +341,7 @@ import MyCustomModule
                   "length": 1,
                   "total": 1
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = MyCustomClient(
@@ -485,7 +485,7 @@ import MyCustomModule
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "user_id": "user_id",
                   "email": "email",
@@ -537,7 +537,7 @@ import MyCustomModule
                   "given_name": "given_name",
                   "family_name": "family_name"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = MyCustomClient(
@@ -613,7 +613,7 @@ import MyCustomModule
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "user_id": "user_id",
                   "email": "email",
@@ -665,7 +665,7 @@ import MyCustomModule
                   "given_name": "given_name",
                   "family_name": "family_name"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = MyCustomClient(
@@ -757,7 +757,7 @@ import MyCustomModule
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "user_id": "user_id",
                   "email": "email",
@@ -809,7 +809,7 @@ import MyCustomModule
                   "given_name": "given_name",
                   "family_name": "family_name"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = MyCustomClient(
@@ -902,7 +902,7 @@ import MyCustomModule
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -955,7 +955,7 @@ import MyCustomModule
                     }
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = MyCustomClient(
@@ -1036,7 +1036,7 @@ import MyCustomModule
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
@@ -1062,7 +1062,7 @@ import MyCustomModule
                     }
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = MyCustomClient(
@@ -1111,7 +1111,7 @@ import MyCustomModule
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "start": 1,
                   "limit": 1,
@@ -1270,7 +1270,7 @@ import MyCustomModule
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = MyCustomClient(
@@ -1485,7 +1485,7 @@ import MyCustomModule
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "client_id": "client_id",
                   "tenant": "tenant",
@@ -1561,7 +1561,7 @@ import MyCustomModule
                     }
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = MyCustomClient(

--- a/seed/swift-sdk/content-type/.fern/metadata.json
+++ b/seed/swift-sdk/content-type/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/cross-package-type-names/.fern/metadata.json
+++ b/seed/swift-sdk/cross-package-type-names/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/cross-package-type-names/Tests/Wire/Resources/FolderA/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/cross-package-type-names/Tests/Wire/Resources/FolderA/Service/ServiceClientWireTests.swift
@@ -7,7 +7,7 @@ import CrossPackageTypeNames
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "foo": {
                     "foo": {
@@ -15,7 +15,7 @@ import CrossPackageTypeNames
                     }
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = CrossPackageTypeNamesClient(

--- a/seed/swift-sdk/cross-package-type-names/Tests/Wire/Resources/FolderD/Service/FolderDServiceClientWireTests.swift
+++ b/seed/swift-sdk/cross-package-type-names/Tests/Wire/Resources/FolderD/Service/FolderDServiceClientWireTests.swift
@@ -7,7 +7,7 @@ import CrossPackageTypeNames
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "foo": {
                     "foo": {
@@ -15,7 +15,7 @@ import CrossPackageTypeNames
                     }
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = CrossPackageTypeNamesClient(

--- a/seed/swift-sdk/cross-package-type-names/Tests/Wire/Resources/Foo/FooClientWireTests.swift
+++ b/seed/swift-sdk/cross-package-type-names/Tests/Wire/Resources/Foo/FooClientWireTests.swift
@@ -7,11 +7,11 @@ import CrossPackageTypeNames
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "imported": "imported"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = CrossPackageTypeNamesClient(

--- a/seed/swift-sdk/dollar-string-examples/.fern/metadata.json
+++ b/seed/swift-sdk/dollar-string-examples/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/empty-clients/.fern/metadata.json
+++ b/seed/swift-sdk/empty-clients/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/endpoint-security-auth/.fern/metadata.json
+++ b/seed/swift-sdk/endpoint-security-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/endpoint-security-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/endpoint-security-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,13 +7,13 @@ import EndpointSecurityAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = EndpointSecurityAuthClient(

--- a/seed/swift-sdk/endpoint-security-auth/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/endpoint-security-auth/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -7,7 +7,7 @@ import EndpointSecurityAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -18,7 +18,7 @@ import EndpointSecurityAuth
                     "name": "name"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = EndpointSecurityAuthClient(
@@ -44,7 +44,7 @@ import EndpointSecurityAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -55,7 +55,7 @@ import EndpointSecurityAuth
                     "name": "name"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = EndpointSecurityAuthClient(
@@ -81,7 +81,7 @@ import EndpointSecurityAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -92,7 +92,7 @@ import EndpointSecurityAuth
                     "name": "name"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = EndpointSecurityAuthClient(
@@ -118,7 +118,7 @@ import EndpointSecurityAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -129,7 +129,7 @@ import EndpointSecurityAuth
                     "name": "name"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = EndpointSecurityAuthClient(
@@ -155,7 +155,7 @@ import EndpointSecurityAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -166,7 +166,7 @@ import EndpointSecurityAuth
                     "name": "name"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = EndpointSecurityAuthClient(
@@ -192,7 +192,7 @@ import EndpointSecurityAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -203,7 +203,7 @@ import EndpointSecurityAuth
                     "name": "name"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = EndpointSecurityAuthClient(
@@ -229,7 +229,7 @@ import EndpointSecurityAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -240,7 +240,7 @@ import EndpointSecurityAuth
                     "name": "name"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = EndpointSecurityAuthClient(

--- a/seed/swift-sdk/enum/.fern/metadata.json
+++ b/seed/swift-sdk/enum/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/error-property/.fern/metadata.json
+++ b/seed/swift-sdk/error-property/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/error-property/Tests/Wire/Resources/PropertyBasedError/PropertyBasedErrorClientWireTests.swift
+++ b/seed/swift-sdk/error-property/Tests/Wire/Resources/PropertyBasedError/PropertyBasedErrorClientWireTests.swift
@@ -7,9 +7,9 @@ import ErrorProperty
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ErrorPropertyClient(

--- a/seed/swift-sdk/errors/.fern/metadata.json
+++ b/seed/swift-sdk/errors/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/errors/Tests/Wire/Resources/Simple/SimpleClientWireTests.swift
+++ b/seed/swift-sdk/errors/Tests/Wire/Resources/Simple/SimpleClientWireTests.swift
@@ -7,11 +7,11 @@ import Errors
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "bar": "bar"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ErrorsClient(
@@ -34,11 +34,11 @@ import Errors
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "bar": "bar"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ErrorsClient(
@@ -61,11 +61,11 @@ import Errors
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "bar": "hello"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ErrorsClient(
@@ -88,11 +88,11 @@ import Errors
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "bar": "bar"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ErrorsClient(

--- a/seed/swift-sdk/examples/no-custom-config/.fern/metadata.json
+++ b/seed/swift-sdk/examples/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/File/Notification/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/File/Notification/Service/ServiceClientWireTests.swift
@@ -7,14 +7,14 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "generic",
                   "exceptionType": "Unavailable",
                   "exceptionMessage": "This component is unavailable!",
                   "exceptionStacktrace": "<logs>"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -43,14 +43,14 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "generic",
                   "exceptionType": "exceptionType",
                   "exceptionMessage": "exceptionMessage",
                   "exceptionStacktrace": "exceptionStacktrace"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/File/Service/FileServiceClientWireTests.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/File/Service/FileServiceClientWireTests.swift
@@ -7,12 +7,12 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "name",
                   "contents": "contents"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/Health/Service/HealthServiceClientWireTests.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/Health/Service/HealthServiceClientWireTests.swift
@@ -7,9 +7,9 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -26,9 +26,9 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(

--- a/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
@@ -7,7 +7,7 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "movie-c06a4ad7",
                   "prequel": "movie-cv9b914f",
@@ -30,7 +30,7 @@ import Examples
                   },
                   "revenue": 1000000
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -73,7 +73,7 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "prequel": "prequel",
@@ -90,7 +90,7 @@ import Examples
                   },
                   "revenue": 1000000
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -127,9 +127,9 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 movie-c06a4ad7
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -170,9 +170,9 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -207,7 +207,7 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "html",
                   "extra": {
@@ -220,7 +220,7 @@ import Examples
                   ],
                   "value": "<head>...</head>"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -240,7 +240,7 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "html",
                   "value": "string",
@@ -251,7 +251,7 @@ import Examples
                     "tags"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -271,7 +271,7 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "response": {
                     "key": "value"
@@ -289,7 +289,7 @@ import Examples
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(

--- a/seed/swift-sdk/examples/readme-config/.fern/metadata.json
+++ b/seed/swift-sdk/examples/readme-config/.fern/metadata.json
@@ -15,8 +15,7 @@
     ]
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/File/Notification/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/File/Notification/Service/ServiceClientWireTests.swift
@@ -7,14 +7,14 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "generic",
                   "exceptionType": "Unavailable",
                   "exceptionMessage": "This component is unavailable!",
                   "exceptionStacktrace": "<logs>"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -43,14 +43,14 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "generic",
                   "exceptionType": "exceptionType",
                   "exceptionMessage": "exceptionMessage",
                   "exceptionStacktrace": "exceptionStacktrace"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(

--- a/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/File/Service/FileServiceClientWireTests.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/File/Service/FileServiceClientWireTests.swift
@@ -7,12 +7,12 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "name",
                   "contents": "contents"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(

--- a/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/Health/Service/HealthServiceClientWireTests.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/Health/Service/HealthServiceClientWireTests.swift
@@ -7,9 +7,9 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -26,9 +26,9 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(

--- a/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
+++ b/seed/swift-sdk/examples/readme-config/Tests/Wire/Resources/Service/ServiceClient_WireTests.swift
@@ -7,7 +7,7 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "movie-c06a4ad7",
                   "prequel": "movie-cv9b914f",
@@ -30,7 +30,7 @@ import Examples
                   },
                   "revenue": 1000000
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -73,7 +73,7 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "prequel": "prequel",
@@ -90,7 +90,7 @@ import Examples
                   },
                   "revenue": 1000000
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -127,9 +127,9 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 movie-c06a4ad7
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -170,9 +170,9 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -207,7 +207,7 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "html",
                   "extra": {
@@ -220,7 +220,7 @@ import Examples
                   ],
                   "value": "<head>...</head>"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -240,7 +240,7 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "html",
                   "value": "string",
@@ -251,7 +251,7 @@ import Examples
                     "tags"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(
@@ -271,7 +271,7 @@ import Examples
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "response": {
                     "key": "value"
@@ -289,7 +289,7 @@ import Examples
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExamplesClient(

--- a/seed/swift-sdk/exhaustive/.fern/metadata.json
+++ b/seed/swift-sdk/exhaustive/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Container/ContainerClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Container/ContainerClientWireTests.swift
@@ -7,12 +7,12 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   "string",
                   "string"
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -38,7 +38,7 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "string": "string"
@@ -47,7 +47,7 @@ import Exhaustive
                     "string": "string"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -81,11 +81,11 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   "string"
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -102,13 +102,13 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "string": "string"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -125,11 +125,11 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": "string"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -153,13 +153,13 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": {
                     "string": "string"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -187,11 +187,11 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": 1.1
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -219,11 +219,11 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": "string"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Enum/EnumClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Enum/EnumClientWireTests.swift
@@ -7,9 +7,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 SUNNY
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/HttpMethods/HttpMethodsClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/HttpMethods/HttpMethodsClientWireTests.swift
@@ -7,9 +7,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -29,7 +29,7 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": "string",
                   "integer": 1,
@@ -52,7 +52,7 @@ import Exhaustive
                   },
                   "bigint": "1000000"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -93,7 +93,7 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": "string",
                   "integer": 1,
@@ -116,7 +116,7 @@ import Exhaustive
                   },
                   "bigint": "1000000"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -158,7 +158,7 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": "string",
                   "integer": 1,
@@ -181,7 +181,7 @@ import Exhaustive
                   },
                   "bigint": "1000000"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -238,9 +238,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Object/ObjectClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Object/ObjectClientWireTests.swift
@@ -7,7 +7,7 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": "string",
                   "integer": 1,
@@ -30,7 +30,7 @@ import Exhaustive
                   },
                   "bigint": "1000000"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -86,11 +86,11 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": "string"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -114,7 +114,7 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "map": {
                     "map": {
@@ -122,7 +122,7 @@ import Exhaustive
                     }
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -154,7 +154,7 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": "string",
                   "NestedObject": {
@@ -180,7 +180,7 @@ import Exhaustive
                     "bigint": "1000000"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -242,7 +242,7 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": "string",
                   "NestedObject": {
@@ -268,7 +268,7 @@ import Exhaustive
                     "bigint": "1000000"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -331,7 +331,7 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": "string",
                   "NestedObject": {
@@ -357,7 +357,7 @@ import Exhaustive
                     "bigint": "1000000"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -442,13 +442,13 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "unknown": {
                     "$ref": "https://example.com/schema"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -478,13 +478,13 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "unknown": {
                     "key": "value"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -514,13 +514,13 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "documentedUnknownType": {
                     "key": "value"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -550,13 +550,13 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": {
                     "key": "value"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -586,14 +586,14 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "requiredString": "hello",
                   "requiredInteger": 0,
                   "optionalString": "world",
                   "requiredLong": 0
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -623,14 +623,14 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "requiredString": "requiredString",
                   "requiredInteger": 1,
                   "optionalString": "optionalString",
                   "requiredLong": 1000000
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -660,7 +660,7 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "requiredString": "hello",
                   "requiredObject": {
@@ -668,7 +668,7 @@ import Exhaustive
                     "NestedObject": {}
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -704,7 +704,7 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "requiredString": "requiredString",
                   "requiredObject": {
@@ -733,7 +733,7 @@ import Exhaustive
                     }
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -801,12 +801,12 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "datetimeLikeString": "2023-08-31T14:15:22Z",
                   "actualDatetime": "2023-08-31T14:15:22Z"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -832,12 +832,12 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "datetimeLikeString": "datetimeLikeString",
                   "actualDatetime": "2024-01-15T09:30:00Z"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Pagination/PaginationClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Pagination/PaginationClientWireTests.swift
@@ -7,7 +7,7 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "items": [
                     {
@@ -19,7 +19,7 @@ import Exhaustive
                   ],
                   "next": "next"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Params/ParamsClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Params/ParamsClientWireTests.swift
@@ -7,9 +7,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -29,9 +29,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -51,9 +51,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -74,9 +74,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -97,11 +97,11 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": "uploaded"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -124,9 +124,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -146,9 +146,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Primitive/PrimitiveClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Primitive/PrimitiveClientWireTests.swift
@@ -7,9 +7,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -29,9 +29,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 1
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -51,9 +51,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 1000000
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -73,9 +73,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 1.1
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -95,9 +95,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -117,9 +117,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 2024-01-15T09:30:00Z
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -139,9 +139,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 2023-01-15
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -161,9 +161,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -183,9 +183,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 SGVsbG8gd29ybGQh
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Put/PutClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Put/PutClientWireTests.swift
@@ -7,7 +7,7 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "errors": [
                     {
@@ -24,7 +24,7 @@ import Exhaustive
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Union/UnionClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Union/UnionClientWireTests.swift
@@ -7,13 +7,13 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "animal": "dog",
                   "name": "name",
                   "likesToWoof": true
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Urls/UrlsClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/Endpoints/Urls/UrlsClientWireTests.swift
@@ -7,9 +7,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -26,9 +26,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -45,9 +45,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -64,9 +64,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/InlinedRequests/InlinedRequestsClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/InlinedRequests/InlinedRequestsClientWireTests.swift
@@ -7,7 +7,7 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": "string",
                   "integer": 1,
@@ -30,7 +30,7 @@ import Exhaustive
                   },
                   "bigint": "1000000"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/NoAuth/NoAuthClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/NoAuth/NoAuthClientWireTests.swift
@@ -7,9 +7,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(

--- a/seed/swift-sdk/exhaustive/Tests/Wire/Resources/NoReqBody/NoReqBodyClientWireTests.swift
+++ b/seed/swift-sdk/exhaustive/Tests/Wire/Resources/NoReqBody/NoReqBodyClientWireTests.swift
@@ -7,7 +7,7 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": "string",
                   "integer": 1,
@@ -30,7 +30,7 @@ import Exhaustive
                   },
                   "bigint": "1000000"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(
@@ -66,9 +66,9 @@ import Exhaustive
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExhaustiveClient(

--- a/seed/swift-sdk/extends/.fern/metadata.json
+++ b/seed/swift-sdk/extends/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/extra-properties/.fern/metadata.json
+++ b/seed/swift-sdk/extra-properties/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/extra-properties/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/extra-properties/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -7,13 +7,13 @@ import ExtraProperties
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "Alice",
                   "age": 30,
                   "location": "Wonderland"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExtraPropertiesClient(
@@ -38,11 +38,11 @@ import ExtraProperties
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "name"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ExtraPropertiesClient(

--- a/seed/swift-sdk/file-download/.fern/metadata.json
+++ b/seed/swift-sdk/file-download/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/file-upload-openapi/.fern/metadata.json
+++ b/seed/swift-sdk/file-upload-openapi/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/file-upload-openapi/Tests/Wire/Resources/FileUploadExample/FileUploadExampleClientWireTests.swift
+++ b/seed/swift-sdk/file-upload-openapi/Tests/Wire/Resources/FileUploadExample/FileUploadExampleClientWireTests.swift
@@ -7,9 +7,9 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(

--- a/seed/swift-sdk/file-upload/.fern/metadata.json
+++ b/seed/swift-sdk/file-upload/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/file-upload/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/file-upload/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -7,9 +7,9 @@ import FileUpload
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 Foo
-                """.utf8
+                """#.utf8
             )
         )
         let client = FileUploadClient(
@@ -28,9 +28,9 @@ import FileUpload
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 Success
-                """.utf8
+                """#.utf8
             )
         )
         let client = FileUploadClient(

--- a/seed/swift-sdk/folders/.fern/metadata.json
+++ b/seed/swift-sdk/folders/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/header-auth-environment-variable/.fern/metadata.json
+++ b/seed/swift-sdk/header-auth-environment-variable/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/header-auth-environment-variable/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/header-auth-environment-variable/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -7,9 +7,9 @@ import HeaderTokenEnvironmentVariable
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = HeaderTokenEnvironmentVariableClient(

--- a/seed/swift-sdk/header-auth/.fern/metadata.json
+++ b/seed/swift-sdk/header-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/header-auth/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/header-auth/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -7,9 +7,9 @@ import HeaderToken
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = HeaderTokenClient(

--- a/seed/swift-sdk/http-head/.fern/metadata.json
+++ b/seed/swift-sdk/http-head/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/http-head/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/http-head/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -7,7 +7,7 @@ import HttpHead
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "name": "name",
@@ -24,7 +24,7 @@ import HttpHead
                     ]
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = HttpHeadClient(

--- a/seed/swift-sdk/idempotency-headers/.fern/metadata.json
+++ b/seed/swift-sdk/idempotency-headers/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/idempotency-headers/Tests/Wire/Resources/Payment/PaymentClientWireTests.swift
+++ b/seed/swift-sdk/idempotency-headers/Tests/Wire/Resources/Payment/PaymentClientWireTests.swift
@@ -7,9 +7,9 @@ import IdempotencyHeaders
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32
-                """.utf8
+                """#.utf8
             )
         )
         let client = IdempotencyHeadersClient(

--- a/seed/swift-sdk/imdb/.fern/metadata.json
+++ b/seed/swift-sdk/imdb/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/imdb/Tests/Wire/Resources/Imdb/ImdbClientWireTests.swift
+++ b/seed/swift-sdk/imdb/Tests/Wire/Resources/Imdb/ImdbClientWireTests.swift
@@ -7,9 +7,9 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -32,13 +32,13 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "title": "title",
                   "rating": 1.1
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(

--- a/seed/swift-sdk/inferred-auth-explicit/.fern/metadata.json
+++ b/seed/swift-sdk/inferred-auth-explicit/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/inferred-auth-explicit/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,13 +7,13 @@ import InferredAuthExplicit
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = InferredAuthExplicitClient(
@@ -42,13 +42,13 @@ import InferredAuthExplicit
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = InferredAuthExplicitClient(

--- a/seed/swift-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
+++ b/seed/swift-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-api-key/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,14 +7,14 @@ import InferredAuthImplicitApiKey
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "token_type": "token_type",
                   "expires_in": 1,
                   "scope": "scope"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = InferredAuthImplicitApiKeyClient(

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,12 +7,12 @@ import InferredAuthImplicitNoExpiry
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = InferredAuthImplicitNoExpiryClient(
@@ -40,12 +40,12 @@ import InferredAuthImplicitNoExpiry
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = InferredAuthImplicitNoExpiryClient(

--- a/seed/swift-sdk/inferred-auth-implicit-reference/.fern/metadata.json
+++ b/seed/swift-sdk/inferred-auth-implicit-reference/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/inferred-auth-implicit-reference/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-reference/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,13 +7,13 @@ import InferredAuthImplicit
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = InferredAuthImplicitClient(
@@ -42,13 +42,13 @@ import InferredAuthImplicit
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = InferredAuthImplicitClient(

--- a/seed/swift-sdk/inferred-auth-implicit/.fern/metadata.json
+++ b/seed/swift-sdk/inferred-auth-implicit/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/inferred-auth-implicit/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,13 +7,13 @@ import InferredAuthImplicit
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = InferredAuthImplicitClient(
@@ -42,13 +42,13 @@ import InferredAuthImplicit
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = InferredAuthImplicitClient(

--- a/seed/swift-sdk/license/.fern/metadata.json
+++ b/seed/swift-sdk/license/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/literals-unions/.fern/metadata.json
+++ b/seed/swift-sdk/literals-unions/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/mixed-case/.fern/metadata.json
+++ b/seed/swift-sdk/mixed-case/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/mixed-case/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/mixed-case/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -7,7 +7,7 @@ import MixedCase
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "status": "ACTIVE",
                   "resource_type": "user",
@@ -21,7 +21,7 @@ import MixedCase
                     "baz": "qux"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = MixedCaseClient(
@@ -56,7 +56,7 @@ import MixedCase
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "resource_type": "user",
                   "userName": "userName",
@@ -69,7 +69,7 @@ import MixedCase
                   },
                   "status": "ACTIVE"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = MixedCaseClient(
@@ -103,7 +103,7 @@ import MixedCase
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "resource_type": "user",
@@ -119,7 +119,7 @@ import MixedCase
                     }
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = MixedCaseClient(
@@ -157,7 +157,7 @@ import MixedCase
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "resource_type": "user",
@@ -184,7 +184,7 @@ import MixedCase
                     "status": "ACTIVE"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = MixedCaseClient(

--- a/seed/swift-sdk/mixed-file-directory/.fern/metadata.json
+++ b/seed/swift-sdk/mixed-file-directory/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/Organization/OrganizationClientWireTests.swift
+++ b/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/Organization/OrganizationClientWireTests.swift
@@ -7,7 +7,7 @@ import MixedFileDirectory
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
@@ -24,7 +24,7 @@ import MixedFileDirectory
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = MixedFileDirectoryClient(

--- a/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/User/Events/EventsClientWireTests.swift
+++ b/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/User/Events/EventsClientWireTests.swift
@@ -7,7 +7,7 @@ import MixedFileDirectory
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -18,7 +18,7 @@ import MixedFileDirectory
                     "name": "name"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = MixedFileDirectoryClient(

--- a/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/User/Events/Metadata/MetadataClientWireTests.swift
+++ b/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/User/Events/Metadata/MetadataClientWireTests.swift
@@ -7,14 +7,14 @@ import MixedFileDirectory
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "value": {
                     "key": "value"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = MixedFileDirectoryClient(

--- a/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/mixed-file-directory/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -7,7 +7,7 @@ import MixedFileDirectory
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -20,7 +20,7 @@ import MixedFileDirectory
                     "age": 1
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = MixedFileDirectoryClient(

--- a/seed/swift-sdk/multi-line-docs/.fern/metadata.json
+++ b/seed/swift-sdk/multi-line-docs/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/multi-line-docs/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/multi-line-docs/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -7,13 +7,13 @@ import MultiLineDocs
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
                   "age": 1
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = MultiLineDocsClient(

--- a/seed/swift-sdk/multi-url-environment-no-default/.fern/metadata.json
+++ b/seed/swift-sdk/multi-url-environment-no-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/multi-url-environment-no-default/Tests/Wire/Resources/S3/S3ClientWireTests.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Tests/Wire/Resources/S3/S3ClientWireTests.swift
@@ -7,9 +7,9 @@ import MultiUrlEnvironmentNoDefault
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = MultiUrlEnvironmentNoDefaultClient(

--- a/seed/swift-sdk/multi-url-environment-reference/.fern/metadata.json
+++ b/seed/swift-sdk/multi-url-environment-reference/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/multi-url-environment-reference/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/multi-url-environment-reference/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,11 +7,11 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -35,11 +35,11 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(

--- a/seed/swift-sdk/multi-url-environment-reference/Tests/Wire/Resources/Files/FilesClientWireTests.swift
+++ b/seed/swift-sdk/multi-url-environment-reference/Tests/Wire/Resources/Files/FilesClientWireTests.swift
@@ -7,9 +7,9 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -31,9 +31,9 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(

--- a/seed/swift-sdk/multi-url-environment-reference/Tests/Wire/Resources/Items/ItemsClientWireTests.swift
+++ b/seed/swift-sdk/multi-url-environment-reference/Tests/Wire/Resources/Items/ItemsClientWireTests.swift
@@ -7,9 +7,9 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -25,9 +25,9 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(

--- a/seed/swift-sdk/multi-url-environment/.fern/metadata.json
+++ b/seed/swift-sdk/multi-url-environment/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/multi-url-environment/Tests/Wire/Resources/S3/S3ClientWireTests.swift
+++ b/seed/swift-sdk/multi-url-environment/Tests/Wire/Resources/S3/S3ClientWireTests.swift
@@ -7,9 +7,9 @@ import MultiUrlEnvironment
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = MultiUrlEnvironmentClient(

--- a/seed/swift-sdk/multiple-request-bodies/.fern/metadata.json
+++ b/seed/swift-sdk/multiple-request-bodies/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/no-content-response/.fern/metadata.json
+++ b/seed/swift-sdk/no-content-response/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/no-content-response/Tests/Wire/Resources/Contacts/ContactsClientWireTests.swift
+++ b/seed/swift-sdk/no-content-response/Tests/Wire/Resources/Contacts/ContactsClientWireTests.swift
@@ -7,13 +7,13 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
                   "email": "email"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -36,13 +36,13 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
                   "email": "email"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -68,13 +68,13 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
                   "email": "email"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -97,13 +97,13 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
                   "email": "email"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(

--- a/seed/swift-sdk/no-environment/.fern/metadata.json
+++ b/seed/swift-sdk/no-environment/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/no-environment/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
+++ b/seed/swift-sdk/no-environment/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
@@ -7,9 +7,9 @@ import NoEnvironment
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = NoEnvironmentClient(

--- a/seed/swift-sdk/no-retries/.fern/metadata.json
+++ b/seed/swift-sdk/no-retries/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/no-retries/Tests/Wire/Resources/Retries/RetriesClientWireTests.swift
+++ b/seed/swift-sdk/no-retries/Tests/Wire/Resources/Retries/RetriesClientWireTests.swift
@@ -7,7 +7,7 @@ import NoRetries
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -18,7 +18,7 @@ import NoRetries
                     "name": "name"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = NoRetriesClient(

--- a/seed/swift-sdk/null-type/.fern/metadata.json
+++ b/seed/swift-sdk/null-type/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/null-type/Tests/Wire/Resources/Conversations/ConversationsClientWireTests.swift
+++ b/seed/swift-sdk/null-type/Tests/Wire/Resources/Conversations/ConversationsClientWireTests.swift
@@ -7,14 +7,14 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "conversation_id": {
                     "key": "value"
                   },
                   "dry_run": true
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -40,14 +40,14 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "conversation_id": {
                     "key": "value"
                   },
                   "dry_run": true
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(

--- a/seed/swift-sdk/null-type/Tests/Wire/Resources/Users/UsersClientWireTests.swift
+++ b/seed/swift-sdk/null-type/Tests/Wire/Resources/Users/UsersClientWireTests.swift
@@ -7,7 +7,7 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
@@ -15,7 +15,7 @@ import Api
                     "key": "value"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -42,7 +42,7 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
@@ -50,7 +50,7 @@ import Api
                     "key": "value"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(

--- a/seed/swift-sdk/nullable-allof-extends/.fern/metadata.json
+++ b/seed/swift-sdk/nullable-allof-extends/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/nullable-optional/no-custom-config/.fern/metadata.json
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Tests/Wire/Resources/NullableOptional/NullableOptionalClient_WireTests.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Tests/Wire/Resources/NullableOptional/NullableOptionalClient_WireTests.swift
@@ -7,7 +7,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "username": "username",
@@ -25,7 +25,7 @@ import NullableOptional
                     "tenantId": "tenantId"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -60,7 +60,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "username": "username",
@@ -78,7 +78,7 @@ import NullableOptional
                     "tenantId": "tenantId"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -126,7 +126,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "username": "username",
@@ -144,7 +144,7 @@ import NullableOptional
                     "tenantId": "tenantId"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -193,7 +193,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -230,7 +230,7 @@ import NullableOptional
                     }
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -287,7 +287,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -324,7 +324,7 @@ import NullableOptional
                     }
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -381,7 +381,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "nullableRole": "ADMIN",
@@ -489,7 +489,7 @@ import NullableOptional
                     "optionalMapOfEnums": "ADMIN"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -755,7 +755,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "nullableRole": "ADMIN",
@@ -863,7 +863,7 @@ import NullableOptional
                     "optionalMapOfEnums": "ADMIN"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -1016,7 +1016,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "nullableRole": "ADMIN",
@@ -1124,7 +1124,7 @@ import NullableOptional
                     "optionalMapOfEnums": "ADMIN"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -1311,7 +1311,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "echo": {
                     "requiredString": "requiredString",
@@ -1371,7 +1371,7 @@ import NullableOptional
                   "nullCount": 1,
                   "presentFieldsCount": 1
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -1511,7 +1511,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -1548,7 +1548,7 @@ import NullableOptional
                     }
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -1604,14 +1604,14 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "email",
                   "emailAddress": "emailAddress",
                   "subject": "subject",
                   "htmlContent": "htmlContent"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -1639,12 +1639,12 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   "string",
                   "string"
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -1680,7 +1680,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "type": "user",
@@ -1719,7 +1719,7 @@ import NullableOptional
                     }
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/.fern/metadata.json
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/.fern/metadata.json
@@ -6,8 +6,7 @@
     "decodeNullableToOptional": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Tests/Wire/Resources/NullableOptional/NullableOptionalClient_WireTests.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Tests/Wire/Resources/NullableOptional/NullableOptionalClient_WireTests.swift
@@ -7,7 +7,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "username": "username",
@@ -25,7 +25,7 @@ import NullableOptional
                     "tenantId": "tenantId"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -60,7 +60,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "username": "username",
@@ -78,7 +78,7 @@ import NullableOptional
                     "tenantId": "tenantId"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -126,7 +126,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "username": "username",
@@ -144,7 +144,7 @@ import NullableOptional
                     "tenantId": "tenantId"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -193,7 +193,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -230,7 +230,7 @@ import NullableOptional
                     }
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -287,7 +287,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -324,7 +324,7 @@ import NullableOptional
                     }
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -381,7 +381,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "nullableRole": "ADMIN",
@@ -489,7 +489,7 @@ import NullableOptional
                     "optionalMapOfEnums": "ADMIN"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -755,7 +755,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "nullableRole": "ADMIN",
@@ -863,7 +863,7 @@ import NullableOptional
                     "optionalMapOfEnums": "ADMIN"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -1016,7 +1016,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "nullableRole": "ADMIN",
@@ -1124,7 +1124,7 @@ import NullableOptional
                     "optionalMapOfEnums": "ADMIN"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -1311,7 +1311,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "echo": {
                     "requiredString": "requiredString",
@@ -1371,7 +1371,7 @@ import NullableOptional
                   "nullCount": 1,
                   "presentFieldsCount": 1
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -1511,7 +1511,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -1548,7 +1548,7 @@ import NullableOptional
                     }
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -1604,14 +1604,14 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "email",
                   "emailAddress": "emailAddress",
                   "subject": "subject",
                   "htmlContent": "htmlContent"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -1639,12 +1639,12 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   "string",
                   "string"
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(
@@ -1680,7 +1680,7 @@ import NullableOptional
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "type": "user",
@@ -1719,7 +1719,7 @@ import NullableOptional
                     }
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableOptionalClient(

--- a/seed/swift-sdk/nullable-request-body/.fern/metadata.json
+++ b/seed/swift-sdk/nullable-request-body/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/nullable-request-body/Tests/Wire/Resources/TestGroup/TestGroupClientWireTests.swift
+++ b/seed/swift-sdk/nullable-request-body/Tests/Wire/Resources/TestGroup/TestGroupClientWireTests.swift
@@ -7,11 +7,11 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "key": "value"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -37,11 +37,11 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "key": "value"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(

--- a/seed/swift-sdk/nullable/no-custom-config/.fern/metadata.json
+++ b/seed/swift-sdk/nullable/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/nullable/no-custom-config/Tests/Wire/Resources/Nullable/NullableClient_WireTests.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Tests/Wire/Resources/Nullable/NullableClient_WireTests.swift
@@ -7,7 +7,7 @@ import Nullable
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "name": "name",
@@ -72,7 +72,7 @@ import Nullable
                     }
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableClient(
@@ -159,7 +159,7 @@ import Nullable
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "name",
                   "id": "id",
@@ -191,7 +191,7 @@ import Nullable
                     }
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableClient(
@@ -259,9 +259,9 @@ import Nullable
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableClient(

--- a/seed/swift-sdk/nullable/nullable-as-optional/.fern/metadata.json
+++ b/seed/swift-sdk/nullable/nullable-as-optional/.fern/metadata.json
@@ -6,8 +6,7 @@
     "decodeNullableToOptional": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/nullable/nullable-as-optional/Tests/Wire/Resources/Nullable/NullableClient_WireTests.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Tests/Wire/Resources/Nullable/NullableClient_WireTests.swift
@@ -7,7 +7,7 @@ import Nullable
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "name": "name",
@@ -72,7 +72,7 @@ import Nullable
                     }
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableClient(
@@ -159,7 +159,7 @@ import Nullable
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "name",
                   "id": "id",
@@ -191,7 +191,7 @@ import Nullable
                     }
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableClient(
@@ -259,9 +259,9 @@ import Nullable
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = NullableClient(

--- a/seed/swift-sdk/oauth-client-credentials-custom/.fern/metadata.json
+++ b/seed/swift-sdk/oauth-client-credentials-custom/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/oauth-client-credentials-custom/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,13 +7,13 @@ import OauthClientCredentials
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsClient(
@@ -44,13 +44,13 @@ import OauthClientCredentials
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsClient(

--- a/seed/swift-sdk/oauth-client-credentials-default/.fern/metadata.json
+++ b/seed/swift-sdk/oauth-client-credentials-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/oauth-client-credentials-default/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,12 +7,12 @@ import OauthClientCredentialsDefault
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsDefaultClient(

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,13 +7,13 @@ import OauthClientCredentialsEnvironmentVariables
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsEnvironmentVariablesClient(
@@ -42,13 +42,13 @@ import OauthClientCredentialsEnvironmentVariables
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsEnvironmentVariablesClient(

--- a/seed/swift-sdk/oauth-client-credentials-mandatory-auth/.fern/metadata.json
+++ b/seed/swift-sdk/oauth-client-credentials-mandatory-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/oauth-client-credentials-mandatory-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-mandatory-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,13 +7,13 @@ import OauthClientCredentialsMandatoryAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsMandatoryAuthClient(
@@ -42,13 +42,13 @@ import OauthClientCredentialsMandatoryAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsMandatoryAuthClient(
@@ -77,13 +77,13 @@ import OauthClientCredentialsMandatoryAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsMandatoryAuthClient(
@@ -113,13 +113,13 @@ import OauthClientCredentialsMandatoryAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsMandatoryAuthClient(

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,13 +7,13 @@ import OauthClientCredentials
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsClient(

--- a/seed/swift-sdk/oauth-client-credentials-openapi/.fern/metadata.json
+++ b/seed/swift-sdk/oauth-client-credentials-openapi/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/oauth-client-credentials-openapi/Tests/Wire/Resources/Identity/IdentityClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-openapi/Tests/Wire/Resources/Identity/IdentityClientWireTests.swift
@@ -7,13 +7,13 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -39,13 +39,13 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(

--- a/seed/swift-sdk/oauth-client-credentials-openapi/Tests/Wire/Resources/Plants/PlantsClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-openapi/Tests/Wire/Resources/Plants/PlantsClientWireTests.swift
@@ -7,7 +7,7 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -15,7 +15,7 @@ import Api
                     "species": "species"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -37,7 +37,7 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "id": "id",
@@ -50,7 +50,7 @@ import Api
                     "species": "species"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -77,13 +77,13 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
                   "species": "species"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -106,13 +106,13 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
                   "species": "species"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(

--- a/seed/swift-sdk/oauth-client-credentials-reference/.fern/metadata.json
+++ b/seed/swift-sdk/oauth-client-credentials-reference/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/oauth-client-credentials-reference/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-reference/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,12 +7,12 @@ import OauthClientCredentialsReference
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 3600
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsReferenceClient(
@@ -37,12 +37,12 @@ import OauthClientCredentialsReference
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsReferenceClient(

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,13 +7,13 @@ import OauthClientCredentialsWithVariables
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsWithVariablesClient(
@@ -42,13 +42,13 @@ import OauthClientCredentialsWithVariables
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsWithVariablesClient(

--- a/seed/swift-sdk/oauth-client-credentials/.fern/metadata.json
+++ b/seed/swift-sdk/oauth-client-credentials/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/oauth-client-credentials/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,13 +7,13 @@ import OauthClientCredentials
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsClient(
@@ -42,13 +42,13 @@ import OauthClientCredentials
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsClient(
@@ -77,13 +77,13 @@ import OauthClientCredentials
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsClient(
@@ -113,13 +113,13 @@ import OauthClientCredentials
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "expires_in": 1,
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = OauthClientCredentialsClient(

--- a/seed/swift-sdk/object/.fern/metadata.json
+++ b/seed/swift-sdk/object/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/objects-with-imports/.fern/metadata.json
+++ b/seed/swift-sdk/objects-with-imports/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/openapi-request-body-ref/.fern/metadata.json
+++ b/seed/swift-sdk/openapi-request-body-ref/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/openapi-request-body-ref/Tests/Wire/Resources/Catalog/CatalogClientWireTests.swift
+++ b/seed/swift-sdk/openapi-request-body-ref/Tests/Wire/Resources/Catalog/CatalogClientWireTests.swift
@@ -7,7 +7,7 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "caption": "caption",
@@ -17,7 +17,7 @@ import Api
                     "catalog_object_id": "catalog_object_id"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -49,7 +49,7 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "caption": "caption",
@@ -59,7 +59,7 @@ import Api
                     "catalog_object_id": "catalog_object_id"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -86,7 +86,7 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "caption": "caption",
@@ -96,7 +96,7 @@ import Api
                     "catalog_object_id": "catalog_object_id"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(

--- a/seed/swift-sdk/openapi-request-body-ref/Tests/Wire/Resources/TeamMember/TeamMemberClientWireTests.swift
+++ b/seed/swift-sdk/openapi-request-body-ref/Tests/Wire/Resources/TeamMember/TeamMemberClientWireTests.swift
@@ -7,13 +7,13 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "given_name": "given_name",
                   "family_name": "family_name"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -37,13 +37,13 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "given_name": "given_name",
                   "family_name": "family_name"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(

--- a/seed/swift-sdk/openapi-request-body-ref/Tests/Wire/Resources/Vendor/VendorClientWireTests.swift
+++ b/seed/swift-sdk/openapi-request-body-ref/Tests/Wire/Resources/Vendor/VendorClientWireTests.swift
@@ -7,7 +7,7 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
@@ -17,7 +17,7 @@ import Api
                     "status": "ACTIVE"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -47,7 +47,7 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
@@ -57,7 +57,7 @@ import Api
                     "status": "ACTIVE"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -88,7 +88,7 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
@@ -98,7 +98,7 @@ import Api
                     "status": "ACTIVE"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(
@@ -125,7 +125,7 @@ import Api
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
@@ -135,7 +135,7 @@ import Api
                     "status": "ACTIVE"
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ApiClient(

--- a/seed/swift-sdk/optional/.fern/metadata.json
+++ b/seed/swift-sdk/optional/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/optional/Tests/Wire/Resources/Optional/OptionalClientWireTests.swift
+++ b/seed/swift-sdk/optional/Tests/Wire/Resources/Optional/OptionalClientWireTests.swift
@@ -7,9 +7,9 @@ import ObjectsWithImports
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ObjectsWithImportsClient(
@@ -32,9 +32,9 @@ import ObjectsWithImports
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = ObjectsWithImportsClient(
@@ -55,11 +55,11 @@ import ObjectsWithImports
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "success": true
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ObjectsWithImportsClient(

--- a/seed/swift-sdk/package-yml/.fern/metadata.json
+++ b/seed/swift-sdk/package-yml/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/pagination-custom/.fern/metadata.json
+++ b/seed/swift-sdk/pagination-custom/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/pagination-custom/Tests/Wire/Resources/Users/UsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination-custom/Tests/Wire/Resources/Users/UsersClientWireTests.swift
@@ -7,7 +7,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "limit": 1,
                   "count": 1,
@@ -29,7 +29,7 @@ import Pagination
                     "data"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(

--- a/seed/swift-sdk/pagination-uri-path/.fern/metadata.json
+++ b/seed/swift-sdk/pagination-uri-path/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/pagination-uri-path/Tests/Wire/Resources/Users/UsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination-uri-path/Tests/Wire/Resources/Users/UsersClientWireTests.swift
@@ -7,7 +7,7 @@ import PaginationUriPath
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "data": [
                     {
@@ -21,7 +21,7 @@ import PaginationUriPath
                   ],
                   "next": "next"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationUriPathClient(
@@ -50,7 +50,7 @@ import PaginationUriPath
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "data": [
                     {
@@ -64,7 +64,7 @@ import PaginationUriPath
                   ],
                   "next": "next"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationUriPathClient(

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/.fern/metadata.json
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/.fern/metadata.json
@@ -7,8 +7,7 @@
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Wire/Resources/Complex/ComplexClientWireTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Wire/Resources/Complex/ComplexClientWireTests.swift
@@ -7,7 +7,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "conversations": [
                     {
@@ -30,7 +30,7 @@ import Pagination
                   "total_count": 1,
                   "type": "conversation.list"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Wire/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Wire/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClientWireTests.swift
@@ -7,7 +7,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -33,7 +33,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -80,7 +80,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "next": "next",
                   "data": {
@@ -96,7 +96,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -130,7 +130,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -156,7 +156,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -202,7 +202,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -228,7 +228,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -275,7 +275,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -301,7 +301,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -348,7 +348,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -374,7 +374,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -420,7 +420,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -446,7 +446,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -492,7 +492,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -518,7 +518,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -564,7 +564,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "total_count": 1,
                   "data": {
@@ -581,7 +581,7 @@ import Pagination
                   },
                   "next": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -616,7 +616,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "total_count": 1,
                   "data": {
@@ -633,7 +633,7 @@ import Pagination
                   },
                   "next": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -668,7 +668,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "cursor": {
                     "after": "after",
@@ -678,7 +678,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -706,14 +706,14 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "results": [
                     "results",
                     "results"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Wire/Resources/Users/UsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Tests/Wire/Resources/Users/UsersClientWireTests.swift
@@ -7,7 +7,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -31,7 +31,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -76,7 +76,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "next": "next",
                   "data": [
@@ -90,7 +90,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -122,7 +122,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -146,7 +146,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -190,7 +190,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "next_cursor": "next_cursor_value",
                   "data": [
@@ -204,7 +204,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -239,7 +239,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "next_cursor": "next_cursor",
                   "data": [
@@ -253,7 +253,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -288,7 +288,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -312,7 +312,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -357,7 +357,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -381,7 +381,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -426,7 +426,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -450,7 +450,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -494,7 +494,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -518,7 +518,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -562,7 +562,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -586,7 +586,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -630,7 +630,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": false,
                   "page": {
@@ -654,7 +654,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -698,7 +698,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -722,7 +722,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -766,7 +766,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "total_count": 1,
                   "data": {
@@ -783,7 +783,7 @@ import Pagination
                   },
                   "next": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -818,7 +818,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "total_count": 1,
                   "data": {
@@ -835,7 +835,7 @@ import Pagination
                   },
                   "next": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -870,7 +870,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "cursor": {
                     "after": "after",
@@ -880,7 +880,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -908,7 +908,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "cursor": {
                     "after": "after",
@@ -918,7 +918,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -946,14 +946,14 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "results": [
                     "results",
                     "results"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -978,7 +978,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -1002,7 +1002,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -1044,7 +1044,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": false,
                   "page": {
@@ -1058,7 +1058,7 @@ import Pagination
                   },
                   "total_count": 0
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -1090,7 +1090,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -1114,7 +1114,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -1156,7 +1156,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -1180,7 +1180,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(

--- a/seed/swift-sdk/pagination/custom-pager/.fern/metadata.json
+++ b/seed/swift-sdk/pagination/custom-pager/.fern/metadata.json
@@ -6,8 +6,7 @@
     "custom-pager-name": "MyPager"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/pagination/custom-pager/Tests/Wire/Resources/Complex/ComplexClientWireTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Tests/Wire/Resources/Complex/ComplexClientWireTests.swift
@@ -7,7 +7,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "conversations": [
                     {
@@ -30,7 +30,7 @@ import Pagination
                   "total_count": 1,
                   "type": "conversation.list"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(

--- a/seed/swift-sdk/pagination/custom-pager/Tests/Wire/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Tests/Wire/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClientWireTests.swift
@@ -7,7 +7,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -33,7 +33,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -80,7 +80,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "next": "next",
                   "data": {
@@ -96,7 +96,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -130,7 +130,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -156,7 +156,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -202,7 +202,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -228,7 +228,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -275,7 +275,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -301,7 +301,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -348,7 +348,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -374,7 +374,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -420,7 +420,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -446,7 +446,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -492,7 +492,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -518,7 +518,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -564,7 +564,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "total_count": 1,
                   "data": {
@@ -581,7 +581,7 @@ import Pagination
                   },
                   "next": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -616,7 +616,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "total_count": 1,
                   "data": {
@@ -633,7 +633,7 @@ import Pagination
                   },
                   "next": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -668,7 +668,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "cursor": {
                     "after": "after",
@@ -678,7 +678,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -706,14 +706,14 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "results": [
                     "results",
                     "results"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(

--- a/seed/swift-sdk/pagination/custom-pager/Tests/Wire/Resources/Users/UsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Tests/Wire/Resources/Users/UsersClientWireTests.swift
@@ -7,7 +7,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -31,7 +31,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -76,7 +76,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "next": "next",
                   "data": [
@@ -90,7 +90,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -122,7 +122,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -146,7 +146,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -190,7 +190,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "next_cursor": "next_cursor_value",
                   "data": [
@@ -204,7 +204,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -239,7 +239,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "next_cursor": "next_cursor",
                   "data": [
@@ -253,7 +253,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -288,7 +288,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -312,7 +312,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -357,7 +357,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -381,7 +381,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -426,7 +426,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -450,7 +450,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -494,7 +494,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -518,7 +518,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -562,7 +562,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -586,7 +586,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -630,7 +630,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": false,
                   "page": {
@@ -654,7 +654,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -698,7 +698,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -722,7 +722,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -766,7 +766,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "total_count": 1,
                   "data": {
@@ -783,7 +783,7 @@ import Pagination
                   },
                   "next": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -818,7 +818,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "total_count": 1,
                   "data": {
@@ -835,7 +835,7 @@ import Pagination
                   },
                   "next": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -870,7 +870,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "cursor": {
                     "after": "after",
@@ -880,7 +880,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -908,7 +908,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "cursor": {
                     "after": "after",
@@ -918,7 +918,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -946,14 +946,14 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "results": [
                     "results",
                     "results"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -978,7 +978,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -1002,7 +1002,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -1044,7 +1044,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": false,
                   "page": {
@@ -1058,7 +1058,7 @@ import Pagination
                   },
                   "total_count": 0
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -1090,7 +1090,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -1114,7 +1114,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -1156,7 +1156,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -1180,7 +1180,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(

--- a/seed/swift-sdk/pagination/no-custom-config/.fern/metadata.json
+++ b/seed/swift-sdk/pagination/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/pagination/no-custom-config/Tests/Wire/Resources/Complex/ComplexClientWireTests.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Tests/Wire/Resources/Complex/ComplexClientWireTests.swift
@@ -7,7 +7,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "conversations": [
                     {
@@ -30,7 +30,7 @@ import Pagination
                   "total_count": 1,
                   "type": "conversation.list"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(

--- a/seed/swift-sdk/pagination/no-custom-config/Tests/Wire/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Tests/Wire/Resources/InlineUsers/InlineUsers/InlineUsersInlineUsersClientWireTests.swift
@@ -7,7 +7,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -33,7 +33,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -80,7 +80,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "next": "next",
                   "data": {
@@ -96,7 +96,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -130,7 +130,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -156,7 +156,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -202,7 +202,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -228,7 +228,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -275,7 +275,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -301,7 +301,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -348,7 +348,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -374,7 +374,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -420,7 +420,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -446,7 +446,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -492,7 +492,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -518,7 +518,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -564,7 +564,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "total_count": 1,
                   "data": {
@@ -581,7 +581,7 @@ import Pagination
                   },
                   "next": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -616,7 +616,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "total_count": 1,
                   "data": {
@@ -633,7 +633,7 @@ import Pagination
                   },
                   "next": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -668,7 +668,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "cursor": {
                     "after": "after",
@@ -678,7 +678,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -706,14 +706,14 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "results": [
                     "results",
                     "results"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(

--- a/seed/swift-sdk/pagination/no-custom-config/Tests/Wire/Resources/Users/UsersClientWireTests.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Tests/Wire/Resources/Users/UsersClientWireTests.swift
@@ -7,7 +7,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -31,7 +31,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -76,7 +76,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "next": "next",
                   "data": [
@@ -90,7 +90,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -122,7 +122,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -146,7 +146,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -190,7 +190,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "next_cursor": "next_cursor_value",
                   "data": [
@@ -204,7 +204,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -239,7 +239,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "next_cursor": "next_cursor",
                   "data": [
@@ -253,7 +253,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -288,7 +288,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -312,7 +312,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -357,7 +357,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -381,7 +381,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -426,7 +426,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -450,7 +450,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -494,7 +494,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -518,7 +518,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -562,7 +562,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -586,7 +586,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -630,7 +630,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": false,
                   "page": {
@@ -654,7 +654,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -698,7 +698,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -722,7 +722,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -766,7 +766,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "total_count": 1,
                   "data": {
@@ -783,7 +783,7 @@ import Pagination
                   },
                   "next": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -818,7 +818,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "total_count": 1,
                   "data": {
@@ -835,7 +835,7 @@ import Pagination
                   },
                   "next": "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -870,7 +870,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "cursor": {
                     "after": "after",
@@ -880,7 +880,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -908,7 +908,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "cursor": {
                     "after": "after",
@@ -918,7 +918,7 @@ import Pagination
                     ]
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -946,14 +946,14 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "results": [
                     "results",
                     "results"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -978,7 +978,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -1002,7 +1002,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -1044,7 +1044,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": false,
                   "page": {
@@ -1058,7 +1058,7 @@ import Pagination
                   },
                   "total_count": 0
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -1090,7 +1090,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -1114,7 +1114,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(
@@ -1156,7 +1156,7 @@ import Pagination
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "hasNextPage": true,
                   "page": {
@@ -1180,7 +1180,7 @@ import Pagination
                     }
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PaginationClient(

--- a/seed/swift-sdk/path-parameters/.fern/metadata.json
+++ b/seed/swift-sdk/path-parameters/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/path-parameters/Tests/Wire/Resources/Organizations/OrganizationsClientWireTests.swift
+++ b/seed/swift-sdk/path-parameters/Tests/Wire/Resources/Organizations/OrganizationsClientWireTests.swift
@@ -7,7 +7,7 @@ import PathParameters
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "name",
                   "tags": [
@@ -15,7 +15,7 @@ import PathParameters
                     "tags"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PathParametersClient(
@@ -41,7 +41,7 @@ import PathParameters
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "name",
                   "tags": [
@@ -49,7 +49,7 @@ import PathParameters
                     "tags"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PathParametersClient(
@@ -75,7 +75,7 @@ import PathParameters
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "name": "name",
@@ -92,7 +92,7 @@ import PathParameters
                     ]
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = PathParametersClient(

--- a/seed/swift-sdk/path-parameters/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/path-parameters/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -7,7 +7,7 @@ import PathParameters
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "name",
                   "tags": [
@@ -15,7 +15,7 @@ import PathParameters
                     "tags"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PathParametersClient(
@@ -40,7 +40,7 @@ import PathParameters
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "name",
                   "tags": [
@@ -48,7 +48,7 @@ import PathParameters
                     "tags"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PathParametersClient(
@@ -80,7 +80,7 @@ import PathParameters
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "name",
                   "tags": [
@@ -88,7 +88,7 @@ import PathParameters
                     "tags"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PathParametersClient(
@@ -120,7 +120,7 @@ import PathParameters
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "name": "name",
@@ -137,7 +137,7 @@ import PathParameters
                     ]
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = PathParametersClient(
@@ -172,7 +172,7 @@ import PathParameters
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "name",
                   "tags": [
@@ -180,7 +180,7 @@ import PathParameters
                     "tags"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PathParametersClient(
@@ -206,7 +206,7 @@ import PathParameters
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "name",
                   "tags": [
@@ -214,7 +214,7 @@ import PathParameters
                     "tags"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = PathParametersClient(

--- a/seed/swift-sdk/plain-text/.fern/metadata.json
+++ b/seed/swift-sdk/plain-text/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/plain-text/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/plain-text/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -7,9 +7,9 @@ import PlainText
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = PlainTextClient(

--- a/seed/swift-sdk/property-access/.fern/metadata.json
+++ b/seed/swift-sdk/property-access/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/public-object/.fern/metadata.json
+++ b/seed/swift-sdk/public-object/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/query-param-name-conflict/.fern/metadata.json
+++ b/seed/swift-sdk/query-param-name-conflict/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/query-parameters-openapi/.fern/metadata.json
+++ b/seed/swift-sdk/query-parameters-openapi/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/query-parameters/.fern/metadata.json
+++ b/seed/swift-sdk/query-parameters/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/query-parameters/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/query-parameters/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -7,7 +7,7 @@ import QueryParameters
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "name",
                   "tags": [
@@ -15,7 +15,7 @@ import QueryParameters
                     "tags"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = QueryParametersClient(

--- a/seed/swift-sdk/request-parameters/.fern/metadata.json
+++ b/seed/swift-sdk/request-parameters/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/request-parameters/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/request-parameters/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -7,7 +7,7 @@ import RequestParameters
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "name",
                   "tags": [
@@ -15,7 +15,7 @@ import RequestParameters
                     "tags"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = RequestParametersClient(

--- a/seed/swift-sdk/required-nullable/no-custom-config/.fern/metadata.json
+++ b/seed/swift-sdk/required-nullable/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/.fern/metadata.json
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/.fern/metadata.json
@@ -6,8 +6,7 @@
     "decodeNullableToOptional": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/reserved-keywords/.fern/metadata.json
+++ b/seed/swift-sdk/reserved-keywords/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/response-property/.fern/metadata.json
+++ b/seed/swift-sdk/response-property/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/response-property/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
+++ b/seed/swift-sdk/response-property/Tests/Wire/Resources/Service/ServiceClientWireTests.swift
@@ -7,7 +7,7 @@ import ResponseProperty
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "data": {
                     "id": "id",
@@ -18,7 +18,7 @@ import ResponseProperty
                   },
                   "docs": "docs"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ResponsePropertyClient(
@@ -46,7 +46,7 @@ import ResponseProperty
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "data": {
                     "id": "id",
@@ -57,7 +57,7 @@ import ResponseProperty
                   },
                   "docs": "docs"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ResponsePropertyClient(
@@ -85,11 +85,11 @@ import ResponseProperty
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "data": "data"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ResponsePropertyClient(
@@ -110,7 +110,7 @@ import ResponseProperty
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "data": {
                     "id": "id",
@@ -121,7 +121,7 @@ import ResponseProperty
                   },
                   "docs": "docs"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ResponsePropertyClient(
@@ -149,7 +149,7 @@ import ResponseProperty
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "data": {
                     "id": "id",
@@ -160,7 +160,7 @@ import ResponseProperty
                   },
                   "docs": "docs"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ResponsePropertyClient(
@@ -188,11 +188,11 @@ import ResponseProperty
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "docs": "docs"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ResponsePropertyClient(
@@ -213,11 +213,11 @@ import ResponseProperty
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "data": "data"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = ResponsePropertyClient(

--- a/seed/swift-sdk/schemaless-request-body-examples/.fern/metadata.json
+++ b/seed/swift-sdk/schemaless-request-body-examples/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/server-sent-event-examples/.fern/metadata.json
+++ b/seed/swift-sdk/server-sent-event-examples/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/server-sent-events-openapi/.fern/metadata.json
+++ b/seed/swift-sdk/server-sent-events-openapi/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/server-sent-events/.fern/metadata.json
+++ b/seed/swift-sdk/server-sent-events/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/server-url-templating/.fern/metadata.json
+++ b/seed/swift-sdk/server-url-templating/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/simple-api/.fern/metadata.json
+++ b/seed/swift-sdk/simple-api/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/simple-api/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/simple-api/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -7,13 +7,13 @@ import SimpleApi
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name",
                   "email": "email"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = SimpleApiClient(

--- a/seed/swift-sdk/simple-fhir/.fern/metadata.json
+++ b/seed/swift-sdk/simple-fhir/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/.fern/metadata.json
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "maxRetries": 5
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
@@ -7,9 +7,9 @@ import SingleUrlEnvironmentDefault
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = SingleUrlEnvironmentDefaultClient(

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/.fern/metadata.json
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/.fern/metadata.json
@@ -6,8 +6,7 @@
     "environmentEnumName": "MyCustomEnvironment"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
@@ -7,9 +7,9 @@ import SingleUrlEnvironmentDefault
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = SingleUrlEnvironmentDefaultClient(

--- a/seed/swift-sdk/single-url-environment-no-default/.fern/metadata.json
+++ b/seed/swift-sdk/single-url-environment-no-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/single-url-environment-no-default/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
@@ -7,9 +7,9 @@ import SingleUrlEnvironmentNoDefault
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = SingleUrlEnvironmentNoDefaultClient(

--- a/seed/swift-sdk/streaming-parameter/.fern/metadata.json
+++ b/seed/swift-sdk/streaming-parameter/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/streaming-parameter/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
+++ b/seed/swift-sdk/streaming-parameter/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
@@ -7,12 +7,12 @@ import Streaming
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = StreamingClient(
@@ -37,12 +37,12 @@ import Streaming
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = StreamingClient(

--- a/seed/swift-sdk/streaming/.fern/metadata.json
+++ b/seed/swift-sdk/streaming/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/streaming/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
+++ b/seed/swift-sdk/streaming/Tests/Wire/Resources/Dummy/DummyClientWireTests.swift
@@ -7,12 +7,12 @@ import Streaming
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = StreamingClient(
@@ -37,12 +37,12 @@ import Streaming
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = StreamingClient(

--- a/seed/swift-sdk/trace/.fern/metadata.json
+++ b/seed/swift-sdk/trace/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/Homepage/HomepageClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/Homepage/HomepageClientWireTests.swift
@@ -7,12 +7,12 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   "string",
                   "string"
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/Migration/MigrationClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/Migration/MigrationClientWireTests.swift
@@ -7,7 +7,7 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "name": "name",
@@ -18,7 +18,7 @@ import Trace
                     "status": "RUNNING"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/Playlist/PlaylistClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/Playlist/PlaylistClientWireTests.swift
@@ -7,7 +7,7 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "playlist_id": "playlist_id",
                   "owner-id": "owner-id",
@@ -17,7 +17,7 @@ import Trace
                     "problems"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(
@@ -54,7 +54,7 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "playlist_id": "playlist_id",
@@ -75,7 +75,7 @@ import Trace
                     ]
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(
@@ -117,7 +117,7 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "playlist_id": "playlist_id",
                   "owner-id": "owner-id",
@@ -127,7 +127,7 @@ import Trace
                     "problems"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(
@@ -156,7 +156,7 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "playlist_id": "playlist_id",
                   "owner-id": "owner-id",
@@ -166,7 +166,7 @@ import Trace
                     "problems"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/Problem/ProblemClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/Problem/ProblemClientWireTests.swift
@@ -7,12 +7,12 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "success",
                   "value": "string"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(
@@ -108,11 +108,11 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "problemVersion": 1
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(
@@ -211,7 +211,7 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "files": {
                     "JAVA": {
@@ -232,7 +232,7 @@ import Trace
                     }
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/Submission/SubmissionClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/Submission/SubmissionClientWireTests.swift
@@ -7,14 +7,14 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "sessionId": "sessionId",
                   "executionSessionUrl": "executionSessionUrl",
                   "language": "JAVA",
                   "status": "CREATING_CONTAINER"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(
@@ -39,14 +39,14 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "sessionId": "sessionId",
                   "executionSessionUrl": "executionSessionUrl",
                   "language": "JAVA",
                   "status": "CREATING_CONTAINER"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(
@@ -71,7 +71,7 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "states": {
                     "states": {
@@ -89,7 +89,7 @@ import Trace
                     "warmingSessionIds"
                   ]
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/Sysprop/SyspropClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/Sysprop/SyspropClientWireTests.swift
@@ -7,11 +7,11 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "JAVA": 1
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/V2/Problem/V2ProblemClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/V2/Problem/V2ProblemClientWireTests.swift
@@ -7,7 +7,7 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "problemId": "problemId",
@@ -30,7 +30,7 @@ import Trace
                     ]
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(
@@ -60,7 +60,7 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "problemId": "problemId",
@@ -645,7 +645,7 @@ import Trace
                     "isPublic": true
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(
@@ -1173,7 +1173,7 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "problemId": "problemId",
                   "problemDescription": {
@@ -1467,7 +1467,7 @@ import Trace
                   ],
                   "isPublic": true
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(
@@ -1743,7 +1743,7 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "problemId": "problemId",
                   "problemDescription": {
@@ -2037,7 +2037,7 @@ import Trace
                   ],
                   "isPublic": true
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(

--- a/seed/swift-sdk/trace/Tests/Wire/Resources/V2/V3/Problem/V3ProblemClientWireTests.swift
+++ b/seed/swift-sdk/trace/Tests/Wire/Resources/V2/V3/Problem/V3ProblemClientWireTests.swift
@@ -7,7 +7,7 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "problemId": "problemId",
@@ -30,7 +30,7 @@ import Trace
                     ]
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(
@@ -60,7 +60,7 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "problemId": "problemId",
@@ -645,7 +645,7 @@ import Trace
                     "isPublic": true
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(
@@ -1173,7 +1173,7 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "problemId": "problemId",
                   "problemDescription": {
@@ -1467,7 +1467,7 @@ import Trace
                   ],
                   "isPublic": true
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(
@@ -1743,7 +1743,7 @@ import Trace
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "problemId": "problemId",
                   "problemDescription": {
@@ -2037,7 +2037,7 @@ import Trace
                   ],
                   "isPublic": true
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = TraceClient(

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/undiscriminated-unions/.fern/metadata.json
+++ b/seed/swift-sdk/undiscriminated-unions/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/undiscriminated-unions/Tests/Wire/Resources/Union/UnionClientWireTests.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Tests/Wire/Resources/Union/UnionClientWireTests.swift
@@ -7,9 +7,9 @@ import UndiscriminatedUnions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = UndiscriminatedUnionsClient(
@@ -32,13 +32,13 @@ import UndiscriminatedUnions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "exampleName",
                   "value": "exampleValue",
                   "default": "exampleDefault"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = UndiscriminatedUnionsClient(
@@ -64,11 +64,11 @@ import UndiscriminatedUnions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "string"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = UndiscriminatedUnionsClient(
@@ -88,9 +88,9 @@ import UndiscriminatedUnions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = UndiscriminatedUnionsClient(
@@ -115,9 +115,9 @@ import UndiscriminatedUnions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = UndiscriminatedUnionsClient(
@@ -142,9 +142,9 @@ import UndiscriminatedUnions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = UndiscriminatedUnionsClient(
@@ -171,9 +171,9 @@ import UndiscriminatedUnions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = UndiscriminatedUnionsClient(
@@ -200,9 +200,9 @@ import UndiscriminatedUnions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = UndiscriminatedUnionsClient(
@@ -225,9 +225,9 @@ import UndiscriminatedUnions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = UndiscriminatedUnionsClient(
@@ -248,9 +248,9 @@ import UndiscriminatedUnions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = UndiscriminatedUnionsClient(
@@ -271,9 +271,9 @@ import UndiscriminatedUnions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = UndiscriminatedUnionsClient(
@@ -297,7 +297,7 @@ import UndiscriminatedUnions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "name": "name",
                   "value": {
@@ -306,7 +306,7 @@ import UndiscriminatedUnions
                     }
                   }
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = UndiscriminatedUnionsClient(
@@ -345,9 +345,9 @@ import UndiscriminatedUnions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 success
-                """.utf8
+                """#.utf8
             )
         )
         let client = UndiscriminatedUnionsClient(
@@ -371,9 +371,9 @@ import UndiscriminatedUnions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = UndiscriminatedUnionsClient(

--- a/seed/swift-sdk/union-query-parameters/.fern/metadata.json
+++ b/seed/swift-sdk/union-query-parameters/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/union-query-parameters/Tests/Wire/Resources/Events/EventsClientWireTests.swift
+++ b/seed/swift-sdk/union-query-parameters/Tests/Wire/Resources/Events/EventsClientWireTests.swift
@@ -7,9 +7,9 @@ import UnionQueryParameters
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 string
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionQueryParametersClient(

--- a/seed/swift-sdk/unions-with-local-date/.fern/metadata.json
+++ b/seed/swift-sdk/unions-with-local-date/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/unions-with-local-date/Tests/Wire/Resources/Bigunion/BigunionClientWireTests.swift
+++ b/seed/swift-sdk/unions-with-local-date/Tests/Wire/Resources/Bigunion/BigunionClientWireTests.swift
@@ -7,7 +7,7 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "normalSweet",
                   "value": "value",
@@ -15,7 +15,7 @@ import Unions
                   "created-at": "2024-01-15T09:30:00Z",
                   "archived-at": "2024-01-15T09:30:00Z"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(
@@ -44,9 +44,9 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(
@@ -69,11 +69,11 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": true
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(

--- a/seed/swift-sdk/unions-with-local-date/Tests/Wire/Resources/Types/TypesClientWireTests.swift
+++ b/seed/swift-sdk/unions-with-local-date/Tests/Wire/Resources/Types/TypesClientWireTests.swift
@@ -7,12 +7,12 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "date",
                   "value": "1994-01-01"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(
@@ -31,12 +31,12 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "datetime",
                   "value": "1994-01-01T01:01:01Z"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(
@@ -55,12 +55,12 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "value",
                   "value": 1
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(
@@ -79,9 +79,9 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(
@@ -102,9 +102,9 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(
@@ -125,9 +125,9 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(

--- a/seed/swift-sdk/unions-with-local-date/Tests/Wire/Resources/Union/UnionClientWireTests.swift
+++ b/seed/swift-sdk/unions-with-local-date/Tests/Wire/Resources/Union/UnionClientWireTests.swift
@@ -7,13 +7,13 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "circle",
                   "radius": 1.1,
                   "id": "id"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(
@@ -40,9 +40,9 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(

--- a/seed/swift-sdk/unions/.fern/metadata.json
+++ b/seed/swift-sdk/unions/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/unions/Tests/Wire/Resources/Bigunion/BigunionClientWireTests.swift
+++ b/seed/swift-sdk/unions/Tests/Wire/Resources/Bigunion/BigunionClientWireTests.swift
@@ -7,7 +7,7 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "normalSweet",
                   "value": "value",
@@ -15,7 +15,7 @@ import Unions
                   "created-at": "2024-01-15T09:30:00Z",
                   "archived-at": "2024-01-15T09:30:00Z"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(
@@ -44,9 +44,9 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(
@@ -69,11 +69,11 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "string": true
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(

--- a/seed/swift-sdk/unions/Tests/Wire/Resources/Union/UnionClientWireTests.swift
+++ b/seed/swift-sdk/unions/Tests/Wire/Resources/Union/UnionClientWireTests.swift
@@ -7,13 +7,13 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "type": "circle",
                   "radius": 1.1,
                   "id": "id"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(
@@ -40,9 +40,9 @@ import Unions
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 true
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnionsClient(

--- a/seed/swift-sdk/unknown/.fern/metadata.json
+++ b/seed/swift-sdk/unknown/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/unknown/Tests/Wire/Resources/Unknown/UnknownClientWireTests.swift
+++ b/seed/swift-sdk/unknown/Tests/Wire/Resources/Unknown/UnknownClientWireTests.swift
@@ -7,7 +7,7 @@ import UnknownAsAny
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "key": "value"
@@ -16,7 +16,7 @@ import UnknownAsAny
                     "key": "value"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnknownAsAnyClient(
@@ -48,7 +48,7 @@ import UnknownAsAny
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 [
                   {
                     "key": "value"
@@ -57,7 +57,7 @@ import UnknownAsAny
                     "key": "value"
                   }
                 ]
-                """.utf8
+                """#.utf8
             )
         )
         let client = UnknownAsAnyClient(

--- a/seed/swift-sdk/url-form-encoded/.fern/metadata.json
+++ b/seed/swift-sdk/url-form-encoded/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/validation/.fern/metadata.json
+++ b/seed/swift-sdk/validation/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/variables/.fern/metadata.json
+++ b/seed/swift-sdk/variables/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/version-no-default/.fern/metadata.json
+++ b/seed/swift-sdk/version-no-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/version-no-default/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/version-no-default/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -7,12 +7,12 @@ import Version
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = VersionClient(

--- a/seed/swift-sdk/version/.fern/metadata.json
+++ b/seed/swift-sdk/version/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/version/Tests/Wire/Resources/User/UserClientWireTests.swift
+++ b/seed/swift-sdk/version/Tests/Wire/Resources/User/UserClientWireTests.swift
@@ -7,12 +7,12 @@ import Version
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "id": "id",
                   "name": "name"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = VersionClient(

--- a/seed/swift-sdk/webhook-audience/.fern/metadata.json
+++ b/seed/swift-sdk/webhook-audience/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/webhooks/.fern/metadata.json
+++ b/seed/swift-sdk/webhooks/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/websocket-bearer-auth/.fern/metadata.json
+++ b/seed/swift-sdk/websocket-bearer-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/websocket-inferred-auth/.fern/metadata.json
+++ b/seed/swift-sdk/websocket-inferred-auth/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/websocket-inferred-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Tests/Wire/Resources/Auth/AuthClientWireTests.swift
@@ -7,12 +7,12 @@ import WebsocketAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = WebsocketAuthClient(
@@ -40,12 +40,12 @@ import WebsocketAuth
         let stub = HTTPStub()
         stub.setResponse(
             body: Data(
-                """
+                #"""
                 {
                   "access_token": "access_token",
                   "refresh_token": "refresh_token"
                 }
-                """.utf8
+                """#.utf8
             )
         )
         let client = WebsocketAuthClient(

--- a/seed/swift-sdk/websocket-multi-url/.fern/metadata.json
+++ b/seed/swift-sdk/websocket-multi-url/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/websocket/.fern/metadata.json
+++ b/seed/swift-sdk/websocket/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/x-fern-default/.fern/metadata.json
+++ b/seed/swift-sdk/x-fern-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }


### PR DESCRIPTION
## Summary
- Adds `rawMultiLineStringLiteral` expression type to Swift AST (`#"""..."""#`), which preserves escape sequences like `\n` as literal characters at runtime
- Updates `WireTestFunctionGenerator` to use raw multi-line string literals for response body stubs, fixing JSON parsing failures when example values contain escape sequences (e.g. iCalendar payloads with `\n`)

Closes FER-10211

## Test plan
- [x] Unit test added for `rawMultiLineStringLiteral` expression rendering
- [ ] Run Square baseline-e2e nightly to verify the 5 Loyalty/Webhook tests pass
- [ ] Verify other wire tests continue to compile and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)