### PR TITLE
fix(cli): strip Windows drive letter prefixes from resolved image paths

### DIFF
--- a/docs-preview-smoke-test/playwright/smoke.spec.ts
+++ b/docs-preview-smoke-test/playwright/smoke.spec.ts
@@ -42,8 +42,8 @@ test.describe("Smoke test: all pages load", () => {
     }
 });
 
-test.describe("Image path validation: no broken file paths", () => {
-    test("GET /welcome should render images without broken file:/// paths", async ({ page }) => {
+test.describe("Image rendering validation", () => {
+    test("GET /welcome should render images that actually load", async ({ page }) => {
         const response = await page.goto("/welcome", {
             waitUntil: "domcontentloaded",
             timeout: 30_000
@@ -51,29 +51,45 @@ test.describe("Image path validation: no broken file paths", () => {
 
         expect(response?.status()).toBe(200);
 
-        // Wait for page to fully render
-        await page.waitForTimeout(2000);
+        // Wait for page to fully render and images to load
+        await page.waitForTimeout(3000);
 
-        // Collect all image src attributes from the page
-        const imgSrcs = await page.evaluate(() => {
+        // Collect image loading status from the DOM
+        const imageResults = await page.evaluate(() => {
             const images = document.querySelectorAll("img");
-            return Array.from(images).map((img) => img.getAttribute("src") ?? img.src);
+            return Array.from(images).map((img) => ({
+                src: img.getAttribute("src") ?? img.src,
+                complete: img.complete,
+                naturalWidth: img.naturalWidth,
+                naturalHeight: img.naturalHeight
+            }));
         });
 
-        expect(imgSrcs.length, "Expected at least one image on /welcome").toBeGreaterThan(0);
+        expect(imageResults.length, "Expected at least one image on /welcome").toBeGreaterThan(0);
 
-        for (const src of imgSrcs) {
+        for (const img of imageResults) {
+            // Image must have finished loading
+            expect(img.complete, `Image did not finish loading: ${img.src}`).toBe(true);
+
+            // Image must have rendered with non-zero dimensions (broken/missing images have naturalWidth 0)
+            expect(
+                img.naturalWidth,
+                `Image failed to load (naturalWidth is 0), likely a broken path: ${img.src}`
+            ).toBeGreaterThan(0);
+
             // Must not contain file:/// protocol (broken local path leak)
-            expect(src, `Image src should not use file:/// protocol: ${src}`).not.toMatch(/^file:\/\/\//);
+            expect(img.src, `Image src should not use file:/// protocol: ${img.src}`).not.toMatch(/^file:\/\/\//);
 
             // Must not contain Windows drive letters (e.g., C:/ or C:\)
-            expect(src, `Image src should not contain Windows drive letter: ${src}`).not.toMatch(/^[a-zA-Z]:[/\\]/);
+            expect(img.src, `Image src should not contain Windows drive letter: ${img.src}`).not.toMatch(
+                /^[a-zA-Z]:[/\\]/
+            );
 
             // Must not contain URL-encoded backslashes (%5C)
-            expect(src, `Image src should not contain encoded backslashes: ${src}`).not.toContain("%5C");
+            expect(img.src, `Image src should not contain encoded backslashes: ${img.src}`).not.toContain("%5C");
 
             // Must not contain raw backslashes
-            expect(src, `Image src should not contain backslashes: ${src}`).not.toContain("\\");
+            expect(img.src, `Image src should not contain backslashes: ${img.src}`).not.toContain("\\");
         }
     });
 });

--- a/packages/cli/cli/changes/unreleased/fix-windows-drive-letter-image-paths.yml
+++ b/packages/cli/cli/changes/unreleased/fix-windows-drive-letter-image-paths.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Strip Windows drive letter prefixes from resolved image paths in docs preview
+    to prevent raw filesystem paths from leaking into rendered HTML on Windows.
+  type: fix

--- a/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
+++ b/packages/cli/docs-markdown-utils/src/parseImagePaths.ts
@@ -1,5 +1,11 @@
 import { FdrAPI as CjsFdrSdk, DocsV1Write } from "@fern-api/fdr-sdk";
-import { AbsoluteFilePath, dirname, RelativeFilePath, resolve } from "@fern-api/fs-utils";
+import {
+    AbsoluteFilePath,
+    convertToFernHostAbsoluteFilePath,
+    dirname,
+    RelativeFilePath,
+    resolve
+} from "@fern-api/fs-utils";
 import { TaskContext } from "@fern-api/task-context";
 import type { Node as EstreeNode } from "estree";
 import grayMatter from "gray-matter";
@@ -546,7 +552,9 @@ function resolvePath(
         RelativeFilePath.of(pathToImage.replace(/^\//, ""))
     );
 
-    return filepath;
+    // Strip Windows drive letter (e.g., C:/) to produce platform-agnostic paths
+    // that work consistently in markdown content and URL maps
+    return convertToFernHostAbsoluteFilePath(filepath);
 }
 
 function isExternalUrl(url: string): boolean {
@@ -644,16 +652,15 @@ export function replaceImagePathsAndUrls(
             return undefined;
         }
 
-        if (isAbsolute(image)) {
-            const absolutePath = AbsoluteFilePath.of(image);
+        if (isAbsolute(image) || isWindowsAbsolutePath(image)) {
+            // Normalize to strip Windows drive letters (e.g., C:/) for consistent lookup
+            const absolutePath = convertToFernHostAbsoluteFilePath(AbsoluteFilePath.of(image));
             const fileId = fileIdsMap.get(absolutePath);
             if (fileId) {
                 return `file:${fileId}`;
             }
 
-            // Only try resolvePath fallback for Unix absolute paths (starting with /)
-            // Skip for Windows absolute paths (e.g., C:\...) since they are already absolute
-            // and resolvePath would throw an error trying to create a RelativeFilePath from them
+            // Fallback: try resolving as a root-relative path
             if (!isWindowsAbsolutePath(image)) {
                 const resolvedFromRoot = resolvePath(image, metadata);
                 if (resolvedFromRoot) {

--- a/packages/commons/fs-utils/src/relative.ts
+++ b/packages/commons/fs-utils/src/relative.ts
@@ -1,8 +1,9 @@
 import path from "path";
 
 import { AbsoluteFilePath } from "./AbsoluteFilePath.js";
+import { convertToOsPath } from "./osPathConverter.js";
 import { RelativeFilePath } from "./RelativeFilePath.js";
 
 export function relative(from: AbsoluteFilePath, to: AbsoluteFilePath): RelativeFilePath {
-    return RelativeFilePath.of(path.relative(from, to));
+    return RelativeFilePath.of(convertToOsPath(path.relative(from, to)));
 }


### PR DESCRIPTION
## Description
Refs #15658

Follow-up fix to PR #15658 which normalized backslashes but did not strip Windows drive letter prefixes (e.g., `C:`). On Windows, resolved image paths like `C:/Users/.../image.svg` would leak into rendered HTML with URL-encoded backslashes (`C:%5CUsers%5C...`) when the `file:uuid` replacement failed due to path format mismatch.

## Root Cause

PR #15658 fixed `resolve()`, `dirname()`, and `join()` in `fs-utils` to convert backslashes to forward slashes. However, the Windows drive letter prefix (e.g., `C:`) was preserved. This caused two issues:

1. **Path mismatch in `mapImage`**: The `fileIdsMap` keys (reconstructed from `/_local` URLs) have the drive letter stripped, but the image paths in markdown retained the prefix. So `fileIdsMap.get("C:/Users/...")` fails because the key is `/Users/...`.

2. **Drive letter in markdown**: The drive letter in the path causes issues with URL parsing in the browser (e.g., `C:` interpreted as a URL scheme).

## Changes Made

- **`parseImagePaths.ts` — `resolvePath()`**: Apply `convertToFernHostAbsoluteFilePath()` to strip the Windows drive letter prefix from resolved image paths, producing platform-agnostic paths (e.g., `/Users/Shadow/.../image.svg`)
- **`parseImagePaths.ts` — `mapImage()`**: Normalize image paths with `convertToFernHostAbsoluteFilePath()` before `fileIdsMap` lookup, and also handle `isWindowsAbsolutePath()` in the condition check for robust matching
- **`fs-utils/relative.ts`**: Apply `convertToOsPath()` to normalize backslashes in `path.relative()` output (consistent with the `resolve`/`dirname`/`join` fixes from #15658)
- **Smoke test**: Updated Playwright test to verify images *actually render* (`naturalWidth > 0`) rather than only checking for bad path patterns. This would have caught the original bug since broken paths produce images with `naturalWidth === 0`.

## Testing
- [x] All 196 `@fern-api/docs-markdown-utils` tests pass
- [x] All 14 `@fern-api/fs-utils` tests pass
- [x] Lint and format checks pass
- [x] Cross-platform smoke test from #15658 validates image paths on ubuntu, macOS, and Windows CI
- [x] Smoke test now asserts images load with non-zero dimensions (not just path pattern checks)

Link to Devin session: https://app.devin.ai/sessions/ced86a2258d04cea8bdc225210f15e93
Requested by: @thesandlord