### PR TITLE
feat(cli): add Python (PyPI) support to `fern sdk preview`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 </div>
 
-# 🌿 What is Fern?
+# 🌿 What is Fern? 
 
 Fern is a platform that transforms your API definitions into production-ready SDKs and beautiful documentation in minutes. 
 

--- a/packages/cli/cli/changes/unreleased/sdk-preview-pypi.yml
+++ b/packages/cli/cli/changes/unreleased/sdk-preview-pypi.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Expand `fern sdk preview` to support Python generators publishing to a PyPI
+    registry. Supports remote and local generation paths and emits a `pip install`
+    command for sharing in PR reviews. Requires `FERN_PREVIEW_PYPI_REGISTRY_URL`
+    or `--output <url>`. `--push-diff` for Python is deferred to a future release.
+  type: feat

--- a/packages/cli/cli/src/commands/automations/__test__/listPreviewGroups.test.ts
+++ b/packages/cli/cli/src/commands/automations/__test__/listPreviewGroups.test.ts
@@ -72,15 +72,17 @@ describe("listPreviewGroups", () => {
         });
     });
 
-    describe("non-TypeScript generators", () => {
-        it("excludes Python SDK generators", () => {
+    describe("generators not supported for SDK preview", () => {
+        it("includes Python SDK generators", () => {
             const workspace = makeWorkspace(undefined, [
                 makeGroup("python", [makeGenerator("fernapi/fern-python-sdk")])
             ]);
 
             const result = listPreviewGroups({ workspaces: [workspace], groupFilter: undefined });
 
-            expect(result).toEqual([]);
+            expect(result).toEqual([
+                { groupName: "python", apiName: null, generator: "fernapi/fern-python-sdk" }
+            ]);
         });
 
         it("excludes Java SDK generators", () => {

--- a/packages/cli/cli/src/commands/automations/listPreviewGroups.ts
+++ b/packages/cli/cli/src/commands/automations/listPreviewGroups.ts
@@ -1,5 +1,5 @@
 import type { AbstractAPIWorkspace } from "@fern-api/api-workspace-commons";
-import { isNpmGenerator } from "../sdk-preview/overrideOutputForPreview.js";
+import { getPreviewLanguage } from "../sdk-preview/overrideOutputForPreview.js";
 
 export interface PreviewGroup {
     groupName: string;
@@ -12,7 +12,7 @@ export interface PreviewGroup {
  *
  * A generator is considered previewable when:
  * - `automation.preview` is not false in generators.yml
- * - It is a supported TypeScript/npm generator (fern-typescript-sdk, node-sdk, browser-sdk)
+ * - It is a supported SDK preview generator (TypeScript/npm or Python/pypi)
  *
  * Returns one entry per unique (groupName, apiName) pair. When a group
  * contains multiple matching generators, the first match is used for the
@@ -43,7 +43,7 @@ export function listPreviewGroups({
             // generators in the group, so we only need to know *that*
             // the group is previewable, not list every generator.
             const firstPreviewable = group.generators.find(
-                (generator) => generator.automation.preview && isNpmGenerator(generator.name)
+                (generator) => generator.automation.preview && getPreviewLanguage(generator.name) != null
             );
             if (firstPreviewable != null) {
                 results.push({

--- a/packages/cli/cli/src/commands/sdk-preview/__test__/installCommand.test.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/__test__/installCommand.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+function npmInstall({
+    originalPackageName,
+    previewPackageName,
+    previewVersion,
+    registryUrl
+}: {
+    originalPackageName: string;
+    previewPackageName: string;
+    previewVersion: string;
+    registryUrl: string;
+}): string {
+    return (
+        `npm install ${originalPackageName}@npm:${previewPackageName}@${previewVersion} ` + `--registry ${registryUrl}`
+    );
+}
+
+function pipInstall({
+    previewPackageName,
+    previewVersion,
+    registryUrl
+}: {
+    previewPackageName: string;
+    previewVersion: string;
+    registryUrl: string;
+}): string {
+    return `pip install ${previewPackageName}==${previewVersion} --index-url ${registryUrl}`;
+}
+
+describe("install command formatting", () => {
+    it("npm canonical", () => {
+        expect(
+            npmInstall({
+                originalPackageName: "@acme/sdk",
+                previewPackageName: "@acme-preview/sdk",
+                previewVersion: "0.0.1-feat-add-auth.1710434700",
+                registryUrl: "https://npm.buildwithfern.com"
+            })
+        ).toBe(
+            "npm install @acme/sdk@npm:@acme-preview/sdk@0.0.1-feat-add-auth.1710434700 " +
+                "--registry https://npm.buildwithfern.com"
+        );
+    });
+
+    it("pypi canonical", () => {
+        expect(
+            pipInstall({
+                previewPackageName: "acme-preview-acme-sdk",
+                previewVersion: "0.0.1.dev1710434700+feat.add.auth",
+                registryUrl: "https://pypi.example.com/legacy/"
+            })
+        ).toBe(
+            "pip install acme-preview-acme-sdk==0.0.1.dev1710434700+feat.add.auth " +
+                "--index-url https://pypi.example.com/legacy/"
+        );
+    });
+
+    it("pypi with PEP 503-normalized name", () => {
+        expect(
+            pipInstall({
+                previewPackageName: "acme-preview-acme-sdk",
+                previewVersion: "0.0.1.dev1710434700+feat.add.auth",
+                registryUrl: "https://pypi.example.com/legacy/"
+            })
+        ).toContain("acme-preview-acme-sdk==");
+    });
+
+    it("pypi with +-segment in version is preserved verbatim in pip URL position", () => {
+        const cmd = pipInstall({
+            previewPackageName: "acme-preview-acme-sdk",
+            previewVersion: "0.0.1.dev1+feat.x",
+            registryUrl: "https://pypi.example.com/legacy/"
+        });
+        expect(cmd).toContain("==0.0.1.dev1+feat.x ");
+    });
+});

--- a/packages/cli/cli/src/commands/sdk-preview/__test__/overrideOutputForPreview.test.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/__test__/overrideOutputForPreview.test.ts
@@ -1,4 +1,3 @@
-import type { generatorsYml } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
 import { describe, expect, it } from "vitest";
@@ -9,45 +8,7 @@ import {
     overrideGroupOutputForDownload,
     overrideGroupOutputForPreview
 } from "../overrideOutputForPreview.js";
-
-/**
- * Creates a minimal GeneratorInvocation for testing.
- * Only the fields relevant to output mode override logic are set;
- * everything else uses safe defaults.
- */
-function makeGenerator(
-    outputMode: FernFiddle.remoteGen.OutputMode,
-    overrides?: Partial<generatorsYml.GeneratorInvocation>
-): generatorsYml.GeneratorInvocation {
-    return {
-        name: "fernapi/fern-typescript-node-sdk",
-        version: "0.57.10",
-        config: {},
-        outputMode,
-        automation: { generate: false, upgrade: false, preview: false, verify: false },
-        containerImage: undefined,
-        irVersionOverride: undefined,
-        absolutePathToLocalOutput: AbsoluteFilePath.of("/tmp/test-output"),
-        absolutePathToLocalSnippets: undefined,
-        keywords: undefined,
-        smartCasing: false,
-        disableExamples: false,
-        language: undefined,
-        publishMetadata: undefined,
-        readme: undefined,
-        settings: undefined,
-        ...overrides
-    };
-}
-
-function makeGroup(generators: generatorsYml.GeneratorInvocation[]): generatorsYml.GeneratorGroup {
-    return {
-        groupName: "test-group",
-        audiences: { type: "all" },
-        generators,
-        reviewers: undefined
-    };
-}
+import { makeGroup, makeNpmGenerator } from "./test-utils.js";
 
 describe("isNpmGenerator", () => {
     it("recognizes known TypeScript SDK generators", () => {
@@ -156,7 +117,7 @@ describe("getGithubOwnerRepo", () => {
 
 describe("overrideGroupOutputForDownload", () => {
     it("overrides output mode to downloadFiles", () => {
-        const generator = makeGenerator(
+        const generator = makeNpmGenerator(
             FernFiddle.OutputMode.publishV2(
                 FernFiddle.remoteGen.PublishOutputModeV2.npmOverride({
                     registryUrl: "https://registry.npmjs.org",
@@ -176,7 +137,7 @@ describe("overrideGroupOutputForDownload", () => {
     });
 
     it("preserves other generator fields", () => {
-        const generator = makeGenerator(FernFiddle.OutputMode.github({ owner: "o", repo: "r" }), {
+        const generator = makeNpmGenerator(FernFiddle.OutputMode.github({ owner: "o", repo: "r" }), {
             name: "fernapi/fern-typescript-sdk",
             version: "1.0.0"
         });
@@ -189,8 +150,8 @@ describe("overrideGroupOutputForDownload", () => {
     });
 
     it("overrides all generators in the group", () => {
-        const gen1 = makeGenerator(FernFiddle.OutputMode.github({ owner: "o", repo: "r" }));
-        const gen2 = makeGenerator(
+        const gen1 = makeNpmGenerator(FernFiddle.OutputMode.github({ owner: "o", repo: "r" }));
+        const gen2 = makeNpmGenerator(
             FernFiddle.OutputMode.publishV2(
                 FernFiddle.remoteGen.PublishOutputModeV2.npmOverride({
                     registryUrl: "https://npm.buildwithfern.com",
@@ -219,7 +180,7 @@ describe("overrideGroupOutputForPreview", () => {
     };
 
     it("always uses publishV2(npmOverride) for github output modes", () => {
-        const generator = makeGenerator(FernFiddle.OutputMode.github({ owner: "o", repo: "r" }));
+        const generator = makeNpmGenerator(FernFiddle.OutputMode.github({ owner: "o", repo: "r" }));
         const group = makeGroup([generator]);
 
         const result = overrideGroupOutputForPreview({ group, ...previewParams });
@@ -231,7 +192,7 @@ describe("overrideGroupOutputForPreview", () => {
     });
 
     it("uses publishV2(npmOverride) for githubV2 output modes", () => {
-        const generator = makeGenerator(
+        const generator = makeNpmGenerator(
             FernFiddle.OutputMode.githubV2(
                 FernFiddle.GithubOutputModeV2.push({
                     owner: "fern-demo",
@@ -250,7 +211,7 @@ describe("overrideGroupOutputForPreview", () => {
     });
 
     it("uses publishV2(npmOverride) for existing publishV2 output modes", () => {
-        const generator = makeGenerator(
+        const generator = makeNpmGenerator(
             FernFiddle.OutputMode.publishV2(
                 FernFiddle.remoteGen.PublishOutputModeV2.npmOverride({
                     registryUrl: "https://registry.npmjs.org",
@@ -268,7 +229,7 @@ describe("overrideGroupOutputForPreview", () => {
     });
 
     it("uses publishV2(npmOverride) for downloadFiles output modes", () => {
-        const generator = makeGenerator(FernFiddle.remoteGen.OutputMode.downloadFiles({}));
+        const generator = makeNpmGenerator(FernFiddle.remoteGen.OutputMode.downloadFiles({}));
         const group = makeGroup([generator]);
 
         const result = overrideGroupOutputForPreview({ group, ...previewParams });
@@ -277,7 +238,7 @@ describe("overrideGroupOutputForPreview", () => {
     });
 
     it("clears absolutePathToLocalOutput", () => {
-        const generator = makeGenerator(FernFiddle.OutputMode.github({ owner: "o", repo: "r" }), {
+        const generator = makeNpmGenerator(FernFiddle.OutputMode.github({ owner: "o", repo: "r" }), {
             absolutePathToLocalOutput: AbsoluteFilePath.of("/tmp/original-output")
         });
         const group = makeGroup([generator]);
@@ -288,7 +249,7 @@ describe("overrideGroupOutputForPreview", () => {
     });
 
     it("preserves group-level fields", () => {
-        const generator = makeGenerator(FernFiddle.remoteGen.OutputMode.downloadFiles({}));
+        const generator = makeNpmGenerator(FernFiddle.remoteGen.OutputMode.downloadFiles({}));
         const group = makeGroup([generator]);
         group.groupName = "my-preview-group";
 
@@ -300,7 +261,7 @@ describe("overrideGroupOutputForPreview", () => {
 
 describe("overrideGroupOutputForDiffBranch", () => {
     it("produces githubV2(push) for generators with github config", () => {
-        const generator = makeGenerator(
+        const generator = makeNpmGenerator(
             FernFiddle.OutputMode.githubV2(
                 FernFiddle.GithubOutputModeV2.push({
                     owner: "fern-demo",
@@ -327,7 +288,7 @@ describe("overrideGroupOutputForDiffBranch", () => {
             packageName: "@fern-demo/sdk-preview-test",
             token: "npm-token-123"
         });
-        const generator = makeGenerator(
+        const generator = makeNpmGenerator(
             FernFiddle.OutputMode.githubV2(
                 FernFiddle.GithubOutputModeV2.push({
                     owner: "fern-demo",
@@ -396,7 +357,7 @@ describe("overrideGroupOutputForDiffBranch", () => {
     });
 
     it("extracts owner/repo from github v1 output mode", () => {
-        const generator = makeGenerator(FernFiddle.OutputMode.github({ owner: "legacy-org", repo: "legacy-sdk" }));
+        const generator = makeNpmGenerator(FernFiddle.OutputMode.github({ owner: "legacy-org", repo: "legacy-sdk" }));
         const group = makeGroup([generator]);
 
         const result = overrideGroupOutputForDiffBranch({ group });
@@ -406,7 +367,7 @@ describe("overrideGroupOutputForDiffBranch", () => {
     });
 
     it("extracts owner/repo from githubV2 commitAndRelease", () => {
-        const generator = makeGenerator(
+        const generator = makeNpmGenerator(
             FernFiddle.OutputMode.githubV2(
                 FernFiddle.GithubOutputModeV2.commitAndRelease({
                     owner: "my-org",
@@ -423,7 +384,7 @@ describe("overrideGroupOutputForDiffBranch", () => {
     });
 
     it("excludes generators without github config (publishV2)", () => {
-        const generator = makeGenerator(
+        const generator = makeNpmGenerator(
             FernFiddle.OutputMode.publishV2(
                 FernFiddle.remoteGen.PublishOutputModeV2.npmOverride({
                     registryUrl: "https://registry.npmjs.org",
@@ -441,7 +402,7 @@ describe("overrideGroupOutputForDiffBranch", () => {
     });
 
     it("excludes generators without github config (downloadFiles)", () => {
-        const generator = makeGenerator(FernFiddle.remoteGen.OutputMode.downloadFiles({}));
+        const generator = makeNpmGenerator(FernFiddle.remoteGen.OutputMode.downloadFiles({}));
         const group = makeGroup([generator]);
 
         const result = overrideGroupOutputForDiffBranch({ group });
@@ -450,7 +411,7 @@ describe("overrideGroupOutputForDiffBranch", () => {
     });
 
     it("keeps only generators with github config in mixed groups", () => {
-        const githubGen = makeGenerator(
+        const githubGen = makeNpmGenerator(
             FernFiddle.OutputMode.githubV2(
                 FernFiddle.GithubOutputModeV2.push({
                     owner: "fern-demo",
@@ -461,7 +422,7 @@ describe("overrideGroupOutputForDiffBranch", () => {
                 })
             )
         );
-        const registryGen = makeGenerator(
+        const registryGen = makeNpmGenerator(
             FernFiddle.OutputMode.publishV2(
                 FernFiddle.remoteGen.PublishOutputModeV2.npmOverride({
                     registryUrl: "https://npm.buildwithfern.com",
@@ -480,7 +441,7 @@ describe("overrideGroupOutputForDiffBranch", () => {
     });
 
     it("preserves group-level fields", () => {
-        const generator = makeGenerator(
+        const generator = makeNpmGenerator(
             FernFiddle.OutputMode.githubV2(
                 FernFiddle.GithubOutputModeV2.push({
                     owner: "o",

--- a/packages/cli/cli/src/commands/sdk-preview/__test__/overrideOutputForPreview.test.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/__test__/overrideOutputForPreview.test.ts
@@ -3,44 +3,11 @@ import { FernFiddle } from "@fern-fern/fiddle-sdk";
 import { describe, expect, it } from "vitest";
 import {
     getGithubOwnerRepo,
-    isNpmGenerator,
     overrideGroupOutputForDiffBranch,
     overrideGroupOutputForDownload,
     overrideGroupOutputForPreview
 } from "../overrideOutputForPreview.js";
-import { makeGroup, makeNpmGenerator } from "./test-utils.js";
-
-describe("isNpmGenerator", () => {
-    it("recognizes known TypeScript SDK generators", () => {
-        expect(isNpmGenerator("fernapi/fern-typescript-node-sdk")).toBe(true);
-        expect(isNpmGenerator("fernapi/fern-typescript-browser-sdk")).toBe(true);
-        expect(isNpmGenerator("fernapi/fern-typescript-sdk")).toBe(true);
-    });
-
-    it("rejects unknown typescript generators not in the set", () => {
-        expect(isNpmGenerator("custom/my-typescript-generator")).toBe(false);
-    });
-
-    it("rejects Python generators", () => {
-        expect(isNpmGenerator("fernapi/fern-python-sdk")).toBe(false);
-    });
-
-    it("rejects Java generators", () => {
-        expect(isNpmGenerator("fernapi/fern-java-sdk")).toBe(false);
-    });
-
-    it("rejects Go generators", () => {
-        expect(isNpmGenerator("fernapi/fern-go-sdk")).toBe(false);
-    });
-
-    it("rejects Ruby generators", () => {
-        expect(isNpmGenerator("fernapi/fern-ruby-sdk")).toBe(false);
-    });
-
-    it("rejects C# generators", () => {
-        expect(isNpmGenerator("fernapi/fern-csharp-sdk")).toBe(false);
-    });
-});
+import { makeGroup, makeNpmGenerator, makePypiGenerator } from "./test-utils.js";
 
 describe("getGithubOwnerRepo", () => {
     it("returns undefined for downloadFiles", () => {
@@ -174,6 +141,7 @@ describe("overrideGroupOutputForDownload", () => {
 
 describe("overrideGroupOutputForPreview", () => {
     const previewParams = {
+        language: "npm" as const,
         packageName: "@fern-preview/acme-sdk",
         token: "fern-token-123",
         registryUrl: "https://npm.buildwithfern.com"
@@ -458,5 +426,46 @@ describe("overrideGroupOutputForDiffBranch", () => {
         const result = overrideGroupOutputForDiffBranch({ group });
 
         expect(result.groupName).toBe("my-diff-group");
+    });
+});
+
+describe("overrideGroupOutputForPreview - pypi", () => {
+    it("uses publishV2(pypiOverride) when language is pypi", () => {
+        const generator = makePypiGenerator(FernFiddle.remoteGen.OutputMode.downloadFiles({}));
+        const group = makeGroup([generator]);
+        const result = overrideGroupOutputForPreview({
+            group,
+            language: "pypi",
+            packageName: "acme-preview-acme-sdk",
+            token: "pypi-pw",
+            registryUrl: "https://pypi.example.com/legacy/"
+        });
+
+        const outputMode = result.generators[0]?.outputMode;
+        expect(outputMode?.type).toBe("publishV2");
+        outputMode?._visit({
+            publishV2: (v) =>
+                v._visit({
+                    pypiOverride: (p) => {
+                        expect(p).toBeDefined();
+                        expect(p?.coordinate).toBe("acme-preview-acme-sdk");
+                        expect(p?.username).toBe("__token__");
+                        expect(p?.password).toBe("pypi-pw");
+                        expect(p?.registryUrl).toBe("https://pypi.example.com/legacy/");
+                    },
+                    npmOverride: () => expect.fail("expected pypiOverride"),
+                    mavenOverride: () => expect.fail("expected pypiOverride"),
+                    nugetOverride: () => expect.fail("expected pypiOverride"),
+                    rubyGemsOverride: () => expect.fail("expected pypiOverride"),
+                    cratesOverride: () => expect.fail("expected pypiOverride"),
+                    postman: () => expect.fail("expected pypiOverride"),
+                    _other: () => expect.fail("expected pypiOverride")
+                }),
+            downloadFiles: () => expect.fail("expected publishV2"),
+            github: () => expect.fail("expected publishV2"),
+            githubV2: () => expect.fail("expected publishV2"),
+            publish: () => expect.fail("expected publishV2"),
+            _other: () => expect.fail("expected publishV2")
+        });
     });
 });

--- a/packages/cli/cli/src/commands/sdk-preview/__test__/pep440.test.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/__test__/pep440.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { isValidPep440DevLocalVersion } from "../pep440.js";
+
+describe("isValidPep440DevLocalVersion", () => {
+    describe("valid versions", () => {
+        it("accepts canonical dev + local segment shape we generate", () => {
+            expect(isValidPep440DevLocalVersion("0.0.1.dev1710434700+feat.add.auth")).toBe(true);
+        });
+
+        it("accepts numeric branch names in local segment", () => {
+            expect(isValidPep440DevLocalVersion("0.0.1.dev1710434700+123.numeric")).toBe(true);
+        });
+
+        it("accepts a single-segment local version", () => {
+            expect(isValidPep440DevLocalVersion("0.0.1.dev1+main")).toBe(true);
+        });
+
+        it("accepts release without dev or local", () => {
+            expect(isValidPep440DevLocalVersion("0.0.1")).toBe(true);
+        });
+
+        it("accepts release with local but no dev", () => {
+            expect(isValidPep440DevLocalVersion("0.0.1+local.id")).toBe(true);
+        });
+
+        it("accepts long-but-bounded local segments", () => {
+            const long = "a".repeat(63);
+            expect(isValidPep440DevLocalVersion(`0.0.1.dev1+${long}`)).toBe(true);
+        });
+    });
+
+    describe("invalid versions", () => {
+        it("rejects empty string", () => {
+            expect(isValidPep440DevLocalVersion("")).toBe(false);
+        });
+
+        it("rejects hyphens in local segment (PEP 440 allows but we restrict)", () => {
+            expect(isValidPep440DevLocalVersion("0.0.1.dev1+feat-add-auth")).toBe(false);
+        });
+
+        it("rejects underscores in local segment (we restrict to dots)", () => {
+            expect(isValidPep440DevLocalVersion("0.0.1.dev1+feat_add_auth")).toBe(false);
+        });
+
+        it("rejects local segment with leading dot", () => {
+            expect(isValidPep440DevLocalVersion("0.0.1.dev1+.foo")).toBe(false);
+        });
+
+        it("rejects local segment with trailing dot", () => {
+            expect(isValidPep440DevLocalVersion("0.0.1.dev1+foo.")).toBe(false);
+        });
+
+        it("rejects empty local segment", () => {
+            expect(isValidPep440DevLocalVersion("0.0.1.dev1+")).toBe(false);
+        });
+
+        it("rejects uppercase in local segment (PEP 503 normalization)", () => {
+            expect(isValidPep440DevLocalVersion("0.0.1.dev1+Foo")).toBe(false);
+        });
+
+        it("rejects unicode in local segment", () => {
+            expect(isValidPep440DevLocalVersion("0.0.1.dev1+caf\u00e9")).toBe(false);
+        });
+
+        it("rejects local segment longer than 64 chars", () => {
+            const tooLong = "a".repeat(65);
+            expect(isValidPep440DevLocalVersion(`0.0.1.dev1+${tooLong}`)).toBe(false);
+        });
+    });
+});

--- a/packages/cli/cli/src/commands/sdk-preview/__test__/previewStrategies.test.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/__test__/previewStrategies.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { getPreviewLanguage, npmPreviewStrategy, pypiPreviewStrategy } from "../previewStrategies.js";
+
+describe("getPreviewLanguage", () => {
+    it("recognizes known TypeScript SDK generators as npm", () => {
+        expect(getPreviewLanguage("fernapi/fern-typescript-node-sdk")).toBe("npm");
+        expect(getPreviewLanguage("fernapi/fern-typescript-browser-sdk")).toBe("npm");
+        expect(getPreviewLanguage("fernapi/fern-typescript-sdk")).toBe("npm");
+    });
+
+    it("recognizes Python SDK as pypi", () => {
+        expect(getPreviewLanguage("fernapi/fern-python-sdk")).toBe("pypi");
+    });
+
+    it("returns undefined for unknown TypeScript generators", () => {
+        expect(getPreviewLanguage("custom/my-typescript-generator")).toBeUndefined();
+    });
+
+    it("returns undefined for Java generators", () => {
+        expect(getPreviewLanguage("fernapi/fern-java-sdk")).toBeUndefined();
+    });
+
+    it("returns undefined for Go generators", () => {
+        expect(getPreviewLanguage("fernapi/fern-go-sdk")).toBeUndefined();
+    });
+
+    it("returns undefined for Ruby generators", () => {
+        expect(getPreviewLanguage("fernapi/fern-ruby-sdk")).toBeUndefined();
+    });
+
+    it("returns undefined for C# generators", () => {
+        expect(getPreviewLanguage("fernapi/fern-csharp-sdk")).toBeUndefined();
+    });
+});
+
+describe("npmPreviewStrategy.buildOutputMode", () => {
+    it("produces publishV2(npmOverride) with the supplied fields", () => {
+        const mode = npmPreviewStrategy.buildOutputMode({
+            registryUrl: "https://npm.example.com",
+            packageName: "@acme-preview/sdk",
+            token: "tok-123"
+        });
+        expect(mode.type).toBe("publishV2");
+        let captured: { registryUrl?: string; packageName?: string; token?: string } = {};
+        mode._visit<void>({
+            publishV2: (v) =>
+                v._visit<void>({
+                    npmOverride: (n) => {
+                        captured = {
+                            registryUrl: n?.registryUrl,
+                            packageName: n?.packageName,
+                            token: n?.token
+                        };
+                    },
+                    pypiOverride: () => expect.fail("expected npmOverride"),
+                    mavenOverride: () => expect.fail("expected npmOverride"),
+                    nugetOverride: () => expect.fail("expected npmOverride"),
+                    rubyGemsOverride: () => expect.fail("expected npmOverride"),
+                    cratesOverride: () => expect.fail("expected npmOverride"),
+                    postman: () => expect.fail("expected npmOverride"),
+                    _other: () => expect.fail("expected npmOverride")
+                }),
+            downloadFiles: () => expect.fail("expected publishV2"),
+            github: () => expect.fail("expected publishV2"),
+            githubV2: () => expect.fail("expected publishV2"),
+            publish: () => expect.fail("expected publishV2"),
+            _other: () => expect.fail("expected publishV2")
+        });
+        expect(captured).toEqual({
+            registryUrl: "https://npm.example.com",
+            packageName: "@acme-preview/sdk",
+            token: "tok-123"
+        });
+    });
+});
+
+describe("pypiPreviewStrategy.buildOutputMode", () => {
+    it("produces publishV2(pypiOverride) with username '__token__'", () => {
+        const mode = pypiPreviewStrategy.buildOutputMode({
+            registryUrl: "https://pypi.example.com/legacy/",
+            packageName: "acme-preview-acme-sdk",
+            token: "pypi-pw"
+        });
+        expect(mode.type).toBe("publishV2");
+        let captured: {
+            registryUrl?: string;
+            coordinate?: string;
+            username?: string;
+            password?: string;
+        } = {};
+        mode._visit<void>({
+            publishV2: (v) =>
+                v._visit<void>({
+                    pypiOverride: (p) => {
+                        captured = {
+                            registryUrl: p?.registryUrl,
+                            coordinate: p?.coordinate,
+                            username: p?.username,
+                            password: p?.password
+                        };
+                    },
+                    npmOverride: () => expect.fail("expected pypiOverride"),
+                    mavenOverride: () => expect.fail("expected pypiOverride"),
+                    nugetOverride: () => expect.fail("expected pypiOverride"),
+                    rubyGemsOverride: () => expect.fail("expected pypiOverride"),
+                    cratesOverride: () => expect.fail("expected pypiOverride"),
+                    postman: () => expect.fail("expected pypiOverride"),
+                    _other: () => expect.fail("expected pypiOverride")
+                }),
+            downloadFiles: () => expect.fail("expected publishV2"),
+            github: () => expect.fail("expected publishV2"),
+            githubV2: () => expect.fail("expected publishV2"),
+            publish: () => expect.fail("expected publishV2"),
+            _other: () => expect.fail("expected publishV2")
+        });
+        expect(captured).toEqual({
+            registryUrl: "https://pypi.example.com/legacy/",
+            coordinate: "acme-preview-acme-sdk",
+            username: "__token__",
+            password: "pypi-pw"
+        });
+    });
+});
+
+describe("sanitizeForVersion", () => {
+    it("npm passes through unchanged", () => {
+        expect(npmPreviewStrategy.sanitizeForVersion("feat-add-auth")).toBe("feat-add-auth");
+    });
+
+    it("pypi collapses to dots and lowercases", () => {
+        expect(pypiPreviewStrategy.sanitizeForVersion("Feat-Add_Auth")).toBe("feat.add.auth");
+    });
+
+    it("pypi handles empty string", () => {
+        expect(pypiPreviewStrategy.sanitizeForVersion("")).toBe("preview");
+    });
+
+    it("pypi caps length", () => {
+        const long = "a".repeat(80);
+        expect(pypiPreviewStrategy.sanitizeForVersion(long).length).toBeLessThanOrEqual(64);
+    });
+
+    it("pypi treats unicode as separator", () => {
+        expect(pypiPreviewStrategy.sanitizeForVersion("caf\u00e9-feat")).toBe("caf.feat");
+    });
+});

--- a/packages/cli/cli/src/commands/sdk-preview/__test__/sdkPreview.test.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/__test__/sdkPreview.test.ts
@@ -1,0 +1,321 @@
+import { CliError } from "@fern-api/task-context";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sdkPreview } from "../sdkPreview.js";
+import { makeGroup, makeNpmGenerator, makePypiGenerator } from "./test-utils.js";
+
+vi.mock("@fern-api/login", () => ({
+    askToLogin: vi.fn()
+}));
+vi.mock("../../../cliCommons.js", () => ({
+    loadProjectAndRegisterWorkspacesWithContext: vi.fn()
+}));
+vi.mock("@fern-api/remote-workspace-runner", () => ({
+    runRemoteGenerationForAPIWorkspace: vi.fn()
+}));
+
+const askToLogin = (await import("@fern-api/login")).askToLogin as ReturnType<typeof vi.fn>;
+const loadProject = (
+    (await import("../../../cliCommons.js")) as {
+        loadProjectAndRegisterWorkspacesWithContext: ReturnType<typeof vi.fn>;
+    }
+).loadProjectAndRegisterWorkspacesWithContext;
+const runRemote = (await import("@fern-api/remote-workspace-runner")).runRemoteGenerationForAPIWorkspace as ReturnType<
+    typeof vi.fn
+>;
+
+function makeCliContextStub() {
+    return {
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        runTask: async <T>(fn: (ctx: unknown) => Promise<T>) => fn({}),
+        runTaskForWorkspace: async <T>(_ws: unknown, fn: (ctx: unknown) => Promise<T>) => fn({})
+    } as unknown as Parameters<typeof sdkPreview>[0]["cliContext"];
+}
+
+function withPypiGroup(generator = makePypiGenerator(/* pypi output mode irrelevant for orchestration */ {} as never)) {
+    askToLogin.mockResolvedValue({ type: "user", value: "fern-token" });
+    loadProject.mockResolvedValue({
+        config: { organization: "acme" },
+        apiWorkspaces: [
+            {
+                workspaceName: "ws",
+                generatorsConfiguration: {
+                    defaultGroup: "preview",
+                    groups: [makeGroup([generator])],
+                    whitelabel: undefined
+                }
+            }
+        ]
+    });
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+afterEach(() => {
+    delete process.env.FERN_PREVIEW_PYPI_REGISTRY_URL;
+});
+
+describe("sdkPreview - npm happy path (preserved)", () => {
+    it("publishes a single npm preview successfully", async () => {
+        askToLogin.mockResolvedValue({ type: "user", value: "tok" });
+        loadProject.mockResolvedValue({
+            config: { organization: "acme" },
+            apiWorkspaces: [
+                {
+                    workspaceName: "ws",
+                    generatorsConfiguration: {
+                        defaultGroup: "preview",
+                        groups: [makeGroup([makeNpmGenerator({ type: "downloadFiles" } as never)])]
+                    }
+                }
+            ]
+        });
+        runRemote.mockResolvedValue(undefined);
+
+        const result = await sdkPreview({
+            cliContext: makeCliContextStub(),
+            groupName: "preview",
+            generatorFilter: undefined,
+            apiName: undefined,
+            output: undefined,
+            local: false,
+            pushDiff: false
+        });
+
+        expect(result.status).toBe("success");
+        if (result.status === "success") {
+            expect(result.previews).toHaveLength(1);
+            expect(result.previews[0]?.install).toMatch(/^npm install .+--registry https:\/\/npm\.buildwithfern\.com/);
+        }
+    });
+});
+
+describe("sdkPreview - pypi preflight failures", () => {
+    it("errors when no PyPI registry is configured", async () => {
+        withPypiGroup();
+        const result = await sdkPreview({
+            cliContext: makeCliContextStub(),
+            groupName: "preview",
+            generatorFilter: undefined,
+            apiName: undefined,
+            output: undefined,
+            local: false,
+            pushDiff: false
+        });
+        expect(result.status).toBe("error");
+        if (result.status === "error") {
+            expect(result.code).toBe(CliError.Code.ConfigError);
+            expect(result.message).toContain("FERN_PREVIEW_PYPI_REGISTRY_URL");
+        }
+    });
+
+    it("errors when PyPI token is missing", async () => {
+        process.env.FERN_PREVIEW_PYPI_REGISTRY_URL = "https://pypi.example.com/legacy/";
+        withPypiGroup();
+        askToLogin.mockResolvedValue({ type: "user", value: "" });
+        const result = await sdkPreview({
+            cliContext: makeCliContextStub(),
+            groupName: "preview",
+            generatorFilter: undefined,
+            apiName: undefined,
+            output: undefined,
+            local: false,
+            pushDiff: false
+        });
+        expect(result.status).toBe("error");
+        if (result.status === "error") {
+            expect(result.code).toBe(CliError.Code.AuthError);
+            expect(result.message).toContain("PyPI token");
+        }
+    });
+
+    it("errors when no Python generator is in the filtered group", async () => {
+        // generatorFilter targets a name not present anywhere
+        askToLogin.mockResolvedValue({ type: "user", value: "tok" });
+        loadProject.mockResolvedValue({
+            config: { organization: "acme" },
+            apiWorkspaces: [
+                {
+                    workspaceName: "ws",
+                    generatorsConfiguration: {
+                        defaultGroup: "preview",
+                        groups: [makeGroup([makeNpmGenerator({ type: "downloadFiles" } as never)])]
+                    }
+                }
+            ]
+        });
+        const result = await sdkPreview({
+            cliContext: makeCliContextStub(),
+            groupName: "preview",
+            generatorFilter: "fernapi/fern-python-sdk",
+            apiName: undefined,
+            output: undefined,
+            local: false,
+            pushDiff: false
+        });
+        expect(result.status).toBe("error");
+        if (result.status === "error") {
+            expect(result.code).toBe(CliError.Code.ConfigError);
+        }
+    });
+
+    it("rejects --push-diff when any Python generator is present", async () => {
+        process.env.FERN_PREVIEW_PYPI_REGISTRY_URL = "https://pypi.example.com/legacy/";
+        withPypiGroup();
+        const result = await sdkPreview({
+            cliContext: makeCliContextStub(),
+            groupName: "preview",
+            generatorFilter: undefined,
+            apiName: undefined,
+            output: undefined,
+            local: false,
+            pushDiff: true
+        });
+        expect(result.status).toBe("error");
+        if (result.status === "error") {
+            expect(result.message).toContain("--push-diff");
+            expect(result.message).toContain("v1");
+        }
+        expect(runRemote).not.toHaveBeenCalled();
+    });
+});
+
+describe("sdkPreview - pypi happy path", () => {
+    it("publishes and emits a pip install command", async () => {
+        process.env.FERN_PREVIEW_PYPI_REGISTRY_URL = "https://pypi.example.com/legacy/";
+        withPypiGroup();
+        runRemote.mockResolvedValue(undefined);
+
+        const result = await sdkPreview({
+            cliContext: makeCliContextStub(),
+            groupName: "preview",
+            generatorFilter: undefined,
+            apiName: undefined,
+            output: undefined,
+            local: false,
+            pushDiff: false
+        });
+        expect(result.status).toBe("success");
+        if (result.status === "success") {
+            expect(result.previews[0]?.install).toMatch(
+                /^pip install acme-preview-.+==0\.0\.1\.dev\d+\+.+ --index-url https:\/\/pypi\.example\.com\/legacy\/$/
+            );
+            expect(result.previews[0]?.version).toMatch(/^0\.0\.1\.dev\d+\+/);
+        }
+    });
+
+    it("surfaces version-already-uploaded as a clear error", async () => {
+        process.env.FERN_PREVIEW_PYPI_REGISTRY_URL = "https://pypi.example.com/legacy/";
+        withPypiGroup();
+        runRemote.mockRejectedValue(new Error("400 File already exists"));
+
+        const result = await sdkPreview({
+            cliContext: makeCliContextStub(),
+            groupName: "preview",
+            generatorFilter: undefined,
+            apiName: undefined,
+            output: undefined,
+            local: false,
+            pushDiff: false
+        });
+        expect(result.status).toBe("error");
+        if (result.status === "error") {
+            expect(result.message).toContain("already exists");
+            expect(result.message).toContain("Bump previewId");
+        }
+    });
+});
+
+describe("sdkPreview - parallel execution", () => {
+    it("fires both Fiddle calls concurrently", async () => {
+        process.env.FERN_PREVIEW_PYPI_REGISTRY_URL = "https://pypi.example.com/legacy/";
+        askToLogin.mockResolvedValue({ type: "user", value: "tok" });
+        loadProject.mockResolvedValue({
+            config: { organization: "acme" },
+            apiWorkspaces: [
+                {
+                    workspaceName: "ws",
+                    generatorsConfiguration: {
+                        defaultGroup: "preview",
+                        groups: [
+                            makeGroup([
+                                makeNpmGenerator({ type: "downloadFiles" } as never),
+                                makePypiGenerator({ type: "downloadFiles" } as never)
+                            ])
+                        ]
+                    }
+                }
+            ]
+        });
+
+        let inflight = 0;
+        let peakInflight = 0;
+        runRemote.mockImplementation(async () => {
+            inflight++;
+            peakInflight = Math.max(peakInflight, inflight);
+            await new Promise((r) => setTimeout(r, 10));
+            inflight--;
+        });
+
+        const result = await sdkPreview({
+            cliContext: makeCliContextStub(),
+            groupName: "preview",
+            generatorFilter: undefined,
+            apiName: undefined,
+            output: undefined,
+            local: false,
+            pushDiff: false
+        });
+        expect(result.status).toBe("success");
+        expect(peakInflight).toBeGreaterThanOrEqual(2);
+    });
+
+    it("emits a partial-success warning on mixed outcomes", async () => {
+        process.env.FERN_PREVIEW_PYPI_REGISTRY_URL = "https://pypi.example.com/legacy/";
+        askToLogin.mockResolvedValue({ type: "user", value: "tok" });
+        loadProject.mockResolvedValue({
+            config: { organization: "acme" },
+            apiWorkspaces: [
+                {
+                    workspaceName: "ws",
+                    generatorsConfiguration: {
+                        defaultGroup: "preview",
+                        groups: [
+                            makeGroup([
+                                makeNpmGenerator({ type: "downloadFiles" } as never),
+                                makePypiGenerator({ type: "downloadFiles" } as never)
+                            ])
+                        ]
+                    }
+                }
+            ]
+        });
+
+        const cli = makeCliContextStub();
+        let call = 0;
+        runRemote.mockImplementation(async () => {
+            call++;
+            if (call === 2) {
+                throw new Error("pypi network error");
+            }
+        });
+
+        const result = await sdkPreview({
+            cliContext: cli,
+            groupName: "preview",
+            generatorFilter: undefined,
+            apiName: undefined,
+            output: undefined,
+            local: false,
+            pushDiff: false
+        });
+        expect(result.status).toBe("success");
+        if (result.status === "success") {
+            expect(result.previews).toHaveLength(1);
+        }
+        const warnCalls = (cli.logger.warn as ReturnType<typeof vi.fn>).mock.calls.flat().join(" ");
+        expect(warnCalls).toContain("Successfully published 1 of 2");
+        expect(warnCalls).toContain("pypi network error");
+    });
+});

--- a/packages/cli/cli/src/commands/sdk-preview/__test__/test-utils.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/__test__/test-utils.ts
@@ -12,11 +12,17 @@ export function makeGenerator(
     outputMode: FernFiddle.remoteGen.OutputMode,
     overrides?: Partial<generatorsYml.GeneratorInvocation>
 ): generatorsYml.GeneratorInvocation {
+    // Test stubs may pass plain objects (e.g. `{ type: "downloadFiles" } as never`).
+    // Normalize to a proper FernFiddle instance so _visit() is always available.
+    const safeOutputMode =
+        typeof (outputMode as unknown as Record<string, unknown>)?._visit === "function"
+            ? outputMode
+            : FernFiddle.remoteGen.OutputMode.downloadFiles({});
     return {
         name,
         version: "0.0.1",
         config: {},
-        outputMode,
+        outputMode: safeOutputMode,
         automation: { generate: false, upgrade: false, preview: false, verify: false },
         containerImage: undefined,
         irVersionOverride: undefined,
@@ -39,6 +45,7 @@ export function makeNpmGenerator(
 ): generatorsYml.GeneratorInvocation {
     return makeGenerator("fernapi/fern-typescript-node-sdk", outputMode, {
         version: "0.57.10",
+        raw: { output: { location: "npm", "package-name": "@acme/sdk" } } as never,
         ...overrides
     });
 }
@@ -49,13 +56,14 @@ export function makePypiGenerator(
 ): generatorsYml.GeneratorInvocation {
     return makeGenerator("fernapi/fern-python-sdk", outputMode, {
         version: "4.3.8",
+        raw: { output: { location: "pypi", "package-name": "acme-sdk" } } as never,
         ...overrides
     });
 }
 
 export function makeGroup(generators: generatorsYml.GeneratorInvocation[]): generatorsYml.GeneratorGroup {
     return {
-        groupName: "test-group",
+        groupName: "preview",
         audiences: { type: "all" },
         generators,
         reviewers: undefined

--- a/packages/cli/cli/src/commands/sdk-preview/__test__/test-utils.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/__test__/test-utils.ts
@@ -1,0 +1,65 @@
+import type { generatorsYml } from "@fern-api/configuration-loader";
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { FernFiddle } from "@fern-fern/fiddle-sdk";
+
+/**
+ * Creates a minimal GeneratorInvocation for testing. NO language defaults;
+ * callers MUST pass a `name` via overrides or use `makeNpmGenerator` /
+ * `makePypiGenerator` factories below.
+ */
+export function makeGenerator(
+    name: string,
+    outputMode: FernFiddle.remoteGen.OutputMode,
+    overrides?: Partial<generatorsYml.GeneratorInvocation>
+): generatorsYml.GeneratorInvocation {
+    return {
+        name,
+        version: "0.0.1",
+        config: {},
+        outputMode,
+        automation: { generate: false, upgrade: false, preview: false, verify: false },
+        containerImage: undefined,
+        irVersionOverride: undefined,
+        absolutePathToLocalOutput: AbsoluteFilePath.of("/tmp/test-output"),
+        absolutePathToLocalSnippets: undefined,
+        keywords: undefined,
+        smartCasing: false,
+        disableExamples: false,
+        language: undefined,
+        publishMetadata: undefined,
+        readme: undefined,
+        settings: undefined,
+        ...overrides
+    };
+}
+
+export function makeNpmGenerator(
+    outputMode: FernFiddle.remoteGen.OutputMode,
+    overrides?: Partial<generatorsYml.GeneratorInvocation>
+): generatorsYml.GeneratorInvocation {
+    return makeGenerator("fernapi/fern-typescript-node-sdk", outputMode, {
+        version: "0.57.10",
+        ...overrides
+    });
+}
+
+export function makePypiGenerator(
+    outputMode: FernFiddle.remoteGen.OutputMode,
+    overrides?: Partial<generatorsYml.GeneratorInvocation>
+): generatorsYml.GeneratorInvocation {
+    return makeGenerator("fernapi/fern-python-sdk", outputMode, {
+        version: "4.3.8",
+        ...overrides
+    });
+}
+
+export function makeGroup(generators: generatorsYml.GeneratorInvocation[]): generatorsYml.GeneratorGroup {
+    return {
+        groupName: "test-group",
+        audiences: { type: "all" },
+        generators,
+        reviewers: undefined
+    };
+}
+
+

--- a/packages/cli/cli/src/commands/sdk-preview/__test__/toPreviewPackageName.test.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/__test__/toPreviewPackageName.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { toPreviewPackageName } from "../toPreviewPackageName.js";
+import { computePypiPreviewVersion, sanitizeForPypiLocalSegment } from "../computePreviewVersion.js";
+import { isValidPep440DevLocalVersion } from "../pep440.js";
+import { toPreviewPackageName, toPypiPreviewPackageName } from "../toPreviewPackageName.js";
 
 describe("toPreviewPackageName", () => {
     it("replaces existing scope with org-preview scope", () => {
@@ -23,5 +25,57 @@ describe("toPreviewPackageName", () => {
         expect(toPreviewPackageName("@fern-fern/docs-parsers-fern-definition", "fern")).toBe(
             "@fern-preview/docs-parsers-fern-definition"
         );
+    });
+});
+
+describe("toPypiPreviewPackageName", () => {
+    it("normalizes hyphens", () => {
+        expect(toPypiPreviewPackageName("acme-sdk", "acme")).toBe("acme-preview-acme-sdk");
+    });
+    it("normalizes underscores to hyphens (PEP 503)", () => {
+        expect(toPypiPreviewPackageName("acme_sdk", "acme")).toBe("acme-preview-acme-sdk");
+    });
+    it("normalizes dots to hyphens (PEP 503)", () => {
+        expect(toPypiPreviewPackageName("acme.sdk", "acme")).toBe("acme-preview-acme-sdk");
+    });
+    it("lowercases mixed-case names", () => {
+        expect(toPypiPreviewPackageName("Acme_SDK", "Acme")).toBe("acme-preview-acme-sdk");
+    });
+    it("collapses runs of separators", () => {
+        expect(toPypiPreviewPackageName("acme___sdk", "acme")).toBe("acme-preview-acme-sdk");
+    });
+});
+
+describe("computePypiPreviewVersion", () => {
+    it("produces a PEP 440-valid version for canonical preview ids", () => {
+        const v = computePypiPreviewVersion({ previewId: "feat-add-auth" });
+        expect(v).toMatch(/^0\.0\.1\.dev\d+\+feat\.add\.auth$/);
+        expect(isValidPep440DevLocalVersion(v)).toBe(true);
+    });
+    it("produces a PEP 440-valid version for slashed branch ids", () => {
+        const v = computePypiPreviewVersion({ previewId: "feat/x" });
+        expect(isValidPep440DevLocalVersion(v)).toBe(true);
+    });
+    it("produces a PEP 440-valid version for numeric prefix", () => {
+        const v = computePypiPreviewVersion({ previewId: "123-numeric" });
+        expect(isValidPep440DevLocalVersion(v)).toBe(true);
+    });
+    it("produces a PEP 440-valid version for RELEASE_BRANCH", () => {
+        const v = computePypiPreviewVersion({ previewId: "RELEASE_BRANCH" });
+        expect(isValidPep440DevLocalVersion(v)).toBe(true);
+    });
+    it("falls back to 'preview' for empty previewId", () => {
+        const v = computePypiPreviewVersion({ previewId: "" });
+        expect(v).toMatch(/^0\.0\.1\.dev\d+\+preview$/);
+    });
+});
+
+describe("sanitizeForPypiLocalSegment", () => {
+    it("rejects unicode by replacing with dot then collapsing", () => {
+        expect(sanitizeForPypiLocalSegment("caf\u00e9-feat")).toBe("caf.feat");
+    });
+    it("caps length at 64", () => {
+        const long = "a".repeat(80);
+        expect(sanitizeForPypiLocalSegment(long).length).toBeLessThanOrEqual(64);
     });
 });

--- a/packages/cli/cli/src/commands/sdk-preview/computePreviewVersion.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/computePreviewVersion.ts
@@ -15,3 +15,37 @@ export function computePreviewVersion({ previewId }: { previewId: string }): str
     const timestamp = Math.floor(Date.now() / 1000);
     return `${BASE_VERSION}-${previewId}.${timestamp}`;
 }
+
+/**
+ * PEP 440 sanitization: lowercase, collapse separators to single dots,
+ * strip leading/trailing dots. PEP 440's local segment allows
+ * `[a-z0-9]+(?:[.-_][a-z0-9]+)*` but we restrict to dots only for
+ * stricter cross-tooling compatibility.
+ *
+ * Examples:
+ *   "feat-add-auth"   -> "feat.add.auth"
+ *   "feat/add_auth"   -> "feat.add.auth"
+ *   "RELEASE_BRANCH"  -> "release.branch"
+ *   ""                -> "preview" (fallback)
+ */
+export function sanitizeForPypiLocalSegment(previewId: string): string {
+    const lowered = previewId.toLowerCase();
+    const collapsed = lowered.replace(/[^a-z0-9]+/g, ".").replace(/^\.+|\.+$/g, "");
+    const truncated = collapsed.slice(0, 64).replace(/\.+$/, "");
+    return truncated.length > 0 ? truncated : "preview";
+}
+
+/**
+ * Computes a PEP 440-compliant preview version for a PyPI package.
+ * Format: 0.0.1.dev{epoch}+{sanitizedPreviewId}
+ * Example: 0.0.1.dev1710434700+feat.add.auth
+ *
+ * - dev{epoch} guarantees uniqueness across runs (PEP 440 dev release).
+ * - +sanitized local segment is a human-readable hint that does not
+ *   participate in version ordering, so it cannot collide.
+ */
+export function computePypiPreviewVersion({ previewId }: { previewId: string }): string {
+    const epoch = Math.floor(Date.now() / 1000);
+    const local = sanitizeForPypiLocalSegment(previewId);
+    return `0.0.1.dev${epoch}+${local}`;
+}

--- a/packages/cli/cli/src/commands/sdk-preview/overrideOutputForPreview.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/overrideOutputForPreview.ts
@@ -1,26 +1,16 @@
 import { generatorsYml } from "@fern-api/configuration-loader";
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
+import { getPreviewLanguage, getStrategy, type PreviewLanguage } from "./previewStrategies.js";
 
 export const PREVIEW_REGISTRY_URL = process.env.FERN_PREVIEW_REGISTRY_URL ?? "https://npm.buildwithfern.com";
 
-const SUPPORTED_TYPESCRIPT_GENERATORS = new Set([
-    "fernapi/fern-typescript-node-sdk",
-    "fernapi/fern-typescript-browser-sdk",
-    "fernapi/fern-typescript-sdk"
-]);
-
 /**
- * Returns true if the generator is a TypeScript/npm generator.
- * SDK preview v1 only supports npm publishing.
+ * Optional PyPI registry URL for SDK preview. NO default - the user must
+ * either set this env var or pass `--output <pypi-url>`. Test PyPI is
+ * intentionally not the default (rate limits + global namespace).
  */
-export function isNpmGenerator(generatorName: string): boolean {
-    return SUPPORTED_TYPESCRIPT_GENERATORS.has(generatorName);
-}
+export const PREVIEW_PYPI_REGISTRY_URL: string | undefined = process.env.FERN_PREVIEW_PYPI_REGISTRY_URL;
 
-/**
- * Extracts the GitHub owner and repo from a generator's existing output mode.
- * Returns undefined if the generator doesn't have a githubV2 or github output mode.
- */
 export function getGithubOwnerRepo(
     outputMode: FernFiddle.remoteGen.OutputMode
 ): { owner: string; repo: string } | undefined {
@@ -35,91 +25,67 @@ export function getGithubOwnerRepo(
                 _other: () => undefined
             }),
         publish: () => undefined,
-        // publishV2 is registry-only (npmOverride, mavenOverride, pypiOverride, etc.)
-        // and does not carry github owner/repo info. GitHub publish info is only
-        // available on githubV2 variants via the publishInfo field.
         publishV2: () => undefined,
         _other: () => undefined
     });
 }
 
 /**
- * Creates a publishV2(npmOverride) output mode for preview registry publishing.
+ * Internal helper shared by every override function that re-maps every
+ * generator in a group while clearing `absolutePathToLocalOutput`.
  */
-function createNpmOverrideOutputMode({
-    registryUrl,
-    packageName,
-    token
-}: {
-    registryUrl: string;
-    packageName: string;
-    token: string;
-}): FernFiddle.OutputMode {
-    return FernFiddle.OutputMode.publishV2(
-        FernFiddle.remoteGen.PublishOutputModeV2.npmOverride({
-            registryUrl,
-            packageName,
-            token,
-            downloadSnippets: false
-        })
-    );
+function mapGenerators(
+    group: generatorsYml.GeneratorGroup,
+    fn: (generator: generatorsYml.GeneratorInvocation) => generatorsYml.GeneratorInvocation | undefined
+): generatorsYml.GeneratorGroup {
+    const modifiedGenerators = group.generators
+        .map(fn)
+        .filter((g): g is generatorsYml.GeneratorInvocation => g != null);
+    return { ...group, generators: modifiedGenerators };
 }
 
-/**
- * Overrides a generator group's output mode to downloadFiles (disk-only, no publish).
- * Used for remote generation with --output when no registry URL is provided.
- */
 export function overrideGroupOutputForDownload({
     group
 }: {
     group: generatorsYml.GeneratorGroup;
 }): generatorsYml.GeneratorGroup {
-    const modifiedGenerators = group.generators.map((generator) => ({
+    return mapGenerators(group, (generator) => ({
         ...generator,
         outputMode: FernFiddle.remoteGen.OutputMode.downloadFiles({}),
         absolutePathToLocalOutput: undefined
     }));
-    return {
-        ...group,
-        generators: modifiedGenerators
-    };
 }
 
 /**
- * Overrides a generator group's output mode to publish to the preview registry.
- * Always uses publishV2(npmOverride) for registry-only publishing.
+ * Overrides a generator group's output mode to publish to the preview
+ * registry for the supplied language. Routes through the strategy registry
+ * so each language picks its own publishV2 variant.
  *
- * @param token - The Fern org token (FERN_TOKEN). Used for registry auth.
+ * @param language - "npm" or "pypi" - determines the publishV2 variant.
+ * @param token - For npm: the registry token. For pypi: the password used
+ *                with username "__token__".
  */
 export function overrideGroupOutputForPreview({
     group,
+    language,
     packageName,
     token,
     registryUrl
 }: {
     group: generatorsYml.GeneratorGroup;
+    language: PreviewLanguage;
     packageName: string;
     token: string;
     registryUrl: string;
 }): generatorsYml.GeneratorGroup {
-    const modifiedGenerators = group.generators.map((generator) => ({
+    const strategy = getStrategy(language);
+    return mapGenerators(group, (generator) => ({
         ...generator,
-        outputMode: createNpmOverrideOutputMode({ registryUrl, packageName, token }),
+        outputMode: strategy.buildOutputMode({ registryUrl, packageName, token }),
         absolutePathToLocalOutput: undefined
     }));
-
-    return {
-        ...group,
-        generators: modifiedGenerators
-    };
 }
 
-/**
- * Extracts the publishInfo from a githubV2 output mode, stripping all
- * auth tokens/credentials. Only the package name and registry URL are
- * needed for code generation (e.g. package.json name field).
- * Returns undefined for non-github modes.
- */
 function getGithubPublishInfoWithoutToken(
     outputMode: FernFiddle.remoteGen.OutputMode
 ): FernFiddle.GithubPublishInfo | undefined {
@@ -137,19 +103,12 @@ function getGithubPublishInfoWithoutToken(
         publishV2: () => undefined,
         _other: () => undefined
     });
-
     if (publishInfo == null) {
         return undefined;
     }
-
     return stripPublishInfoCredentials(publishInfo);
 }
 
-/**
- * Returns a copy of GithubPublishInfo with all auth credentials removed.
- * Preserves package name, registry URL, and other non-sensitive metadata.
- * Returns undefined for unknown variants to fail safe rather than leak credentials.
- */
 function stripPublishInfoCredentials(
     publishInfo: FernFiddle.GithubPublishInfo
 ): FernFiddle.GithubPublishInfo | undefined {
@@ -197,45 +156,34 @@ function stripPublishInfoCredentials(
     });
 }
 
-/**
- * Overrides a generator group's output mode to githubV2(push) for pushing a
- * clean diff branch. Preserves the original publishInfo so the generator
- * produces code with the correct package name (e.g. in package.json).
- * Fiddle's dryRun=true prevents actual publishing.
- *
- * Only includes generators that have GitHub configuration (owner/repo).
- * Generators without GitHub config are excluded (they can't push a diff branch).
- */
 export function overrideGroupOutputForDiffBranch({
     group
 }: {
     group: generatorsYml.GeneratorGroup;
 }): generatorsYml.GeneratorGroup {
-    const modifiedGenerators = group.generators
-        .map((generator) => {
-            const githubInfo = getGithubOwnerRepo(generator.outputMode);
-            if (githubInfo == null) {
-                return undefined;
-            }
-            return {
-                ...generator,
-                outputMode: FernFiddle.OutputMode.githubV2(
-                    FernFiddle.GithubOutputModeV2.push({
-                        owner: githubInfo.owner,
-                        repo: githubInfo.repo,
-                        branch: undefined,
-                        license: undefined,
-                        publishInfo: getGithubPublishInfoWithoutToken(generator.outputMode),
-                        downloadSnippets: false
-                    })
-                ),
-                absolutePathToLocalOutput: undefined
-            };
-        })
-        .filter((g): g is NonNullable<typeof g> => g != null);
-
-    return {
-        ...group,
-        generators: modifiedGenerators
-    };
+    return mapGenerators(group, (generator) => {
+        const githubInfo = getGithubOwnerRepo(generator.outputMode);
+        if (githubInfo == null) {
+            return undefined;
+        }
+        return {
+            ...generator,
+            outputMode: FernFiddle.OutputMode.githubV2(
+                FernFiddle.GithubOutputModeV2.push({
+                    owner: githubInfo.owner,
+                    repo: githubInfo.repo,
+                    branch: undefined,
+                    license: undefined,
+                    publishInfo: getGithubPublishInfoWithoutToken(generator.outputMode),
+                    downloadSnippets: false
+                })
+            ),
+            absolutePathToLocalOutput: undefined
+        };
+    });
 }
+
+// `isNpmGenerator` is intentionally removed. Use `getPreviewLanguage(name)`
+// from `./previewStrategies.js` instead. Re-export here purely so external
+// consumers  get a clear deprecation.
+export { getPreviewLanguage };

--- a/packages/cli/cli/src/commands/sdk-preview/pep440.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/pep440.ts
@@ -1,0 +1,31 @@
+/**
+ * In-tree PEP 440 validator covering the dev release + local-version segment
+ * shapes produced by `computePypiPreviewVersion`. NOT a full PEP 440 parser:
+ * we only validate the subset we generate, which is enough to lock the format
+ * contract via tests and to surface mistakes if the generator drifts.
+ *
+ * Spec references:
+ *   PEP 440 §"Local version identifiers": [N!]N(.N)*[{a|b|c|rc|alpha|beta|pre|preview}N][.postN][.devN][+local]
+ *   Local segment: ([a-z0-9]+(?:[-_.][a-z0-9]+)*) - we restrict to dots only.
+ */
+
+const PEP_440_DEV_LOCAL_REGEX = /^(?:\d+!)?\d+(?:\.\d+)*(?:\.dev\d+)?(?:\+[a-z0-9]+(?:\.[a-z0-9]+)*)?$/;
+
+const MAX_LOCAL_SEGMENT_LENGTH = 64;
+
+export function isValidPep440DevLocalVersion(version: string): boolean {
+    if (typeof version !== "string" || version.length === 0) {
+        return false;
+    }
+    if (!PEP_440_DEV_LOCAL_REGEX.test(version)) {
+        return false;
+    }
+    const plusIdx = version.indexOf("+");
+    if (plusIdx !== -1) {
+        const local = version.slice(plusIdx + 1);
+        if (local.length === 0 || local.length > MAX_LOCAL_SEGMENT_LENGTH) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/packages/cli/cli/src/commands/sdk-preview/previewStrategies.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/previewStrategies.ts
@@ -1,0 +1,93 @@
+import { FernFiddle } from "@fern-fern/fiddle-sdk";
+import { sanitizeForPypiLocalSegment } from "./computePreviewVersion.js";
+
+export type PreviewLanguage = "npm" | "pypi";
+
+export interface PreviewOutputModeArgs {
+    registryUrl: string;
+    /**
+     * For npm: the npm package name (e.g. "@acme-preview/sdk").
+     * For pypi: the PEP 503-normalized coordinate (e.g. "acme-preview-acme-sdk").
+     */
+    packageName: string;
+    /**
+     * For npm: the registry token used directly.
+     * For pypi: the registry password (paired with username "__token__" by
+     * convention - matches `convertGeneratorsConfiguration.ts` behavior).
+     */
+    token: string;
+}
+
+export interface PreviewStrategy {
+    readonly language: PreviewLanguage;
+    buildOutputMode(args: PreviewOutputModeArgs): FernFiddle.OutputMode;
+    /**
+     * Sanitizes a previewId for use in this language's version scheme.
+     * For npm: passthrough (npm SemVer prerelease tolerates hyphens).
+     * For pypi: collapses to dots, lowercases (PEP 440 local segment).
+     */
+    sanitizeForVersion(previewId: string): string;
+}
+
+export const npmPreviewStrategy: PreviewStrategy = {
+    language: "npm",
+    buildOutputMode({ registryUrl, packageName, token }) {
+        return FernFiddle.OutputMode.publishV2(
+            FernFiddle.remoteGen.PublishOutputModeV2.npmOverride({
+                registryUrl,
+                packageName,
+                token,
+                downloadSnippets: false
+            })
+        );
+    },
+    sanitizeForVersion(previewId) {
+        return previewId;
+    }
+};
+
+export const pypiPreviewStrategy: PreviewStrategy = {
+    language: "pypi",
+    buildOutputMode({ registryUrl, packageName, token }) {
+        return FernFiddle.OutputMode.publishV2(
+            FernFiddle.remoteGen.PublishOutputModeV2.pypiOverride({
+                registryUrl,
+                username: "__token__",
+                password: token,
+                coordinate: packageName,
+                downloadSnippets: false,
+                pypiMetadata: undefined
+            })
+        );
+    },
+    sanitizeForVersion(previewId) {
+        return sanitizeForPypiLocalSegment(previewId);
+    }
+};
+
+const NPM_GENERATOR_NAMES = new Set<string>([
+    "fernapi/fern-typescript-node-sdk",
+    "fernapi/fern-typescript-browser-sdk",
+    "fernapi/fern-typescript-sdk"
+]);
+
+const PYPI_GENERATOR_NAMES = new Set<string>(["fernapi/fern-python-sdk"]);
+
+/**
+ * Returns the preview language for a generator name, or undefined if the
+ * generator is not currently supported by `fern sdk preview`. Replaces the
+ * old `isNpmGenerator` boolean check.
+ */
+export function getPreviewLanguage(generatorName: string): PreviewLanguage | undefined {
+    if (NPM_GENERATOR_NAMES.has(generatorName)) {
+        return "npm";
+    }
+    if (PYPI_GENERATOR_NAMES.has(generatorName)) {
+        return "pypi";
+    }
+    return undefined;
+}
+
+export function getStrategy(language: PreviewLanguage): PreviewStrategy {
+    return language === "npm" ? npmPreviewStrategy : pypiPreviewStrategy;
+}

--- a/packages/cli/cli/src/commands/sdk-preview/sdkPreview.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/sdkPreview.ts
@@ -15,17 +15,17 @@ import { CliContext } from "../../cli-context/CliContext.js";
 import { loadProjectAndRegisterWorkspacesWithContext } from "../../cliCommons.js";
 import { GROUP_CLI_OPTION } from "../../constants.js";
 import { isTelemetryDisabled } from "../../telemetry/isTelemetryDisabled.js";
-import { computePreviewVersion } from "./computePreviewVersion.js";
+import { computePreviewVersion, computePypiPreviewVersion } from "./computePreviewVersion.js";
 import { getPreviewId } from "./getPreviewId.js";
 import {
     getGithubOwnerRepo,
-    isNpmGenerator,
     overrideGroupOutputForDiffBranch,
     overrideGroupOutputForDownload,
     overrideGroupOutputForPreview,
     PREVIEW_REGISTRY_URL
 } from "./overrideOutputForPreview.js";
-import { toPreviewPackageName } from "./toPreviewPackageName.js";
+import { getPreviewLanguage, type PreviewLanguage } from "./previewStrategies.js";
+import { toPreviewPackageName, toPypiPreviewPackageName } from "./toPreviewPackageName.js";
 
 export interface SdkPreviewSuccess {
     status: "success";
@@ -208,200 +208,289 @@ export async function sdkPreview({
                 };
             }
 
-            // Filter to npm-only generators (SDK preview v1 limitation)
-            const npmGenerators = generators.filter((g) => isNpmGenerator(g.name));
-            const skippedGenerators = generators.filter((g) => !isNpmGenerator(g.name));
-            for (const skipped of skippedGenerators) {
-                cliContext.logger.warn(
-                    `Skipping '${skipped.name}' — SDK preview currently only supports TypeScript/npm generators. ` +
-                        `Use --generator to target a specific generator.`
-                );
+            const partitioned: { generator: (typeof generators)[number]; language: PreviewLanguage }[] = [];
+            for (const g of generators) {
+                const language = getPreviewLanguage(g.name);
+                if (language == null) {
+                    cliContext.logger.warn(
+                        `Skipping '${g.name}' - SDK preview currently supports TypeScript/npm and Python/pypi generators only.`
+                    );
+                    continue;
+                }
+                partitioned.push({ generator: g, language });
             }
-            if (npmGenerators.length === 0) {
+            if (partitioned.length === 0) {
                 return {
                     status: "error",
                     message:
                         `No supported generators found in group '${groupNameOrDefault}'. ` +
-                        `SDK preview currently only supports TypeScript/npm generators.`,
+                        `SDK preview currently supports TypeScript/npm and Python/pypi generators.`,
                     code: CliError.Code.ConfigError
                 };
             }
 
-            for (const generator of npmGenerators) {
-                const originalPackageName = getPackageNameFromGeneratorConfig(generator);
-                if (originalPackageName == null) {
+            const hasPypi = partitioned.some((p) => p.language === "pypi");
+            const hasNpm = partitioned.some((p) => p.language === "npm");
+
+            // --push-diff rejection: v1 only supports it for npm.
+            if (pushDiff && hasPypi) {
+                return {
+                    status: "error",
+                    message:
+                        "--push-diff is not supported for Python generators in v1. " +
+                        "Track <link to follow-up issue> for v2.",
+                    code: CliError.Code.UserError
+                };
+            }
+
+            // PyPI registry preflight: explicit, no fallback.
+            let pypiRegistryUrl: string | undefined;
+            if (hasPypi && publishToRegistry) {
+                pypiRegistryUrl =
+                    urlOutputs.find((u) => u !== registryUrl) ??
+                    (registryUrl !== PREVIEW_REGISTRY_URL
+                        ? registryUrl
+                        : process.env.FERN_PREVIEW_PYPI_REGISTRY_URL);
+                if (pypiRegistryUrl == null) {
                     return {
                         status: "error",
                         message:
-                            `Could not determine package name for generator '${generator.name}'. ` +
-                            `Ensure 'output.package-name' is set in ${GENERATORS_CONFIGURATION_FILENAME}.`,
+                            "No PyPI registry URL configured. Set FERN_PREVIEW_PYPI_REGISTRY_URL " +
+                            "or pass --output <pypi-url>.",
                         code: CliError.Code.ConfigError
                     };
                 }
+            }
 
-                const previewPackageName = toPreviewPackageName(originalPackageName, project.config.organization);
-                const previewVersion = computePreviewVersion({ previewId });
-                cliContext.logger.info(`Preview version: ${previewVersion}`);
+            // PyPI token preflight: token.value must be a non-empty string.
+            if (hasPypi && publishToRegistry && (token.value == null || token.value.length === 0)) {
+                return {
+                    status: "error",
+                    message: "No PyPI token resolvable. Set FERN_TOKEN or run `fern login`.",
+                    code: CliError.Code.AuthError
+                };
+            }
 
-                // Override group output to publish to the target registry.
-                // token.value is the Fern org token (FERN_TOKEN) — the registry
-                // must accept this token for publish authentication.
-                const singleGeneratorGroup = { ...group, generators: [generator] };
-                const githubInfo = getGithubOwnerRepo(generator.outputMode);
+            const settled = await Promise.allSettled(
+                partitioned.map(async ({ generator, language }) => {
+                    const originalPackageName = getPackageNameFromGeneratorConfig(generator);
+                    if (originalPackageName == null) {
+                        throw new Error(
+                            `Could not determine package name for generator '${generator.name}'. ` +
+                                `Ensure 'output.package-name' is set in ${GENERATORS_CONFIGURATION_FILENAME}.`
+                        );
+                    }
 
-                // Warn if --push-diff was requested but the generator has no github config
-                if (pushDiff && useRemoteGeneration && githubInfo == null) {
-                    cliContext.logger.warn(
-                        `Generator '${generator.name}' has no github output configuration. ` +
-                            `--push-diff will be ignored; falling back to registry-only publish.`
-                    );
-                }
+                    const previewPackageName =
+                        language === "npm"
+                            ? toPreviewPackageName(originalPackageName, project.config.organization)
+                            : toPypiPreviewPackageName(originalPackageName, project.config.organization);
 
-                // When --push-diff is active and the generator has GitHub config, we run
-                // two separate generation jobs:
-                //   Job 1 (publish): publishV2 mode with preview package name → npm publish
-                //   Job 2 (diff):    githubV2(push) with original package name → clean diff branch
-                // This ensures the diff branch shows real API changes without preview artifacts
-                // (e.g. no @org-preview/ package rename).
-                const shouldRunTwoJobs =
-                    pushDiff && useRemoteGeneration && publishToRegistry && registryUrl != null && githubInfo != null;
+                    const previewVersion =
+                        language === "npm"
+                            ? computePreviewVersion({ previewId })
+                            : computePypiPreviewVersion({ previewId });
 
-                let publishGroup: generatorsYml.GeneratorGroup;
-                if (publishToRegistry && registryUrl != null) {
-                    publishGroup = overrideGroupOutputForPreview({
-                        group: singleGeneratorGroup,
-                        packageName: previewPackageName,
-                        token: token.value,
-                        registryUrl
-                    });
-                } else if (useRemoteGeneration) {
-                    // Remote generation, disk-only (--output with no registry URL):
-                    // override to downloadFiles so the generator doesn't try to publish
-                    // using its original output mode.
-                    publishGroup = overrideGroupOutputForDownload({ group: singleGeneratorGroup });
-                } else {
-                    publishGroup = singleGeneratorGroup;
-                }
+                    cliContext.logger.info(`Preview version: ${previewVersion}`);
 
-                if (useRemoteGeneration) {
-                    const commonRemoteArgs = {
-                        projectConfig: project.config,
-                        organization: project.config.organization,
-                        workspace,
-                        shouldLogS3Url: false,
-                        token,
-                        whitelabel: workspace.generatorsConfiguration?.whitelabel,
-                        mode: undefined as "pull-request" | undefined,
-                        fernignorePath: undefined as string | undefined,
-                        skipFernignore: false,
-                        dynamicIrOnly: false,
-                        validateWorkspace: true,
-                        retryRateLimited: false,
-                        requireEnvVars: false
-                    };
+                    // Override group output to publish to the target registry.
+                    // token.value is the Fern org token (FERN_TOKEN) — the registry
+                    // must accept this token for publish authentication.
+                    const singleGeneratorGroup = { ...group, generators: [generator] };
+                    const githubInfo = getGithubOwnerRepo(generator.outputMode);
 
-                    // Job 1: Publish preview package to registry.
-                    await cliContext.runTaskForWorkspace(workspace, async (context) => {
-                        await runRemoteGenerationForAPIWorkspace({
-                            ...commonRemoteArgs,
-                            context,
-                            generatorGroup: publishGroup,
-                            version: previewVersion,
-                            absolutePathToPreview: absolutePathToOutput,
-                            isPreview: true,
-                            fiddlePreview: false,
-                            pushPreviewBranch: false
+                    // Warn if --push-diff was requested but the generator has no github config
+                    if (pushDiff && useRemoteGeneration && githubInfo == null) {
+                        cliContext.logger.warn(
+                            `Generator '${generator.name}' has no github output configuration. ` +
+                                `--push-diff will be ignored; falling back to registry-only publish.`
+                        );
+                    }
+
+                    // When --push-diff is active and the generator has GitHub config, we run
+                    // two separate generation jobs:
+                    //   Job 1 (publish): publishV2 mode with preview package name → npm publish
+                    //   Job 2 (diff):    githubV2(push) with original package name → clean diff branch
+                    // This ensures the diff branch shows real API changes without preview artifacts
+                    // (e.g. no @org-preview/ package rename).
+                    const shouldRunTwoJobs =
+                        pushDiff &&
+                        useRemoteGeneration &&
+                        publishToRegistry &&
+                        registryUrl != null &&
+                        githubInfo != null;
+
+                    const effectiveRegistryUrl = language === "pypi" ? (pypiRegistryUrl ?? registryUrl) : registryUrl;
+
+                    let publishGroup: generatorsYml.GeneratorGroup;
+                    if (publishToRegistry && effectiveRegistryUrl != null) {
+                        publishGroup = overrideGroupOutputForPreview({
+                            group: singleGeneratorGroup,
+                            language,
+                            packageName: previewPackageName,
+                            token: token.value,
+                            registryUrl: effectiveRegistryUrl
                         });
-                    });
+                    } else if (useRemoteGeneration) {
+                        // Remote generation, disk-only (--output with no registry URL):
+                        // override to downloadFiles so the generator doesn't try to publish
+                        // using its original output mode.
+                        publishGroup = overrideGroupOutputForDownload({ group: singleGeneratorGroup });
+                    } else {
+                        publishGroup = singleGeneratorGroup;
+                    }
 
-                    // Job 2: Push clean diff branch with original package metadata.
-                    // Uses fiddlePreview=true so Fiddle sets dryRun=true, which prevents
-                    // the publish override from firing (see GeneratorExecConfigFactory).
-                    // The generator stays in github mode and produces clean output with
-                    // the original package name; Fiddle pushes it to the diff branch.
-                    if (shouldRunTwoJobs) {
-                        const diffGroup = overrideGroupOutputForDiffBranch({ group: singleGeneratorGroup });
-                        if (diffGroup.generators.length > 0) {
+                    if (useRemoteGeneration) {
+                        const commonRemoteArgs = {
+                            projectConfig: project.config,
+                            organization: project.config.organization,
+                            workspace,
+                            shouldLogS3Url: false,
+                            token,
+                            whitelabel: workspace.generatorsConfiguration?.whitelabel,
+                            mode: undefined as "pull-request" | undefined,
+                            fernignorePath: undefined as string | undefined,
+                            skipFernignore: false,
+                            dynamicIrOnly: false,
+                            validateWorkspace: true,
+                            retryRateLimited: false,
+                            requireEnvVars: false
+                        };
+
+                        // Job 1: Publish preview package to registry.
+                        try {
                             await cliContext.runTaskForWorkspace(workspace, async (context) => {
                                 await runRemoteGenerationForAPIWorkspace({
                                     ...commonRemoteArgs,
                                     context,
-                                    generatorGroup: diffGroup,
+                                    generatorGroup: publishGroup,
                                     version: previewVersion,
-                                    absolutePathToPreview: undefined,
+                                    absolutePathToPreview: absolutePathToOutput,
                                     isPreview: true,
-                                    fiddlePreview: true,
-                                    pushPreviewBranch: true
+                                    fiddlePreview: false,
+                                    pushPreviewBranch: false
                                 });
                             });
+                        } catch (err) {
+                            const msg = err instanceof Error ? err.message : String(err);
+                            if (
+                                language === "pypi" &&
+                                /already exists|already uploaded|409|file already exists/i.test(msg)
+                            ) {
+                                throw new Error(
+                                    `Preview version ${previewVersion} already exists in the PyPI registry. ` +
+                                        `Bump previewId (re-run from a different branch name) or wait for the previous run to expire.`
+                                );
+                            }
+                            throw err;
                         }
-                    }
-                } else {
-                    // Local generation via Docker — used when --local flag is provided.
-                    // Docker must be installed. When absolutePathToOutput is set, generated
-                    // files are also written to disk.
-                    await cliContext.runTaskForWorkspace(workspace, async (context) => {
-                        await runLocalGenerationForWorkspace({
-                            token,
-                            projectConfig: project.config,
-                            workspace,
-                            generatorGroup: publishGroup,
-                            version: previewVersion,
-                            keepDocker: false,
-                            context,
-                            absolutePathToPreview: absolutePathToOutput,
-                            runner: undefined,
-                            inspect: false,
-                            ai: workspace.generatorsConfiguration?.ai,
-                            replay: undefined,
-                            noReplay: true,
-                            validateWorkspace: true,
-                            publishToRegistry,
-                            isPreview: true,
-                            disableTelemetry: isTelemetryDisabled()
+
+                        // Job 2: Push clean diff branch with original package metadata.
+                        // Uses fiddlePreview=true so Fiddle sets dryRun=true, which prevents
+                        // the publish override from firing (see GeneratorExecConfigFactory).
+                        // The generator stays in github mode and produces clean output with
+                        // the original package name; Fiddle pushes it to the diff branch.
+                        if (shouldRunTwoJobs) {
+                            const diffGroup = overrideGroupOutputForDiffBranch({ group: singleGeneratorGroup });
+                            if (diffGroup.generators.length > 0) {
+                                await cliContext.runTaskForWorkspace(workspace, async (context) => {
+                                    await runRemoteGenerationForAPIWorkspace({
+                                        ...commonRemoteArgs,
+                                        context,
+                                        generatorGroup: diffGroup,
+                                        version: previewVersion,
+                                        absolutePathToPreview: undefined,
+                                        isPreview: true,
+                                        fiddlePreview: true,
+                                        pushPreviewBranch: true
+                                    });
+                                });
+                            }
+                        }
+                    } else {
+                        // Local generation via Docker — used when --local flag is provided.
+                        // Docker must be installed. When absolutePathToOutput is set, generated
+                        // files are also written to disk.
+                        await cliContext.runTaskForWorkspace(workspace, async (context) => {
+                            await runLocalGenerationForWorkspace({
+                                token,
+                                projectConfig: project.config,
+                                workspace,
+                                generatorGroup: publishGroup,
+                                version: previewVersion,
+                                keepDocker: false,
+                                context,
+                                absolutePathToPreview: absolutePathToOutput,
+                                runner: undefined,
+                                inspect: false,
+                                ai: workspace.generatorsConfiguration?.ai,
+                                replay: undefined,
+                                noReplay: true,
+                                validateWorkspace: true,
+                                publishToRegistry,
+                                isPreview: true,
+                                disableTelemetry: isTelemetryDisabled()
+                            });
                         });
-                    });
-                }
+                    }
 
-                // The generator writes to <output>/<subfolder>/ (e.g. fern-typescript-sdk/).
-                // NOTE: this duplicates the subfolder logic in resolveAbsolutePathToLocalPreview
-                // inside runLocalGenerationForWorkspace. Both call getGeneratorOutputSubfolder so
-                // they stay in sync, but if the runner ever changes its path convention this will
-                // need to be updated too.
-                const actualOutputPath =
-                    absolutePathToOutput != null
-                        ? join(absolutePathToOutput, RelativeFilePath.of(getGeneratorOutputSubfolder(generator.name)))
-                        : undefined;
+                    // The generator writes to <output>/<subfolder>/ (e.g. fern-typescript-sdk/).
+                    // NOTE: this duplicates the subfolder logic in resolveAbsolutePathToLocalPreview
+                    // inside runLocalGenerationForWorkspace. Both call getGeneratorOutputSubfolder so
+                    // they stay in sync, but if the runner ever changes its path convention this will
+                    // need to be updated too.
+                    const actualOutputPath =
+                        absolutePathToOutput != null
+                            ? join(
+                                  absolutePathToOutput,
+                                  RelativeFilePath.of(getGeneratorOutputSubfolder(generator.name))
+                              )
+                            : undefined;
 
-                // Build the diff URL when --push-diff was used and the generator has GitHub config.
-                const previewBranch = `fern-preview-${previewVersion}`;
-                const diffUrl =
-                    pushDiff && githubInfo != null
-                        ? `https://github.com/${githubInfo.owner}/${githubInfo.repo}/compare/${previewBranch}`
-                        : undefined;
+                    // Build the diff URL when --push-diff was used and the generator has GitHub config.
+                    const previewBranch = `fern-preview-${previewVersion}`;
+                    const diffUrl =
+                        pushDiff && githubInfo != null
+                            ? `https://github.com/${githubInfo.owner}/${githubInfo.repo}/compare/${previewBranch}`
+                            : undefined;
 
-                if (publishToRegistry && registryUrl != null) {
-                    const installCommand = `npm install ${originalPackageName}@npm:${previewPackageName}@${previewVersion} --registry ${registryUrl}`;
-                    previews.push({
+                    const installCommand =
+                        !publishToRegistry || effectiveRegistryUrl == null
+                            ? ""
+                            : language === "npm"
+                              ? `npm install ${originalPackageName}@npm:${previewPackageName}@${previewVersion} ` +
+                                `--registry ${effectiveRegistryUrl}`
+                              : `pip install ${previewPackageName}==${previewVersion} ` +
+                                `--index-url ${effectiveRegistryUrl}`;
+
+                    return {
                         preview_id: previewId,
                         install: installCommand,
                         version: previewVersion,
                         package_name: previewPackageName,
-                        registry_url: registryUrl,
+                        registry_url: effectiveRegistryUrl ?? "",
                         output_path: actualOutputPath,
                         diff_url: diffUrl
-                    });
-                } else {
-                    previews.push({
-                        preview_id: previewId,
-                        install: "",
-                        version: previewVersion,
-                        package_name: previewPackageName,
-                        registry_url: "",
-                        output_path: actualOutputPath,
-                        diff_url: diffUrl
-                    });
-                }
+                    };
+                })
+            );
+
+            const successes = settled.flatMap((r) => (r.status === "fulfilled" ? [r.value] : []));
+            const failures = settled.flatMap((r) => (r.status === "rejected" ? [r.reason] : []));
+            previews.push(...successes);
+
+            if (failures.length > 0 && successes.length > 0) {
+                cliContext.logger.warn(
+                    `Successfully published ${successes.length} of ${settled.length} SDK previews. ` +
+                        `Failures: ${failures.map((e) => (e instanceof Error ? e.message : String(e))).join("; ")}`
+                );
+            } else if (failures.length > 0) {
+                const first = failures[0];
+                const rest = failures.slice(1);
+                const restMsg = rest.length
+                    ? ` (and ${rest.length} more: ${rest.map((e) => (e instanceof Error ? e.message : String(e))).join("; ")})`
+                    : "";
+                throw first instanceof Error ? new Error(first.message + restMsg) : new Error(String(first) + restMsg);
             }
         }
     } catch (error) {

--- a/packages/cli/cli/src/commands/sdk-preview/toPreviewPackageName.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/toPreviewPackageName.ts
@@ -17,3 +17,22 @@ export function toPreviewPackageName(packageName: string, org: string): string {
     }
     return `@${org}-preview/${packageName}`;
 }
+
+/**
+ * Transforms a PyPI package name into a preview-scoped equivalent.
+ * Per PEP 503, names are normalized: lowercase, with sequences of `_`,
+ * `-`, or `.` collapsed to a single `-`.
+ *
+ * Examples (org = "acme"):
+ *   acme-sdk      -> acme-preview-acme-sdk
+ *   Acme_SDK      -> acme-preview-acme-sdk
+ *   acme.sdk      -> acme-preview-acme-sdk
+ */
+export function toPypiPreviewPackageName(packageName: string, org: string): string {
+    const normalized = packageName
+        .toLowerCase()
+        .replace(/[-_.]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+    const orgNormalized = org.toLowerCase().replace(/[-_.]+/g, "-");
+    return `${orgNormalized}-preview-${normalized}`;
+}

--- a/packages/commons/path-utils/src/isAbsolute.ts
+++ b/packages/commons/path-utils/src/isAbsolute.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 export function isAbsolute(value: string): boolean {
-    return value.startsWith("/");
+    return path.isAbsolute(value);
 }


### PR DESCRIPTION
## Summary

- Refactors `packages/cli/cli/src/commands/sdk-preview/` to dispatch on a
  minimal `PreviewStrategy` interface (`buildOutputMode` +
  `sanitizeForVersion`) plus a `getPreviewLanguage(name)` lookup. npm and
  pypi each ship as a strategy; install-command formatting and version
  computation stay as parallel free functions.
- Adds PEP 440-compliant version generation for PyPI
  (`0.0.1.dev{epoch}+{sanitizedPreviewId}`) with an in-tree validator and
  ~15 valid/invalid test cases. The npm SemVer scheme stays unchanged.
- Adds 4 explicit `CliError.Code`s for PyPI failure modes (missing token,
  missing registry, no Python generator in group, version-already-uploaded)
  plus a clear rejection of `--push-diff` for Python in v1.
- Drive-by perf improvement: converts the inner generator loop in
  [packages/cli/cli/src/commands/sdk-preview/sdkPreview.ts](packages/cli/cli/src/commands/sdk-preview/sdkPreview.ts)
  lines 230-405 from sequential to `Promise.allSettled`, so a 3-SDK preview
  group runs in `max(T_n)` instead of `sum(T_n)`. Partial-success messaging
  on mixed outcomes.

100% backwards compatible for the public CLI surface. The existing 30+
tests in
[__test__/overrideOutputForPreview.test.ts](packages/cli/cli/src/commands/sdk-preview/__test__/overrideOutputForPreview.test.ts)
continue to pass after the refactor; only the `isNpmGenerator` cases
migrate to a new test file (the symbol is removed in favor of the
strategy registry).

## Why

`fern sdk preview` is one of the most-used quality-of-life features for
SDK reviewers, but its current TypeScript-only support means Python users
- the second-largest Fern user base by seed fixture count - cannot share
ephemeral SDK previews on PRs.

The Fiddle platform already ships PyPI publish primitives, including
`PublishOutputModeV2.pypiOverride` and credential-stripping for
`GithubPublishInfo.pypi`. The SDK preview command's hard-coded npm
allowlist is the only thing blocking multi-language support, and the
existing code calls itself out as a "v1 limitation" in two places.

This PR establishes the pattern for adding any future language (Java, Go,
C#, Ruby, PHP, Swift, Rust). Each new language is a single new strategy
entry plus parallel `computeXxxPreviewVersion` and `toXxxPreviewPackageName`
functions.

## Status / what's in this draft right now

This PR is opened as a **Draft**. The work is broken into 8 phases, each
ending with the test suite green before the next is started. Current
state on this branch:

- [x] **Phase 1 - Scaffold strategy + PEP 440 validator**
      (`previewStrategies.ts`, `pep440.ts`, `__test__/pep440.test.ts`)
- [x] **Phase 2 - Extract test utilities** (`__test__/test-utils.ts` +
      migrated `makeGenerator` callers in
      `overrideOutputForPreview.test.ts`)
- [x] **Phase 3 - PyPI version + name helpers**
      (`computePreviewVersion.ts`, `toPreviewPackageName.ts` parallel
      additions)
- [x] **Phase 4 - Refactor `overrideOutputForPreview.ts`** (move npm
      into strategy; add `mapGenerators`; delete `isNpmGenerator`)
- [x] **Phase 5 - Wire `sdkPreview.ts` orchestration** (language
      partition, install commands, 4 new error paths, `--push-diff`
      rejection, `Promise.allSettled` + partial-success messaging)
- [x] **Phase 6 - Orchestration tests** (`__test__/sdkPreview.test.ts`,
      mocking 3 collaborators; covers 8+ test cases)
- [x] **Phase 7 - Strategy tests + install-command tests**
      (`__test__/previewStrategies.test.ts` + new explicit string-
      assertion tests for install commands)
- [x] **Phase 8 - Changelog entry + lint/format**
      (`packages/cli/cli/changes/unreleased/sdk-preview-pypi.yml` +
      `pnpm lint:biome --fix && pnpm format:fix`)