### PR TITLE
fix(cli): normalize file path separators for cross-platform image resolution

### DIFF
--- a/docs-preview-smoke-test/fern/docs/assets/plant-logo.svg
+++ b/docs-preview-smoke-test/fern/docs/assets/plant-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <circle cx="50" cy="50" r="40" fill="#81C784"/>
+  <text x="50" y="58" text-anchor="middle" font-size="24" fill="white">🌱</text>
+</svg>

--- a/docs-preview-smoke-test/fern/docs/pages/welcome.mdx
+++ b/docs-preview-smoke-test/fern/docs/pages/welcome.mdx
@@ -6,6 +6,8 @@ slug: welcome
 
 Welcome to the Plant Store API documentation. This is a smoke test fixture used to validate that `fern docs dev` works correctly across Linux, macOS, and Windows.
 
+![Plant Store Logo](../assets/plant-logo.svg)
+
 ## Getting started
 
 Use the REST API to manage your plant inventory.

--- a/docs-preview-smoke-test/playwright/smoke.spec.ts
+++ b/docs-preview-smoke-test/playwright/smoke.spec.ts
@@ -41,3 +41,39 @@ test.describe("Smoke test: all pages load", () => {
         });
     }
 });
+
+test.describe("Image path validation: no broken file paths", () => {
+    test("GET /welcome should render images without broken file:/// paths", async ({ page }) => {
+        const response = await page.goto("/welcome", {
+            waitUntil: "domcontentloaded",
+            timeout: 30_000
+        });
+
+        expect(response?.status()).toBe(200);
+
+        // Wait for page to fully render
+        await page.waitForTimeout(2000);
+
+        // Collect all image src attributes from the page
+        const imgSrcs = await page.evaluate(() => {
+            const images = document.querySelectorAll("img");
+            return Array.from(images).map((img) => img.getAttribute("src") ?? img.src);
+        });
+
+        expect(imgSrcs.length, "Expected at least one image on /welcome").toBeGreaterThan(0);
+
+        for (const src of imgSrcs) {
+            // Must not contain file:/// protocol (broken local path leak)
+            expect(src, `Image src should not use file:/// protocol: ${src}`).not.toMatch(/^file:\/\/\//);
+
+            // Must not contain Windows drive letters (e.g., C:/ or C:\)
+            expect(src, `Image src should not contain Windows drive letter: ${src}`).not.toMatch(/^[a-zA-Z]:[/\\]/);
+
+            // Must not contain URL-encoded backslashes (%5C)
+            expect(src, `Image src should not contain encoded backslashes: ${src}`).not.toContain("%5C");
+
+            // Must not contain raw backslashes
+            expect(src, `Image src should not contain backslashes: ${src}`).not.toContain("\\");
+        }
+    });
+});

--- a/packages/cli/cli/changes/unreleased/fix-windows-image-paths.yml
+++ b/packages/cli/cli/changes/unreleased/fix-windows-image-paths.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix image path resolution on Windows for `fern docs dev` and `fern generate docs`.
+    Path utilities (`resolve`, `dirname`, `join`) now normalize output to forward slashes,
+    preventing file ID lookup mismatches caused by mixed path separators on Windows.
+  type: fix

--- a/packages/cli/docs-markdown-utils/src/__test__/parseImagePaths.test.ts
+++ b/packages/cli/docs-markdown-utils/src/__test__/parseImagePaths.test.ts
@@ -747,6 +747,77 @@ describe("replaceImagePaths", () => {
     });
 });
 
+describe("cross-platform image path round-trip", () => {
+    it("should produce consistent paths that match fileIdsMap keys", () => {
+        const page = "![image](./assets/images/diagram.png)";
+        const parseResult = parseImagePaths(page, PATHS, CONTEXT);
+
+        // parseImagePaths should produce forward-slash normalized paths
+        expect(parseResult.filepaths).toEqual(["/Volume/git/fern/my/docs/folder/assets/images/diagram.png"]);
+
+        // Build fileIdsMap from the SAME filepaths (simulating the upload flow)
+        const fileIdsMap = new Map(
+            parseResult.filepaths.map((fp) => [AbsoluteFilePath.of(fp), "cross-platform-file-id"])
+        );
+
+        // replaceImagePathsAndUrls should find the file ID via the same normalized path
+        const replaced = replaceImagePathsAndUrls(parseResult.markdown, fileIdsMap, {}, PATHS, CONTEXT);
+        expect(replaced).toContain("file:cross-platform-file-id");
+        expect(replaced).not.toContain("/Volume/git/fern/my/docs/folder/assets/images/diagram.png");
+    });
+
+    it("should handle root-relative paths in round-trip", () => {
+        const page = "![logo](/assets/images/logo.svg)";
+        const parseResult = parseImagePaths(page, PATHS, CONTEXT);
+
+        expect(parseResult.filepaths).toEqual(["/Volume/git/fern/assets/images/logo.svg"]);
+
+        const fileIdsMap = new Map(parseResult.filepaths.map((fp) => [AbsoluteFilePath.of(fp), "logo-file-id"]));
+
+        const replaced = replaceImagePathsAndUrls(parseResult.markdown, fileIdsMap, {}, PATHS, CONTEXT);
+        expect(replaced).toContain("file:logo-file-id");
+    });
+
+    it("should handle mixed image types in round-trip", () => {
+        const page = [
+            "![md-image](./images/photo.png)",
+            "<img src='./images/icon.svg' />",
+            '<Frame><img src="./images/screenshot.webp" /></Frame>'
+        ].join("\n");
+
+        const parseResult = parseImagePaths(page, PATHS, CONTEXT);
+
+        expect(parseResult.filepaths).toHaveLength(3);
+        // All paths should use forward slashes
+        for (const fp of parseResult.filepaths) {
+            expect(fp).not.toContain("\\");
+        }
+
+        const fileIdsMap = new Map(parseResult.filepaths.map((fp, i) => [AbsoluteFilePath.of(fp), `file-id-${i}`]));
+
+        const replaced = replaceImagePathsAndUrls(parseResult.markdown, fileIdsMap, {}, PATHS, CONTEXT);
+        expect(replaced).toContain("file:file-id-0");
+        expect(replaced).toContain("file:file-id-1");
+        expect(replaced).toContain("file:file-id-2");
+    });
+
+    it("should never produce paths with backslashes in resolved filepaths", () => {
+        const pages = [
+            "![a](../other/image.png)",
+            "![b](./local/image.png)",
+            "![c](/root/image.png)",
+            "<img src='deep/nested/path/to/image.png' />"
+        ];
+
+        for (const page of pages) {
+            const result = parseImagePaths(page, PATHS, CONTEXT);
+            for (const filepath of result.filepaths) {
+                expect(filepath).not.toContain("\\");
+            }
+        }
+    });
+});
+
 function testMdxFixture(filename: string) {
     const page = fs.readFileSync(resolve(__dirname, `fixtures/${filename}`), "utf-8");
     const result = parseImagePaths(page, PATHS);

--- a/packages/commons/fs-utils/src/__test__/osPathConverter.test.ts
+++ b/packages/commons/fs-utils/src/__test__/osPathConverter.test.ts
@@ -2,13 +2,15 @@ import { AbsoluteFilePath } from "../AbsoluteFilePath.js";
 import { convertToFernHostAbsoluteFilePath } from "../osPathConverter.js";
 
 describe("convertToFernHostAbsoluteFilePath", () => {
+
     it("should strip Windows drive letter with backslash", () => {
         // Simulating a Windows path that uses backslashes (e.g., C:\Users\...)
         // After convertToOsPath normalization, this becomes C:/Users/...
-        const windowsPath = "/Users/fchu/docs/images/logo.png" as AbsoluteFilePath;
+        const windowsPath = "C:\\Users\\fchu\\docs\\images\\logo.png" as AbsoluteFilePath;
         const result = convertToFernHostAbsoluteFilePath(windowsPath);
         expect(result).toBe("/Users/fchu/docs/images/logo.png");
     });
+
 
     it("should strip Windows drive letter with forward slash", () => {
         // After resolve() normalization, Windows paths use forward slashes: C:/Users/...

--- a/packages/commons/fs-utils/src/__test__/osPathConverter.test.ts
+++ b/packages/commons/fs-utils/src/__test__/osPathConverter.test.ts
@@ -2,7 +2,6 @@ import { AbsoluteFilePath } from "../AbsoluteFilePath.js";
 import { convertToFernHostAbsoluteFilePath } from "../osPathConverter.js";
 
 describe("convertToFernHostAbsoluteFilePath", () => {
-
     it("should strip Windows drive letter with backslash", () => {
         // Simulating a Windows path that uses backslashes (e.g., C:\Users\...)
         // After convertToOsPath normalization, this becomes C:/Users/...
@@ -10,7 +9,6 @@ describe("convertToFernHostAbsoluteFilePath", () => {
         const result = convertToFernHostAbsoluteFilePath(windowsPath);
         expect(result).toBe("/Users/fchu/docs/images/logo.png");
     });
-
 
     it("should strip Windows drive letter with forward slash", () => {
         // After resolve() normalization, Windows paths use forward slashes: C:/Users/...

--- a/packages/commons/fs-utils/src/__test__/osPathConverter.test.ts
+++ b/packages/commons/fs-utils/src/__test__/osPathConverter.test.ts
@@ -1,0 +1,31 @@
+import { AbsoluteFilePath } from "../AbsoluteFilePath.js";
+import { convertToFernHostAbsoluteFilePath } from "../osPathConverter.js";
+
+describe("convertToFernHostAbsoluteFilePath", () => {
+    it("should strip Windows drive letter with backslash", () => {
+        // Simulating a Windows path that uses backslashes (e.g., C:\Users\...)
+        // After convertToOsPath normalization, this becomes C:/Users/...
+        const windowsPath = "/Users/fchu/docs/images/logo.png" as AbsoluteFilePath;
+        const result = convertToFernHostAbsoluteFilePath(windowsPath);
+        expect(result).toBe("/Users/fchu/docs/images/logo.png");
+    });
+
+    it("should strip Windows drive letter with forward slash", () => {
+        // After resolve() normalization, Windows paths use forward slashes: C:/Users/...
+        const windowsPath = "C:/Users/fchu/docs/images/logo.png" as AbsoluteFilePath;
+        const result = convertToFernHostAbsoluteFilePath(windowsPath);
+        expect(result).toBe("/Users/fchu/docs/images/logo.png");
+    });
+
+    it("should handle Unix paths unchanged", () => {
+        const unixPath = "/home/user/docs/images/logo.png" as AbsoluteFilePath;
+        const result = convertToFernHostAbsoluteFilePath(unixPath);
+        expect(result).toBe("/home/user/docs/images/logo.png");
+    });
+
+    it("should handle Windows path with lowercase drive letter", () => {
+        const windowsPath = "d:/projects/docs/images/logo.png" as AbsoluteFilePath;
+        const result = convertToFernHostAbsoluteFilePath(windowsPath);
+        expect(result).toBe("/projects/docs/images/logo.png");
+    });
+});

--- a/packages/commons/fs-utils/src/dirname.ts
+++ b/packages/commons/fs-utils/src/dirname.ts
@@ -1,10 +1,11 @@
 import path from "path";
 
 import { AbsoluteFilePath } from "./AbsoluteFilePath.js";
+import { convertToOsPath } from "./osPathConverter.js";
 import { RelativeFilePath } from "./RelativeFilePath.js";
 
 export function dirname(filepath: RelativeFilePath): RelativeFilePath;
 export function dirname(filepath: AbsoluteFilePath): AbsoluteFilePath;
 export function dirname(filepath: string): string {
-    return path.dirname(filepath);
+    return convertToOsPath(path.dirname(filepath));
 }

--- a/packages/commons/fs-utils/src/join.ts
+++ b/packages/commons/fs-utils/src/join.ts
@@ -1,11 +1,12 @@
 import path from "path";
 
 import { AbsoluteFilePath } from "./AbsoluteFilePath.js";
+import { convertToOsPath } from "./osPathConverter.js";
 import { RelativeFilePath } from "./RelativeFilePath.js";
 
 export function join(first: RelativeFilePath, ...parts: RelativeFilePath[]): RelativeFilePath;
 export function join(first: AbsoluteFilePath, ...parts: RelativeFilePath[]): AbsoluteFilePath;
 export function join(...parts: RelativeFilePath[]): RelativeFilePath;
 export function join(...parts: string[]): string {
-    return path.join(...parts);
+    return convertToOsPath(path.join(...parts));
 }

--- a/packages/commons/fs-utils/src/osPathConverter.ts
+++ b/packages/commons/fs-utils/src/osPathConverter.ts
@@ -16,7 +16,7 @@ export function convertToFernHostRelativeFilePath(path: RelativeFilePath): Relat
 
 function convertToFernHostPath(path: string): string {
     let unixPath = path;
-    if (/^[a-zA-Z]:\\/.test(path)) {
+    if (/^[a-zA-Z]:[/\\]/.test(path)) {
         unixPath = path.substring(2);
     }
 

--- a/packages/commons/fs-utils/src/resolve.ts
+++ b/packages/commons/fs-utils/src/resolve.ts
@@ -5,5 +5,5 @@ import { convertToOsPath } from "./osPathConverter.js";
 
 export function resolve(first: AbsoluteFilePath, ...rest: string[]): AbsoluteFilePath;
 export function resolve(...paths: string[]): string {
-    return path.resolve(...paths.map(convertToOsPath));
+    return convertToOsPath(path.resolve(...paths.map(convertToOsPath)));
 }


### PR DESCRIPTION
## Description

Fixes a known bug where images fail to load on Windows in both `fern docs dev` and `fern generate docs`. The browser shows "Not allowed to load local resource" errors with `file:///C:/Users/...` paths because image path resolution produces inconsistent path separators on Windows.

## Root Cause

On Windows, Node.js `path.resolve()`, `path.dirname()`, and `path.join()` output backslash (`\`) separators, but `AbsoluteFilePath.of()` normalizes to forward slashes (`/`) via `convertToOsPath`. This inconsistency causes file ID lookups to fail during image path replacement:

1. `parseImagePaths` resolves relative image paths → `resolve()` returns `C:\Users\...\image.png` (backslashes)
2. These paths are stored in `fileIdsMap` and injected into markdown
3. `replaceImagePathsAndUrls` looks up `AbsoluteFilePath.of(image)` → normalizes to `C:/Users/.../image.png` (forward slashes)
4. **Lookup fails** because the map key uses `\` but the lookup uses `/`
5. Raw absolute `file:///` paths remain in the rendered HTML → browser blocks them

Additionally, `convertToFernHostPath` only handled `C:\` (backslash) when stripping Windows drive letters, not `C:/` (forward slash), which could produce broken `/_local` URLs after path normalization.

## Changes Made

- **`packages/commons/fs-utils/src/resolve.ts`**: Wrap `path.resolve()` output with `convertToOsPath()` to normalize to forward slashes
- **`packages/commons/fs-utils/src/dirname.ts`**: Wrap `path.dirname()` output with `convertToOsPath()` to normalize to forward slashes
- **`packages/commons/fs-utils/src/join.ts`**: Wrap `path.join()` output with `convertToOsPath()` to normalize to forward slashes
- **`packages/commons/fs-utils/src/osPathConverter.ts`**: Update `convertToFernHostPath` regex from `^[a-zA-Z]:\\` to `^[a-zA-Z]:[/\\]` to handle both `C:\` and `C:/`
- **`docs-preview-smoke-test/`**: Add image to smoke test fixture and Playwright assertion that verifies rendered `<img>` tags don't contain `file:///`, Windows drive letters, URL-encoded backslashes, or raw backslashes — runs on all platforms (ubuntu, macOS, Windows)
- [ ] Updated README.md generator (if applicable)

## Testing

- [x] Unit tests added/updated
  - Added `osPathConverter.test.ts` verifying `convertToFernHostAbsoluteFilePath` handles `C:/` (forward-slash) Windows paths
  - Added cross-platform round-trip tests in `parseImagePaths.test.ts` verifying that `parseImagePaths` → `replaceImagePathsAndUrls` correctly resolves file IDs
  - Added test verifying resolved filepaths never contain backslashes
- [x] Playwright smoke test added
  - Added `plant-logo.svg` image to smoke test fixture
  - Added image reference in `welcome.mdx`
  - Added Playwright test asserting all rendered `<img>` src attributes are valid (no `file:///`, no drive letters, no `%5C`, no backslashes)
  - Test runs on ubuntu, macOS, and Windows via `docs-bundle-smoke-test` workflow
- [x] All 14 fs-utils tests pass
- [x] All 196 docs-markdown-utils tests pass
- [x] Lint checks pass (`pnpm lint:biome`, `pnpm format`)


Link to Devin session: https://app.devin.ai/sessions/ced86a2258d04cea8bdc225210f15e93
Requested by: @thesandlord