### PR TITLE
feat(typescript): add unified `auth` option to BaseClientOptions

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/add-custom-auth-option.yml
+++ b/generators/typescript/sdk/changes/unreleased/add-custom-auth-option.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Add `auth` option to `BaseClientOptions` for custom auth handling. Accepts an
+    undiscriminated union of a function returning auth headers, an `AuthProvider`
+    implementation, or the existing auth credential options. This allows users with
+    `alwaysSendAuth: true` to handle auth via custom fetchers without the built-in
+    auth provider throwing on missing credentials.
+  type: feat

--- a/generators/typescript/sdk/client-class-generator/src/BaseClientTypeGenerator.ts
+++ b/generators/typescript/sdk/client-class-generator/src/BaseClientTypeGenerator.ts
@@ -70,13 +70,14 @@ export class BaseClientTypeGenerator {
         const authOptionsIntersection = authOptionsTypes.join(" & ");
         const typeCode = `
 export type AuthOption =
+    | false
     | ${authProviderType}["getAuthRequest"]
     | ${authProviderType}
     | (${authOptionsIntersection});
 
 export type BaseClientOptions = {
     ${basePropertiesStr}
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & ${authOptionsIntersection};`;
 
@@ -427,6 +428,10 @@ export type NormalizedClientOptionsWithAuth<T extends BaseClientOptions = BaseCl
         const hasAuthOptions = this.getAuthOptionsTypes(context).length > 0;
         const authBlock = hasAuthOptions
             ? `
+    if (${OPTIONS_PARAMETER_NAME}.auth === false) {
+        normalized.authProvider = new ${noOpAuthProviderRef}();
+        return normalized;
+    }
     if (${OPTIONS_PARAMETER_NAME}.auth != null) {
         if (typeof ${OPTIONS_PARAMETER_NAME}.auth === "function") {
             normalized.authProvider = { getAuthRequest: ${OPTIONS_PARAMETER_NAME}.auth };

--- a/generators/typescript/sdk/client-class-generator/src/BaseClientTypeGenerator.ts
+++ b/generators/typescript/sdk/client-class-generator/src/BaseClientTypeGenerator.ts
@@ -426,13 +426,9 @@ export type NormalizedClientOptionsWithAuth<T extends BaseClientOptions = BaseCl
         }
 
         const noOpAuthProviderRef = getTextOfTsNode(context.coreUtilities.auth.NoOpAuthProvider._getReferenceTo());
-        const authProviderRef = getTextOfTsNode(context.coreUtilities.auth.AuthProvider._getReferenceToType());
+        const isAuthProviderRef = getTextOfTsNode(context.coreUtilities.auth.isAuthProvider._getReferenceTo());
 
         const functionCode = `
-function isAuthProvider(auth: AuthOption): auth is ${authProviderRef} {
-    return typeof auth === "object" && auth !== null && "getAuthRequest" in auth && typeof auth.getAuthRequest === "function";
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     ${OPTIONS_PARAMETER_NAME}: T
 ): NormalizedClientOptionsWithAuth<T> {
@@ -443,7 +439,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: ${OPTIONS_PARAMETER_NAME}.auth };
             return normalized;
         }
-        if (isAuthProvider(${OPTIONS_PARAMETER_NAME}.auth)) {
+        if (${isAuthProviderRef}(${OPTIONS_PARAMETER_NAME}.auth)) {
             normalized.authProvider = ${OPTIONS_PARAMETER_NAME}.auth;
             return normalized;
         }

--- a/generators/typescript/sdk/client-class-generator/src/BaseClientTypeGenerator.ts
+++ b/generators/typescript/sdk/client-class-generator/src/BaseClientTypeGenerator.ts
@@ -424,12 +424,9 @@ export type NormalizedClientOptionsWithAuth<T extends BaseClientOptions = BaseCl
         const noOpAuthProviderRef = getTextOfTsNode(context.coreUtilities.auth.NoOpAuthProvider._getReferenceTo());
         const isAuthProviderRef = getTextOfTsNode(context.coreUtilities.auth.isAuthProvider._getReferenceTo());
 
-        const functionCode = `
-export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
-    ${OPTIONS_PARAMETER_NAME}: T
-): NormalizedClientOptionsWithAuth<T> {
-    const normalized = normalizeClientOptions(${OPTIONS_PARAMETER_NAME}) as NormalizedClientOptionsWithAuth<T>;
-
+        const hasAuthOptions = this.getAuthOptionsTypes(context).length > 0;
+        const authBlock = hasAuthOptions
+            ? `
     if (${OPTIONS_PARAMETER_NAME}.auth != null) {
         if (typeof ${OPTIONS_PARAMETER_NAME}.auth === "function") {
             normalized.authProvider = { getAuthRequest: ${OPTIONS_PARAMETER_NAME}.auth };
@@ -441,7 +438,15 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
         }
         Object.assign(normalized, ${OPTIONS_PARAMETER_NAME}.auth);
     }
+`
+            : "";
 
+        const functionCode = `
+export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
+    ${OPTIONS_PARAMETER_NAME}: T
+): NormalizedClientOptionsWithAuth<T> {
+    const normalized = normalizeClientOptions(${OPTIONS_PARAMETER_NAME}) as NormalizedClientOptionsWithAuth<T>;
+${authBlock}
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= ${authProviderCreation};
     return normalized;

--- a/generators/typescript/sdk/client-class-generator/src/BaseClientTypeGenerator.ts
+++ b/generators/typescript/sdk/client-class-generator/src/BaseClientTypeGenerator.ts
@@ -57,6 +57,12 @@ export class BaseClientTypeGenerator {
             return;
         }
 
+        const authProviderType = getTextOfTsNode(context.coreUtilities.auth.AuthProvider._getReferenceToType());
+        const authRequestType = getTextOfTsNode(context.coreUtilities.auth.AuthRequest._getReferenceToType());
+        const endpointMetadataType = getTextOfTsNode(
+            context.coreUtilities.fetcher.EndpointMetadata._getReferenceToType()
+        );
+
         const basePropertiesStr = baseInterface.properties
             .map((prop) => {
                 const docs = prop.docs ? `/** ${prop.docs.join(" ")} */\n    ` : "";
@@ -67,8 +73,15 @@ export class BaseClientTypeGenerator {
 
         const authOptionsIntersection = authOptionsTypes.join(" & ");
         const typeCode = `
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: ${endpointMetadataType} }) => Promise<${authRequestType}>)
+    | ${authProviderType}
+    | (${authOptionsIntersection});
+
 export type BaseClientOptions = {
     ${basePropertiesStr}
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & ${authOptionsIntersection};`;
 
         context.sourceFile.addStatements(typeCode);
@@ -412,11 +425,31 @@ export type NormalizedClientOptionsWithAuth<T extends BaseClientOptions = BaseCl
             return;
         }
 
+        const noOpAuthProviderRef = getTextOfTsNode(context.coreUtilities.auth.NoOpAuthProvider._getReferenceTo());
+        const authProviderRef = getTextOfTsNode(context.coreUtilities.auth.AuthProvider._getReferenceToType());
+
         const functionCode = `
+function isAuthProvider(auth: AuthOption): auth is ${authProviderRef} {
+    return typeof auth === "object" && auth !== null && "getAuthRequest" in auth && typeof auth.getAuthRequest === "function";
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     ${OPTIONS_PARAMETER_NAME}: T
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(${OPTIONS_PARAMETER_NAME}) as NormalizedClientOptionsWithAuth<T>;
+
+    if (${OPTIONS_PARAMETER_NAME}.auth != null) {
+        if (typeof ${OPTIONS_PARAMETER_NAME}.auth === "function") {
+            normalized.authProvider = { getAuthRequest: ${OPTIONS_PARAMETER_NAME}.auth };
+            return normalized;
+        }
+        if (isAuthProvider(${OPTIONS_PARAMETER_NAME}.auth)) {
+            normalized.authProvider = ${OPTIONS_PARAMETER_NAME}.auth;
+            return normalized;
+        }
+        Object.assign(normalized, ${OPTIONS_PARAMETER_NAME}.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= ${authProviderCreation};
     return normalized;
@@ -427,7 +460,7 @@ function withNoOpAuthProvider<T extends BaseClientOptions = BaseClientOptions>(
 ): NormalizedClientOptionsWithAuth<T> {
     return {
         ...options,
-        authProvider: new ${getTextOfTsNode(context.coreUtilities.auth.NoOpAuthProvider._getReferenceTo())}()
+        authProvider: new ${noOpAuthProviderRef}()
     };
 }`;
 

--- a/generators/typescript/sdk/client-class-generator/src/BaseClientTypeGenerator.ts
+++ b/generators/typescript/sdk/client-class-generator/src/BaseClientTypeGenerator.ts
@@ -58,10 +58,6 @@ export class BaseClientTypeGenerator {
         }
 
         const authProviderType = getTextOfTsNode(context.coreUtilities.auth.AuthProvider._getReferenceToType());
-        const authRequestType = getTextOfTsNode(context.coreUtilities.auth.AuthRequest._getReferenceToType());
-        const endpointMetadataType = getTextOfTsNode(
-            context.coreUtilities.fetcher.EndpointMetadata._getReferenceToType()
-        );
 
         const basePropertiesStr = baseInterface.properties
             .map((prop) => {
@@ -74,7 +70,7 @@ export class BaseClientTypeGenerator {
         const authOptionsIntersection = authOptionsTypes.join(" & ");
         const typeCode = `
 export type AuthOption =
-    | ((arg?: { endpointMetadata?: ${endpointMetadataType} }) => Promise<${authRequestType}>)
+    | ${authProviderType}["getAuthRequest"]
     | ${authProviderType}
     | (${authOptionsIntersection});
 

--- a/generators/typescript/sdk/client-class-generator/src/__test__/BaseClientTypeGenerator.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/BaseClientTypeGenerator.test.ts
@@ -159,6 +159,9 @@ function createMockContext(opts?: {
                 },
                 NoOpAuthProvider: {
                     _getReferenceTo: () => ts.factory.createIdentifier("core.NoOpAuthProvider")
+                },
+                isAuthProvider: {
+                    _getReferenceTo: () => ts.factory.createIdentifier("core.isAuthProvider")
                 }
             },
             fetcher: {

--- a/generators/typescript/sdk/client-class-generator/src/__test__/BaseClientTypeGenerator.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/BaseClientTypeGenerator.test.ts
@@ -154,8 +154,16 @@ function createMockContext(opts?: {
                 AuthProvider: {
                     _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.AuthProvider")
                 },
+                AuthRequest: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.AuthRequest")
+                },
                 NoOpAuthProvider: {
                     _getReferenceTo: () => ts.factory.createIdentifier("core.NoOpAuthProvider")
+                }
+            },
+            fetcher: {
+                EndpointMetadata: {
+                    _getReferenceToType: () => ts.factory.createTypeReferenceNode("core.EndpointMetadata")
                 }
             }
         },

--- a/generators/typescript/utils/commons/src/core-utilities/Auth.ts
+++ b/generators/typescript/utils/commons/src/core-utilities/Auth.ts
@@ -31,6 +31,10 @@ export interface Auth {
         };
     };
 
+    isAuthProvider: {
+        _getReferenceTo: () => ts.Expression;
+    };
+
     NoOpAuthProvider: {
         _getReferenceTo: () => ts.Expression;
     };
@@ -162,6 +166,13 @@ export class AuthImpl extends CoreUtility implements Auth {
                     this.AuthRequest._getReferenceToType()
                 ])
         }
+    };
+
+    public readonly isAuthProvider = {
+        _getReferenceTo: this.withExportedName(
+            "isAuthProvider",
+            (isAuthProviderFn) => () => isAuthProviderFn.getExpression()
+        )
     };
 
     public readonly NoOpAuthProvider = {

--- a/generators/typescript/utils/core-utilities/src/core/auth/AuthProvider.ts
+++ b/generators/typescript/utils/core-utilities/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/generators/typescript/utils/core-utilities/src/core/auth/index.ts
+++ b/generators/typescript/utils/core-utilities/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider";
 export type { AuthRequest } from "./AuthRequest";
 export { BasicAuth } from "./BasicAuth";
 export { BearerToken } from "./BearerToken";

--- a/seed/ts-sdk/accept-header/.fern/metadata.json
+++ b/seed/ts-sdk/accept-header/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/accept-header/src/BaseClient.ts
+++ b/seed/ts-sdk/accept-header/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/accept-header/src/BaseClient.ts
+++ b/seed/ts-sdk/accept-header/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/accept-header/src/BaseClient.ts
+++ b/seed/ts-sdk/accept-header/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/accept-header/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/accept-header/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/accept-header/src/core/auth/index.ts
+++ b/seed/ts-sdk/accept-header/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/alias-extends/.fern/metadata.json
+++ b/seed/ts-sdk/alias-extends/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/alias/.fern/metadata.json
+++ b/seed/ts-sdk/alias/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/allof-inline/.fern/metadata.json
+++ b/seed/ts-sdk/allof-inline/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/allof/.fern/metadata.json
+++ b/seed/ts-sdk/allof/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/any-auth/always-send-auth/.fern/metadata.json
+++ b/seed/ts-sdk/any-auth/always-send-auth/.fern/metadata.json
@@ -6,8 +6,7 @@
         "alwaysSendAuth": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/any-auth/always-send-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/src/BaseClient.ts
@@ -10,7 +10,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
 export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider["getAuthRequest"]
     | core.AuthProvider
     | AnyAuthProvider.AuthOptions<
           [

--- a/seed/ts-sdk/any-auth/always-send-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/src/BaseClient.ts
@@ -10,6 +10,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
 export type AuthOption =
+    | false
     | core.AuthProvider["getAuthRequest"]
     | core.AuthProvider
     | AnyAuthProvider.AuthOptions<
@@ -36,7 +37,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & AnyAuthProvider.AuthOptions<
     [
@@ -98,6 +99,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/any-auth/always-send-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/src/BaseClient.ts
@@ -93,15 +93,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -112,7 +103,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/any-auth/always-send-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/src/BaseClient.ts
@@ -9,6 +9,19 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | AnyAuthProvider.AuthOptions<
+          [
+              BearerAuthProvider.AuthOptions,
+              HeaderAuthProvider.AuthOptions,
+              OAuthAuthProvider.AuthOptions,
+              BasicAuthProvider.AuthOptions,
+              InferredAuthProvider.AuthOptions,
+          ]
+      >;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -23,6 +36,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & AnyAuthProvider.AuthOptions<
     [
         BearerAuthProvider.AuthOptions,
@@ -78,10 +93,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= AnyAuthProvider.createInstance(normalizedWithNoOpAuthProvider, [
         BearerAuthProvider,

--- a/seed/ts-sdk/any-auth/always-send-auth/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/any-auth/always-send-auth/src/core/auth/index.ts
+++ b/seed/ts-sdk/any-auth/always-send-auth/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/.fern/metadata.json
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/.fern/metadata.json
@@ -6,8 +6,7 @@
         "generateEndpointMetadata": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/BaseClient.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/BaseClient.ts
@@ -10,7 +10,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
 export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider["getAuthRequest"]
     | core.AuthProvider
     | AnyAuthProvider.AuthOptions<
           [

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/BaseClient.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/BaseClient.ts
@@ -10,6 +10,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
 export type AuthOption =
+    | false
     | core.AuthProvider["getAuthRequest"]
     | core.AuthProvider
     | AnyAuthProvider.AuthOptions<
@@ -36,7 +37,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & AnyAuthProvider.AuthOptions<
     [
@@ -98,6 +99,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/BaseClient.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/BaseClient.ts
@@ -93,15 +93,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -112,7 +103,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/BaseClient.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/BaseClient.ts
@@ -9,6 +9,19 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | AnyAuthProvider.AuthOptions<
+          [
+              BearerAuthProvider.AuthOptions,
+              HeaderAuthProvider.AuthOptions,
+              OAuthAuthProvider.AuthOptions,
+              BasicAuthProvider.AuthOptions,
+              InferredAuthProvider.AuthOptions,
+          ]
+      >;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -23,6 +36,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & AnyAuthProvider.AuthOptions<
     [
         BearerAuthProvider.AuthOptions,
@@ -78,10 +93,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= AnyAuthProvider.createInstance(normalizedWithNoOpAuthProvider, [
         BearerAuthProvider,

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/auth/index.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/any-auth/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/any-auth/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/any-auth/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/BaseClient.ts
@@ -10,7 +10,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
 export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider["getAuthRequest"]
     | core.AuthProvider
     | AnyAuthProvider.AuthOptions<
           [

--- a/seed/ts-sdk/any-auth/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/BaseClient.ts
@@ -10,6 +10,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
 export type AuthOption =
+    | false
     | core.AuthProvider["getAuthRequest"]
     | core.AuthProvider
     | AnyAuthProvider.AuthOptions<
@@ -36,7 +37,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & AnyAuthProvider.AuthOptions<
     [
@@ -98,6 +99,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/any-auth/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/BaseClient.ts
@@ -93,15 +93,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -112,7 +103,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/any-auth/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/BaseClient.ts
@@ -9,6 +9,19 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | AnyAuthProvider.AuthOptions<
+          [
+              BearerAuthProvider.AuthOptions,
+              HeaderAuthProvider.AuthOptions,
+              OAuthAuthProvider.AuthOptions,
+              BasicAuthProvider.AuthOptions,
+              InferredAuthProvider.AuthOptions,
+          ]
+      >;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -23,6 +36,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & AnyAuthProvider.AuthOptions<
     [
         BearerAuthProvider.AuthOptions,
@@ -78,10 +93,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= AnyAuthProvider.createInstance(normalizedWithNoOpAuthProvider, [
         BearerAuthProvider,

--- a/seed/ts-sdk/any-auth/no-custom-config/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/any-auth/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/api-wide-base-path/.fern/metadata.json
+++ b/seed/ts-sdk/api-wide-base-path/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/audiences/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/audiences/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/audiences/with-partner-audience/.fern/metadata.json
+++ b/seed/ts-sdk/audiences/with-partner-audience/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/basic-auth-environment-variables/.fern/metadata.json
+++ b/seed/ts-sdk/basic-auth-environment-variables/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/basic-auth-environment-variables/src/BaseClient.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/basic-auth-environment-variables/src/BaseClient.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BasicAuthProvider } from "./auth/BasicAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BasicAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BasicAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BasicAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/basic-auth-environment-variables/src/BaseClient.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BasicAuthProvider } from "./auth/BasicAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BasicAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BasicAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/basic-auth-environment-variables/src/BaseClient.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BasicAuthProvider } from "./auth/BasicAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BasicAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BasicAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BasicAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/auth/index.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/basic-auth-pw-omitted/.fern/metadata.json
+++ b/seed/ts-sdk/basic-auth-pw-omitted/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/basic-auth-pw-omitted/src/BaseClient.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/basic-auth-pw-omitted/src/BaseClient.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BasicAuthProvider } from "./auth/BasicAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BasicAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BasicAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BasicAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/basic-auth-pw-omitted/src/BaseClient.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BasicAuthProvider } from "./auth/BasicAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BasicAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BasicAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/basic-auth-pw-omitted/src/BaseClient.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BasicAuthProvider } from "./auth/BasicAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BasicAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BasicAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BasicAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/basic-auth-pw-omitted/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/basic-auth-pw-omitted/src/core/auth/index.ts
+++ b/seed/ts-sdk/basic-auth-pw-omitted/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/basic-auth/.fern/metadata.json
+++ b/seed/ts-sdk/basic-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/basic-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/basic-auth/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/basic-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/basic-auth/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BasicAuthProvider } from "./auth/BasicAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BasicAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BasicAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BasicAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/basic-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/basic-auth/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BasicAuthProvider } from "./auth/BasicAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BasicAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BasicAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/basic-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/basic-auth/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BasicAuthProvider } from "./auth/BasicAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BasicAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BasicAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BasicAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/basic-auth/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/basic-auth/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/basic-auth/src/core/auth/index.ts
+++ b/seed/ts-sdk/basic-auth/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/bearer-token-environment-variable/.fern/metadata.json
+++ b/seed/ts-sdk/bearer-token-environment-variable/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/bearer-token-environment-variable/src/BaseClient.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/BaseClient.ts
@@ -77,15 +77,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -96,7 +87,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/bearer-token-environment-variable/src/BaseClient.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/bearer-token-environment-variable/src/BaseClient.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -20,6 +25,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,10 +77,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/bearer-token-environment-variable/src/BaseClient.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -22,7 +26,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -79,6 +83,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/auth/index.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/bytes-download/.fern/metadata.json
+++ b/seed/ts-sdk/bytes-download/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/bytes-upload/.fern/metadata.json
+++ b/seed/ts-sdk/bytes-upload/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/circular-references-advanced/.fern/metadata.json
+++ b/seed/ts-sdk/circular-references-advanced/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/circular-references-extends/.fern/metadata.json
+++ b/seed/ts-sdk/circular-references-extends/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/circular-references/.fern/metadata.json
+++ b/seed/ts-sdk/circular-references/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/client-side-params/.fern/metadata.json
+++ b/seed/ts-sdk/client-side-params/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/client-side-params/src/BaseClient.ts
+++ b/seed/ts-sdk/client-side-params/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/client-side-params/src/BaseClient.ts
+++ b/seed/ts-sdk/client-side-params/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/client-side-params/src/BaseClient.ts
+++ b/seed/ts-sdk/client-side-params/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/client-side-params/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/client-side-params/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/client-side-params/src/core/auth/index.ts
+++ b/seed/ts-sdk/client-side-params/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/content-type/.fern/metadata.json
+++ b/seed/ts-sdk/content-type/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/.fern/metadata.json
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/.fern/metadata.json
@@ -6,8 +6,7 @@
         "noSerdeLayer": false
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/dollar-string-examples/.fern/metadata.json
+++ b/seed/ts-sdk/dollar-string-examples/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/empty-clients/.fern/metadata.json
+++ b/seed/ts-sdk/empty-clients/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/endpoint-security-auth/.fern/metadata.json
+++ b/seed/ts-sdk/endpoint-security-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/endpoint-security-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/BaseClient.ts
@@ -10,6 +10,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
 export type AuthOption =
+    | false
     | core.AuthProvider["getAuthRequest"]
     | core.AuthProvider
     | RoutingAuthProvider.AuthOptions<
@@ -36,7 +37,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & RoutingAuthProvider.AuthOptions<
     [
@@ -98,6 +99,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/endpoint-security-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/BaseClient.ts
@@ -93,15 +93,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -112,7 +103,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/endpoint-security-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/BaseClient.ts
@@ -9,6 +9,19 @@ import { RoutingAuthProvider } from "./auth/RoutingAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | RoutingAuthProvider.AuthOptions<
+          [
+              BearerAuthProvider.AuthOptions,
+              HeaderAuthProvider.AuthOptions,
+              OAuthAuthProvider.AuthOptions,
+              BasicAuthProvider.AuthOptions,
+              InferredAuthProvider.AuthOptions,
+          ]
+      >;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -23,6 +36,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & RoutingAuthProvider.AuthOptions<
     [
         BearerAuthProvider.AuthOptions,
@@ -78,10 +93,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= RoutingAuthProvider.createInstance(normalizedWithNoOpAuthProvider, [
         BearerAuthProvider,

--- a/seed/ts-sdk/endpoint-security-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/BaseClient.ts
@@ -10,7 +10,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
 export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider["getAuthRequest"]
     | core.AuthProvider
     | RoutingAuthProvider.AuthOptions<
           [

--- a/seed/ts-sdk/endpoint-security-auth/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/endpoint-security-auth/src/core/auth/index.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/.fern/metadata.json
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/.fern/metadata.json
@@ -7,8 +7,7 @@
         "noSerdeLayer": false
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/enum/forward-compatible-enums/.fern/metadata.json
+++ b/seed/ts-sdk/enum/forward-compatible-enums/.fern/metadata.json
@@ -6,8 +6,7 @@
         "enableForwardCompatibleEnums": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/enum/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/enum/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/enum/serde/.fern/metadata.json
+++ b/seed/ts-sdk/enum/serde/.fern/metadata.json
@@ -6,8 +6,7 @@
         "noSerdeLayer": false
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/error-property/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/error-property/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/error-property/union-utils/.fern/metadata.json
+++ b/seed/ts-sdk/error-property/union-utils/.fern/metadata.json
@@ -7,8 +7,7 @@
         "includeOtherInUnionTypes": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/errors/.fern/metadata.json
+++ b/seed/ts-sdk/errors/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/examples/examples-with-api-reference/.fern/metadata.json
+++ b/seed/ts-sdk/examples/examples-with-api-reference/.fern/metadata.json
@@ -16,8 +16,7 @@
         ]
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/BaseClient.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedExamplesEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/BaseClient.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedExamplesEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/BaseClient.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedExamplesEnvironment | string>;

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/auth/index.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/examples/retain-original-casing/.fern/metadata.json
+++ b/seed/ts-sdk/examples/retain-original-casing/.fern/metadata.json
@@ -6,8 +6,7 @@
         "retainOriginalCasing": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/examples/retain-original-casing/src/BaseClient.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedExamplesEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/examples/retain-original-casing/src/BaseClient.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedExamplesEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/examples/retain-original-casing/src/BaseClient.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedExamplesEnvironment | string>;

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/auth/index.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/.fern/metadata.json
@@ -6,8 +6,7 @@
         "allowExtraFields": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/.fern/metadata.json
@@ -8,8 +8,7 @@
         "testFramework": "jest"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/bigint/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/bigint/.fern/metadata.json
@@ -7,8 +7,7 @@
         "testFramework": "jest"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/bigint/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/bigint/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/bigint/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/bigint/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/bigint/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/.fern/metadata.json
@@ -6,8 +6,7 @@
         "consolidateTypeFiles": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/.fern/metadata.json
@@ -6,8 +6,7 @@
         "exportAllRequestsAtRoot": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/BaseClient.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/BaseClient.d.ts
@@ -1,8 +1,6 @@
 import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import * as core from "./core/index.js";
-export type AuthOption = ((arg?: {
-    endpointMetadata?: core.EndpointMetadata;
-}) => Promise<core.AuthRequest>) | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/BaseClient.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/BaseClient.d.ts
@@ -1,5 +1,8 @@
 import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import * as core from "./core/index.js";
+export type AuthOption = ((arg?: {
+    endpointMetadata?: core.EndpointMetadata;
+}) => Promise<core.AuthRequest>) | core.AuthProvider | BearerAuthProvider.AuthOptions;
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -14,6 +17,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 export interface BaseRequestOptions {
     /** The maximum time to wait for a response in seconds. */

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/BaseClient.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/BaseClient.d.ts
@@ -1,6 +1,6 @@
 import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import * as core from "./core/index.js";
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption = false | core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -15,7 +15,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 export interface BaseRequestOptions {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/BaseClient.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/BaseClient.js
@@ -50,6 +50,10 @@ function normalizeClientOptions(options) {
 function normalizeClientOptionsWithAuth(options) {
     var _a;
     const normalized = normalizeClientOptions(options);
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/BaseClient.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/BaseClient.js
@@ -50,6 +50,17 @@ function normalizeClientOptions(options) {
 function normalizeClientOptionsWithAuth(options) {
     var _a;
     const normalized = normalizeClientOptions(options);
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     (_a = normalized.authProvider) !== null && _a !== void 0 ? _a : (normalized.authProvider = new BearerAuthProvider_js_1.BearerAuthProvider(normalizedWithNoOpAuthProvider));
     return normalized;

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/AuthProvider.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/AuthProvider.d.ts
@@ -5,3 +5,4 @@ export interface AuthProvider {
         endpointMetadata?: EndpointMetadata;
     }): Promise<AuthRequest>;
 }
+export declare function isAuthProvider(value: unknown): value is AuthProvider;

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/AuthProvider.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/AuthProvider.js
@@ -1,2 +1,9 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.isAuthProvider = isAuthProvider;
+function isAuthProvider(value) {
+    return (typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function");
+}

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/index.d.ts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/index.d.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/index.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/auth/index.js
@@ -1,6 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.NoOpAuthProvider = exports.BearerToken = exports.BasicAuth = void 0;
+exports.NoOpAuthProvider = exports.BearerToken = exports.BasicAuth = exports.isAuthProvider = void 0;
+var AuthProvider_js_1 = require("./AuthProvider.js");
+Object.defineProperty(exports, "isAuthProvider", { enumerable: true, get: function () { return AuthProvider_js_1.isAuthProvider; } });
 var BasicAuth_js_1 = require("./BasicAuth.js");
 Object.defineProperty(exports, "BasicAuth", { enumerable: true, get: function () { return BasicAuth_js_1.BasicAuth; } });
 var BearerToken_js_1 = require("./BearerToken.js");

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/BaseClient.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/BaseClient.d.mts
@@ -1,5 +1,8 @@
 import { BearerAuthProvider } from "./auth/BearerAuthProvider.mjs";
 import * as core from "./core/index.mjs";
+export type AuthOption = ((arg?: {
+    endpointMetadata?: core.EndpointMetadata;
+}) => Promise<core.AuthRequest>) | core.AuthProvider | BearerAuthProvider.AuthOptions;
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -14,6 +17,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 export interface BaseRequestOptions {
     /** The maximum time to wait for a response in seconds. */

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/BaseClient.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/BaseClient.d.mts
@@ -1,6 +1,6 @@
 import { BearerAuthProvider } from "./auth/BearerAuthProvider.mjs";
 import * as core from "./core/index.mjs";
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption = false | core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -15,7 +15,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 export interface BaseRequestOptions {

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/BaseClient.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/BaseClient.d.mts
@@ -1,8 +1,6 @@
 import { BearerAuthProvider } from "./auth/BearerAuthProvider.mjs";
 import * as core from "./core/index.mjs";
-export type AuthOption = ((arg?: {
-    endpointMetadata?: core.EndpointMetadata;
-}) => Promise<core.AuthRequest>) | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/BaseClient.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/BaseClient.mjs
@@ -13,6 +13,17 @@ export function normalizeClientOptions(options) {
 export function normalizeClientOptionsWithAuth(options) {
     var _a;
     const normalized = normalizeClientOptions(options);
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     (_a = normalized.authProvider) !== null && _a !== void 0 ? _a : (normalized.authProvider = new BearerAuthProvider(normalizedWithNoOpAuthProvider));
     return normalized;

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/BaseClient.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/BaseClient.mjs
@@ -13,6 +13,10 @@ export function normalizeClientOptions(options) {
 export function normalizeClientOptionsWithAuth(options) {
     var _a;
     const normalized = normalizeClientOptions(options);
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/AuthProvider.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/AuthProvider.d.mts
@@ -5,3 +5,4 @@ export interface AuthProvider {
         endpointMetadata?: EndpointMetadata;
     }): Promise<AuthRequest>;
 }
+export declare function isAuthProvider(value: unknown): value is AuthProvider;

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/AuthProvider.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/AuthProvider.mjs
@@ -1,1 +1,6 @@
-export {};
+export function isAuthProvider(value) {
+    return (typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function");
+}

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/index.d.mts
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/index.d.mts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.mjs";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.mjs";
 export type { AuthRequest } from "./AuthRequest.mjs";
 export { BasicAuth } from "./BasicAuth.mjs";
 export { BearerToken } from "./BearerToken.mjs";

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/index.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/auth/index.mjs
@@ -1,3 +1,4 @@
+export { isAuthProvider } from "./AuthProvider.mjs";
 export { BasicAuth } from "./BasicAuth.mjs";
 export { BearerToken } from "./BearerToken.mjs";
 export { NoOpAuthProvider } from "./NoOpAuthProvider.mjs";

--- a/seed/ts-sdk/exhaustive/local-files/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/local-files/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -71,6 +75,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/local-files/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/local-files/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/local-files/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/local-files/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -66,6 +73,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/local-files/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/local-files/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/multiple-exports/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/multiple-exports/.fern/metadata.json
@@ -6,8 +6,7 @@
         "generateSubpackageExports": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/never-throw-errors/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/.fern/metadata.json
@@ -6,8 +6,7 @@
         "neverThrowErrors": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/node-fetch/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/node-fetch/.fern/metadata.json
@@ -6,8 +6,7 @@
         "fetchSupport": "node-fetch"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/node-fetch/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/node-fetch/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/node-fetch/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/output-src-only/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -71,6 +75,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/output-src-only/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/output-src-only/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -66,6 +73,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/output-src-only/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/output-src-only/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/package-path/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/package-path/.fern/metadata.json
@@ -6,8 +6,7 @@
         "packagePath": "src/test-packagePath"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/.fern/metadata.json
@@ -6,8 +6,7 @@
         "parameterNaming": "camelCase"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/.fern/metadata.json
@@ -6,8 +6,7 @@
         "parameterNaming": "originalName"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/.fern/metadata.json
@@ -6,8 +6,7 @@
         "parameterNaming": "snakeCase"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/.fern/metadata.json
@@ -6,8 +6,7 @@
         "parameterNaming": "wireValue"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/retain-original-casing/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/.fern/metadata.json
@@ -6,8 +6,7 @@
         "retainOriginalCasing": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/serde-layer/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/serde-layer/.fern/metadata.json
@@ -6,8 +6,7 @@
         "noSerdeLayer": false
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/serde-layer/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/serde-layer/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/serde-layer/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/use-jest/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/use-jest/.fern/metadata.json
@@ -6,8 +6,7 @@
         "testFramework": "jest"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/use-jest/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/use-jest/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/use-jest/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/use-jest/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/use-jest/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/.fern/metadata.json
@@ -6,8 +6,7 @@
         "streamType": "web"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/exhaustive/with-audiences/.fern/metadata.json
+++ b/seed/ts-sdk/exhaustive/with-audiences/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/exhaustive/with-audiences/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/exhaustive/with-audiences/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/exhaustive/with-audiences/src/BaseClient.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/auth/index.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/extends/.fern/metadata.json
+++ b/seed/ts-sdk/extends/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/extra-properties/.fern/metadata.json
+++ b/seed/ts-sdk/extra-properties/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/file-download/file-download-response-headers/.fern/metadata.json
+++ b/seed/ts-sdk/file-download/file-download-response-headers/.fern/metadata.json
@@ -6,8 +6,7 @@
         "includeContentHeadersOnFileDownloadResponse": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/file-download/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/file-download/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/file-download/stream-wrapper/.fern/metadata.json
+++ b/seed/ts-sdk/file-download/stream-wrapper/.fern/metadata.json
@@ -8,8 +8,7 @@
         "testFramework": "jest"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/file-upload-openapi/.fern/metadata.json
+++ b/seed/ts-sdk/file-upload-openapi/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/file-upload/form-data-node16/.fern/metadata.json
+++ b/seed/ts-sdk/file-upload/form-data-node16/.fern/metadata.json
@@ -6,8 +6,7 @@
         "formDataSupport": "Node16"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/file-upload/inline/.fern/metadata.json
+++ b/seed/ts-sdk/file-upload/inline/.fern/metadata.json
@@ -7,8 +7,7 @@
         "inlinePathParameters": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/file-upload/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/file-upload/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/file-upload/serde/.fern/metadata.json
+++ b/seed/ts-sdk/file-upload/serde/.fern/metadata.json
@@ -6,8 +6,7 @@
         "noSerdeLayer": false
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/file-upload/use-jest/.fern/metadata.json
+++ b/seed/ts-sdk/file-upload/use-jest/.fern/metadata.json
@@ -6,8 +6,7 @@
         "testFramework": "jest"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/file-upload/wrapper/.fern/metadata.json
+++ b/seed/ts-sdk/file-upload/wrapper/.fern/metadata.json
@@ -7,8 +7,7 @@
         "testFramework": "jest"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/folders/.fern/metadata.json
+++ b/seed/ts-sdk/folders/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/header-auth-environment-variable/.fern/metadata.json
+++ b/seed/ts-sdk/header-auth-environment-variable/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/header-auth-environment-variable/src/BaseClient.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/header-auth-environment-variable/src/BaseClient.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { HeaderAuthProvider } from "./auth/HeaderAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | HeaderAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | HeaderAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & HeaderAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/header-auth-environment-variable/src/BaseClient.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { HeaderAuthProvider } from "./auth/HeaderAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | HeaderAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & HeaderAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new HeaderAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/header-auth-environment-variable/src/BaseClient.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { HeaderAuthProvider } from "./auth/HeaderAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | HeaderAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | HeaderAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/header-auth-environment-variable/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/header-auth-environment-variable/src/core/auth/index.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/header-auth/.fern/metadata.json
+++ b/seed/ts-sdk/header-auth/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/header-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/header-auth/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/header-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/header-auth/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { HeaderAuthProvider } from "./auth/HeaderAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | HeaderAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | HeaderAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & HeaderAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/header-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/header-auth/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { HeaderAuthProvider } from "./auth/HeaderAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | HeaderAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & HeaderAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new HeaderAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/header-auth/src/BaseClient.ts
+++ b/seed/ts-sdk/header-auth/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { HeaderAuthProvider } from "./auth/HeaderAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | HeaderAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | HeaderAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/header-auth/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/header-auth/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/header-auth/src/core/auth/index.ts
+++ b/seed/ts-sdk/header-auth/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/http-head/.fern/metadata.json
+++ b/seed/ts-sdk/http-head/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/idempotency-headers/.fern/metadata.json
+++ b/seed/ts-sdk/idempotency-headers/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/idempotency-headers/src/BaseClient.ts
+++ b/seed/ts-sdk/idempotency-headers/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/idempotency-headers/src/BaseClient.ts
+++ b/seed/ts-sdk/idempotency-headers/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -74,6 +81,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/idempotency-headers/src/BaseClient.ts
+++ b/seed/ts-sdk/idempotency-headers/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -79,6 +83,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/idempotency-headers/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/idempotency-headers/src/core/auth/index.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/imdb/branded-string-aliases/.fern/metadata.json
+++ b/seed/ts-sdk/imdb/branded-string-aliases/.fern/metadata.json
@@ -7,8 +7,7 @@
         "maxRetries": 5
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/BaseClient.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/BaseClient.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/BaseClient.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/auth/index.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/imdb/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/imdb/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/imdb/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/imdb/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/imdb/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/imdb/omit-undefined/.fern/metadata.json
+++ b/seed/ts-sdk/imdb/omit-undefined/.fern/metadata.json
@@ -6,8 +6,7 @@
         "omitUndefined": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/imdb/omit-undefined/src/BaseClient.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/imdb/omit-undefined/src/BaseClient.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/imdb/omit-undefined/src/BaseClient.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/auth/index.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/inferred-auth-explicit/.fern/metadata.json
+++ b/seed/ts-sdk/inferred-auth-explicit/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/inferred-auth-explicit/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | InferredAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | InferredAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & InferredAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/inferred-auth-explicit/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/inferred-auth-explicit/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | InferredAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & InferredAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new InferredAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/inferred-auth-explicit/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | InferredAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | InferredAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/inferred-auth-explicit/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/inferred-auth-explicit/src/core/auth/index.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | InferredAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | InferredAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & InferredAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | InferredAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & InferredAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new InferredAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | InferredAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | InferredAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/auth/index.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | InferredAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | InferredAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & InferredAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | InferredAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & InferredAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new InferredAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | InferredAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | InferredAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/auth/index.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/inferred-auth-implicit-reference/.fern/metadata.json
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/inferred-auth-implicit-reference/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | InferredAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | InferredAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & InferredAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/inferred-auth-implicit-reference/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/inferred-auth-implicit-reference/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | InferredAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & InferredAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new InferredAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/inferred-auth-implicit-reference/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | InferredAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | InferredAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/inferred-auth-implicit-reference/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/inferred-auth-implicit-reference/src/core/auth/index.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/inferred-auth-implicit/.fern/metadata.json
+++ b/seed/ts-sdk/inferred-auth-implicit/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/inferred-auth-implicit/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | InferredAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | InferredAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & InferredAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/inferred-auth-implicit/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/inferred-auth-implicit/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | InferredAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & InferredAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new InferredAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/inferred-auth-implicit/src/BaseClient.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | InferredAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | InferredAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/inferred-auth-implicit/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/inferred-auth-implicit/src/core/auth/index.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/license/.fern/metadata.json
+++ b/seed/ts-sdk/license/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/literal/.fern/metadata.json
+++ b/seed/ts-sdk/literal/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/literals-unions/.fern/metadata.json
+++ b/seed/ts-sdk/literals-unions/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/mixed-case/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/mixed-case/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/mixed-case/retain-original-casing/.fern/metadata.json
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/.fern/metadata.json
@@ -6,8 +6,7 @@
         "retainOriginalCasing": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/mixed-file-directory/.fern/metadata.json
+++ b/seed/ts-sdk/mixed-file-directory/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/multi-line-docs/.fern/metadata.json
+++ b/seed/ts-sdk/multi-line-docs/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/multi-url-environment-no-default/.fern/metadata.json
+++ b/seed/ts-sdk/multi-url-environment-no-default/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/multi-url-environment-no-default/src/BaseClient.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<
         | environments.SeedMultiUrlEnvironmentNoDefaultEnvironment
@@ -22,6 +27,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -73,6 +80,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/multi-url-environment-no-default/src/BaseClient.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<
@@ -24,7 +28,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -78,6 +82,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/multi-url-environment-no-default/src/BaseClient.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/auth/index.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/multi-url-environment-reference/.fern/metadata.json
+++ b/seed/ts-sdk/multi-url-environment-reference/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/multi-url-environment-reference/src/BaseClient.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedApiEnvironment | environments.SeedApiEnvironmentUrls>;

--- a/seed/ts-sdk/multi-url-environment-reference/src/BaseClient.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedApiEnvironment | environments.SeedApiEnvironmentUrls>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/multi-url-environment-reference/src/BaseClient.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedApiEnvironment | environments.SeedApiEnvironmentUrls>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/multi-url-environment-reference/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/multi-url-environment-reference/src/core/auth/index.ts
+++ b/seed/ts-sdk/multi-url-environment-reference/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/multi-url-environment/.fern/metadata.json
+++ b/seed/ts-sdk/multi-url-environment/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/multi-url-environment/src/BaseClient.ts
+++ b/seed/ts-sdk/multi-url-environment/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<
@@ -23,7 +27,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -77,6 +81,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/multi-url-environment/src/BaseClient.ts
+++ b/seed/ts-sdk/multi-url-environment/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment?: core.Supplier<
         environments.SeedMultiUrlEnvironmentEnvironment | environments.SeedMultiUrlEnvironmentEnvironmentUrls
@@ -21,6 +26,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -72,6 +79,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/multi-url-environment/src/BaseClient.ts
+++ b/seed/ts-sdk/multi-url-environment/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<

--- a/seed/ts-sdk/multi-url-environment/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/multi-url-environment/src/core/auth/index.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/multiple-request-bodies/.fern/metadata.json
+++ b/seed/ts-sdk/multiple-request-bodies/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/multiple-request-bodies/src/BaseClient.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedApiEnvironment | string>;

--- a/seed/ts-sdk/multiple-request-bodies/src/BaseClient.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedApiEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/multiple-request-bodies/src/BaseClient.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/multiple-request-bodies/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/multiple-request-bodies/src/core/auth/index.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/no-content-response/.fern/metadata.json
+++ b/seed/ts-sdk/no-content-response/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/no-environment/.fern/metadata.json
+++ b/seed/ts-sdk/no-environment/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/no-environment/src/BaseClient.ts
+++ b/seed/ts-sdk/no-environment/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/no-environment/src/BaseClient.ts
+++ b/seed/ts-sdk/no-environment/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/no-environment/src/BaseClient.ts
+++ b/seed/ts-sdk/no-environment/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/no-environment/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/no-environment/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/no-environment/src/core/auth/index.ts
+++ b/seed/ts-sdk/no-environment/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/no-retries/.fern/metadata.json
+++ b/seed/ts-sdk/no-retries/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/null-type/.fern/metadata.json
+++ b/seed/ts-sdk/null-type/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/nullable-allof-extends/.fern/metadata.json
+++ b/seed/ts-sdk/nullable-allof-extends/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/nullable-optional/.fern/metadata.json
+++ b/seed/ts-sdk/nullable-optional/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/nullable-request-body/.fern/metadata.json
+++ b/seed/ts-sdk/nullable-request-body/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/nullable/.fern/metadata.json
+++ b/seed/ts-sdk/nullable/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/oauth-client-credentials-custom/.fern/metadata.json
+++ b/seed/ts-sdk/oauth-client-credentials-custom/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= OAuthAuthProvider.createInstance(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | OAuthAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/oauth-client-credentials-default/.fern/metadata.json
+++ b/seed/ts-sdk/oauth-client-credentials-default/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/oauth-client-credentials-default/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/oauth-client-credentials-default/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/oauth-client-credentials-default/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | OAuthAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/oauth-client-credentials-default/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= OAuthAuthProvider.createInstance(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | OAuthAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= OAuthAuthProvider.createInstance(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | OAuthAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= OAuthAuthProvider.createInstance(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/.fern/metadata.json
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/.fern/metadata.json
@@ -6,8 +6,7 @@
         "neverThrowErrors": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | OAuthAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= OAuthAuthProvider.createInstance(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | OAuthAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= OAuthAuthProvider.createInstance(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/oauth-client-credentials-openapi/.fern/metadata.json
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/oauth-client-credentials-openapi/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/oauth-client-credentials-openapi/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/oauth-client-credentials-openapi/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | OAuthAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/oauth-client-credentials-openapi/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= OAuthAuthProvider.createInstance(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/oauth-client-credentials-openapi/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/oauth-client-credentials-openapi/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/oauth-client-credentials-reference/.fern/metadata.json
+++ b/seed/ts-sdk/oauth-client-credentials-reference/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | OAuthAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= OAuthAuthProvider.createInstance(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= OAuthAuthProvider.createInstance(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | OAuthAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | OAuthAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= OAuthAuthProvider.createInstance(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/oauth-client-credentials/serde/.fern/metadata.json
+++ b/seed/ts-sdk/oauth-client-credentials/serde/.fern/metadata.json
@@ -6,8 +6,7 @@
         "noSerdeLayer": false
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | OAuthAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | OAuthAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/BaseClient.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { OAuthAuthProvider } from "./auth/OAuthAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | OAuthAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & OAuthAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= OAuthAuthProvider.createInstance(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/core/auth/index.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/object/.fern/metadata.json
+++ b/seed/ts-sdk/object/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/objects-with-imports/.fern/metadata.json
+++ b/seed/ts-sdk/objects-with-imports/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/openapi-request-body-ref/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/openapi-request-body-ref/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/optional/.fern/metadata.json
+++ b/seed/ts-sdk/optional/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/package-yml/.fern/metadata.json
+++ b/seed/ts-sdk/package-yml/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/pagination-custom/.fern/metadata.json
+++ b/seed/ts-sdk/pagination-custom/.fern/metadata.json
@@ -6,8 +6,7 @@
         "customPagerName": "MyPager"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/pagination-custom/src/BaseClient.ts
+++ b/seed/ts-sdk/pagination-custom/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/pagination-custom/src/BaseClient.ts
+++ b/seed/ts-sdk/pagination-custom/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/pagination-custom/src/BaseClient.ts
+++ b/seed/ts-sdk/pagination-custom/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/pagination-custom/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/pagination-custom/src/core/auth/index.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/pagination-uri-path/.fern/metadata.json
+++ b/seed/ts-sdk/pagination-uri-path/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/pagination-uri-path/src/BaseClient.ts
+++ b/seed/ts-sdk/pagination-uri-path/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/pagination-uri-path/src/BaseClient.ts
+++ b/seed/ts-sdk/pagination-uri-path/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/pagination-uri-path/src/BaseClient.ts
+++ b/seed/ts-sdk/pagination-uri-path/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/pagination-uri-path/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/pagination-uri-path/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/pagination-uri-path/src/core/auth/index.ts
+++ b/seed/ts-sdk/pagination-uri-path/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/pagination/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/pagination/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/pagination/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/pagination/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/pagination/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/pagination/no-custom-config/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/pagination/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/pagination/page-index-semantics/.fern/metadata.json
+++ b/seed/ts-sdk/pagination/page-index-semantics/.fern/metadata.json
@@ -6,8 +6,7 @@
         "offsetSemantics": "page-index"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/pagination/page-index-semantics/src/BaseClient.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/pagination/page-index-semantics/src/BaseClient.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/pagination/page-index-semantics/src/BaseClient.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/pagination/page-index-semantics/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/pagination/page-index-semantics/src/core/auth/index.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/path-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/path-parameters/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/.fern/metadata.json
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/.fern/metadata.json
@@ -7,8 +7,7 @@
         "retainOriginalCasing": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/.fern/metadata.json
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/.fern/metadata.json
@@ -7,8 +7,7 @@
         "noSerdeLayer": false
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/.fern/metadata.json
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/.fern/metadata.json
@@ -6,8 +6,7 @@
         "inlinePathParameters": false
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/.fern/metadata.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/.fern/metadata.json
@@ -6,8 +6,7 @@
         "parameterNaming": "camelCase"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/.fern/metadata.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/.fern/metadata.json
@@ -6,8 +6,7 @@
         "parameterNaming": "originalName"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/.fern/metadata.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/.fern/metadata.json
@@ -6,8 +6,7 @@
         "parameterNaming": "snakeCase"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/.fern/metadata.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/.fern/metadata.json
@@ -6,8 +6,7 @@
         "parameterNaming": "wireValue"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/path-parameters/retain-original-casing/.fern/metadata.json
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/.fern/metadata.json
@@ -6,8 +6,7 @@
         "retainOriginalCasing": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/plain-text/.fern/metadata.json
+++ b/seed/ts-sdk/plain-text/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/.fern/metadata.json
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/.fern/metadata.json
@@ -6,8 +6,7 @@
         "experimentalGenerateReadWriteOnlyTypes": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/property-access/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/property-access/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/public-object/.fern/metadata.json
+++ b/seed/ts-sdk/public-object/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/query-param-name-conflict/.fern/metadata.json
+++ b/seed/ts-sdk/query-param-name-conflict/.fern/metadata.json
@@ -8,8 +8,7 @@
         "resolveQueryParameterNameConflicts": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/query-parameters-openapi/.fern/metadata.json
+++ b/seed/ts-sdk/query-parameters-openapi/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/query-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/query-parameters/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/.fern/metadata.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/.fern/metadata.json
@@ -6,8 +6,7 @@
         "parameterNaming": "camelCase"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/.fern/metadata.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/.fern/metadata.json
@@ -6,8 +6,7 @@
         "parameterNaming": "originalName"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/.fern/metadata.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/.fern/metadata.json
@@ -6,8 +6,7 @@
         "parameterNaming": "snakeCase"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/.fern/metadata.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/.fern/metadata.json
@@ -6,8 +6,7 @@
         "parameterNaming": "wireValue"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/query-parameters/serde/.fern/metadata.json
+++ b/seed/ts-sdk/query-parameters/serde/.fern/metadata.json
@@ -6,8 +6,7 @@
         "noSerdeLayer": false
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/.fern/metadata.json
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/.fern/metadata.json
@@ -6,8 +6,7 @@
         "flattenRequestParameters": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/request-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/request-parameters/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/.fern/metadata.json
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/.fern/metadata.json
@@ -8,8 +8,7 @@
         "testFramework": "jest"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/.fern/metadata.json
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/.fern/metadata.json
@@ -6,8 +6,7 @@
         "useDefaultRequestParameterValues": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/required-nullable/.fern/metadata.json
+++ b/seed/ts-sdk/required-nullable/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/reserved-keywords/.fern/metadata.json
+++ b/seed/ts-sdk/reserved-keywords/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/response-property/.fern/metadata.json
+++ b/seed/ts-sdk/response-property/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/schemaless-request-body-examples/.fern/metadata.json
+++ b/seed/ts-sdk/schemaless-request-body-examples/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/server-sent-event-examples/.fern/metadata.json
+++ b/seed/ts-sdk/server-sent-event-examples/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/server-sent-events/.fern/metadata.json
+++ b/seed/ts-sdk/server-sent-events/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/server-url-templating/.fern/metadata.json
+++ b/seed/ts-sdk/server-url-templating/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/.fern/metadata.json
@@ -6,8 +6,7 @@
         "allowCustomFetcher": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -20,6 +25,8 @@ export type BaseClientOptions = {
     fetcher?: core.FetchFunction;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -71,6 +78,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
@@ -22,7 +26,7 @@ export type BaseClientOptions = {
     fetcher?: core.FetchFunction;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -76,6 +80,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/allow-extra-fields/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/.fern/metadata.json
@@ -6,8 +6,7 @@
         "allowExtraFields": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/bundle/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/bundle/.fern/metadata.json
@@ -9,8 +9,7 @@
         }
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/bundle/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/bundle/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/bundle/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/bundle/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/bundle/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/custom-package-json/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/custom-package-json/.fern/metadata.json
@@ -35,8 +35,7 @@
         }
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/custom-package-json/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/custom-package-json/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/custom-package-json/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/custom-package-json/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/custom-package-json/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/jsr/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/jsr/.fern/metadata.json
@@ -6,8 +6,7 @@
         "publishToJsr": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/jsr/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/jsr/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/jsr/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/jsr/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/jsr/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/legacy-exports/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/legacy-exports/.fern/metadata.json
@@ -6,8 +6,7 @@
         "useLegacyExports": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/legacy-exports/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/BaseClient.ts
@@ -5,6 +5,11 @@ import * as core from "./core";
 import { mergeHeaders } from "./core/headers";
 import type * as environments from "./environments";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/legacy-exports/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/BaseClient.ts
@@ -5,10 +5,7 @@ import * as core from "./core";
 import { mergeHeaders } from "./core/headers";
 import type * as environments from "./environments";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/legacy-exports/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/BaseClient.ts
@@ -5,7 +5,11 @@ import * as core from "./core";
 import { mergeHeaders } from "./core/headers";
 import type * as environments from "./environments";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/legacy-exports/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/legacy-exports/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider";
 export type { AuthRequest } from "./AuthRequest";
 export { BasicAuth } from "./BasicAuth";
 export { BearerToken } from "./BearerToken";

--- a/seed/ts-sdk/simple-api/naming-shorthand/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/naming-shorthand/.fern/metadata.json
@@ -6,8 +6,7 @@
         "naming": "acme"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/naming-shorthand/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.AcmeEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/naming-shorthand/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.AcmeEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/naming-shorthand/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.AcmeEnvironment | string>;

--- a/seed/ts-sdk/simple-api/naming-shorthand/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/naming-shorthand/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/naming/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/naming/.fern/metadata.json
@@ -14,8 +14,7 @@
         }
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/naming/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/naming/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.AcmeApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/naming/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/naming/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.AcmeApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/naming/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/naming/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.AcmeApiEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/naming/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/naming/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/naming/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/naming/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/no-custom-config/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/.fern/metadata.json
@@ -7,8 +7,7 @@
     "formatter": "none"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/src/BaseClient.ts
@@ -6,6 +6,11 @@ import type { AuthProvider } from "./core/auth/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | (BearerAuthProvider.AuthOptions);
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -20,6 +25,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -63,6 +70,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/src/BaseClient.ts
@@ -7,7 +7,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as environments from "./environments.js";
 
 export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider["getAuthRequest"]
     | core.AuthProvider
     | (BearerAuthProvider.AuthOptions);
 

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/src/BaseClient.ts
@@ -7,6 +7,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as environments from "./environments.js";
 
 export type AuthOption =
+    | false
     | core.AuthProvider["getAuthRequest"]
     | core.AuthProvider
     | (BearerAuthProvider.AuthOptions);
@@ -25,7 +26,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -71,6 +72,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/no-scripts/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/no-scripts/.fern/metadata.json
@@ -6,8 +6,7 @@
     "noScripts": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/no-scripts/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/BaseClient.ts
@@ -6,6 +6,11 @@ import type { AuthProvider } from "./core/auth/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | (BearerAuthProvider.AuthOptions);
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -20,6 +25,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -63,6 +70,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/no-scripts/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/BaseClient.ts
@@ -7,7 +7,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as environments from "./environments.js";
 
 export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider["getAuthRequest"]
     | core.AuthProvider
     | (BearerAuthProvider.AuthOptions);
 

--- a/seed/ts-sdk/simple-api/no-scripts/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/BaseClient.ts
@@ -7,6 +7,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as environments from "./environments.js";
 
 export type AuthOption =
+    | false
     | core.AuthProvider["getAuthRequest"]
     | core.AuthProvider
     | (BearerAuthProvider.AuthOptions);
@@ -25,7 +26,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -71,6 +72,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/no-scripts/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/no-scripts/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/oidc-token/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/oidc-token/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/oidc-token/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/oidc-token/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/oidc-token/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/oidc-token/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/oidc-token/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/omit-fern-headers/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/.fern/metadata.json
@@ -6,8 +6,7 @@
         "omitFernHeaders": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -56,6 +63,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -61,6 +65,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/use-oxc/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/use-oxc/.fern/metadata.json
@@ -7,8 +7,7 @@
         "formatter": "oxfmt"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/use-oxc/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/src/BaseClient.ts
@@ -6,7 +6,11 @@ import type { AuthProvider } from "./core/auth/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
@@ -22,7 +26,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -76,6 +80,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/use-oxc/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/src/BaseClient.ts
@@ -6,6 +6,11 @@ import type { AuthProvider } from "./core/auth/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -20,6 +25,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -71,6 +78,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/use-oxc/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/src/BaseClient.ts
@@ -6,10 +6,7 @@ import type { AuthProvider } from "./core/auth/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/use-oxc/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/use-oxc/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/use-oxfmt/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/use-oxfmt/.fern/metadata.json
@@ -6,8 +6,7 @@
         "formatter": "oxfmt"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/BaseClient.ts
@@ -5,10 +5,7 @@ import * as core from "./core/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/BaseClient.ts
@@ -5,6 +5,11 @@ import * as core from "./core/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/BaseClient.ts
@@ -5,7 +5,11 @@ import * as core from "./core/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/use-oxlint/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/use-oxlint/.fern/metadata.json
@@ -6,8 +6,7 @@
         "linter": "oxlint"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/use-oxlint/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/BaseClient.ts
@@ -6,7 +6,11 @@ import type { AuthProvider } from "./core/auth/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
@@ -22,7 +26,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -76,6 +80,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/use-oxlint/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/BaseClient.ts
@@ -6,6 +6,11 @@ import type { AuthProvider } from "./core/auth/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -20,6 +25,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -71,6 +78,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/use-oxlint/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/BaseClient.ts
@@ -6,10 +6,7 @@ import type { AuthProvider } from "./core/auth/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/use-oxlint/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/use-oxlint/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/.fern/metadata.json
@@ -7,8 +7,7 @@
         "linter": "none"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/BaseClient.ts
@@ -6,7 +6,11 @@ import type { AuthProvider } from "./core/auth/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
@@ -22,7 +26,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -76,6 +80,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/BaseClient.ts
@@ -6,6 +6,11 @@ import type { AuthProvider } from "./core/auth/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -20,6 +25,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -71,6 +78,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/BaseClient.ts
@@ -6,10 +6,7 @@ import type { AuthProvider } from "./core/auth/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/use-prettier/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/use-prettier/.fern/metadata.json
@@ -6,8 +6,7 @@
         "formatter": "prettier"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/use-prettier/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/BaseClient.ts
@@ -5,10 +5,7 @@ import * as core from "./core/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/use-prettier/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/BaseClient.ts
@@ -5,6 +5,11 @@ import * as core from "./core/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/use-prettier/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/BaseClient.ts
@@ -5,7 +5,11 @@ import * as core from "./core/index.js";
 import { mergeHeaders } from "./core/headers.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/use-prettier/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/use-prettier/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-api/use-yarn/.fern/metadata.json
+++ b/seed/ts-sdk/simple-api/use-yarn/.fern/metadata.json
@@ -6,8 +6,7 @@
         "packageManager": "yarn"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/simple-api/use-yarn/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/simple-api/use-yarn/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/simple-api/use-yarn/src/BaseClient.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSimpleApiEnvironment | string>;

--- a/seed/ts-sdk/simple-api/use-yarn/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/simple-api/use-yarn/src/core/auth/index.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/simple-fhir/.fern/metadata.json
+++ b/seed/ts-sdk/simple-fhir/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/single-url-environment-default/.fern/metadata.json
+++ b/seed/ts-sdk/single-url-environment-default/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/single-url-environment-default/src/BaseClient.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedSingleUrlEnvironmentDefaultEnvironment | string>;

--- a/seed/ts-sdk/single-url-environment-default/src/BaseClient.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedSingleUrlEnvironmentDefaultEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/single-url-environment-default/src/BaseClient.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedSingleUrlEnvironmentDefaultEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/single-url-environment-default/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/single-url-environment-default/src/core/auth/index.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/single-url-environment-no-default/.fern/metadata.json
+++ b/seed/ts-sdk/single-url-environment-no-default/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/single-url-environment-no-default/src/BaseClient.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSingleUrlEnvironmentNoDefaultEnvironment | string>;

--- a/seed/ts-sdk/single-url-environment-no-default/src/BaseClient.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSingleUrlEnvironmentNoDefaultEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -19,6 +24,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -70,6 +77,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/single-url-environment-no-default/src/BaseClient.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<environments.SeedSingleUrlEnvironmentNoDefaultEnvironment | string>;
@@ -21,7 +25,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -75,6 +79,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/auth/index.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/streaming-parameter/.fern/metadata.json
+++ b/seed/ts-sdk/streaming-parameter/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/streaming/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/streaming/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/streaming/serde-layer/.fern/metadata.json
+++ b/seed/ts-sdk/streaming/serde-layer/.fern/metadata.json
@@ -6,8 +6,7 @@
         "noSerdeLayer": false
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/streaming/wrapper/.fern/metadata.json
+++ b/seed/ts-sdk/streaming/wrapper/.fern/metadata.json
@@ -7,8 +7,7 @@
         "testFramework": "jest"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/trace/exhaustive/.fern/metadata.json
+++ b/seed/ts-sdk/trace/exhaustive/.fern/metadata.json
@@ -11,8 +11,7 @@
         "timeoutInSeconds": "infinity"
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/trace/exhaustive/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedTraceEnvironment | string>;
@@ -23,7 +27,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -80,6 +84,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/trace/exhaustive/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedTraceEnvironment | string>;

--- a/seed/ts-sdk/trace/exhaustive/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedTraceEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -21,6 +26,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -75,6 +82,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/trace/exhaustive/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/trace/exhaustive/src/core/auth/index.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/trace/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/trace/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/trace/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedTraceEnvironment | string>;
@@ -23,7 +27,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -80,6 +84,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/trace/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedTraceEnvironment | string>;

--- a/seed/ts-sdk/trace/no-custom-config/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedTraceEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -21,6 +26,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -75,6 +82,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/trace/no-custom-config/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/trace/no-custom-config/src/core/auth/index.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/trace/serde-no-throwing/.fern/metadata.json
+++ b/seed/ts-sdk/trace/serde-no-throwing/.fern/metadata.json
@@ -7,8 +7,7 @@
         "neverThrowErrors": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/trace/serde-no-throwing/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedTraceEnvironment | string>;
@@ -23,7 +27,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -80,6 +84,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/trace/serde-no-throwing/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedTraceEnvironment | string>;

--- a/seed/ts-sdk/trace/serde-no-throwing/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedTraceEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -21,6 +26,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -75,6 +82,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/auth/index.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/trace/serde/.fern/metadata.json
+++ b/seed/ts-sdk/trace/serde/.fern/metadata.json
@@ -6,8 +6,7 @@
         "noSerdeLayer": false
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/trace/serde/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/serde/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedTraceEnvironment | string>;
@@ -23,7 +27,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -80,6 +84,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/trace/serde/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/serde/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedTraceEnvironment | string>;

--- a/seed/ts-sdk/trace/serde/src/BaseClient.ts
+++ b/seed/ts-sdk/trace/serde/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment?: core.Supplier<environments.SeedTraceEnvironment | string>;
     /** Specify a custom URL to connect the client to. */
@@ -21,6 +26,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -75,6 +82,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/trace/serde/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/trace/serde/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/trace/serde/src/core/auth/index.ts
+++ b/seed/ts-sdk/trace/serde/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/ts-express-casing/.fern/metadata.json
+++ b/seed/ts-sdk/ts-express-casing/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/ts-express-casing/src/BaseClient.ts
+++ b/seed/ts-sdk/ts-express-casing/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/ts-express-casing/src/BaseClient.ts
+++ b/seed/ts-sdk/ts-express-casing/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/ts-express-casing/src/BaseClient.ts
+++ b/seed/ts-sdk/ts-express-casing/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -69,6 +76,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/ts-express-casing/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/ts-express-casing/src/core/auth/index.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/ts-extra-properties/.fern/metadata.json
+++ b/seed/ts-sdk/ts-extra-properties/.fern/metadata.json
@@ -6,8 +6,7 @@
         "noSerdeLayer": false
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/ts-inline-types/inline/.fern/metadata.json
+++ b/seed/ts-sdk/ts-inline-types/inline/.fern/metadata.json
@@ -6,8 +6,7 @@
         "enableInlineTypes": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/ts-inline-types/no-inline/.fern/metadata.json
+++ b/seed/ts-sdk/ts-inline-types/no-inline/.fern/metadata.json
@@ -6,8 +6,7 @@
         "enableInlineTypes": false
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/.fern/metadata.json
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/.fern/metadata.json
@@ -6,8 +6,7 @@
         "skipResponseValidation": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/union-query-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/union-query-parameters/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/unions-with-local-date/.fern/metadata.json
+++ b/seed/ts-sdk/unions-with-local-date/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/unions/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/unions/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/unions/serde-layer/.fern/metadata.json
+++ b/seed/ts-sdk/unions/serde-layer/.fern/metadata.json
@@ -6,8 +6,7 @@
         "noSerdeLayer": false
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/unknown/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/unknown/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/unknown/unknown-as-any/.fern/metadata.json
+++ b/seed/ts-sdk/unknown/unknown-as-any/.fern/metadata.json
@@ -6,8 +6,7 @@
         "treatUnknownAsAny": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/url-form-encoded/.fern/metadata.json
+++ b/seed/ts-sdk/url-form-encoded/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/validation/.fern/metadata.json
+++ b/seed/ts-sdk/validation/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/variables/.fern/metadata.json
+++ b/seed/ts-sdk/variables/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/version-no-default/.fern/metadata.json
+++ b/seed/ts-sdk/version-no-default/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/version/.fern/metadata.json
+++ b/seed/ts-sdk/version/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/webhook-audience/.fern/metadata.json
+++ b/seed/ts-sdk/webhook-audience/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/webhooks/no-custom-config/.fern/metadata.json
+++ b/seed/ts-sdk/webhooks/no-custom-config/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/.fern/metadata.json
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/.fern/metadata.json
@@ -6,8 +6,7 @@
         "generateWebSocketClients": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/BaseClient.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/BaseClient.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/BaseClient.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/BaseClient.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { BearerAuthProvider } from "./auth/BearerAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/auth/index.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/.fern/metadata.json
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/.fern/metadata.json
@@ -6,8 +6,7 @@
         "generateWebSocketClients": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/BaseClient.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/BaseClient.ts
@@ -4,7 +4,11 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | InferredAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | InferredAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
@@ -20,7 +24,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & InferredAuthProvider.AuthOptions;
 
@@ -74,6 +78,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/BaseClient.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/BaseClient.ts
@@ -72,15 +72,6 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
-function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
-    return (
-        typeof auth === "object" &&
-        auth !== null &&
-        "getAuthRequest" in auth &&
-        typeof auth.getAuthRequest === "function"
-    );
-}
-
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
@@ -91,7 +82,7 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
             normalized.authProvider = { getAuthRequest: options.auth };
             return normalized;
         }
-        if (isAuthProvider(options.auth)) {
+        if (core.isAuthProvider(options.auth)) {
             normalized.authProvider = options.auth;
             return normalized;
         }

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/BaseClient.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/BaseClient.ts
@@ -4,6 +4,11 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | InferredAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment: core.Supplier<string>;
     /** Specify a custom URL to connect the client to. */
@@ -18,6 +23,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & InferredAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -65,10 +72,32 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
     } as NormalizedClientOptions<T>;
 }
 
+function isAuthProvider(auth: AuthOption): auth is core.AuthProvider {
+    return (
+        typeof auth === "object" &&
+        auth !== null &&
+        "getAuthRequest" in auth &&
+        typeof auth.getAuthRequest === "function"
+    );
+}
+
 export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = BaseClientOptions>(
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new InferredAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/BaseClient.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/BaseClient.ts
@@ -4,10 +4,7 @@ import { InferredAuthProvider } from "./auth/InferredAuthProvider.js";
 import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | InferredAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | InferredAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment: core.Supplier<string>;

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/auth/index.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/websocket-multi-url/.fern/metadata.json
+++ b/seed/ts-sdk/websocket-multi-url/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/websocket-multi-url/src/BaseClient.ts
+++ b/seed/ts-sdk/websocket-multi-url/src/BaseClient.ts
@@ -5,7 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
+export type AuthOption =
+    | false
+    | core.AuthProvider["getAuthRequest"]
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<
@@ -23,7 +27,7 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
-    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    /** Override auth. Pass false to disable, a function returning auth headers, an AuthProvider, or auth options. */
     auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
@@ -77,6 +81,10 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
 
+    if (options.auth === false) {
+        normalized.authProvider = new core.NoOpAuthProvider();
+        return normalized;
+    }
     if (options.auth != null) {
         if (typeof options.auth === "function") {
             normalized.authProvider = { getAuthRequest: options.auth };

--- a/seed/ts-sdk/websocket-multi-url/src/BaseClient.ts
+++ b/seed/ts-sdk/websocket-multi-url/src/BaseClient.ts
@@ -5,10 +5,7 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
-export type AuthOption =
-    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
-    | core.AuthProvider
-    | BearerAuthProvider.AuthOptions;
+export type AuthOption = core.AuthProvider["getAuthRequest"] | core.AuthProvider | BearerAuthProvider.AuthOptions;
 
 export type BaseClientOptions = {
     environment?: core.Supplier<

--- a/seed/ts-sdk/websocket-multi-url/src/BaseClient.ts
+++ b/seed/ts-sdk/websocket-multi-url/src/BaseClient.ts
@@ -5,6 +5,11 @@ import { mergeHeaders } from "./core/headers.js";
 import * as core from "./core/index.js";
 import type * as environments from "./environments.js";
 
+export type AuthOption =
+    | ((arg?: { endpointMetadata?: core.EndpointMetadata }) => Promise<core.AuthRequest>)
+    | core.AuthProvider
+    | BearerAuthProvider.AuthOptions;
+
 export type BaseClientOptions = {
     environment?: core.Supplier<
         environments.SeedWebsocketMultiUrlEnvironment | environments.SeedWebsocketMultiUrlEnvironmentUrls
@@ -21,6 +26,8 @@ export type BaseClientOptions = {
     fetch?: typeof fetch;
     /** Configure logging for the client. */
     logging?: core.logging.LogConfig | core.logging.Logger;
+    /** Override auth. Accepts auth options, an AuthProvider, or a function returning auth headers. */
+    auth?: AuthOption;
 } & BearerAuthProvider.AuthOptions;
 
 export interface BaseRequestOptions {
@@ -72,6 +79,19 @@ export function normalizeClientOptionsWithAuth<T extends BaseClientOptions = Bas
     options: T,
 ): NormalizedClientOptionsWithAuth<T> {
     const normalized = normalizeClientOptions(options) as NormalizedClientOptionsWithAuth<T>;
+
+    if (options.auth != null) {
+        if (typeof options.auth === "function") {
+            normalized.authProvider = { getAuthRequest: options.auth };
+            return normalized;
+        }
+        if (core.isAuthProvider(options.auth)) {
+            normalized.authProvider = options.auth;
+            return normalized;
+        }
+        Object.assign(normalized, options.auth);
+    }
+
     const normalizedWithNoOpAuthProvider = withNoOpAuthProvider(normalized);
     normalized.authProvider ??= new BearerAuthProvider(normalizedWithNoOpAuthProvider);
     return normalized;

--- a/seed/ts-sdk/websocket-multi-url/src/core/auth/AuthProvider.ts
+++ b/seed/ts-sdk/websocket-multi-url/src/core/auth/AuthProvider.ts
@@ -4,3 +4,12 @@ import type { AuthRequest } from "./AuthRequest.js";
 export interface AuthProvider {
     getAuthRequest(arg?: { endpointMetadata?: EndpointMetadata }): Promise<AuthRequest>;
 }
+
+export function isAuthProvider(value: unknown): value is AuthProvider {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "getAuthRequest" in value &&
+        typeof value.getAuthRequest === "function"
+    );
+}

--- a/seed/ts-sdk/websocket-multi-url/src/core/auth/index.ts
+++ b/seed/ts-sdk/websocket-multi-url/src/core/auth/index.ts
@@ -1,4 +1,4 @@
-export type { AuthProvider } from "./AuthProvider.js";
+export { type AuthProvider, isAuthProvider } from "./AuthProvider.js";
 export type { AuthRequest } from "./AuthRequest.js";
 export { BasicAuth } from "./BasicAuth.js";
 export { BearerToken } from "./BearerToken.js";

--- a/seed/ts-sdk/websocket/no-serde/.fern/metadata.json
+++ b/seed/ts-sdk/websocket/no-serde/.fern/metadata.json
@@ -7,8 +7,7 @@
         "generateWebSocketClients": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/websocket/no-websocket-clients/.fern/metadata.json
+++ b/seed/ts-sdk/websocket/no-websocket-clients/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/websocket/serde/.fern/metadata.json
+++ b/seed/ts-sdk/websocket/serde/.fern/metadata.json
@@ -7,8 +7,7 @@
         "generateWebSocketClients": true
     },
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }

--- a/seed/ts-sdk/x-fern-default/.fern/metadata.json
+++ b/seed/ts-sdk/x-fern-default/.fern/metadata.json
@@ -3,8 +3,7 @@
     "generatorName": "fernapi/fern-typescript-sdk",
     "generatorVersion": "local",
     "originGitCommit": "DUMMY",
-    "invokedBy": "ci",
+    "invokedBy": "manual",
     "requestedVersion": "0.0.1",
-    "ciProvider": "github",
     "sdkVersion": "0.0.1"
 }


### PR DESCRIPTION
## Description

When `alwaysSendAuth: true` is configured, the generated `BasicAuthProvider` (or other auth providers) throws if credentials aren't provided — even when users handle auth through custom fetchers. This adds a unified `auth` option to `BaseClientOptions` that lets users supply custom auth handling, bypassing the built-in provider.

## Changes Made

- Added `AuthOption` type as an undiscriminated union of:
  1. A function `(arg?: { endpointMetadata? }) => Promise<AuthRequest>` — for fully custom auth
  2. An `AuthProvider` object (has `getAuthRequest` method) — for custom provider instances
  3. The existing auth credential options (e.g. `{ username, password }`) — backwards compatible
- Added optional `auth?: AuthOption` field to generated `BaseClientOptions` type
- Updated `normalizeClientOptionsWithAuth` to detect which variant was passed:
  - If function → wraps in `{ getAuthRequest: fn }` adapter
  - If `AuthProvider` object → uses directly
  - Otherwise → merges as credential options via `Object.assign`, falls through to default provider creation
- Moved `isAuthProvider` type guard to `core/auth/AuthProvider.ts` (colocated with `AuthProvider` interface) instead of generating it inline in each SDK
- Updated test mock context to include `AuthRequest`, `EndpointMetadata`, and `isAuthProvider` references
- Regenerated **all** auth-related seed fixtures (213 fixtures, all pass)
- Added unreleased changelog entry
- [ ] Updated README.md generator (not applicable — generated code only)

**Backwards compatible**: existing top-level credential fields continue to work unchanged. The `auth` option is purely additive.

### Auth schemes covered

All 5 auth scheme types + both multi-auth modes regenerated and verified:
- **bearer**: simple-api, imdb, exhaustive, pagination, trace, etc.
- **basic**: basic-auth, basic-auth-pw-omitted, basic-auth-environment-variables
- **header**: header-auth, header-auth-environment-variable
- **inferred** (OAuth): inferred-auth-explicit, inferred-auth-implicit (+ api-key, no-expiry, reference variants)
- **oauth**: oauth-client-credentials (+ custom, default, environment-variables, mandatory-auth, nested-root, openapi, reference, with-variables)
- **ANY** (multiple schemes): any-auth (3 variants)
- **ENDPOINT_SECURITY** (routing): endpoint-security-auth

### Example usage (custom fetcher pattern)
```typescript
new MavenAGIClient({
  environment: proxyUrl,
  organizationId,
  agentId,
  auth: async () => ({ headers: { Authorization: `Bearer ${jwt}` } }),
  fetcher: async args => fetcherImpl(args),
})
```

## Testing
- [x] Unit tests added/updated (542/542 pass)
- [x] All 213 ts-sdk seed fixtures regenerated and pass
- [x] TypeScript compilation passes
- [x] Runtime wire tests against mock servers for all 3 auth patterns
- [x] Manual testing completed
- [x] CI green (49 passed, 0 failed)

Link to Devin session: https://app.devin.ai/sessions/977f0a939523430b98a4455b53c75b6a
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
