### PR TITLE
chore(java): upgrade glibc in Java SDK generator container to fix CVE-2026-4046

### DIFF
--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -73,6 +73,9 @@ RUN rm -f /opt/gradle/lib/plugins/bcpg-jdk18on-*.jar \
 # CVE-2025-11468, CVE-2025-15282, CVE-2026-0672, CVE-2026-0865, CVE-2026-1299,
 # CVE-2026-2297, CVE-2026-4224, CVE-2026-4519),
 # libnghttp2 (ALAS2023-2026-1542, CVE-2026-27135)
+# Security update 2026-05-04: add glibc/glibc-common/glibc-minimal-langpack
+# (CVE-2026-4046, iconv() assertion failure when converting IBM1390/IBM1399
+# inputs; fixed in glibc 2.34-231.amzn2023.0.4)
 RUN dnf --releasever=latest update -y \
     openssl-fips-provider-latest \
     openssl-libs \
@@ -92,7 +95,10 @@ RUN dnf --releasever=latest update -y \
     freetype \
     python3 \
     python3-libs \
-    libnghttp2 && \
+    libnghttp2 \
+    glibc \
+    glibc-common \
+    glibc-minimal-langpack && \
     dnf remove -y git-lfs wget || true && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/generators/java/sdk/changes/unreleased/upgrade-glibc-cve-2026-4046.yml
+++ b/generators/java/sdk/changes/unreleased/upgrade-glibc-cve-2026-4046.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Upgrade glibc/glibc-common/glibc-minimal-langpack in the Java SDK generator
+    container to address CVE-2026-4046 (iconv() assertion failure when converting
+    IBM1390/IBM1399 inputs; fixed in glibc 2.34-231.amzn2023.0.4).
+  type: chore


### PR DESCRIPTION
## Description
Linear ticket: Refs

Addresses [CVE-2026-4046](https://access.redhat.com/security/cve/CVE-2026-4046) reported by AWS Inspector against the Java SDK generator container image. The vulnerability is an assertion failure in `iconv()` (GNU C Library ≤ 2.43) when converting inputs from the IBM1390 / IBM1399 character sets, which can be used to remotely crash an application.

- Affected packages: `glibc`, `glibc-common`, `glibc-minimal-langpack`
- Installed (vulnerable) version: `0:2.34-231.amzn2023.0.3` (Amazon Linux 2023)
- Fixed version: `0:2.34-231.amzn2023.0.4`

The Java SDK generator image is built from `gradle:jdk11-corretto`, which is based on Amazon Linux 2023, so it is affected. The Java model generator image (`gradle:8.5.0-jdk17-jammy`) is Ubuntu-based and is **not** affected by this CVE, so no change is needed there.

## Changes Made
- `generators/java/sdk/Dockerfile`: add `glibc`, `glibc-common`, and `glibc-minimal-langpack` to the existing `dnf --releasever=latest update -y` package list so the patched glibc 2.34-231.amzn2023.0.4 is pulled in. Comment header updated with the security-update entry.
- Added a chore-level changelog entry under `generators/java/sdk/changes/unreleased/` describing the fix.
- [ ] Updated README.md generator (if applicable) — N/A

## Testing
- [ ] Unit tests added/updated — N/A; this is an OS-package patch in the generator container.
- [ ] Manual testing completed — Pending. Once CI passes, the container build itself exercises the `dnf update` step. Recommended follow-up: rebuild the Java SDK generator image and re-scan with AWS Inspector to confirm the finding clears.

Link to Devin session: https://app.devin.ai/sessions/b311577af8fc4e2b8a3bc0fdde61fbda
Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->