### PR TITLE
fix(python): widen pydantic-core constraint to <3.0.0

### DIFF
--- a/generators/python/pydantic/versions.yml
+++ b/generators/python/pydantic/versions.yml
@@ -1,5 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.12.0-rc.2
+  changelogEntry:
+    - summary: |
+        Widen the generated `pydantic-core` constraint from `>=2.18.2,<2.44.0` to
+        `>=2.18.2,<3.0.0`, unblocking customers who need newer pydantic-core (e.g.
+        2.46.x, required by pydantic 2.13). The previous cap targeted 2.44.0's
+        missing wheels; that release is yanked on PyPI, so the explicit cap is no
+        longer needed.
+      type: fix
+  createdAt: "2026-05-04"
+  irVersion: 66
+
 - version: 1.12.0-rc.1
   changelogEntry:
     - summary: |

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 5.9.2
+  changelogEntry:
+    - summary: |
+        Widen the generated `pydantic-core` constraint from `>=2.18.2,<2.44.0` to
+        `>=2.18.2,<3.0.0`, unblocking customers who need newer pydantic-core (e.g.
+        2.46.x, required by pydantic 2.13). The previous cap targeted 2.44.0's
+        missing wheels; that release is yanked on PyPI, so the explicit cap is no
+        longer needed.
+      type: fix
+  createdAt: "2026-05-04"
+  irVersion: 66
 - version: 5.9.1
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/external_dependencies/pydantic.py
+++ b/generators/python/src/fern_python/external_dependencies/pydantic.py
@@ -2,7 +2,7 @@ import enum
 
 from fern_python.codegen import AST
 
-PYDANTIC_CORE_DEPENDENCY = AST.Dependency(name="pydantic-core", version=">=2.18.2,<2.44.0")
+PYDANTIC_CORE_DEPENDENCY = AST.Dependency(name="pydantic-core", version=">=2.18.2,<3.0.0")
 PYDANTIC_DEPENDENCY = AST.Dependency(name="pydantic", version=">= 1.9.2")
 PYDANTIC_V1_DEPENDENCY = AST.Dependency(name="pydantic", version=">= 1.9.2,<= 1.10.14")
 PYDANTIC_V2_DEPENDENCY = AST.Dependency(name="pydantic", version=">= 2.0.0")


### PR DESCRIPTION
## Summary

- Widens the generated `pydantic-core` dependency constraint from `>=2.18.2,<2.44.0` to `>=2.18.2,<3.0.0`.
- Unblocks customers who need newer pydantic-core (e.g. **pydantic 2.13**, which depends on **pydantic-core 2.46.x**).
- Closes FER-10303 ([Truefoundry](https://app.usepylon.com/issues?issueNumber=20035)).

## Why the cap was there

The `<2.44.0` cap was added in [`16554589b`](https://github.com/fern-api/fern/commit/16554589b74) to unblock CI when pydantic-core 2.44.0 shipped without installable wheels. That release is now **yanked on PyPI**:

```
$ curl -s https://pypi.org/pypi/pydantic-core/2.44.0/json | jq '.urls[0].yanked_reason'
"incomplete wheels"
```

Pip's resolver skips yanked releases automatically, so the explicit `<2.44.0` cap is no longer needed. Widening to `<3.0.0` restores the original `^2.18.2` semantic intent.

## Diff

```python
# generators/python/src/fern_python/external_dependencies/pydantic.py
-PYDANTIC_CORE_DEPENDENCY = AST.Dependency(name="pydantic-core", version=">=2.18.2,<2.44.0")
+PYDANTIC_CORE_DEPENDENCY = AST.Dependency(name="pydantic-core", version=">=2.18.2,<3.0.0")
```

## Verification

Regenerated `seed/python-sdk/alias/` against this branch and installed into a fresh Python 3.11 venv alongside `pydantic==2.13.*`:

```
$ pip install pydantic==2.13.* .
Successfully installed pydantic-2.13.3 pydantic-core-2.46.3 fern_alias-0.0.1 ...

$ python -c "from seed.client import SeedAlias; from seed.types.type import Type; \
  print(Type(id='x', name='y').model_dump_json())"
{"id":"x","name":"y"}
```

Pip resolves cleanly to `pydantic-core 2.46.3`, the SDK imports, and pydantic-core round-trips serialization/validation.

## Test plan

- [ ] CI green
- [ ] On a downstream Python SDK regenerated with the new generator version, confirm `pip install pydantic==2.13.*` resolves alongside the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)