### PR TITLE
fix(cli): exit with error when docs preview server crashes instead of false 'ready' message

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-preview-server-crash-handling.yml
+++ b/packages/cli/cli/changes/unreleased/fix-preview-server-crash-handling.yml
@@ -1,8 +1,6 @@
 - summary: |
     Fix docs preview server showing "ready" message when the server process
     crashes on startup. The CLI now exits with a clear error message instead.
-    Also adds the standalone node_modules to NODE_PATH to improve module
-    resolution on newer Node.js versions.
   type: fix
 - summary: |
     On Windows, recover critical standalone node_modules packages (next,

--- a/packages/cli/cli/changes/unreleased/fix-preview-server-crash-handling.yml
+++ b/packages/cli/cli/changes/unreleased/fix-preview-server-crash-handling.yml
@@ -4,3 +4,9 @@
     Also adds the standalone node_modules to NODE_PATH to improve module
     resolution on newer Node.js versions.
   type: fix
+- summary: |
+    On Windows, recover critical standalone node_modules packages (next,
+    react-dom, styled-jsx) when symlink resolution fails due to long .pnpm
+    directory names. The CLI now scans the .pnpm store and copies packages
+    directly as a fallback.
+  type: fix

--- a/packages/cli/cli/changes/unreleased/fix-preview-server-crash-handling.yml
+++ b/packages/cli/cli/changes/unreleased/fix-preview-server-crash-handling.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix docs preview server showing "ready" message when the server process
+    crashes on startup. The CLI now exits with a clear error message instead.
+    Also adds the standalone node_modules to NODE_PATH to improve module
+    resolution on newer Node.js versions.
+  type: fix

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -6,7 +6,7 @@ import chalk from "chalk";
 import { execSync } from "child_process";
 import cliProgress from "cli-progress";
 import decompress from "decompress";
-import { cpSync, existsSync, lstatSync, mkdirSync, symlinkSync } from "fs";
+import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, symlinkSync } from "fs";
 import { mkdir, readFile, rename, rm, writeFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
@@ -150,6 +150,7 @@ function resolveWindowsSymlinks(
         }
 
         if (!existsSync(sourcePath)) {
+            logger.debug(`Symlink target not found: ${symlinkPath} -> ${linkname} (resolved: ${sourcePath})`);
             failed++;
             continue;
         }
@@ -180,12 +181,58 @@ function resolveWindowsSymlinks(
             `out of ${symlinks.length}`
     );
 
-    // Verify critical top-level packages
+    // Verify critical top-level packages and attempt recovery for any that are missing.
+    // On Windows the .pnpm directory names can be extremely long (peer-dep hashes) which
+    // may cause extraction or junction creation to fail silently. When a critical package
+    // is missing, scan the .pnpm store for a matching directory and copy it directly.
     const standaloneNM = path.join(outputDir, "standalone", "node_modules");
-    for (const dep of ["next", "react", "react-dom", "styled-jsx"]) {
-        if (!existsSync(path.join(standaloneNM, dep))) {
-            logger.warn(`${dep} is MISSING from standalone/node_modules/`);
+    const criticalDeps = ["next", "react", "react-dom", "styled-jsx"];
+    for (const dep of criticalDeps) {
+        const depPath = path.join(standaloneNM, dep);
+        if (existsSync(depPath)) {
+            continue;
         }
+
+        logger.warn(`${dep} is MISSING from standalone/node_modules/ — attempting recovery`);
+
+        // Search .pnpm store for the real package directory.
+        // Structure: .pnpm/<dep>@<version>[_peer-hash]/node_modules/<dep>/
+        if (existsSync(rootPnpmStore)) {
+            try {
+                const pnpmDirs = readdirSync(rootPnpmStore);
+                // Match directories that start with "<dep>@" (e.g., "next@15.3.2_...")
+                const matchingDir = pnpmDirs.find((d) => d === dep || d.startsWith(`${dep}@`));
+                if (matchingDir != null) {
+                    const realPkgPath = path.join(rootPnpmStore, matchingDir, "node_modules", dep);
+                    if (existsSync(realPkgPath)) {
+                        logger.debug(`Found ${dep} in .pnpm store at ${realPkgPath}, copying...`);
+                        mkdirSync(path.dirname(depPath), { recursive: true });
+                        cpSync(realPkgPath, depPath, { recursive: true });
+                        if (existsSync(depPath)) {
+                            logger.info(`Recovered ${dep} via direct copy from .pnpm store`);
+                            continue;
+                        }
+                    }
+                }
+            } catch (recoverError) {
+                logger.debug(`Recovery scan for ${dep} failed: ${recoverError}`);
+            }
+        }
+
+        // If we still don't have it, search through symlink entries for the original
+        // linkname and try to resolve from any matching .pnpm directory
+        const symlinkEntry = symlinks.find(
+            (s) =>
+                s.path === path.join("standalone", "node_modules", dep).replace(/\\/g, "/") ||
+                s.path.endsWith(`/node_modules/${dep}`)
+        );
+        if (symlinkEntry != null) {
+            logger.debug(
+                `${dep} was a symlink: ${symlinkEntry.path} -> ${symlinkEntry.linkname} but resolution failed`
+            );
+        }
+
+        logger.error(`${dep} could not be recovered and will be unavailable at runtime`);
     }
 }
 

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -1097,7 +1097,7 @@ export async function runAppPreviewServer({
         NEXT_PUBLIC_IS_LOCAL: "1",
         NEXT_DISABLE_CACHE: "1",
         NODE_ENV: "production",
-        NODE_PATH: [bundleRoot, path.join(bundleRoot, "standalone", "node_modules")].join(path.delimiter),
+        NODE_PATH: bundleRoot,
         NODE_OPTIONS: `--max-old-space-size=8096 --enable-source-maps --require ${polyfillPath}`
     };
 

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -1097,7 +1097,7 @@ export async function runAppPreviewServer({
         NEXT_PUBLIC_IS_LOCAL: "1",
         NEXT_DISABLE_CACHE: "1",
         NODE_ENV: "production",
-        NODE_PATH: bundleRoot,
+        NODE_PATH: [bundleRoot, path.join(bundleRoot, "standalone", "node_modules")].join(path.delimiter),
         NODE_OPTIONS: `--max-old-space-size=8096 --enable-source-maps --require ${polyfillPath}`
     };
 
@@ -1107,7 +1107,10 @@ export async function runAppPreviewServer({
 
     // Function to start the Next.js server
     const startNextJsServer = (): Promise<void> => {
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
+            let settled = false;
+            let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
+
             serverProcess = runExeca(context.logger, "node", [serverPath], {
                 env,
                 doNotPipeOutput: true
@@ -1122,7 +1125,11 @@ export async function runAppPreviewServer({
                     actualPort = Number(portMatch[1]);
                 }
 
-                if (output.includes("Ready in") || output.includes("✓ Ready")) {
+                if (!settled && (output.includes("Ready in") || output.includes("✓ Ready"))) {
+                    settled = true;
+                    if (fallbackTimer != null) {
+                        clearTimeout(fallbackTimer);
+                    }
                     resolve();
                 }
             };
@@ -1137,13 +1144,31 @@ export async function runAppPreviewServer({
 
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             serverProcess.on("error", (err) => {
-                context.logger.debug(`Server process error: ${err.message}`);
+                context.logger.error(`Server process error: ${err.message}`);
+                if (!settled) {
+                    settled = true;
+                    if (fallbackTimer != null) {
+                        clearTimeout(fallbackTimer);
+                    }
+                    reject(new Error(`Server process failed to start: ${err.message}`));
+                }
             });
 
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             serverProcess.on("exit", (code, signal) => {
-                if (code) {
-                    context.logger.debug(`Server process exited with code: ${code}`);
+                if (code != null && code !== 0) {
+                    context.logger.error(`Server process exited with code: ${code}`);
+                    if (!settled) {
+                        settled = true;
+                        if (fallbackTimer != null) {
+                            clearTimeout(fallbackTimer);
+                        }
+                        reject(
+                            new Error(
+                                `Server process exited with code ${code}. Check the debug logs above for details.`
+                            )
+                        );
+                    }
                 } else if (signal) {
                     context.logger.debug(`Server process killed with signal: ${signal}`);
                 } else {
@@ -1152,14 +1177,26 @@ export async function runAppPreviewServer({
             });
 
             // Fallback timeout in case we miss the ready message
-            setTimeout(() => {
-                resolve();
+            fallbackTimer = setTimeout(() => {
+                if (!settled) {
+                    settled = true;
+                    resolve();
+                }
             }, 10000);
         });
     };
 
     // Start the initial server
-    await startNextJsServer();
+    try {
+        await startNextJsServer();
+    } catch (err) {
+        context.failAndThrow(
+            `Docs preview server failed to start: ${extractErrorMessage(err)}. ` +
+                `Run with --log-level debug for more details.`,
+            undefined,
+            { code: CliError.Code.InternalError }
+        );
+    }
 
     // Attach the watcher event handler
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -1320,7 +1357,7 @@ export async function runAppPreviewServer({
     process.on("beforeExit", cleanup);
 
     // Server is ready after startNextJsServer completes
-    context.logger.info(`Docs preview server ready on http://localhost:${port}`);
+    context.logger.info(`Docs preview server ready on http://localhost:${actualPort}`);
 
     // await infinitely
     // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
## Description

Two fixes for `fern docs dev` on Windows:

1. **False "ready" message when server crashes**: The CLI printed `Docs preview server ready on http://localhost:3000` even after the server process exited with code 1. Now it exits with a clear error message.
2. **Missing critical packages from symlink resolution**: On Windows, tar symlinks are recreated as NTFS junctions, but this can fail for packages with very long `.pnpm` directory names (peer-dep hashes). The CLI now scans the `.pnpm` store and copies packages directly as a fallback when `next`, `react`, `react-dom`, or `styled-jsx` are missing.

## Root Cause

**False "ready"**: The `startNextJsServer()` promise had a 10-second fallback timeout that resolved unconditionally, even after the server process crashed. The `exit` handler only logged at `debug` level and didn't reject the promise.

**Missing modules**: `resolveWindowsSymlinks()` silently skipped symlinks when the target path didn't exist (`failed++` with no logging), and the verification step only warned about missing packages without attempting recovery.

## Changes Made

### `runAppPreviewServer.ts`
- `startNextJsServer()` now rejects the promise when the process exits with non-zero code or emits an `error` event
- Added `settled` flag to prevent double-settle and cancel the fallback timeout on early resolution/rejection
- Server crashes now logged at `error` level instead of `debug`
- Caller wraps `startNextJsServer()` in try/catch and calls `context.failAndThrow()` with actionable error message
- "Ready" message now uses `actualPort` instead of the requested port

### `downloadLocalDocsBundle.ts`
- Added debug logging when symlink target doesn't exist (shows source path, linkname, resolved path)
- After symlink resolution, missing critical packages trigger a recovery scan of the `.pnpm` store
- Recovery finds the real package directory by matching `<dep>@*` directory names and copies it recursively
- Added `readdirSync` import for `.pnpm` store scanning

## Testing
- [x] Compiles successfully (`tsc`)
- [x] Lint and format pass (`biome`)
- [x] Changelog entry added

Link to Devin session: https://app.devin.ai/sessions/ced86a2258d04cea8bdc225210f15e93
Requested by: @thesandlord