### PR TITLE
fix(cli): load tabs and navigation from version overlay nav files

### DIFF
--- a/packages/cli/configuration-loader/src/docs-yml/__test__/translationsDocsConfiguration.test.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/__test__/translationsDocsConfiguration.test.ts
@@ -300,6 +300,125 @@ describe("parseDocsConfiguration — translation navigation overlay docs.yml loc
         expect(productOverlay?.displayName).toBe("Produit");
         expect(productOverlay?.tabs?.["guides"]?.displayName).toBe("Guides");
     });
+
+    it("should load tabs and navigation from a top-level version's referenced nav file", async () => {
+        const fernDir = tmpDir as AbsoluteFilePath;
+        const configPath = path.join(tmpDir, "docs.yml") as AbsoluteFilePath;
+        await writeFile(configPath, "");
+
+        const frDir = path.join(tmpDir, "translations", "fr");
+        const versionsDir = path.join(frDir, "versions");
+        await mkdir(versionsDir, { recursive: true });
+        await writeFile(
+            path.join(frDir, "docs.yml"),
+            ["versions:", "  - display-name: V1", "    slug: v1", "    path: ./versions/v1.yml"].join("\n") + "\n"
+        );
+        await writeFile(
+            path.join(versionsDir, "v1.yml"),
+            [
+                "tabs:",
+                "  api:",
+                "    display-name: Référence API",
+                "navigation:",
+                "  - tab: api",
+                "    layout:",
+                "      - section: Aperçu"
+            ].join("\n") + "\n"
+        );
+
+        const config = makeMinimalRawConfig({
+            translations: [{ lang: "en", default: true }, { lang: "fr" }]
+        });
+
+        const parsed = await parseDocsConfiguration({
+            rawDocsConfiguration: config,
+            absolutePathToFernFolder: fernDir,
+            absoluteFilepathToDocsConfig: configPath,
+            context: createMockTaskContext()
+        });
+
+        const versionOverlay = parsed.translationNavigationOverlays?.["fr"]?.versions?.[0];
+        expect(versionOverlay?.displayName).toBe("V1");
+        expect(versionOverlay?.slug).toBe("v1");
+        expect(versionOverlay?.tabs?.["api"]?.displayName).toBe("Référence API");
+        expect(versionOverlay?.navigation).toBeDefined();
+    });
+
+    it("should parse versions nested inside a product and load their nav files", async () => {
+        const fernDir = tmpDir as AbsoluteFilePath;
+        const configPath = path.join(tmpDir, "docs.yml") as AbsoluteFilePath;
+        await writeFile(configPath, "");
+
+        const frDir = path.join(tmpDir, "translations", "fr");
+        const versionsDir = path.join(frDir, "versions");
+        await mkdir(versionsDir, { recursive: true });
+        await writeFile(
+            path.join(frDir, "docs.yml"),
+            [
+                "products:",
+                "  - display-name: Plateforme",
+                "    versions:",
+                "      - display-name: V4",
+                "        slug: v4",
+                "        path: ./versions/v4.yml",
+                "      - display-name: Hérité",
+                "        slug: v2"
+            ].join("\n") + "\n"
+        );
+        await writeFile(
+            path.join(versionsDir, "v4.yml"),
+            ["tabs:", "  docs:", "    display-name: Documentation"].join("\n") + "\n"
+        );
+
+        const config = makeMinimalRawConfig({
+            translations: [{ lang: "en", default: true }, { lang: "fr" }]
+        });
+
+        const parsed = await parseDocsConfiguration({
+            rawDocsConfiguration: config,
+            absolutePathToFernFolder: fernDir,
+            absoluteFilepathToDocsConfig: configPath,
+            context: createMockTaskContext()
+        });
+
+        const productOverlay = parsed.translationNavigationOverlays?.["fr"]?.products?.[0];
+        expect(productOverlay?.displayName).toBe("Plateforme");
+        expect(productOverlay?.versions).toHaveLength(2);
+        expect(productOverlay?.versions?.[0]?.displayName).toBe("V4");
+        expect(productOverlay?.versions?.[0]?.tabs?.["docs"]?.displayName).toBe("Documentation");
+        // Second version has no `path:` and should still parse with display-name only
+        expect(productOverlay?.versions?.[1]?.displayName).toBe("Hérité");
+        expect(productOverlay?.versions?.[1]?.tabs).toBeUndefined();
+    });
+
+    it("should warn and skip when a version's path escapes the translations directory", async () => {
+        const fernDir = tmpDir as AbsoluteFilePath;
+        const configPath = path.join(tmpDir, "docs.yml") as AbsoluteFilePath;
+        await writeFile(configPath, "");
+
+        const frDir = path.join(tmpDir, "translations", "fr");
+        await mkdir(frDir, { recursive: true });
+        await writeFile(
+            path.join(frDir, "docs.yml"),
+            ["versions:", "  - display-name: V1", "    path: ../../../etc/passwd"].join("\n") + "\n"
+        );
+
+        const config = makeMinimalRawConfig({
+            translations: [{ lang: "en", default: true }, { lang: "fr" }]
+        });
+
+        const parsed = await parseDocsConfiguration({
+            rawDocsConfiguration: config,
+            absolutePathToFernFolder: fernDir,
+            absoluteFilepathToDocsConfig: configPath,
+            context: createMockTaskContext()
+        });
+
+        const versionOverlay = parsed.translationNavigationOverlays?.["fr"]?.versions?.[0];
+        expect(versionOverlay?.displayName).toBe("V1");
+        expect(versionOverlay?.tabs).toBeUndefined();
+        expect(versionOverlay?.navigation).toBeUndefined();
+    });
 });
 
 describe("parseDocsConfiguration — translation navbar-links overrides", () => {

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -2272,7 +2272,8 @@ async function parseNavigationOverlayFromDocsYml({
                 subtitle: typeof productObj.subtitle === "string" ? productObj.subtitle : undefined,
                 announcement: undefined,
                 tabs: undefined,
-                navigation: undefined
+                navigation: undefined,
+                versions: undefined
             };
 
             if (isPlainObject(productObj.announcement)) {
@@ -2285,33 +2286,32 @@ async function parseNavigationOverlayFromDocsYml({
             // If this product references a nav file, load its tab/navigation overrides
             // These are stored per-product to avoid collision when multiple products share tab IDs
             if (typeof productObj.path === "string") {
-                // Validate path to prevent path traversal attacks
-                const resolvedNavFilePath = path.resolve(overlayDir, productObj.path) as AbsoluteFilePath;
-                if (!resolvedNavFilePath.startsWith(overlayDir)) {
-                    context.logger.warn(
-                        `Invalid path in product overlay: "${productObj.path}" escapes the translations directory. Skipping.`
-                    );
-                    overlay.products.push(productOverlay);
-                    continue;
+                const navFile = await loadNavOverlayFile({
+                    relativeNavPath: productObj.path,
+                    overlayDir,
+                    overlayKind: "product",
+                    context
+                });
+                if (navFile != null) {
+                    productOverlay.tabs = navFile.tabs;
+                    productOverlay.navigation = navFile.navigation;
                 }
-                const navFilePath = resolvedNavFilePath;
-                if (await doesPathExist(navFilePath)) {
-                    try {
-                        const navContent = yaml.load(await readFile(navFilePath, "utf-8"));
-                        if (isPlainObject(navContent)) {
-                            const navObj = navContent as Record<string, unknown>;
-                            // Tabs defined in the nav file - stored per-product
-                            if (isPlainObject(navObj.tabs)) {
-                                productOverlay.tabs = parseTabOverlays(navObj.tabs as Record<string, unknown>);
-                            }
-                            // Navigation items defined in the nav file - stored per-product
-                            if (Array.isArray(navObj.navigation)) {
-                                productOverlay.navigation = parseNavigationItemOverlays(navObj.navigation);
-                            }
-                        }
-                    } catch (error) {
-                        context.logger.warn(`Failed to load translation nav file "${navFilePath}": ${String(error)}`);
+            }
+
+            // Parse versions nested inside the product
+            if (Array.isArray(productObj.versions)) {
+                productOverlay.versions = [];
+                for (const version of productObj.versions) {
+                    if (!isPlainObject(version)) {
+                        continue;
                     }
+                    productOverlay.versions.push(
+                        await parseVersionOverlay({
+                            versionObj: version as Record<string, unknown>,
+                            overlayDir,
+                            context
+                        })
+                    );
                 }
             }
 
@@ -2319,18 +2319,20 @@ async function parseNavigationOverlayFromDocsYml({
         }
     }
 
-    // Parse versions
+    // Parse top-level versions (for docs configs without products)
     if (Array.isArray(docsYmlContent.versions)) {
         overlay.versions = [];
         for (const version of docsYmlContent.versions) {
             if (!isPlainObject(version)) {
                 continue;
             }
-            const versionObj = version as Record<string, unknown>;
-            overlay.versions.push({
-                slug: typeof versionObj.slug === "string" ? versionObj.slug : undefined,
-                displayName: typeof versionObj["display-name"] === "string" ? versionObj["display-name"] : undefined
-            });
+            overlay.versions.push(
+                await parseVersionOverlay({
+                    versionObj: version as Record<string, unknown>,
+                    overlayDir,
+                    context
+                })
+            );
         }
     }
 
@@ -2340,6 +2342,91 @@ async function parseNavigationOverlayFromDocsYml({
     }
 
     return overlay;
+}
+
+/**
+ * Parses a single version entry from a translation overlay, including any
+ * `tabs` and `navigation` defined in a referenced nav YAML file via `path:`.
+ */
+async function parseVersionOverlay({
+    versionObj,
+    overlayDir,
+    context
+}: {
+    versionObj: Record<string, unknown>;
+    overlayDir: AbsoluteFilePath;
+    context: TaskContext;
+}): Promise<docsYml.VersionOverlay> {
+    const versionOverlay: docsYml.VersionOverlay = {
+        slug: typeof versionObj.slug === "string" ? versionObj.slug : undefined,
+        displayName: typeof versionObj["display-name"] === "string" ? versionObj["display-name"] : undefined,
+        tabs: undefined,
+        navigation: undefined
+    };
+
+    if (typeof versionObj.path === "string") {
+        const navFile = await loadNavOverlayFile({
+            relativeNavPath: versionObj.path,
+            overlayDir,
+            overlayKind: "version",
+            context
+        });
+        if (navFile != null) {
+            versionOverlay.tabs = navFile.tabs;
+            versionOverlay.navigation = navFile.navigation;
+        }
+    }
+
+    return versionOverlay;
+}
+
+/**
+ * Loads `tabs` and `navigation` from a nav YAML file referenced by a translation
+ * overlay (product or version). Returns `undefined` when the path is invalid,
+ * does not exist, or fails to parse — callers fall back to no per-scope overrides.
+ */
+async function loadNavOverlayFile({
+    relativeNavPath,
+    overlayDir,
+    overlayKind,
+    context
+}: {
+    relativeNavPath: string;
+    overlayDir: AbsoluteFilePath;
+    overlayKind: "product" | "version";
+    context: TaskContext;
+}): Promise<
+    | {
+          tabs: Record<string, docsYml.TabOverlay> | undefined;
+          navigation: docsYml.NavigationItemOverlay[] | undefined;
+      }
+    | undefined
+> {
+    // Validate path to prevent path traversal attacks
+    const resolvedNavFilePath = path.resolve(overlayDir, relativeNavPath) as AbsoluteFilePath;
+    if (!resolvedNavFilePath.startsWith(overlayDir)) {
+        context.logger.warn(
+            `Invalid path in ${overlayKind} overlay: "${relativeNavPath}" escapes the translations directory. Skipping.`
+        );
+        return undefined;
+    }
+    if (!(await doesPathExist(resolvedNavFilePath))) {
+        return undefined;
+    }
+    try {
+        const navContent = yaml.load(await readFile(resolvedNavFilePath, "utf-8"));
+        if (!isPlainObject(navContent)) {
+            return undefined;
+        }
+        const navObj = navContent as Record<string, unknown>;
+        return {
+            tabs: isPlainObject(navObj.tabs) ? parseTabOverlays(navObj.tabs as Record<string, unknown>) : undefined,
+            navigation: Array.isArray(navObj.navigation) ? parseNavigationItemOverlays(navObj.navigation) : undefined
+        };
+    } catch (error) {
+        context.logger.warn(`Failed to load translation nav file "${resolvedNavFilePath}": ${String(error)}`);
+        return undefined;
+    }
 }
 
 function parseTabOverlays(tabsObj: Record<string, unknown>): Record<string, docsYml.TabOverlay> {

--- a/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
@@ -580,11 +580,17 @@ export interface ProductOverlay {
     tabs: Record<string, TabOverlay> | undefined;
     /** Per-product navigation overlays from the referenced nav file */
     navigation: NavigationItemOverlay[] | undefined;
+    /** Per-product version overlays for products with multiple versions */
+    versions: VersionOverlay[] | undefined;
 }
 
 export interface VersionOverlay {
     slug: string | undefined;
     displayName: string | undefined;
+    /** Per-version tab overlays from the referenced nav file */
+    tabs: Record<string, TabOverlay> | undefined;
+    /** Per-version navigation overlays from the referenced nav file */
+    navigation: NavigationItemOverlay[] | undefined;
 }
 
 export interface AnnouncementOverlay {

--- a/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
@@ -64,7 +64,8 @@ describe("applyTranslatedNavigationOverlays", () => {
                     subtitle: "ようこそ",
                     announcement: undefined,
                     tabs: undefined,
-                    navigation: undefined
+                    navigation: undefined,
+                    versions: undefined
                 }
             ]
         };
@@ -114,8 +115,8 @@ describe("applyTranslatedNavigationOverlays", () => {
         const overlay: docsYml.TranslationNavigationOverlay = {
             ...emptyOverlay(),
             versions: [
-                { slug: "v2", displayName: "v2 (最新)" },
-                { slug: "v1", displayName: "v1 (旧)" }
+                { slug: "v2", displayName: "v2 (最新)", tabs: undefined, navigation: undefined },
+                { slug: "v1", displayName: "v1 (旧)", tabs: undefined, navigation: undefined }
             ]
         };
 
@@ -126,6 +127,104 @@ describe("applyTranslatedNavigationOverlays", () => {
         const versions = versioned.children as Array<Record<string, unknown>>;
         expect(versions[0]?.title).toBe("v2 (最新)");
         expect(versions[1]?.title).toBe("v1 (旧)");
+    });
+
+    it("applies version-scoped tab and section overrides nested inside a product", () => {
+        const root = {
+            type: "root",
+            child: {
+                type: "productgroup",
+                children: [
+                    {
+                        type: "product",
+                        productId: "Platform",
+                        title: "Platform",
+                        subtitle: "",
+                        slug: "platform",
+                        child: {
+                            type: "versioned",
+                            children: [
+                                {
+                                    type: "version",
+                                    versionId: "v4",
+                                    title: "V4",
+                                    slug: "platform/v4",
+                                    child: {
+                                        type: "tabbed",
+                                        children: [
+                                            {
+                                                type: "tab",
+                                                title: "Docs",
+                                                slug: "platform/v4/docs",
+                                                child: {
+                                                    type: "sidebarRoot",
+                                                    children: [
+                                                        {
+                                                            type: "section",
+                                                            title: "Introduction",
+                                                            slug: "platform/v4/docs/introduction",
+                                                            children: []
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        };
+        const overlay: docsYml.TranslationNavigationOverlay = {
+            ...emptyOverlay(),
+            products: [
+                {
+                    slug: undefined,
+                    displayName: "プラットフォーム",
+                    subtitle: undefined,
+                    announcement: undefined,
+                    tabs: undefined,
+                    navigation: undefined,
+                    versions: [
+                        {
+                            slug: "v4",
+                            displayName: "V4",
+                            tabs: { docs: { displayName: "ドキュメント", slug: undefined } },
+                            navigation: [
+                                {
+                                    type: "tab",
+                                    tabId: "docs",
+                                    layout: [
+                                        {
+                                            type: "section",
+                                            title: "はじめに",
+                                            slug: undefined,
+                                            contents: undefined
+                                        }
+                                    ],
+                                    variants: undefined
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        const result = applyTranslatedNavigationOverlays(asRoot(root), overlay);
+        const productGroup = (result as unknown as Record<string, unknown>).child as Record<string, unknown>;
+        const products = productGroup.children as Array<Record<string, unknown>>;
+        expect(products[0]?.title).toBe("プラットフォーム");
+        const versioned = products[0]?.child as Record<string, unknown>;
+        const versions = versioned.children as Array<Record<string, unknown>>;
+        const tabbed = versions[0]?.child as Record<string, unknown>;
+        const tabs = tabbed.children as Array<Record<string, unknown>>;
+        expect(tabs[0]?.title).toBe("ドキュメント");
+        const sidebarRoot = tabs[0]?.child as Record<string, unknown>;
+        const sections = sidebarRoot.children as Array<Record<string, unknown>>;
+        expect(sections[0]?.title).toBe("はじめに");
     });
 
     it("applies tab display-name override", () => {
@@ -332,7 +431,8 @@ describe("applyTranslatedNavigationOverlays", () => {
                     subtitle: undefined,
                     announcement: { message: "v2がリリースされました！" },
                     tabs: undefined,
-                    navigation: undefined
+                    navigation: undefined,
+                    versions: undefined
                 }
             ]
         };

--- a/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
+++ b/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
@@ -75,11 +75,11 @@ function applyChildOverlays(
             }
             const productOverlay = findProductOverlay(childObj, overlay.products ?? [], index);
             if (productOverlay != null) {
-                // Create a scoped overlay with product-specific tabs/navigation
+                // Create a scoped overlay with product-specific tabs/navigation/versions
                 const scopedOverlay: docsYml.TranslationNavigationOverlay = {
                     tabs: productOverlay.tabs ?? overlay.tabs,
                     products: undefined,
-                    versions: overlay.versions,
+                    versions: productOverlay.versions ?? overlay.versions,
                     announcement: productOverlay.announcement ?? overlay.announcement,
                     navigation: productOverlay.navigation ?? overlay.navigation,
                     navbarLinks: overlay.navbarLinks
@@ -99,11 +99,20 @@ function applyChildOverlays(
                 return walkAndApply(child, overlay);
             }
             const versionOverlay = findVersionOverlay(childObj, overlay.versions ?? [], index);
-            const walked = walkAndApply(child, overlay) as Record<string, unknown>;
             if (versionOverlay != null) {
+                // Create a scoped overlay with version-specific tabs/navigation
+                const scopedOverlay: docsYml.TranslationNavigationOverlay = {
+                    tabs: versionOverlay.tabs ?? overlay.tabs,
+                    products: undefined,
+                    versions: undefined,
+                    announcement: overlay.announcement,
+                    navigation: versionOverlay.navigation ?? overlay.navigation,
+                    navbarLinks: overlay.navbarLinks
+                };
+                const walked = walkAndApply(child, scopedOverlay) as Record<string, unknown>;
                 return applyVersionOverlayToNode(walked, versionOverlay);
             }
-            return walked;
+            return walkAndApply(child, overlay);
         });
     }
 


### PR DESCRIPTION
## Summary

When a docs project uses versioned products (`products[].versions[]` in `docs.yml`), translation overlays for those nested versions were silently dropped:

- The parser only read top-level `versions:` and ignored `versions:` nested inside `products[]`.
- Even at the top level, version overlay entries only extracted `slug` and `display-name`. The `path:` field — which products use to load tabs/navigation from a separate file — was unsupported for versions.
- Result: when a translator wrote `translations/<lang>/versions/v4.yml` with translated tabs and sidebar sections, the file was never loaded, and labels stayed in the source language even on `/<lang>/...` URLs.

## What changed

- **`parseDocsConfiguration.ts`** — adds `path:` support to version overlay entries (mirroring product overlays); parses `versions:` nested inside `products[]`; factors the nav-file loader into a shared `loadNavOverlayFile` helper used by both product and version overlay parsers.
- **`applyTranslatedNavigationOverlays.ts`** — when descending into a version node, scopes the overlay to use that version's `tabs` and `navigation` (parallel to the existing product scoping at the productgroup level). Also threads `productOverlay.versions` into the scoped overlay when entering a product, so per-product version overlays reach the matching version subtree.
- **`ParsedDocsConfiguration.ts`** — adds `tabs` and `navigation` fields on `VersionOverlay` and a `versions` field on `ProductOverlay`.

## Repro / before-and-after

Real-world layout that motivated the fix (Frame.io docs, abridged):

```yaml
# fern/docs.yml
products:
  - display-name: Platform
    path: ./versions/v4.yml
    versions:
      - display-name: V4
        path: ./versions/v4.yml
        slug: v4
      - display-name: V4 Experimental
        path: ./versions/v4-experimental.yml
        slug: v4-experimental

# fern/translations/ja/docs.yml
products:
  - display-name: プラットフォーム
    versions:
      - display-name: V4
        slug: v4
        path: ./versions/v4.yml      # ← was ignored before this fix

# fern/translations/ja/versions/v4.yml
tabs:
  docs:
    display-name: ドキュメント
  api:
    display-name: API リファレンス
navigation:
  - tab: docs
    layout:
      - section: はじめに
        contents:
          - page: 概要
```

Before: on `/ja/...`, tabs render as `Docs / API Reference`, sidebar as `Introduction / Overview`.
After: tabs render as `ドキュメント / API リファレンス`, sidebar as `はじめに / 概要`.

## Test plan

- [x] New unit tests for the parser cover: top-level version with `path:`, versions nested inside a product (mixed: one with `path:`, one without), path-traversal escape (warns and skips).
- [x] New unit test for `applyTranslatedNavigationOverlays` exercises a product → versioned → tabbed → sidebarRoot tree, asserting the version's tabs/navigation overlay reaches the tab title and section title.
- [x] All 17 existing translation parser tests pass.
- [x] All 56 existing docs-resolver tests pass (1 new + 55 prior).
- [ ] Manual smoke against a real docs preview — left for reviewer with access to a live multi-version site if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)