### PR TITLE
chore(ci): add continue-on-error to upload Playwright report step

### DIFF
--- a/.github/workflows/docs-bundle-smoke-test.yml
+++ b/.github/workflows/docs-bundle-smoke-test.yml
@@ -340,6 +340,7 @@ jobs:
       - name: Upload Playwright report
         uses: actions/upload-artifact@v6
         if: always() && steps.node-check.outputs.available == 'true'
+        continue-on-error: true
         with:
           name: smoke-test-playwright-report-${{ matrix.os }}-node${{ matrix.node-version }}
           path: docs-preview-smoke-test/playwright/playwright-report/


### PR DESCRIPTION
## Description

The `Upload Playwright report` step in the docs bundle smoke test workflow can fail due to transient GitHub Actions artifact upload issues, causing the entire job to fail even when all Playwright tests pass. This was observed on `windows-latest, node22` where the upload step failed at 0s with no error message while all 4 smoke tests passed.

## Changes Made

- Added `continue-on-error: true` to the `Upload Playwright report` step so artifact upload failures don't fail the entire smoke test job
- The Playwright report upload is a nice-to-have for debugging, not a test gate

## Testing
- [x] Verified the workflow YAML is valid
- [x] The change is a single-line addition that doesn't affect test execution

Link to Devin session: https://app.devin.ai/sessions/5dd3f6d4d7fc4b65b398e61379417b8d
Requested by: @thesandlord