### PR TITLE
fix(cli): resolve shared snippets in translated docs pages

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-translation-snippet-resolution.yml
+++ b/packages/cli/cli/changes/unreleased/fix-translation-snippet-resolution.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix translated docs pages failing to resolve shared snippets (`<Markdown src="..."/>` and `<Code src="..."/>`).
+    Snippet references are now resolved before registering translations, with locale-aware loading that prefers
+    translated snippets (e.g., `translations/zh/snippets/foo.mdx`) when available.
+  type: fix

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -4,11 +4,22 @@ import {
     applyTranslatedNavigationOverlays,
     getTranslatedAnnouncement,
     replaceImagePathsAndUrls,
+    replaceReferencedCode,
+    replaceReferencedMarkdown,
     stripMdxComments,
+    transformAtPrefixImports,
     wrapWithHttps
 } from "@fern-api/docs-resolver";
 import { DocsV1Read, DocsV2Read, FernNavigation } from "@fern-api/fdr-sdk";
-import { AbsoluteFilePath, dirname, doesPathExist, listFiles, RelativeFilePath, resolve } from "@fern-api/fs-utils";
+import {
+    AbsoluteFilePath,
+    dirname,
+    doesPathExist,
+    listFiles,
+    RelativeFilePath,
+    relative,
+    resolve
+} from "@fern-api/fs-utils";
 import { runExeca } from "@fern-api/logging-execa";
 import { Project } from "@fern-api/project-loader";
 import { CliError, TaskContext } from "@fern-api/task-context";
@@ -711,7 +722,9 @@ export async function runAppPreviewServer({
      * Computes translated definitions for each locale.
      * Similar to what publishDocs.ts does for production, but for local preview.
      */
-    function computeTranslatedDefinitions(result: PreviewDocsResult): Map<string, DocsV1Read.DocsDefinition> {
+    async function computeTranslatedDefinitions(
+        result: PreviewDocsResult
+    ): Promise<Map<string, DocsV1Read.DocsDefinition>> {
         const translations = new Map<string, DocsV1Read.DocsDefinition>();
         const { docsDefinition, translationPages, translationNavigationOverlays, collectedFileIds, docsWorkspacePath } =
             result;
@@ -729,6 +742,28 @@ export async function runAppPreviewServer({
             }
 
             try {
+                // Locale-aware file loaders that prefer translated snippets when available
+                const resolveLocalePath = async (filepath: AbsoluteFilePath): Promise<AbsoluteFilePath> => {
+                    const relPath = relative(docsWorkspacePath, filepath);
+                    const translatedPath = resolve(
+                        docsWorkspacePath,
+                        RelativeFilePath.of(`translations/${locale}/${relPath}`)
+                    );
+                    return (await doesPathExist(translatedPath)) ? translatedPath : filepath;
+                };
+
+                const localeAwareMarkdownLoader = async (filepath: AbsoluteFilePath): Promise<string> => {
+                    const pathToRead = await resolveLocalePath(filepath);
+                    const raw = await readFile(pathToRead, "utf-8");
+                    const fmMatch = raw.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+                    return fmMatch != null ? raw.slice(fmMatch[0].length) : raw;
+                };
+
+                const localeAwareFileLoader = async (filepath: AbsoluteFilePath): Promise<string> => {
+                    const pathToRead = await resolveLocalePath(filepath);
+                    return readFile(pathToRead, "utf-8");
+                };
+
                 // Build translated pages by merging base pages with locale-specific pages
                 // Start by copying all defined pages from the base definition
                 const translatedPages: Record<string, DocsV1Read.PageContent> = {};
@@ -741,10 +776,37 @@ export async function runAppPreviewServer({
                 for (const [pagePath, rawMarkdown] of Object.entries(localePages)) {
                     try {
                         const basePage = translatedPages[pagePath];
-                        // Strip MDX comments first
-                        let processedMarkdown = stripMdxComments(rawMarkdown);
-                        // Replace image paths using collected file IDs
                         const absolutePathToMarkdownFile = resolve(docsWorkspacePath, RelativeFilePath.of(pagePath));
+
+                        // Resolve <Markdown src="..."/> snippets (locale-aware)
+                        const { markdown: markdownResolved } = await replaceReferencedMarkdown({
+                            markdown: rawMarkdown,
+                            absolutePathToFernFolder: docsWorkspacePath,
+                            absolutePathToMarkdownFile,
+                            context,
+                            markdownLoader: localeAwareMarkdownLoader
+                        });
+
+                        // Resolve <Code src="..."/> references (locale-aware)
+                        const codeResolved = await replaceReferencedCode({
+                            markdown: markdownResolved,
+                            absolutePathToFernFolder: docsWorkspacePath,
+                            absolutePathToMarkdownFile,
+                            context,
+                            fileLoader: localeAwareFileLoader
+                        });
+
+                        // Transform @/ prefix imports to relative paths
+                        const importsResolved = transformAtPrefixImports({
+                            markdown: codeResolved,
+                            absolutePathToFernFolder: docsWorkspacePath,
+                            absolutePathToMarkdownFile
+                        });
+
+                        // Strip MDX comments
+                        let processedMarkdown = stripMdxComments(importsResolved);
+
+                        // Replace image paths using collected file IDs
                         processedMarkdown = replaceImagePathsAndUrls(
                             processedMarkdown,
                             collectedFileIds,
@@ -890,7 +952,7 @@ export async function runAppPreviewServer({
 
     // Compute translated definitions after loading
     if (previewResult != null) {
-        translatedDefinitions = computeTranslatedDefinitions(previewResult);
+        translatedDefinitions = await computeTranslatedDefinitions(previewResult);
         if (translatedDefinitions.size > 0) {
             context.logger.info(`Computed translations for ${translatedDefinitions.size} locale(s)`);
         }
@@ -1156,7 +1218,7 @@ export async function runAppPreviewServer({
                     previewResult = reloadedPreviewResult;
 
                     // Recompute translated definitions
-                    translatedDefinitions = computeTranslatedDefinitions(reloadedPreviewResult);
+                    translatedDefinitions = await computeTranslatedDefinitions(reloadedPreviewResult);
                     if (translatedDefinitions.size > 0) {
                         context.logger.debug(`Recomputed translations for ${translatedDefinitions.size} locale(s)`);
                     }

--- a/packages/cli/docs-preview/src/runPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runPreviewServer.ts
@@ -3,17 +3,21 @@ import {
     applyTranslatedNavigationOverlays,
     getTranslatedAnnouncement,
     replaceImagePathsAndUrls,
+    replaceReferencedCode,
+    replaceReferencedMarkdown,
     stripMdxComments,
+    transformAtPrefixImports,
     wrapWithHttps
 } from "@fern-api/docs-resolver";
 import { DocsV1Read, DocsV2Read, FernNavigation } from "@fern-api/fdr-sdk";
-import { AbsoluteFilePath, dirname, doesPathExist, RelativeFilePath, resolve } from "@fern-api/fs-utils";
+import { AbsoluteFilePath, dirname, doesPathExist, RelativeFilePath, relative, resolve } from "@fern-api/fs-utils";
 import { Project } from "@fern-api/project-loader";
 import { CliError, TaskContext } from "@fern-api/task-context";
 
 import chalk from "chalk";
 import cors from "cors";
 import express from "express";
+import { readFile } from "fs/promises";
 import http from "http";
 import path from "path";
 import Watcher from "watcher";
@@ -144,7 +148,9 @@ export async function runPreviewServer({
     /**
      * Computes translated definitions for each locale.
      */
-    function computeTranslatedDefinitions(result: PreviewDocsResult): Map<string, DocsV1Read.DocsDefinition> {
+    async function computeTranslatedDefinitions(
+        result: PreviewDocsResult
+    ): Promise<Map<string, DocsV1Read.DocsDefinition>> {
         const translations = new Map<string, DocsV1Read.DocsDefinition>();
         const { docsDefinition, translationPages, translationNavigationOverlays, collectedFileIds, docsWorkspacePath } =
             result;
@@ -162,6 +168,28 @@ export async function runPreviewServer({
             }
 
             try {
+                // Locale-aware file loaders that prefer translated snippets when available
+                const resolveLocalePath = async (filepath: AbsoluteFilePath): Promise<AbsoluteFilePath> => {
+                    const relPath = relative(docsWorkspacePath, filepath);
+                    const translatedPath = resolve(
+                        docsWorkspacePath,
+                        RelativeFilePath.of(`translations/${locale}/${relPath}`)
+                    );
+                    return (await doesPathExist(translatedPath)) ? translatedPath : filepath;
+                };
+
+                const localeAwareMarkdownLoader = async (filepath: AbsoluteFilePath): Promise<string> => {
+                    const pathToRead = await resolveLocalePath(filepath);
+                    const raw = await readFile(pathToRead, "utf-8");
+                    const fmMatch = raw.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+                    return fmMatch != null ? raw.slice(fmMatch[0].length) : raw;
+                };
+
+                const localeAwareFileLoader = async (filepath: AbsoluteFilePath): Promise<string> => {
+                    const pathToRead = await resolveLocalePath(filepath);
+                    return readFile(pathToRead, "utf-8");
+                };
+
                 // Build translated pages by merging base pages with locale-specific pages
                 // Start by copying all defined pages from the base definition
                 const translatedPages: Record<string, DocsV1Read.PageContent> = {};
@@ -174,10 +202,37 @@ export async function runPreviewServer({
                 for (const [pagePath, rawMarkdown] of Object.entries(localePages)) {
                     try {
                         const basePage = translatedPages[pagePath];
-                        // Strip MDX comments first
-                        let processedMarkdown = stripMdxComments(rawMarkdown);
-                        // Replace image paths using collected file IDs
                         const absolutePathToMarkdownFile = resolve(docsWorkspacePath, RelativeFilePath.of(pagePath));
+
+                        // Resolve <Markdown src="..."/> snippets (locale-aware)
+                        const { markdown: markdownResolved } = await replaceReferencedMarkdown({
+                            markdown: rawMarkdown,
+                            absolutePathToFernFolder: docsWorkspacePath,
+                            absolutePathToMarkdownFile,
+                            context,
+                            markdownLoader: localeAwareMarkdownLoader
+                        });
+
+                        // Resolve <Code src="..."/> references (locale-aware)
+                        const codeResolved = await replaceReferencedCode({
+                            markdown: markdownResolved,
+                            absolutePathToFernFolder: docsWorkspacePath,
+                            absolutePathToMarkdownFile,
+                            context,
+                            fileLoader: localeAwareFileLoader
+                        });
+
+                        // Transform @/ prefix imports to relative paths
+                        const importsResolved = transformAtPrefixImports({
+                            markdown: codeResolved,
+                            absolutePathToFernFolder: docsWorkspacePath,
+                            absolutePathToMarkdownFile
+                        });
+
+                        // Strip MDX comments
+                        let processedMarkdown = stripMdxComments(importsResolved);
+
+                        // Replace image paths using collected file IDs
                         processedMarkdown = replaceImagePathsAndUrls(
                             processedMarkdown,
                             collectedFileIds,
@@ -280,7 +335,7 @@ export async function runPreviewServer({
 
     // Compute translated definitions after loading
     if (previewResult != null) {
-        translatedDefinitions = computeTranslatedDefinitions(previewResult);
+        translatedDefinitions = await computeTranslatedDefinitions(previewResult);
         if (translatedDefinitions.size > 0) {
             context.logger.info(`Computed translations for ${translatedDefinitions.size} locale(s)`);
         }
@@ -327,7 +382,7 @@ export async function runPreviewServer({
                 if (reloadedPreviewResult != null) {
                     previewResult = reloadedPreviewResult;
                     // Recompute translated definitions
-                    translatedDefinitions = computeTranslatedDefinitions(reloadedPreviewResult);
+                    translatedDefinitions = await computeTranslatedDefinitions(reloadedPreviewResult);
                     if (translatedDefinitions.size > 0) {
                         context.logger.debug(`Recomputed translations for ${translatedDefinitions.size} locale(s)`);
                     }

--- a/packages/cli/docs-resolver/src/index.ts
+++ b/packages/cli/docs-resolver/src/index.ts
@@ -1,7 +1,13 @@
 import { type docsYml } from "@fern-api/configuration";
 
 // Re-export markdown utilities needed for translation processing
-export { replaceImagePathsAndUrls, stripMdxComments } from "@fern-api/docs-markdown-utils";
+export {
+    replaceImagePathsAndUrls,
+    replaceReferencedCode,
+    replaceReferencedMarkdown,
+    stripMdxComments,
+    transformAtPrefixImports
+} from "@fern-api/docs-markdown-utils";
 export { applyTranslatedFrontmatterToNavTree } from "./applyTranslatedFrontmatterToNavTree.js";
 export {
     applyTranslatedNavigationOverlays,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -9,7 +9,10 @@ import {
     DocsDefinitionResolver,
     getTranslatedAnnouncement,
     replaceImagePathsAndUrls,
+    replaceReferencedCode,
+    replaceReferencedMarkdown,
     stripMdxComments,
+    transformAtPrefixImports,
     UploadedFile,
     wrapWithHttps
 } from "@fern-api/docs-resolver";
@@ -21,7 +24,14 @@ type SnippetsConfig = APIV1Write.SnippetsConfig;
 type DocsDefinition = DocsV1Write.DocsDefinition;
 
 import { stitchGlobalTheme } from "@fern-api/docs-resolver";
-import { AbsoluteFilePath, convertToFernHostRelativeFilePath, RelativeFilePath, resolve } from "@fern-api/fs-utils";
+import {
+    AbsoluteFilePath,
+    convertToFernHostRelativeFilePath,
+    doesPathExist,
+    RelativeFilePath,
+    relative,
+    resolve
+} from "@fern-api/fs-utils";
 import { convertIrToDynamicSnippetsIr, generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { getOriginalName } from "@fern-api/ir-utils";
 import { detectAirGappedMode, OSSWorkspace } from "@fern-api/lazy-fern-workspace";
@@ -652,70 +662,123 @@ export async function publishDocs({
                         // any sidebar-title / slug frontmatter in the translated pages.
                         //
                         // For each translated page, we apply the same transformations as default locale pages:
-                        // 1. Strip MDX comments to prevent leakage
-                        // 2. Replace relative image paths with file IDs (using base page path for resolution)
-                        // 3. Preserve editThisPageUrl/editThisPageLaunch from the base page
-                        //
-                        // TODO(translations-alpha): Translated pages still need:
-                        // - replaceReferencedMarkdown/Code for <Markdown src="..."/> and <CodeBlock src="..."/>
-                        // - transformAtPrefixImports for @/... and @components/... imports
+                        // 1. Resolve <Markdown src="..."/> and <Code src="..."/> snippet references
+                        // 2. Transform @/ prefix imports to relative paths
+                        // 3. Strip MDX comments to prevent leakage
+                        // 4. Replace relative image paths with file IDs (using base page path for resolution)
+                        // 5. Preserve editThisPageUrl/editThisPageLaunch from the base page
                         const collectedFileIds = resolver.getCollectedFileIds();
                         const docsWorkspacePath = resolver.getDocsWorkspacePath();
+
+                        // Create a locale-aware file loader that prefers translated snippets
+                        // (e.g., translations/zh/snippets/foo.mdx) over base snippets.
+                        const resolveLocalePath = async (filepath: AbsoluteFilePath): Promise<AbsoluteFilePath> => {
+                            const relPath = relative(docsWorkspacePath, filepath);
+                            const translatedPath = resolve(
+                                docsWorkspacePath,
+                                RelativeFilePath.of(`translations/${locale}/${relPath}`)
+                            );
+                            return (await doesPathExist(translatedPath)) ? translatedPath : filepath;
+                        };
+
+                        const localeAwareMarkdownLoader = async (filepath: AbsoluteFilePath): Promise<string> => {
+                            const pathToRead = await resolveLocalePath(filepath);
+                            const raw = await readFile(pathToRead, "utf-8");
+                            // Strip frontmatter (---\n...\n---) from snippet files
+                            const fmMatch = raw.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+                            return fmMatch != null ? raw.slice(fmMatch[0].length) : raw;
+                        };
+
+                        const localeAwareFileLoader = async (filepath: AbsoluteFilePath): Promise<string> => {
+                            const pathToRead = await resolveLocalePath(filepath);
+                            return readFile(pathToRead, "utf-8");
+                        };
+
+                        const translatedPageEntries = await Promise.all(
+                            Object.entries(localePages).map(async ([path, rawMarkdown]) => {
+                                try {
+                                    const basePage = docsDefinition.pages[path as DocsV1Write.PageId];
+                                    const absolutePathToMarkdownFile = resolve(
+                                        docsWorkspacePath,
+                                        RelativeFilePath.of(path)
+                                    );
+
+                                    // Resolve <Markdown src="..."/> snippets (must happen before image processing).
+                                    // Uses locale-aware loader to prefer translated snippets when available.
+                                    const { markdown: markdownResolved } = await replaceReferencedMarkdown({
+                                        markdown: rawMarkdown,
+                                        absolutePathToFernFolder: docsWorkspacePath,
+                                        absolutePathToMarkdownFile,
+                                        context,
+                                        markdownLoader: localeAwareMarkdownLoader
+                                    });
+
+                                    // Resolve <Code src="..."/> references (also locale-aware)
+                                    const codeResolved = await replaceReferencedCode({
+                                        markdown: markdownResolved,
+                                        absolutePathToFernFolder: docsWorkspacePath,
+                                        absolutePathToMarkdownFile,
+                                        context,
+                                        fileLoader: localeAwareFileLoader
+                                    });
+
+                                    // Transform @/ prefix imports to relative paths
+                                    const importsResolved = transformAtPrefixImports({
+                                        markdown: codeResolved,
+                                        absolutePathToFernFolder: docsWorkspacePath,
+                                        absolutePathToMarkdownFile
+                                    });
+
+                                    // Strip MDX comments
+                                    let processedMarkdown = stripMdxComments(importsResolved);
+
+                                    // Replace image paths using the base page's location for resolution
+                                    // (translated pages reference the same images as the default locale)
+                                    processedMarkdown = replaceImagePathsAndUrls(
+                                        processedMarkdown,
+                                        collectedFileIds,
+                                        {}, // markdownFilesToPathName not needed for translations
+                                        {
+                                            absolutePathToMarkdownFile,
+                                            absolutePathToFernFolder: docsWorkspacePath
+                                        },
+                                        context
+                                    );
+
+                                    // Rewrite editThisPageUrl to point to the translated file
+                                    let editThisPageUrl = basePage?.editThisPageUrl;
+                                    if (editThisPageUrl != null) {
+                                        const fernPathPattern = `/fern/${path}`;
+                                        const translatedPath = `/fern/translations/${locale}/${path}`;
+                                        editThisPageUrl = editThisPageUrl.replace(
+                                            fernPathPattern,
+                                            translatedPath
+                                        ) as typeof editThisPageUrl;
+                                    }
+                                    return [
+                                        path,
+                                        {
+                                            markdown: processedMarkdown,
+                                            rawMarkdown: processedMarkdown,
+                                            editThisPageUrl,
+                                            editThisPageLaunch: basePage?.editThisPageLaunch
+                                        }
+                                    ];
+                                } catch (pageError) {
+                                    context.logger.warn(
+                                        `Failed to process translated page "${path}" for locale "${locale}": ${String(pageError)}. Falling back to base page.`
+                                    );
+                                    return undefined;
+                                }
+                            })
+                        );
 
                         const translatedPages = {
                             ...docsDefinition.pages,
                             ...Object.fromEntries(
-                                Object.entries(localePages)
-                                    .map(([path, rawMarkdown]) => {
-                                        try {
-                                            const basePage = docsDefinition.pages[path as DocsV1Write.PageId];
-                                            // Strip MDX comments first
-                                            let processedMarkdown = stripMdxComments(rawMarkdown);
-                                            // Replace image paths using the base page's location for resolution
-                                            // (translated pages reference the same images as the default locale)
-                                            const absolutePathToMarkdownFile = resolve(
-                                                docsWorkspacePath,
-                                                RelativeFilePath.of(path)
-                                            );
-                                            processedMarkdown = replaceImagePathsAndUrls(
-                                                processedMarkdown,
-                                                collectedFileIds,
-                                                {}, // markdownFilesToPathName not needed for translations
-                                                {
-                                                    absolutePathToMarkdownFile,
-                                                    absolutePathToFernFolder: docsWorkspacePath
-                                                },
-                                                context
-                                            );
-                                            // Rewrite editThisPageUrl to point to the translated file
-                                            // URL format: .../fern/${path}?plain=1 -> .../fern/translations/${locale}/${path}?plain=1
-                                            let editThisPageUrl = basePage?.editThisPageUrl;
-                                            if (editThisPageUrl != null) {
-                                                // Replace /fern/${path} with /fern/translations/${locale}/${path}
-                                                const fernPathPattern = `/fern/${path}`;
-                                                const translatedPath = `/fern/translations/${locale}/${path}`;
-                                                editThisPageUrl = editThisPageUrl.replace(
-                                                    fernPathPattern,
-                                                    translatedPath
-                                                ) as typeof editThisPageUrl;
-                                            }
-                                            return [
-                                                path,
-                                                {
-                                                    markdown: processedMarkdown,
-                                                    rawMarkdown: processedMarkdown,
-                                                    editThisPageUrl,
-                                                    editThisPageLaunch: basePage?.editThisPageLaunch
-                                                }
-                                            ];
-                                        } catch (pageError) {
-                                            context.logger.warn(
-                                                `Failed to process translated page "${path}" for locale "${locale}": ${String(pageError)}. Falling back to base page.`
-                                            );
-                                            return undefined;
-                                        }
-                                    })
-                                    .filter((entry): entry is NonNullable<typeof entry> => entry != null)
+                                translatedPageEntries.filter(
+                                    (entry): entry is NonNullable<typeof entry> => entry != null
+                                )
                             )
                         };
                         let updatedRoot = applyTranslatedFrontmatterToNavTree(


### PR DESCRIPTION
## Description

Fixes translated docs pages showing "Something went wrong" when they reference shared snippets via `<Markdown src="..."/>` or `<Code src="..."/>`.

## Changes Made

- **Snippet resolution for translated pages**: Added `replaceReferencedMarkdown`, `replaceReferencedCode`, and `transformAtPrefixImports` processing to translated pages before they are registered with FDR. Previously these transformations were only applied to default-locale pages.
- **Locale-aware snippet loading**: Implemented custom file loaders that prefer translated snippets (e.g., `translations/zh/snippets/version-number-go.mdx`) over base snippets when available, falling back to the base version if no translation exists.
- **Re-exported utilities from `@fern-api/docs-resolver`**: Exposed `replaceReferencedMarkdown`, `replaceReferencedCode`, and `transformAtPrefixImports` so they can be consumed by `publishDocs.ts` without adding new direct dependencies.
- **Fixed in all code paths**: Applied the fix in `publishDocs.ts` (production publish), `runPreviewServer.ts` (legacy preview), and `runAppPreviewServer.ts` (app preview).

### Root Cause

The TODO at `publishDocs.ts:659-661` explicitly documented this gap:
```
// TODO(translations-alpha): Translated pages still need:
// - replaceReferencedMarkdown/Code for <Markdown src="..."/> and <CodeBlock src="..."/>
// - transformAtPrefixImports for @/... and @components/... imports
```

When a translated page contained `<Markdown src="/snippets/version-number-go.mdx"/>`, it was sent as-is to the docs renderer without resolving the snippet content, causing the "Something went wrong" error.

## Testing

- [x] `pnpm turbo run compile` passes for all affected packages (46 tasks)
- [x] `pnpm run check` (biome lint) passes
- [ ] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/fc8ebca529a84512a481f4550cf4e4cf
Requested by: @dsinghvi