### PR TITLE
fix(typescript): preserve nullable wrappers on map value types in serde schema

### DIFF
--- a/generators/typescript/model/type-reference-converters/src/TypeReferenceToSchemaConverter.ts
+++ b/generators/typescript/model/type-reference-converters/src/TypeReferenceToSchemaConverter.ts
@@ -98,9 +98,10 @@ export class TypeReferenceToSchemaConverter extends AbstractTypeReferenceConvert
         { keyType, valueType }: FernIr.MapType,
         params: ConvertTypeReferenceParams
     ): Zurg.Schema {
-        // Strip optional/nullable wrappers from the value type to match the type converter,
+        // Strip optional wrappers from the value type to match the type converter,
         // which uses `typeNodeWithoutUndefined` for record value types.
-        const unwrappedValueType = unwrapOptionalAndNullable(valueType);
+        // Nullable wrappers are preserved so the schema correctly reflects nullable map values.
+        const unwrappedValueType = unwrapOptional(valueType);
         return this.zurg.record({
             keySchema: this.convert({ ...params, typeReference: keyType }),
             valueSchema: this.convert({ ...params, typeReference: unwrappedValueType })
@@ -128,18 +129,14 @@ export class TypeReferenceToSchemaConverter extends AbstractTypeReferenceConvert
 }
 
 /**
- * Unwraps optional and nullable container wrappers from a type reference.
- * This is used for map value types where the type converter strips optional/nullable
- * (via `typeNodeWithoutUndefined`) but the schema converter needs to match.
+ * Unwraps optional container wrappers from a type reference.
+ * This is used for map value types where the type converter strips undefined
+ * (via `typeNodeWithoutUndefined`) but preserves null. The schema converter
+ * must match: strip optional but keep nullable so `.nullable()` is emitted.
  */
-function unwrapOptionalAndNullable(typeReference: FernIr.TypeReference): FernIr.TypeReference {
-    if (typeReference.type === "container") {
-        if (typeReference.container.type === "optional") {
-            return unwrapOptionalAndNullable(typeReference.container.optional);
-        }
-        if (typeReference.container.type === "nullable") {
-            return unwrapOptionalAndNullable(typeReference.container.nullable);
-        }
+function unwrapOptional(typeReference: FernIr.TypeReference): FernIr.TypeReference {
+    if (typeReference.type === "container" && typeReference.container.type === "optional") {
+        return unwrapOptional(typeReference.container.optional);
     }
     return typeReference;
 }

--- a/generators/typescript/model/type-reference-converters/src/__test__/TypeReferenceConverters.test.ts
+++ b/generators/typescript/model/type-reference-converters/src/__test__/TypeReferenceConverters.test.ts
@@ -407,6 +407,32 @@ describe("TypeReferenceToSchemaConverter", () => {
             expect(getTextOfTsNode(result.toExpression())).toBe("zurg.record(zurg.string(), zurg.number())");
         });
 
+        it("converts map with nullable values to zurg.record() with .nullable() on value schema", () => {
+            const converter = createConverter({
+                resolveTypeReference: () =>
+                    FernIr.ResolvedTypeReference.primitive({ v1: FernIr.PrimitiveTypeV1.String, v2: undefined })
+            });
+            const result = converter.convert({
+                typeReference: mapRef(primitiveRef("STRING"), nullableRef(primitiveRef("INTEGER")))
+            });
+            expect(getTextOfTsNode(result.toExpression())).toBe(
+                "zurg.record(zurg.string(), zurg.number().nullable())"
+            );
+        });
+
+        it("converts map with optional(nullable) values strips optional, preserves nullable", () => {
+            const converter = createConverter({
+                resolveTypeReference: () =>
+                    FernIr.ResolvedTypeReference.primitive({ v1: FernIr.PrimitiveTypeV1.String, v2: undefined })
+            });
+            const result = converter.convert({
+                typeReference: mapRef(primitiveRef("STRING"), optionalRef(nullableRef(primitiveRef("INTEGER"))))
+            });
+            expect(getTextOfTsNode(result.toExpression())).toBe(
+                "zurg.record(zurg.string(), zurg.number().nullable())"
+            );
+        });
+
         it("converts map with enum keys to zurg.partialRecord()", () => {
             const converter = createConverter({
                 resolveTypeReference: (ref) => {

--- a/generators/typescript/model/type-reference-converters/src/__test__/TypeReferenceConverters.test.ts
+++ b/generators/typescript/model/type-reference-converters/src/__test__/TypeReferenceConverters.test.ts
@@ -415,9 +415,7 @@ describe("TypeReferenceToSchemaConverter", () => {
             const result = converter.convert({
                 typeReference: mapRef(primitiveRef("STRING"), nullableRef(primitiveRef("INTEGER")))
             });
-            expect(getTextOfTsNode(result.toExpression())).toBe(
-                "zurg.record(zurg.string(), zurg.number().nullable())"
-            );
+            expect(getTextOfTsNode(result.toExpression())).toBe("zurg.record(zurg.string(), zurg.number().nullable())");
         });
 
         it("converts map with optional(nullable) values strips optional, preserves nullable", () => {
@@ -428,9 +426,7 @@ describe("TypeReferenceToSchemaConverter", () => {
             const result = converter.convert({
                 typeReference: mapRef(primitiveRef("STRING"), optionalRef(nullableRef(primitiveRef("INTEGER"))))
             });
-            expect(getTextOfTsNode(result.toExpression())).toBe(
-                "zurg.record(zurg.string(), zurg.number().nullable())"
-            );
+            expect(getTextOfTsNode(result.toExpression())).toBe("zurg.record(zurg.string(), zurg.number().nullable())");
         });
 
         it("converts map with enum keys to zurg.partialRecord()", () => {

--- a/generators/typescript/sdk/changes/unreleased/fix-nullable-map-values-serde.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-nullable-map-values-serde.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix serialization schema for map types with nullable values. Previously, the
+    schema generator stripped nullable wrappers from map value types, causing a
+    type mismatch between the API types (which correctly included `| null`) and
+    the serialization layer (which omitted `.nullable()` on the value schema).
+  type: fix


### PR DESCRIPTION
## Description

Fixes a bug where the TypeScript SDK generator produced invalid serialization schemas for map types with nullable values, causing `tsc` compilation errors in generated SDKs (e.g. the Junction/Vital TypeScript SDK).

The root cause was in `TypeReferenceToSchemaConverter.mapWithNonEnumKeys()`: the `unwrapOptionalAndNullable()` helper stripped **both** `optional` and `nullable` wrappers from map value types before converting to a schema. But the corresponding type converter (`AbstractTypeReferenceToTypeNodeConverter`) only strips `undefined` (from `optional`) via `typeNodeWithoutUndefined` — it **preserves** `null` (from `nullable`).

This created a mismatch:
| Layer | Output | Correct? |
|-------|--------|----------|
| API type | `Record<string, SampleData \| null>` | ✓ |
| Raw type | `Record<string, SampleData.Raw \| null>` | ✓ |
| Serde schema | `record(string(), SampleData)` — missing `.nullable()` | ✗ |

## Changes Made
- Renamed `unwrapOptionalAndNullable` → `unwrapOptional` in `TypeReferenceToSchemaConverter.ts` to only strip `optional` wrappers, preserving `nullable` so the schema converter's `nullable()` handler correctly emits `.nullable()` on the value schema
- Added unit tests for `map<string, nullable<T>>` and `map<string, optional<nullable<T>>>` in `TypeReferenceConverters.test.ts`
- Added unreleased changelog entry (`fix`)

## Testing
- [x] Unit tests added — 108/108 pass in `@fern-typescript/type-reference-converters`
- [x] Seed test `nullable` fixture passes (no serde layer, confirms no regression)
- [x] Seed test `exhaustive` fixture (22/22 configs including `serde-layer`) passes with zero TypeScript diffs

Link to Devin session: https://app.devin.ai/sessions/18aa4ea85a564325af555bdc89b7425f
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
