### PR TITLE
fix(cli): handle spaces in filesystem paths when resolving image URLs

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-spaces-in-image-paths.yml
+++ b/packages/cli/cli/changes/unreleased/fix-spaces-in-image-paths.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix image paths not resolving when project directory contains spaces (e.g. "Chainalysis Docs").
+    Absolute paths injected during markdown processing are now percent-encoded so they survive
+    the CommonMark parser round-trip in `replaceImagePathsAndUrls`.
+  type: fix

--- a/packages/cli/docs-markdown-utils/src/__test__/parseImagePaths.test.ts
+++ b/packages/cli/docs-markdown-utils/src/__test__/parseImagePaths.test.ts
@@ -982,6 +982,120 @@ describe("streaming parser for large files", () => {
     });
 });
 
+describe("paths with spaces in directory names", () => {
+    const SPACE_DOCS_PATH = AbsoluteFilePath.of("/Users/user/Documents/Chainalysis Docs/developer-docs/fern");
+    const SPACE_MDX_PATH = AbsoluteFilePath.of(
+        "/Users/user/Documents/Chainalysis Docs/developer-docs/fern/pages/file.mdx"
+    );
+    const SPACE_PATHS = {
+        absolutePathToFernFolder: SPACE_DOCS_PATH,
+        absolutePathToMarkdownFile: SPACE_MDX_PATH
+    };
+
+    it("should percent-encode spaces in resolved markdown image paths", () => {
+        const page = "![overview](/assets/images/overview.png)";
+        const result = parseImagePaths(page, SPACE_PATHS);
+        expect(result.filepaths).toEqual([
+            "/Users/user/Documents/Chainalysis Docs/developer-docs/fern/assets/images/overview.png"
+        ]);
+        expect(result.markdown.trim()).toContain(
+            "![overview](/Users/user/Documents/Chainalysis%20Docs/developer-docs/fern/assets/images/overview.png)"
+        );
+    });
+
+    it("should percent-encode spaces in relative image paths", () => {
+        const page = "![img](../assets/image.png)";
+        const result = parseImagePaths(page, SPACE_PATHS);
+        expect(result.filepaths).toEqual([
+            "/Users/user/Documents/Chainalysis Docs/developer-docs/fern/assets/image.png"
+        ]);
+        expect(result.markdown.trim()).toContain(
+            "![img](/Users/user/Documents/Chainalysis%20Docs/developer-docs/fern/assets/image.png)"
+        );
+    });
+
+    it("should percent-encode spaces in HTML img src paths", () => {
+        const page = "<img src='/assets/images/overview.png' />";
+        const result = parseImagePaths(page, SPACE_PATHS);
+        expect(result.filepaths).toEqual([
+            "/Users/user/Documents/Chainalysis Docs/developer-docs/fern/assets/images/overview.png"
+        ]);
+        expect(result.markdown.trim()).toContain(
+            "/Users/user/Documents/Chainalysis%20Docs/developer-docs/fern/assets/images/overview.png"
+        );
+    });
+
+    it("should round-trip through parseImagePaths and replaceImagePathsAndUrls with spaces", () => {
+        const page = "![overview](/assets/images/overview.png)";
+        const parseResult = parseImagePaths(page, SPACE_PATHS, CONTEXT);
+        const fileIdsMap = new Map([
+            [
+                AbsoluteFilePath.of(
+                    "/Users/user/Documents/Chainalysis Docs/developer-docs/fern/assets/images/overview.png"
+                ),
+                "test-file-id"
+            ]
+        ]);
+        const replaced = replaceImagePathsAndUrls(parseResult.markdown, fileIdsMap, {}, SPACE_PATHS, CONTEXT);
+        expect(replaced).toContain("![overview](file:test-file-id)");
+    });
+
+    it("should round-trip HTML img through both functions with spaces", () => {
+        const page = "<img src='/assets/images/overview.png' />";
+        const parseResult = parseImagePaths(page, SPACE_PATHS, CONTEXT);
+        const fileIdsMap = new Map([
+            [
+                AbsoluteFilePath.of(
+                    "/Users/user/Documents/Chainalysis Docs/developer-docs/fern/assets/images/overview.png"
+                ),
+                "html-file-id"
+            ]
+        ]);
+        const replaced = replaceImagePathsAndUrls(parseResult.markdown, fileIdsMap, {}, SPACE_PATHS, CONTEXT);
+        expect(replaced).toContain("html-file-id");
+    });
+
+    it("should produce same results for AST and streaming parsers with spaces", () => {
+        const originalEnv = process.env.FERN_DOCS_LARGE_FILE_BYTES;
+        try {
+            const page =
+                "![overview](/assets/images/overview.png) and more content to pad past the byte threshold for streaming";
+
+            process.env.FERN_DOCS_LARGE_FILE_BYTES = "10000000";
+            const astResult = parseImagePaths(page, SPACE_PATHS, CONTEXT);
+
+            process.env.FERN_DOCS_LARGE_FILE_BYTES = "10";
+            const streamingResult = parseImagePaths(page, SPACE_PATHS, CONTEXT);
+
+            expect(streamingResult.filepaths.sort()).toEqual(astResult.filepaths.sort());
+            expect(streamingResult.markdown.trim()).toEqual(astResult.markdown.trim());
+        } finally {
+            if (originalEnv !== undefined) {
+                process.env.FERN_DOCS_LARGE_FILE_BYTES = originalEnv;
+            } else {
+                delete process.env.FERN_DOCS_LARGE_FILE_BYTES;
+            }
+        }
+    });
+
+    it("should handle paths with parentheses in directory names", () => {
+        const PAREN_DOCS_PATH = AbsoluteFilePath.of("/Users/user/Projects (old)/fern");
+        const PAREN_MDX_PATH = AbsoluteFilePath.of("/Users/user/Projects (old)/fern/pages/file.mdx");
+        const parenPaths = {
+            absolutePathToFernFolder: PAREN_DOCS_PATH,
+            absolutePathToMarkdownFile: PAREN_MDX_PATH
+        };
+        const page = "![img](/assets/image.png)";
+        const parseResult = parseImagePaths(page, parenPaths, CONTEXT);
+        expect(parseResult.filepaths).toEqual(["/Users/user/Projects (old)/fern/assets/image.png"]);
+        const fileIdsMap = new Map([
+            [AbsoluteFilePath.of("/Users/user/Projects (old)/fern/assets/image.png"), "paren-file-id"]
+        ]);
+        const replaced = replaceImagePathsAndUrls(parseResult.markdown, fileIdsMap, {}, parenPaths, CONTEXT);
+        expect(replaced).toContain("![img](file:paren-file-id)");
+    });
+});
+
 describe("replaceImagePathsAndUrls with streaming parser for large files", () => {
     const originalEnv = process.env.FERN_DOCS_LARGE_FILE_BYTES;
 

--- a/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
+++ b/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
@@ -21,6 +21,23 @@ function getLargeFileBytes(): number {
     return parseInt(process.env.FERN_DOCS_LARGE_FILE_BYTES ?? "5000000", 10);
 }
 
+/**
+ * Percent-encode characters in a filesystem path that are invalid in
+ * CommonMark bare link destinations (spaces, unbalanced parentheses).
+ * Literal `%` signs are encoded first to avoid ambiguity.
+ */
+function encodePathForMarkdown(filepath: string): string {
+    return filepath.replaceAll("%", "%25").replaceAll(" ", "%20").replaceAll("(", "%28").replaceAll(")", "%29");
+}
+
+/**
+ * Decode percent-encoded characters produced by {@link encodePathForMarkdown}.
+ * Decoding order is the reverse of encoding order.
+ */
+function decodeMarkdownPath(encoded: string): string {
+    return encoded.replaceAll("%29", ")").replaceAll("%28", "(").replaceAll("%20", " ").replaceAll("%25", "%");
+}
+
 interface Edit {
     start: number;
     end: number;
@@ -150,7 +167,7 @@ function parseMarkdownImage(
     const resolvedPath = resolvePath(src, metadata);
 
     if (rawSrc && src && resolvedPath) {
-        const replacement = url.replace(rawSrc, resolvedPath);
+        const replacement = url.replace(rawSrc, encodePathForMarkdown(resolvedPath));
         return {
             filepath: resolvedPath,
             edit: { start: urlStart, end: urlEnd, replacement },
@@ -255,7 +272,11 @@ function parseJsxTag(
                     const resolvedPath = resolvePath(src, metadata);
                     if (src && resolvedPath) {
                         filepaths.add(resolvedPath);
-                        edits.push({ start: valueStart, end: valueStart + value.length, replacement: resolvedPath });
+                        edits.push({
+                            start: valueStart,
+                            end: valueStart + value.length,
+                            replacement: encodePathForMarkdown(resolvedPath)
+                        });
                     }
                 }
             } else if (content[i] === "{") {
@@ -282,7 +303,7 @@ function parseJsxTag(
                             edits.push({
                                 start: exprStart + 1,
                                 end: exprStart + 1 + value.length,
-                                replacement: resolvedPath
+                                replacement: encodePathForMarkdown(resolvedPath)
                             });
                         }
                     }
@@ -296,7 +317,7 @@ function parseJsxTag(
                             edits.push({
                                 start: exprStart + 1,
                                 end: exprStart + 1 + value.length,
-                                replacement: resolvedPath
+                                replacement: encodePathForMarkdown(resolvedPath)
                             });
                         }
                     }
@@ -447,7 +468,7 @@ export function parseImagePaths(
                 const resolvedPath = resolvePath(src, metadata);
                 if (src != null && resolvedPath != null) {
                     filepaths.add(resolvedPath);
-                    replaced = replaced.replaceAll(src, resolvedPath);
+                    replaced = replaced.replaceAll(src, encodePathForMarkdown(resolvedPath));
                 }
             }
 
@@ -458,7 +479,7 @@ export function parseImagePaths(
                         const resolvedPath = resolvePath(src, metadata);
                         if (src && resolvedPath) {
                             filepaths.add(resolvedPath);
-                            replaced = replaced.replaceAll(src, resolvedPath);
+                            replaced = replaced.replaceAll(src, encodePathForMarkdown(resolvedPath));
                         }
                         return;
                     },
@@ -468,7 +489,7 @@ export function parseImagePaths(
                             const resolvedPath = resolvePath(icon, metadata);
                             if (icon && resolvedPath) {
                                 filepaths.add(resolvedPath);
-                                replaced = replaced.replaceAll(icon, resolvedPath);
+                                replaced = replaced.replaceAll(icon, encodePathForMarkdown(resolvedPath));
                             }
                         }
                         return;
@@ -484,7 +505,7 @@ export function parseImagePaths(
                     const resolvedPath = resolvePath(src, metadata);
                     if (resolvedPath != null) {
                         filepaths.add(resolvedPath);
-                        replaced = replaced.replaceAll(src, resolvedPath);
+                        replaced = replaced.replaceAll(src, encodePathForMarkdown(resolvedPath));
                     }
                 }
 
@@ -495,7 +516,7 @@ export function parseImagePaths(
                     const resolvedPath = resolvePath(icon, metadata);
                     if (resolvedPath != null) {
                         filepaths.add(resolvedPath);
-                        replaced = replaced.replaceAll(icon, resolvedPath);
+                        replaced = replaced.replaceAll(icon, encodePathForMarkdown(resolvedPath));
                     }
                 }
 
@@ -652,17 +673,21 @@ export function replaceImagePathsAndUrls(
             return undefined;
         }
 
-        if (isAbsolute(image) || isWindowsAbsolutePath(image)) {
+        // Decode percent-encoded characters that were added by parseImagePaths
+        // to make paths with spaces (and parens) valid in CommonMark link destinations.
+        const decoded = decodeMarkdownPath(image);
+
+        if (isAbsolute(decoded) || isWindowsAbsolutePath(decoded)) {
             // Normalize to strip Windows drive letters (e.g., C:/) for consistent lookup
-            const absolutePath = convertToFernHostAbsoluteFilePath(AbsoluteFilePath.of(image));
+            const absolutePath = convertToFernHostAbsoluteFilePath(AbsoluteFilePath.of(decoded));
             const fileId = fileIdsMap.get(absolutePath);
             if (fileId) {
                 return `file:${fileId}`;
             }
 
             // Fallback: try resolving as a root-relative path
-            if (!isWindowsAbsolutePath(image)) {
-                const resolvedFromRoot = resolvePath(image, metadata);
+            if (!isWindowsAbsolutePath(decoded)) {
+                const resolvedFromRoot = resolvePath(decoded, metadata);
                 if (resolvedFromRoot) {
                     const fallbackFileId = fileIdsMap.get(resolvedFromRoot);
                     if (fallbackFileId) {
@@ -673,7 +698,7 @@ export function replaceImagePathsAndUrls(
             return undefined;
         }
 
-        const resolvedPath = resolvePath(image, metadata);
+        const resolvedPath = resolvePath(decoded, metadata);
         if (resolvedPath) {
             const fileId = fileIdsMap.get(resolvedPath);
             return fileId ? `file:${fileId}` : undefined;


### PR DESCRIPTION
## Description

Fixes an issue where images fail to render in `fern docs dev` (and preview links) when the project directory path contains spaces (e.g. `/Users/.../Chainalysis Docs/developer-docs/fern/...`).

## Root Cause

The Fern CLI processes markdown images in two passes:

1. **`parseImagePaths`** resolves relative image paths to absolute filesystem paths and injects them into the markdown content.
2. **`replaceImagePathsAndUrls`** re-parses that markdown to find absolute paths and replace them with internal `file:` references.

When the resolved absolute path contains spaces, the injected markdown (e.g. `![alt](/Users/.../Chainalysis Docs/.../image.png)`) violates the [CommonMark spec](https://spec.commonmark.org/0.31.2/#link-destination) — bare link destinations cannot contain spaces. The remark parser in the second pass fails to recognize the image node and leaves the raw absolute filesystem path in the output.

This only manifests when the repo is cloned into a directory whose path contains spaces. Users whose paths have no spaces are unaffected.

## Changes Made

- Added `encodePathForMarkdown()` / `decodeMarkdownPath()` helpers that percent-encode characters invalid in CommonMark bare link destinations (spaces, parentheses, literal `%`).
- Updated all path injection sites in `parseImagePaths` (both AST and streaming parser paths) to encode resolved paths before inserting them into markdown text.
- Updated `mapImage()` in `replaceImagePathsAndUrls` to decode percent-encoded paths before looking them up in the `fileIdsMap`.
- `filepaths` returned by `parseImagePaths` remain real filesystem paths (unencoded) so file I/O is unaffected.

## Testing

- [x] Unit tests added: 7 new tests covering spaces in directory names, parentheses in paths, AST/streaming parser consistency with spaces, and full round-trip (`parseImagePaths` → `replaceImagePathsAndUrls`) with spaces.
- [x] All 199 existing tests continue to pass (paths without spaces are unaffected by encoding).
- [x] Lint and format checks pass.

Link to Devin session: https://app.devin.ai/sessions/6bc891ac580b4f00856b26e4298d92c2
Requested by: @fern-support