### PR TITLE
fix(cli): show actionable error when GitHub App is not installed on target repo

### DIFF
--- a/packages/cli/cli/changes/unreleased/github-app-not-installed-error.yml
+++ b/packages/cli/cli/changes/unreleased/github-app-not-installed-error.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Show a clear, actionable error when the Fern GitHub App is not installed on
+    the target repository instead of the generic "Failed to create job" message.
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -210,6 +210,17 @@ async function createJob({
         if (rawError?.content?.reason === "status-code" && rawError.content.statusCode === 429) {
             throw new TooManyRequestsError();
         }
+
+        // GithubAppNotInstalled is not in the SDK's error union for createJobV3, so
+        // handle it before the visitor. Fiddle returns this when the Fern GitHub App
+        // is not installed on the target repository.
+        const githubAppNotInstalledMessage = extractGithubAppNotInstalledMessage(rawError);
+        if (githubAppNotInstalledMessage != null) {
+            return context.failAndThrow(githubAppNotInstalledMessage, undefined, {
+                code: CliError.Code.ConfigError
+            });
+        }
+
         return convertCreateJobError(rawError)._visit({
             illegalApiNameError: () => {
                 return context.failAndThrow(
@@ -432,6 +443,29 @@ export function extractErrorMessage(error: any): string | undefined {
         return body.message;
     }
     return undefined;
+}
+
+/**
+ * Checks whether a raw SDK error is a GithubAppNotInstalled response from Fiddle.
+ * The error body shape is: { error: "GithubAppNotInstalled", content: { message, repositoryName } }.
+ * Returns a user-friendly message if matched, undefined otherwise.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: the error shape from the SDK is not well-typed
+function extractGithubAppNotInstalledMessage(error: any): string | undefined {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional dynamic navigation
+    const body: any = error?.content?.reason === "status-code" ? error.content.body : undefined;
+    if (body?.error !== "GithubAppNotInstalled") {
+        return undefined;
+    }
+    if (typeof body?.content?.message === "string") {
+        return body.content.message;
+    }
+    const repo =
+        typeof body?.content?.repositoryName === "string" ? body.content.repositoryName : "the target repository";
+    return (
+        `The Fern GitHub App is not installed on ${repo}. ` +
+        "Please install it (https://github.com/apps/fern-api) and try again."
+    );
 }
 
 // Fiddle's ErrorBody serializes as { error: "<ErrorType>", content: <TypedBody> }.


### PR DESCRIPTION
## Description
Refs: Candidhealth support ticket — users running `fern generate` against a repo without the Fern GitHub App installed see a generic "Failed to create job" error instead of a helpful message.

## Changes Made
- Added `extractGithubAppNotInstalledMessage` helper that detects `GithubAppNotInstalled` errors from Fiddle before the generic visitor fallback
- When detected, the CLI now shows the descriptive message from Fiddle (e.g. "The Fern GitHub App is not installed on owner/repo. Please install the Fern GitHub App (https://github.com/apps/fern-api) on owner/repo to continue.") with a `ConfigError` code instead of `NetworkError`
- Added changelog entry

## Testing
- [ ] Manual testing: run `fern generate` against a repo without the GitHub App installed — should show the descriptive error instead of "Failed to create job"
- [ ] Manual testing: run `fern generate` against a repo WITH the GitHub App installed — should work normally

**Companion PR:** https://github.com/fern-api/fiddle/pull/726 (server-side: validates GitHub App installation during job creation)

Link to Devin session: https://app.devin.ai/sessions/31bd0a5e2af94759a21a1e3ecdaa92fa
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->