### PR TITLE
fix(cli): send customDomains when publishing docs translations

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-translation-publish-custom-domains.yml
+++ b/packages/cli/cli/changes/unreleased/fix-translation-publish-custom-domains.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Send `customDomains` when publishing docs translations so FDR mirrors the translated blob to every URL the docs are published to. Previously translations were only written under the canonical fern URL, so docs sites served from a custom domain with a basepath (e.g. `buildwithfern.com/learn`) 404'd on every localized page.
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -826,6 +826,11 @@ export async function publishDocs({
                             },
                             body: JSON.stringify({
                                 domain: translationDomain,
+                                // Send customDomains in production so FDR fans the translation
+                                // S3 write out across every URL the docs are published to.
+                                // Skipped in preview because preview deploys to a single
+                                // ephemeral URL with no custom-domain mirrors.
+                                customDomains: preview ? [] : customDomains,
                                 orgId: organization,
                                 locale,
                                 docsDefinition: translatedDefinition


### PR DESCRIPTION
## Description
Companion to https://github.com/fern-api/fern-platform/pull/10460. Sends `customDomains` to `/v2/registry/docs/translations/register` so FDR can mirror the translated S3 blob to every URL the docs are published to.

## The bug
A docs site served on a custom domain with a basepath (e.g. `buildwithfern.com/learn`) hit `buildwithfern.com/learn/v1/translations/zh.json` and 404'd on every localized page, even though the same site rendered fine on the fern URL. We were only sending the canonical fern URL to the translation endpoint, so the blob landed at the fern URL prefix only. Preview URLs worked because they hit the same domain the CLI registered against.

## Changes Made
- Forward `customDomains` (already plumbed from `runRemoteGenerationForDocsWorkspace`) to the `registerTranslation` fetch body.
- Skip the fan-out in preview mode — preview deploys to a single ephemeral URL with no custom-domain mirrors.
- Added changelog entry as a `fix`.

The companion fern-platform change updates `RegisterTranslationInputSchema` to accept `customDomains` (default `[]` for backward compat) and loops the S3 write + cache invalidation across `[fernUrl, ...customDomains]`. Mirrors the per-URL fan-out in `finishDocsRegister`.

## Testing
- [x] Type-checks (changed file has no errors; pre-existing failures in `@fern-api/register` for a different `Availability` enum mismatch are unrelated)
- [ ] End-to-end: republish a docs site that uses a custom-domain + basepath + translations, confirm `<custom-domain>/<basepath>/<locale>/<page>` loads the translated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)