### PR TITLE
fix(cli): fail with clear error when docs.yml is missing from `fern docs dev`

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-docs-dev-missing-docs-yml.yml
+++ b/packages/cli/cli/changes/unreleased/fix-docs-dev-missing-docs-yml.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    `fern docs dev` now fails with a clear error when no `docs.yml` is present, instead of exiting silently.
+  type: fix

--- a/packages/cli/cli/src/commands/docs-dev/devDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/docs-dev/devDocsWorkspace.ts
@@ -33,6 +33,7 @@ export async function previewDocsWorkspace({
             undefined,
             { code: CliError.Code.ConfigError }
         );
+        return;
     }
 
     if (legacyPreview) {

--- a/packages/cli/cli/src/commands/docs-dev/devDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/docs-dev/devDocsWorkspace.ts
@@ -1,6 +1,7 @@
 import { runAppPreviewServer, runPreviewServer } from "@fern-api/docs-preview";
 import { filterOssWorkspaces } from "@fern-api/docs-resolver";
 import { Project } from "@fern-api/project-loader";
+import { CliError } from "@fern-api/task-context";
 
 import { CliContext } from "../../cli-context/CliContext.js";
 import { validateDocsWorkspaceWithoutExiting } from "../validate/validateDocsWorkspaceAndLogIssues.js";
@@ -27,7 +28,11 @@ export async function previewDocsWorkspace({
     const project = await loadProject();
     const docsWorkspace = project.docsWorkspaces;
     if (docsWorkspace == null) {
-        return;
+        cliContext.failAndThrow(
+            "No docs.yml found in your Fern project. Add a docs.yml to configure your documentation site.",
+            undefined,
+            { code: CliError.Code.ConfigError }
+        );
     }
 
     if (legacyPreview) {


### PR DESCRIPTION
## Description
Cleans up #15143. `fern docs dev` previously exited silently when no `docs.yml` was present. Now it fails with a clear, actionable error message.

## Changes Made
- Added `failAndThrow` call with `ConfigError` code when `docsWorkspace` is null in `previewDocsWorkspace`
- Removed the silent `return` that previously caused the command to exit without feedback
- Added unreleased changelog entry

## Testing
- [x] Lint and format checks pass (`pnpm check`, `pnpm format`)


Link to Devin session: https://app.devin.ai/sessions/61227bbf76834c8882a5daa11bab1259
Requested by: @thesandlord