### PR TITLE
feat(cli): Add GitHub Actions annotations for CLI errors and warnings

### DIFF
--- a/packages/cli/cli-logger/src/TtyAwareLogger.ts
+++ b/packages/cli/cli-logger/src/TtyAwareLogger.ts
@@ -5,6 +5,11 @@ import chalk from "chalk";
 import IS_CI from "is-ci";
 import ora, { Ora } from "ora";
 
+import {
+    areLoggerAnnotationsSuppressed,
+    renderGithubAnnotationFromLog,
+    shouldEmitGithubAnnotations
+} from "./githubAnnotations.js";
 import { Log } from "./Log.js";
 
 interface Task {
@@ -114,6 +119,9 @@ export class TtyAwareLogger {
                 this.writeStdout(content);
             }
         };
+        // Cache the env-var check + the suppression flag once per call. Both are stable for the
+        // duration of this batch; checking each iteration would just be noise.
+        const emitAnnotations = shouldEmitGithubAnnotations() && !areLoggerAnnotationsSuppressed();
         for (const log of logs) {
             const content = formatLog(log, { includeDebugInfo });
             const omitOnTTY = log.omitOnTTY ?? false;
@@ -121,6 +129,19 @@ export class TtyAwareLogger {
                 write(content);
             } else if (!omitOnTTY) {
                 write(this.clear() + content + this.lastPaint);
+            }
+            // Emit a GitHub Actions workflow command alongside the normal log when the runner is
+            // GitHub Actions. The runner parses these from the step's stdout and renders them as
+            // inline annotations on the run/PR — surfacing errors and warnings the user would
+            // otherwise have to scroll the raw log to find. Gated purely on `GITHUB_ACTIONS=true`
+            // (not on `isTTY`) so it also works if someone forces the env var locally for testing.
+            // Commands that emit their own structured annotations (e.g. `fern automations
+            // generate`) suppress this hook to avoid duplicates — see `setLoggerAnnotationsSuppressed`.
+            if (emitAnnotations) {
+                const annotation = renderGithubAnnotationFromLog(log);
+                if (annotation != null) {
+                    this.stdout.write(annotation);
+                }
             }
         }
     }

--- a/packages/cli/cli-logger/src/TtyAwareLogger.ts
+++ b/packages/cli/cli-logger/src/TtyAwareLogger.ts
@@ -136,7 +136,7 @@ export class TtyAwareLogger {
             // otherwise have to scroll the raw log to find. Gated purely on `GITHUB_ACTIONS=true`
             // (not on `isTTY`) so it also works if someone forces the env var locally for testing.
             // Commands that emit their own structured annotations (e.g. `fern automations
-            // generate`) suppress this hook to avoid duplicates — see `setLoggerAnnotationsSuppressed`.
+            // generate`) suppress this hook to avoid duplicates — see `withSuppressedLoggerAnnotations`.
             if (emitAnnotations) {
                 const annotation = renderGithubAnnotationFromLog(log);
                 if (annotation != null) {

--- a/packages/cli/cli-logger/src/__test__/TtyAwareLogger.githubAnnotations.test.ts
+++ b/packages/cli/cli-logger/src/__test__/TtyAwareLogger.githubAnnotations.test.ts
@@ -1,0 +1,129 @@
+import { PassThrough } from "node:stream";
+import { LogLevel } from "@fern-api/logger";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { withSuppressedLoggerAnnotations } from "../githubAnnotations.js";
+import { TtyAwareLogger } from "../TtyAwareLogger.js";
+
+const ENV_KEYS = ["GITHUB_ACTIONS"] as const;
+
+/**
+ * Integration tests for the GHA annotation hook in `TtyAwareLogger.log`. The hook lives in the
+ * hot path of every CLI log line, so we want explicit coverage of the env-var gate, the
+ * suppression flag, the level filter, and the omit-on-TTY filter.
+ */
+describe("TtyAwareLogger GitHub Actions annotations", () => {
+    const saved: Record<(typeof ENV_KEYS)[number], string | undefined> = { GITHUB_ACTIONS: undefined };
+
+    let stdout: TestStream;
+    let stderr: TestStream;
+    let logger: TtyAwareLogger;
+
+    beforeEach(() => {
+        for (const key of ENV_KEYS) {
+            saved[key] = process.env[key];
+            delete process.env[key];
+        }
+        stdout = makeStream();
+        stderr = makeStream();
+        logger = new TtyAwareLogger(stdout.stream, stderr.stream);
+    });
+
+    afterEach(() => {
+        logger.finish();
+        for (const key of ENV_KEYS) {
+            if (saved[key] == null) {
+                delete process.env[key];
+            } else {
+                process.env[key] = saved[key];
+            }
+        }
+    });
+
+    it("emits no annotation lines when GITHUB_ACTIONS is unset", () => {
+        delete process.env.GITHUB_ACTIONS;
+        logger.log([{ level: LogLevel.Error, parts: ["boom"], time: new Date() }]);
+        expect(stdout.read()).not.toContain("::error::");
+        expect(stderr.read()).not.toContain("::error::");
+    });
+
+    it("emits ::error:: on stdout when GITHUB_ACTIONS=true and level is Error", () => {
+        process.env.GITHUB_ACTIONS = "true";
+        logger.log([{ level: LogLevel.Error, parts: ["boom"], time: new Date() }]);
+        expect(stdout.read()).toContain("::error::boom\n");
+    });
+
+    it("emits ::warning:: on stdout for warn-level logs", () => {
+        process.env.GITHUB_ACTIONS = "true";
+        logger.log([{ level: LogLevel.Warn, parts: ["careful"], time: new Date() }]);
+        expect(stdout.read()).toContain("::warning::careful\n");
+    });
+
+    it("does not emit annotations for info / debug / trace levels", () => {
+        process.env.GITHUB_ACTIONS = "true";
+        logger.log([
+            { level: LogLevel.Info, parts: ["x"], time: new Date() },
+            { level: LogLevel.Debug, parts: ["y"], time: new Date() },
+            { level: LogLevel.Trace, parts: ["z"], time: new Date() }
+        ]);
+        const out = stdout.read();
+        expect(out).not.toContain("::error");
+        expect(out).not.toContain("::warning");
+    });
+
+    it("suppresses annotations inside withSuppressedLoggerAnnotations(...)", async () => {
+        // `fern automations generate` runs its body inside `withSuppressedLoggerAnnotations` while
+        // it emits its own structured annotations from the GeneratorRunCollector; the generic
+        // logger hook must stay quiet so the user doesn't see two annotations per failure.
+        process.env.GITHUB_ACTIONS = "true";
+        await withSuppressedLoggerAnnotations(async () => {
+            logger.log([{ level: LogLevel.Error, parts: ["boom"], time: new Date() }]);
+        });
+        expect(stdout.read()).not.toContain("::error::");
+    });
+
+    it("re-emits annotations after the suppression scope exits", async () => {
+        process.env.GITHUB_ACTIONS = "true";
+        await withSuppressedLoggerAnnotations(async () => {
+            logger.log([{ level: LogLevel.Error, parts: ["first"], time: new Date() }]);
+        });
+        logger.log([{ level: LogLevel.Error, parts: ["second"], time: new Date() }]);
+        const out = stdout.read();
+        expect(out).not.toContain("::error::first");
+        expect(out).toContain("::error::second\n");
+    });
+
+    it("skips annotations for omitOnTTY: true logs even at error level", () => {
+        // The CLI uses `omitOnTTY: true` for status-only lines like "Failed." that exist for
+        // non-TTY readability. They aren't the actual error and shouldn't burn an annotation.
+        process.env.GITHUB_ACTIONS = "true";
+        logger.log([{ level: LogLevel.Error, parts: ["Failed."], time: new Date(), omitOnTTY: true }]);
+        expect(stdout.read()).not.toContain("::error::");
+    });
+
+    it("uses the log prefix as the annotation title (with ANSI stripped)", () => {
+        process.env.GITHUB_ACTIONS = "true";
+        // Hardcoded ANSI escapes so the test doesn't depend on chalk's TTY-detection behavior.
+        const prefix = `[34m[workspace-foo][39m   `;
+        logger.log([{ level: LogLevel.Error, parts: ["boom"], time: new Date(), prefix }]);
+        expect(stdout.read()).toContain("::error title=[workspace-foo]::boom\n");
+    });
+});
+
+interface TestStream {
+    stream: NodeJS.WriteStream;
+    read: () => string;
+}
+
+function makeStream(): TestStream {
+    const buffers: Buffer[] = [];
+    const passthrough = new PassThrough();
+    passthrough.on("data", (chunk: Buffer) => buffers.push(chunk));
+    // The TtyAwareLogger only reads `isTTY` and `write`; cast is enough for our purposes.
+    const stream = passthrough as unknown as NodeJS.WriteStream;
+    (stream as { isTTY?: boolean }).isTTY = false;
+    return {
+        stream,
+        read: () => Buffer.concat(buffers).toString("utf8")
+    };
+}

--- a/packages/cli/cli-logger/src/__test__/githubAnnotations.test.ts
+++ b/packages/cli/cli-logger/src/__test__/githubAnnotations.test.ts
@@ -136,6 +136,15 @@ describe("renderGithubAnnotation", () => {
         expect(renderGithubAnnotation("error", "line one\nline two")).toBe("::error::line one%0Aline two\n");
     });
 
+    it("escapes a literal '%' in the body to '%25' before encoding newlines", () => {
+        // If we didn't escape `%` first, a body containing the literal text `%0A` (e.g. a URL-
+        // encoded string the user logged) would round-trip through the runner as a real newline
+        // and split the annotation visually. Escaping `%` first preserves the literal text.
+        expect(renderGithubAnnotation("error", "value%0Ainjected")).toBe("::error::value%250Ainjected\n");
+        // Real newlines still encode correctly after the % pre-escape.
+        expect(renderGithubAnnotation("error", "100% done\nthen failed")).toBe("::error::100%25 done%0Athen failed\n");
+    });
+
     it("trims trailing newlines from the body before encoding", () => {
         expect(renderGithubAnnotation("error", "boom\n\n")).toBe("::error::boom\n");
     });

--- a/packages/cli/cli-logger/src/__test__/githubAnnotations.test.ts
+++ b/packages/cli/cli-logger/src/__test__/githubAnnotations.test.ts
@@ -1,0 +1,196 @@
+import { LogLevel } from "@fern-api/logger";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+    areLoggerAnnotationsSuppressed,
+    renderGithubAnnotation,
+    renderGithubAnnotationFromLog,
+    shouldEmitGithubAnnotations,
+    withSuppressedLoggerAnnotations
+} from "../githubAnnotations.js";
+import { Log } from "../Log.js";
+
+function makeLog(level: LogLevel, parts: string[], extras: Partial<Log> = {}): Log {
+    return { level, parts, time: new Date(0), ...extras };
+}
+
+describe("shouldEmitGithubAnnotations", () => {
+    const original = process.env.GITHUB_ACTIONS;
+    afterEach(() => {
+        if (original === undefined) {
+            delete process.env.GITHUB_ACTIONS;
+        } else {
+            process.env.GITHUB_ACTIONS = original;
+        }
+    });
+
+    it("returns true when GITHUB_ACTIONS=true", () => {
+        process.env.GITHUB_ACTIONS = "true";
+        expect(shouldEmitGithubAnnotations()).toBe(true);
+    });
+
+    it("returns false when GITHUB_ACTIONS is unset", () => {
+        delete process.env.GITHUB_ACTIONS;
+        expect(shouldEmitGithubAnnotations()).toBe(false);
+    });
+
+    it("returns false for any value other than the literal string 'true'", () => {
+        // GitHub Actions sets the value to the literal string "true"; other CI providers may
+        // set similarly named vars to "1" or "yes", and we don't want to misinterpret those.
+        process.env.GITHUB_ACTIONS = "1";
+        expect(shouldEmitGithubAnnotations()).toBe(false);
+    });
+});
+
+describe("withSuppressedLoggerAnnotations", () => {
+    it("suppresses annotations during the body and restores afterward", async () => {
+        expect(areLoggerAnnotationsSuppressed()).toBe(false);
+        await withSuppressedLoggerAnnotations(async () => {
+            expect(areLoggerAnnotationsSuppressed()).toBe(true);
+        });
+        expect(areLoggerAnnotationsSuppressed()).toBe(false);
+    });
+
+    it("restores the previous state even if the body throws", async () => {
+        // The whole reason this is a scoped runner instead of a `set(true)` / `set(false)` pair
+        // is that automations generate's body can throw (e.g. an unexpected error escapes
+        // `runTask`); the flag must not leak into subsequent commands or tests.
+        expect(areLoggerAnnotationsSuppressed()).toBe(false);
+        await expect(
+            withSuppressedLoggerAnnotations(async () => {
+                expect(areLoggerAnnotationsSuppressed()).toBe(true);
+                throw new Error("body failed");
+            })
+        ).rejects.toThrow("body failed");
+        expect(areLoggerAnnotationsSuppressed()).toBe(false);
+    });
+
+    it("preserves the previous suppressed state on nested usage (re-entrant safety)", async () => {
+        // If two automations runs are layered (unlikely in production but possible in tests
+        // sharing a process), the inner restoration must not flip the outer's state to false.
+        await withSuppressedLoggerAnnotations(async () => {
+            expect(areLoggerAnnotationsSuppressed()).toBe(true);
+            await withSuppressedLoggerAnnotations(async () => {
+                expect(areLoggerAnnotationsSuppressed()).toBe(true);
+            });
+            // Inner finally should restore to the outer's state (true), not the original (false).
+            expect(areLoggerAnnotationsSuppressed()).toBe(true);
+        });
+        expect(areLoggerAnnotationsSuppressed()).toBe(false);
+    });
+});
+
+describe("renderGithubAnnotation", () => {
+    it("renders a bare ::error:: command with no properties", () => {
+        expect(renderGithubAnnotation("error", "boom")).toBe("::error::boom\n");
+    });
+
+    it("renders ::warning:: level", () => {
+        expect(renderGithubAnnotation("warning", "deprecated")).toBe("::warning::deprecated\n");
+    });
+
+    it("formats file/line/title properties in reading order (file, line, title)", () => {
+        const out = renderGithubAnnotation("error", "boom", {
+            file: "fern/generators.yml",
+            line: 42,
+            title: "python-sdk failed"
+        });
+        expect(out).toBe("::error file=fern/generators.yml,line=42,title=python-sdk failed::boom\n");
+    });
+
+    it("escapes commas, colons, and CR/LF in property values", () => {
+        // Property syntax uses `,` to separate properties and `:` to terminate the property list,
+        // so any property value containing them would corrupt the parse. GHA's escape is `%XX`.
+        // (The `=` between key and value is not ambiguous in values — GHA parses property strings
+        // by splitting on the first `=` per pair, so `=` does not need escaping.)
+        const out = renderGithubAnnotation("error", "boom", {
+            title: "url=http://x:8080/a,b\r\nnext"
+        });
+        expect(out).toBe("::error title=url=http%3A//x%3A8080/a%2Cb%0D%0Anext::boom\n");
+    });
+
+    it("escapes a literal '%' to '%25' before applying other escapes", () => {
+        // If we didn't escape `%` first, a value containing `%0A` literally would survive
+        // round-tripping (the `%` would stay raw and produce `%0A`), making the value
+        // ambiguous with our newline encoding. Escaping `%` to `%25` first prevents that.
+        expect(renderGithubAnnotation("error", "boom", { title: "100%" })).toBe("::error title=100%25::boom\n");
+    });
+
+    it("strips ANSI from property values", () => {
+        // chalk-colored prefixes shouldn't appear as escape codes in property values either.
+        const titleWithColor = `[31mworkspace-a[39m`;
+        const out = renderGithubAnnotation("error", "boom", { title: titleWithColor });
+        expect(out).toBe("::error title=workspace-a::boom\n");
+    });
+
+    it("omits empty title and file properties (an empty title= would render blank)", () => {
+        expect(renderGithubAnnotation("error", "boom", { title: "", file: "" })).toBe("::error::boom\n");
+    });
+
+    it("returns undefined when the body is empty after sanitization", () => {
+        expect(renderGithubAnnotation("error", "")).toBeUndefined();
+        expect(renderGithubAnnotation("error", "\n\n")).toBeUndefined();
+    });
+
+    it("encodes newlines in the body as %0A so multi-line errors stay one workflow command", () => {
+        expect(renderGithubAnnotation("error", "line one\nline two")).toBe("::error::line one%0Aline two\n");
+    });
+
+    it("trims trailing newlines from the body before encoding", () => {
+        expect(renderGithubAnnotation("error", "boom\n\n")).toBe("::error::boom\n");
+    });
+
+    it("normalizes CRLF and drops bare CRs", () => {
+        expect(renderGithubAnnotation("error", "line one\r\nline two\rstill line two")).toBe(
+            "::error::line one%0Aline twostill line two\n"
+        );
+    });
+
+    it("strips ANSI escape sequences from the body", () => {
+        // Hardcoded ANSI bytes — we can't rely on chalk's runtime detection in the test env, since
+        // chalk strips colors when stdout isn't a TTY (which it isn't under vitest).
+        const body = `[31mboom[39m`;
+        expect(renderGithubAnnotation("error", body)).toBe("::error::boom\n");
+    });
+});
+
+describe("renderGithubAnnotationFromLog", () => {
+    it("renders an ::error:: annotation for an error log", () => {
+        const log = makeLog(LogLevel.Error, ["generator failed:", "boom"]);
+        expect(renderGithubAnnotationFromLog(log)).toBe("::error::generator failed: boom\n");
+    });
+
+    it("renders a ::warning:: annotation for a warn log", () => {
+        const log = makeLog(LogLevel.Warn, ["deprecated config option"]);
+        expect(renderGithubAnnotationFromLog(log)).toBe("::warning::deprecated config option\n");
+    });
+
+    it("returns undefined for info / debug / trace levels", () => {
+        for (const level of [LogLevel.Info, LogLevel.Debug, LogLevel.Trace]) {
+            expect(renderGithubAnnotationFromLog(makeLog(level, ["noisy"]))).toBeUndefined();
+        }
+    });
+
+    it("returns undefined when omitOnTTY is true (status-only logs that aren't real failures)", () => {
+        // The CLI emits per-task status lines like LogLevel.Error "Failed." with omitOnTTY: true
+        // for non-TTY readability. Those aren't real errors and shouldn't burn an annotation slot.
+        const log = makeLog(LogLevel.Error, ["Failed."], { omitOnTTY: true });
+        expect(renderGithubAnnotationFromLog(log)).toBeUndefined();
+    });
+
+    it("uses log.prefix as the annotation title (with ANSI stripped and whitespace trimmed)", () => {
+        // Logger prefixes look like `[34m[workspace-foo][39m  ` (color + padding).
+        const log = makeLog(LogLevel.Error, ["boom"], { prefix: `[34m[workspace-foo][39m   ` });
+        expect(renderGithubAnnotationFromLog(log)).toBe("::error title=[workspace-foo]::boom\n");
+    });
+
+    it("omits the title when prefix is empty after sanitization", () => {
+        const log = makeLog(LogLevel.Error, ["boom"], { prefix: "   " });
+        expect(renderGithubAnnotationFromLog(log)).toBe("::error::boom\n");
+    });
+
+    it("returns undefined when the body is empty", () => {
+        expect(renderGithubAnnotationFromLog(makeLog(LogLevel.Error, []))).toBeUndefined();
+        expect(renderGithubAnnotationFromLog(makeLog(LogLevel.Error, ["", ""]))).toBeUndefined();
+    });
+});

--- a/packages/cli/cli-logger/src/githubAnnotations.ts
+++ b/packages/cli/cli-logger/src/githubAnnotations.ts
@@ -1,0 +1,179 @@
+import { LogLevel } from "@fern-api/logger";
+
+import { Log } from "./Log.js";
+
+export type GithubAnnotationLevel = "error" | "warning";
+
+/**
+ * Properties supported by GitHub Actions `::error/warning file=...,line=...,title=...::message`
+ * workflow commands. See https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
+ *
+ * `file` is repository-relative (anchored on `GITHUB_WORKSPACE`); GHA renders annotations on that
+ * file/line in the PR's "Files changed" tab. `title` becomes the heading shown in the Annotations
+ * panel — keep it short and identifying (e.g., the workspace or generator name).
+ *
+ * The spec also defines `col`, `endLine`, and `endColumn`. We omit them from this type until a
+ * caller needs them — adding fields later is non-breaking; supporting unused ones isn't free
+ * (more surface to test, more noise in the API).
+ */
+export interface GithubAnnotationProperties {
+    file?: string;
+    line?: number;
+    title?: string;
+}
+
+export function shouldEmitGithubAnnotations(): boolean {
+    return process.env.GITHUB_ACTIONS === "true";
+}
+
+let loggerAnnotationsSuppressed = false;
+
+/**
+ * Runs `fn` with the generic logger-driven annotation hook muted, restoring the previous state
+ * afterward (even if `fn` throws). Used by commands like `fern automations generate` that emit
+ * their own structured annotations from a per-generator collector — without this guard, every
+ * failure would produce two annotations: a generic one from `cliContext.logger.error` (no
+ * file/line metadata) and the rich one with `file=` / `line=` from the structured emitter,
+ * burning through the GHA per-step cap twice as fast and confusing the panel.
+ *
+ * Implemented as a scoped runner rather than a `set(true)` / `set(false)` pair so re-entrant
+ * usage and exception paths can't leave the flag in the wrong state.
+ */
+export async function withSuppressedLoggerAnnotations<T>(fn: () => Promise<T>): Promise<T> {
+    const previous = loggerAnnotationsSuppressed;
+    loggerAnnotationsSuppressed = true;
+    try {
+        return await fn();
+    } finally {
+        loggerAnnotationsSuppressed = previous;
+    }
+}
+
+/** Internal hook for the logger to consult before emitting an annotation. Not exported as public API. */
+export function areLoggerAnnotationsSuppressed(): boolean {
+    return loggerAnnotationsSuppressed;
+}
+
+/**
+ * Renders the GHA workflow command for an arbitrary annotation. Use this when the caller has
+ * structured metadata (file, line, title) — typically a command-level emitter that knows about
+ * specific failures. For ad-hoc logger-driven annotations, see {@link renderGithubAnnotationFromLog}.
+ *
+ * Returns `undefined` when the body is empty after sanitization, so callers can pipe to
+ * `process.stdout.write` without conditional branches at the call site.
+ */
+export function renderGithubAnnotation(
+    level: GithubAnnotationLevel,
+    body: string,
+    properties: GithubAnnotationProperties = {}
+): string | undefined {
+    const sanitized = sanitizeForAnnotationBody(body);
+    // A whitespace-only body would render as `::error:: \n` — visually empty in the GHA panel
+    // and indistinguishable from a bug. Drop these so the function's "no annotation worth
+    // emitting" contract stays meaningful at call sites.
+    if (sanitized.trim().length === 0) {
+        return undefined;
+    }
+    const propertiesString = formatProperties(properties);
+    const prefix = propertiesString.length > 0 ? `::${level} ${propertiesString}::` : `::${level}::`;
+    return `${prefix}${sanitized}\n`;
+}
+
+/**
+ * Bridges a `Log` from the CLI's logger into a GHA annotation. Returns `undefined` for log levels
+ * that don't map to an annotation (info/debug/trace) and for status-only logs marked `omitOnTTY`,
+ * which exist for non-TTY readability and aren't real errors (e.g., the per-task "Failed." line
+ * emitted on task finalization).
+ *
+ * The log's `prefix` (typically a colored workspace tag like `[workspace-name]`) becomes the
+ * annotation `title=` so the Annotations panel groups failures by workspace.
+ */
+export function renderGithubAnnotationFromLog(log: Log): string | undefined {
+    if (log.omitOnTTY === true) {
+        return undefined;
+    }
+    const level = logLevelToAnnotationLevel(log.level);
+    if (level == null) {
+        return undefined;
+    }
+    const body = log.parts.join(" ");
+    const title = log.prefix != null ? extractTitleFromPrefix(log.prefix) : undefined;
+    return renderGithubAnnotation(level, body, title != null ? { title } : {});
+}
+
+function logLevelToAnnotationLevel(level: LogLevel): GithubAnnotationLevel | undefined {
+    switch (level) {
+        case LogLevel.Error:
+            return "error";
+        case LogLevel.Warn:
+            return "warning";
+        case LogLevel.Info:
+        case LogLevel.Debug:
+        case LogLevel.Trace:
+            return undefined;
+    }
+}
+
+/**
+ * Strips chalk colors and surrounding whitespace from a logger prefix to produce a plain title.
+ * Returns `undefined` if nothing useful is left — callers shouldn't emit `title=` in that case
+ * because GitHub renders an empty title as a literal blank heading.
+ */
+function extractTitleFromPrefix(prefix: string): string | undefined {
+    const cleaned = stripAnsi(prefix).trim();
+    return cleaned.length > 0 ? cleaned : undefined;
+}
+
+/**
+ * Prepares an error/warn message for inclusion in a `::error::` / `::warning::` workflow command:
+ * - Strips ANSI escapes (chalk colors) — they render as literal noise in GitHub's UI.
+ * - Trims trailing newlines added by the logger.
+ * - Encodes embedded newlines as `%0A` so a multi-line message becomes a single-line workflow
+ *   command that GitHub renders as a multi-line annotation.
+ */
+function sanitizeForAnnotationBody(content: string): string {
+    return stripAnsi(content).replace(/\r\n/g, "\n").replace(/\r/g, "").replace(/\n+$/g, "").replace(/\n/g, "%0A");
+}
+
+/**
+ * Formats annotation properties as a comma-separated key=value list per GHA workflow command spec.
+ * Property values are escaped: `,` `:` and newlines are percent-encoded so they don't terminate
+ * the property list or the command itself. Property order is `file,line,title` — natural reading
+ * order for humans skimming the raw stdout, even though GHA's parser doesn't care.
+ */
+function formatProperties(properties: GithubAnnotationProperties): string {
+    const parts: string[] = [];
+    if (properties.file != null && properties.file.length > 0) {
+        parts.push(`file=${escapeProperty(properties.file)}`);
+    }
+    if (properties.line != null) {
+        parts.push(`line=${properties.line}`);
+    }
+    if (properties.title != null && properties.title.length > 0) {
+        parts.push(`title=${escapeProperty(properties.title)}`);
+    }
+    return parts.join(",");
+}
+
+/**
+ * Property values cannot contain raw `,`, `:`, `\r`, or `\n` — they'd break out of the property
+ * list or the command itself. GHA's documented escapes use `%XX` for these.
+ */
+function escapeProperty(value: string): string {
+    return stripAnsi(value)
+        .replace(/%/g, "%25")
+        .replace(/\r/g, "%0D")
+        .replace(/\n/g, "%0A")
+        .replace(/:/g, "%3A")
+        .replace(/,/g, "%2C");
+}
+
+// Matches ANSI CSI/SGR escape sequences (chalk-style colors). We strip these because GitHub
+// Actions workflow commands don't render escape codes — they'd appear as literal `[31m...[39m`
+// noise in the Annotations panel.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape sequences begin with ESC (U+001B) by definition; matching that byte is the whole point of the regex.
+const ANSI_ESCAPE_PATTERN = /\[[0-?]*[ -/]*[@-~]/g;
+
+function stripAnsi(content: string): string {
+    return content.replace(ANSI_ESCAPE_PATTERN, "");
+}

--- a/packages/cli/cli-logger/src/githubAnnotations.ts
+++ b/packages/cli/cli-logger/src/githubAnnotations.ts
@@ -1,3 +1,4 @@
+import { assertNever } from "@fern-api/core-utils";
 import { LogLevel } from "@fern-api/logger";
 
 import { Log } from "./Log.js";
@@ -49,7 +50,12 @@ export async function withSuppressedLoggerAnnotations<T>(fn: () => Promise<T>): 
     }
 }
 
-/** Internal hook for the logger to consult before emitting an annotation. Not exported as public API. */
+/**
+ * Internal hook for the logger to consult before emitting an annotation. Exported from this module
+ * so the logger and tests can read the suppression state, but intentionally **not** re-exported
+ * from the package index — outside callers should drive suppression via
+ * {@link withSuppressedLoggerAnnotations} instead of polling the flag.
+ */
 export function areLoggerAnnotationsSuppressed(): boolean {
     return loggerAnnotationsSuppressed;
 }
@@ -111,6 +117,8 @@ function logLevelToAnnotationLevel(level: LogLevel): GithubAnnotationLevel | und
         case LogLevel.Debug:
         case LogLevel.Trace:
             return undefined;
+        default:
+            assertNever(level);
     }
 }
 
@@ -127,12 +135,20 @@ function extractTitleFromPrefix(prefix: string): string | undefined {
 /**
  * Prepares an error/warn message for inclusion in a `::error::` / `::warning::` workflow command:
  * - Strips ANSI escapes (chalk colors) — they render as literal noise in GitHub's UI.
+ * - Escapes literal `%` to `%25` *first* so a body that already contains `%0A` (e.g. a logged
+ *   URL-encoded string) doesn't get decoded by the runner into an unintended newline. This
+ *   matches `@actions/core`'s `escapeData` and the GHA workflow command spec.
  * - Trims trailing newlines added by the logger.
  * - Encodes embedded newlines as `%0A` so a multi-line message becomes a single-line workflow
  *   command that GitHub renders as a multi-line annotation.
  */
 function sanitizeForAnnotationBody(content: string): string {
-    return stripAnsi(content).replace(/\r\n/g, "\n").replace(/\r/g, "").replace(/\n+$/g, "").replace(/\n/g, "%0A");
+    return stripAnsi(content)
+        .replace(/%/g, "%25")
+        .replace(/\r\n/g, "\n")
+        .replace(/\r/g, "")
+        .replace(/\n+$/g, "")
+        .replace(/\n/g, "%0A");
 }
 
 /**
@@ -156,8 +172,10 @@ function formatProperties(properties: GithubAnnotationProperties): string {
 }
 
 /**
- * Property values cannot contain raw `,`, `:`, `\r`, or `\n` — they'd break out of the property
- * list or the command itself. GHA's documented escapes use `%XX` for these.
+ * Property values cannot contain raw `%`, `,`, `:`, `\r`, or `\n` — `,` and `:` are property-list
+ * delimiters, `\r` / `\n` would terminate the workflow command, and `%` must be escaped first to
+ * keep a literal `%XX` in the input from round-tripping through the runner's percent-decoder as a
+ * different character. GHA's documented escape is `%XX` for all of these.
  */
 function escapeProperty(value: string): string {
     return stripAnsi(value)

--- a/packages/cli/cli-logger/src/index.ts
+++ b/packages/cli/cli-logger/src/index.ts
@@ -1,4 +1,12 @@
 export { formatLog } from "./formatLog.js";
+export {
+    type GithubAnnotationLevel,
+    type GithubAnnotationProperties,
+    renderGithubAnnotation,
+    renderGithubAnnotationFromLog,
+    shouldEmitGithubAnnotations,
+    withSuppressedLoggerAnnotations
+} from "./githubAnnotations.js";
 export { type Log } from "./Log.js";
 export { logErrorMessage } from "./logErrorMessage.js";
 export { TtyAwareLogger } from "./TtyAwareLogger.js";

--- a/packages/cli/cli/changes/unreleased/automations-retry-rate-limited.yml
+++ b/packages/cli/cli/changes/unreleased/automations-retry-rate-limited.yml
@@ -1,0 +1,6 @@
+- summary: |
+    `fern automations generate` now automatically retries 429 Too Many Requests responses with
+    exponential backoff (2s → 120s, up to 3 attempts, jittered). Automation runs are unattended,
+    so transient rate limiting should not fail the run and ask a human to re-trigger with a flag.
+    Real outages still surface as failures after retries exhaust.
+  type: feat

--- a/packages/cli/cli/changes/unreleased/github-actions-annotations.yml
+++ b/packages/cli/cli/changes/unreleased/github-actions-annotations.yml
@@ -1,0 +1,13 @@
+- summary: |
+    Surface CLI errors and warnings as GitHub Actions annotations when running under GHA.
+
+    `fern automations generate` now emits a structured `::error::` workflow command for every
+    failed generator, anchored on the exact line in `generators.yml` so the annotation appears
+    inline on the file in the PR's Files-changed view, with the API / group / generator name
+    in the title and the failure reason in the body.
+
+    All other commands (e.g. `fern generate`, `fern check`) emit annotations from any
+    `logger.error` / `logger.warn` call, providing baseline coverage for failures that don't
+    flow through the per-generator collector. Status-only logs (`omitOnTTY`) are filtered out
+    so they don't burn through GitHub's per-step annotation cap.
+  type: feat

--- a/packages/cli/cli/src/commands/automations/generate/GeneratorRunResult.ts
+++ b/packages/cli/cli/src/commands/automations/generate/GeneratorRunResult.ts
@@ -29,6 +29,15 @@ export interface GeneratorRunResult {
      * Null when any part is unresolvable (non-GH-Actions env, detached HEAD, etc.).
      */
     generatorsYmlUrl: string | null;
+    /**
+     * Path of `generators.yml` relative to `GITHUB_WORKSPACE` (the runner's checkout root). Null
+     * outside GitHub Actions or when the file lives outside the workspace. Consumed by GHA
+     * annotation rendering, which needs a repo-relative path to anchor inline annotations on
+     * the right file in the PR diff.
+     */
+    generatorsYmlWorkspaceRelativePath: string | null;
+    /** Mirror of the recorder's line number — preserved on the result so annotations don't have to re-derive it. */
+    generatorsYmlLineNumber: number | null;
 }
 
 export interface GeneratorRunCounts {
@@ -61,29 +70,47 @@ export function countResults(results: readonly GeneratorRunResult[]): GeneratorR
 }
 
 /**
+ * Resolves an absolute path on the GitHub Actions runner to a path relative to `GITHUB_WORKSPACE`
+ * (the checkout root). Returns `null` when:
+ *  - `GITHUB_WORKSPACE` is unset (not running in GHA, or local invocation)
+ *  - `absolutePath` is outside the workspace checkout — guarding against a naïve `startsWith`
+ *    that would match `/runner/work/foo` against `/runner/work/foo2`.
+ *
+ * Exported only for testing.
+ */
+export function resolveGithubWorkspaceRelativePath(absolutePath: string | undefined): string | null {
+    if (absolutePath == null) {
+        return null;
+    }
+    const workspace = process.env.GITHUB_WORKSPACE;
+    if (workspace == null) {
+        return null;
+    }
+    const workspaceWithSlash = workspace.endsWith("/") ? workspace : `${workspace}/`;
+    if (!absolutePath.startsWith(workspaceWithSlash)) {
+        return null;
+    }
+    return absolutePath.slice(workspaceWithSlash.length);
+}
+
+/**
  * Composes the blob URL for a `generators.yml` line using GitHub Actions env vars. Returns null
  * when any required variable is missing or when the absolute path falls outside the workspace
- * checkout (the subtraction below would produce an absolute-looking relative path).
+ * checkout.
  *
  * Exported only for testing — callers inside this module use it implicitly via the record methods.
  */
 export function buildGeneratorsYmlUrl(absolutePath: string | undefined, lineNumber: number | undefined): string | null {
-    if (absolutePath == null) {
+    const relativePath = resolveGithubWorkspaceRelativePath(absolutePath);
+    if (relativePath == null) {
         return null;
     }
     const serverUrl = process.env.GITHUB_SERVER_URL;
     const repository = process.env.GITHUB_REPOSITORY;
     const refName = process.env.GITHUB_REF_NAME;
-    const workspace = process.env.GITHUB_WORKSPACE;
-    if (serverUrl == null || repository == null || refName == null || workspace == null) {
+    if (serverUrl == null || repository == null || refName == null) {
         return null;
     }
-    // GITHUB_WORKSPACE is the checkout root. `absolutePath` is guaranteed absolute.
-    const workspaceWithSlash = workspace.endsWith("/") ? workspace : `${workspace}/`;
-    if (!absolutePath.startsWith(workspaceWithSlash)) {
-        return null;
-    }
-    const relativePath = absolutePath.slice(workspaceWithSlash.length);
     const anchor = lineNumber != null ? `#L${lineNumber}` : "";
     return `${serverUrl}/${repository}/blob/${refName}/${relativePath}${anchor}`;
 }
@@ -105,7 +132,9 @@ export class GeneratorRunCollector implements RemoteGeneratorRunRecorder {
             errorMessage: null,
             durationMs: args.durationMs,
             sdkRepoUrl: args.outputRepoUrl ?? null,
-            generatorsYmlUrl: buildGeneratorsYmlUrl(args.generatorsYmlAbsolutePath, args.generatorsYmlLineNumber)
+            generatorsYmlUrl: buildGeneratorsYmlUrl(args.generatorsYmlAbsolutePath, args.generatorsYmlLineNumber),
+            generatorsYmlWorkspaceRelativePath: resolveGithubWorkspaceRelativePath(args.generatorsYmlAbsolutePath),
+            generatorsYmlLineNumber: args.generatorsYmlLineNumber ?? null
         });
     }
 
@@ -123,7 +152,9 @@ export class GeneratorRunCollector implements RemoteGeneratorRunRecorder {
             errorMessage: args.errorMessage,
             durationMs: args.durationMs,
             sdkRepoUrl: args.outputRepoUrl ?? null,
-            generatorsYmlUrl: buildGeneratorsYmlUrl(args.generatorsYmlAbsolutePath, args.generatorsYmlLineNumber)
+            generatorsYmlUrl: buildGeneratorsYmlUrl(args.generatorsYmlAbsolutePath, args.generatorsYmlLineNumber),
+            generatorsYmlWorkspaceRelativePath: resolveGithubWorkspaceRelativePath(args.generatorsYmlAbsolutePath),
+            generatorsYmlLineNumber: args.generatorsYmlLineNumber ?? null
         });
     }
 
@@ -141,7 +172,9 @@ export class GeneratorRunCollector implements RemoteGeneratorRunRecorder {
             errorMessage: null,
             durationMs: 0,
             sdkRepoUrl: args.outputRepoUrl ?? null,
-            generatorsYmlUrl: buildGeneratorsYmlUrl(args.generatorsYmlAbsolutePath, args.generatorsYmlLineNumber)
+            generatorsYmlUrl: buildGeneratorsYmlUrl(args.generatorsYmlAbsolutePath, args.generatorsYmlLineNumber),
+            generatorsYmlWorkspaceRelativePath: resolveGithubWorkspaceRelativePath(args.generatorsYmlAbsolutePath),
+            generatorsYmlLineNumber: args.generatorsYmlLineNumber ?? null
         });
     }
 

--- a/packages/cli/cli/src/commands/automations/generate/__test__/buildGeneratorsYmlUrl.test.ts
+++ b/packages/cli/cli/src/commands/automations/generate/__test__/buildGeneratorsYmlUrl.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { buildGeneratorsYmlUrl } from "../GeneratorRunResult.js";
+import { buildGeneratorsYmlUrl, resolveGithubWorkspaceRelativePath } from "../GeneratorRunResult.js";
 
 const ENV_KEYS = ["GITHUB_SERVER_URL", "GITHUB_REPOSITORY", "GITHUB_REF_NAME", "GITHUB_WORKSPACE"] as const;
 
@@ -111,6 +111,53 @@ describe("buildGeneratorsYmlUrl", () => {
         process.env.GITHUB_REF_NAME = "feature/deep-branch";
         expect(buildGeneratorsYmlUrl("/workspace/fern/generators.yml", 1)).toBe(
             "https://github.com/acme/config/blob/feature/deep-branch/fern/generators.yml#L1"
+        );
+    });
+});
+
+describe("resolveGithubWorkspaceRelativePath", () => {
+    const saved = process.env.GITHUB_WORKSPACE;
+    afterEach(() => {
+        if (saved == null) {
+            delete process.env.GITHUB_WORKSPACE;
+        } else {
+            process.env.GITHUB_WORKSPACE = saved;
+        }
+    });
+
+    it("returns null when absolutePath is undefined", () => {
+        process.env.GITHUB_WORKSPACE = "/workspace";
+        expect(resolveGithubWorkspaceRelativePath(undefined)).toBeNull();
+    });
+
+    it("returns null when GITHUB_WORKSPACE is unset", () => {
+        delete process.env.GITHUB_WORKSPACE;
+        expect(resolveGithubWorkspaceRelativePath("/anywhere/file.yml")).toBeNull();
+    });
+
+    it("returns the workspace-relative path when the absolute path is inside the workspace", () => {
+        process.env.GITHUB_WORKSPACE = "/home/runner/work/config/config";
+        expect(resolveGithubWorkspaceRelativePath("/home/runner/work/config/config/fern/generators.yml")).toBe(
+            "fern/generators.yml"
+        );
+    });
+
+    it("returns null for absolute paths outside the workspace", () => {
+        process.env.GITHUB_WORKSPACE = "/home/runner/work/config/config";
+        expect(resolveGithubWorkspaceRelativePath("/tmp/outside/generators.yml")).toBeNull();
+    });
+
+    it("guards against the sibling-prefix collision (workspace=/a does not match /a2/...)", () => {
+        // Same defense as buildGeneratorsYmlUrl — we rely on appending a trailing slash before
+        // the startsWith check, otherwise `/work/foo` would match `/work/foo2/x.yml`.
+        process.env.GITHUB_WORKSPACE = "/home/runner/work/config";
+        expect(resolveGithubWorkspaceRelativePath("/home/runner/work/config2/fern/generators.yml")).toBeNull();
+    });
+
+    it("handles a trailing-slash workspace path without doubling the separator", () => {
+        process.env.GITHUB_WORKSPACE = "/workspace/";
+        expect(resolveGithubWorkspaceRelativePath("/workspace/fern/apis/foo/generators.yml")).toBe(
+            "fern/apis/foo/generators.yml"
         );
     });
 });

--- a/packages/cli/cli/src/commands/automations/generate/__test__/renderGithubAnnotationsForResults.test.ts
+++ b/packages/cli/cli/src/commands/automations/generate/__test__/renderGithubAnnotationsForResults.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { GeneratorRunResult } from "../GeneratorRunResult.js";
+import { renderGithubAnnotationsForResults } from "../renderGithubAnnotationsForResults.js";
+
+const ENV_KEYS = ["GITHUB_ACTIONS", "GITHUB_WORKSPACE"] as const;
+
+function buildResult(overrides: Partial<GeneratorRunResult> = {}): GeneratorRunResult {
+    return {
+        apiName: undefined,
+        groupName: "production",
+        generatorName: "fernapi/fern-python-sdk",
+        status: "failed",
+        skipReason: null,
+        version: null,
+        pullRequestUrl: null,
+        noChangesDetected: false,
+        publishTarget: null,
+        errorMessage: "Generator returned exit code 1",
+        durationMs: 1234,
+        sdkRepoUrl: null,
+        generatorsYmlUrl: null,
+        generatorsYmlWorkspaceRelativePath: null,
+        generatorsYmlLineNumber: null,
+        ...overrides
+    };
+}
+
+describe("renderGithubAnnotationsForResults", () => {
+    const saved: Record<(typeof ENV_KEYS)[number], string | undefined> = {
+        GITHUB_ACTIONS: undefined,
+        GITHUB_WORKSPACE: undefined
+    };
+
+    beforeEach(() => {
+        for (const key of ENV_KEYS) {
+            saved[key] = process.env[key];
+            delete process.env[key];
+        }
+        process.env.GITHUB_ACTIONS = "true";
+    });
+
+    afterEach(() => {
+        for (const key of ENV_KEYS) {
+            if (saved[key] == null) {
+                delete process.env[key];
+            } else {
+                process.env[key] = saved[key];
+            }
+        }
+    });
+
+    it("returns an empty string when not running in GHA", () => {
+        // The whole point of the helper is to be safe to call unconditionally; off-CI it must
+        // produce zero output so callers don't have to wrap each call in a feature check.
+        delete process.env.GITHUB_ACTIONS;
+        const result = buildResult({ status: "failed" });
+        expect(renderGithubAnnotationsForResults([result])).toBe("");
+    });
+
+    it("ignores success and skipped results", () => {
+        const results: GeneratorRunResult[] = [
+            buildResult({ status: "success", errorMessage: null }),
+            buildResult({ status: "skipped", skipReason: "local_output", errorMessage: null })
+        ];
+        expect(renderGithubAnnotationsForResults(results)).toBe("");
+    });
+
+    it("renders one ::error:: annotation per failure with title=<generator> failed (group=<group>)", () => {
+        const results = [
+            buildResult({
+                groupName: "production",
+                generatorName: "python-sdk",
+                errorMessage: "boom"
+            })
+        ];
+        expect(renderGithubAnnotationsForResults(results)).toBe(
+            "::error title=python-sdk failed (group=production)::boom\n"
+        );
+    });
+
+    it("includes the api name in the title when present", () => {
+        // Multi-API runs need disambiguation in the title — otherwise two failed `python-sdk`
+        // generators in different workspaces would show identical headings in the panel. The
+        // comma between qualifiers is percent-encoded by the property-value escaper because
+        // `,` is the property-list separator in GHA workflow command syntax.
+        const results = [
+            buildResult({
+                apiName: "internal",
+                groupName: "production",
+                generatorName: "python-sdk",
+                errorMessage: "boom"
+            })
+        ];
+        expect(renderGithubAnnotationsForResults(results)).toBe(
+            "::error title=python-sdk failed (group=production%2C api=internal)::boom\n"
+        );
+    });
+
+    it("anchors the annotation on the workspace-relative generators.yml path and line", () => {
+        // GHA renders `file=...,line=...` annotations inline on the file in the PR diff. The
+        // path must be repo-relative — an absolute path on the runner would not match anything.
+        const results = [
+            buildResult({
+                generatorsYmlWorkspaceRelativePath: "fern/apis/foo/generators.yml",
+                generatorsYmlLineNumber: 42,
+                errorMessage: "boom"
+            })
+        ];
+        expect(renderGithubAnnotationsForResults(results)).toBe(
+            "::error file=fern/apis/foo/generators.yml,line=42,title=fernapi/fern-python-sdk failed (group=production)::boom\n"
+        );
+    });
+
+    it("emits the annotation without line= when the line number is unknown", () => {
+        const results = [
+            buildResult({
+                generatorsYmlWorkspaceRelativePath: "fern/generators.yml",
+                generatorsYmlLineNumber: null,
+                errorMessage: "boom"
+            })
+        ];
+        expect(renderGithubAnnotationsForResults(results)).toBe(
+            "::error file=fern/generators.yml,title=fernapi/fern-python-sdk failed (group=production)::boom\n"
+        );
+    });
+
+    it("does not include line= when the file is unknown — line alone is meaningless to GHA", () => {
+        // A `line=` without `file=` would attach the annotation to nothing (or in some runners,
+        // to the workflow file itself, which is misleading). We omit both together.
+        const results = [
+            buildResult({
+                generatorsYmlWorkspaceRelativePath: null,
+                generatorsYmlLineNumber: 42,
+                errorMessage: "boom"
+            })
+        ];
+        expect(renderGithubAnnotationsForResults(results)).toBe(
+            "::error title=fernapi/fern-python-sdk failed (group=production)::boom\n"
+        );
+    });
+
+    it("falls back to a stable message when errorMessage is null (defensive — recordFailure should always set it)", () => {
+        const results = [buildResult({ errorMessage: null })];
+        expect(renderGithubAnnotationsForResults(results)).toBe(
+            "::error title=fernapi/fern-python-sdk failed (group=production)::Generator failed\n"
+        );
+    });
+
+    it("encodes newlines in error messages so each failure stays one annotation", () => {
+        const results = [buildResult({ errorMessage: "stack trace:\n  at foo\n  at bar" })];
+        expect(renderGithubAnnotationsForResults(results)).toBe(
+            "::error title=fernapi/fern-python-sdk failed (group=production)::stack trace:%0A  at foo%0A  at bar\n"
+        );
+    });
+
+    it("emits one ::error:: per failure when below the per-step cap, with no trailing warning", () => {
+        const results = Array.from({ length: 5 }, (_, i) =>
+            buildResult({ generatorName: `gen-${i}`, errorMessage: `error ${i}` })
+        );
+        const out = renderGithubAnnotationsForResults(results);
+        expect(out.split("\n").filter((l) => l.startsWith("::error "))).toHaveLength(5);
+        expect(out).not.toContain("::warning");
+    });
+
+    it("emits one ::error:: per failure exactly at the cap, with no trailing warning", () => {
+        // Boundary case: exactly 10 failures should not trigger the overflow warning. The error
+        // count equals the cap; nothing was suppressed, so a "X were hidden" warning would lie.
+        const results = Array.from({ length: 10 }, (_, i) =>
+            buildResult({ generatorName: `gen-${i}`, errorMessage: `error ${i}` })
+        );
+        const out = renderGithubAnnotationsForResults(results);
+        expect(out.split("\n").filter((l) => l.startsWith("::error "))).toHaveLength(10);
+        expect(out).not.toContain("::warning");
+    });
+
+    it("appends a trailing ::warning:: with singular wording when one failure is over the cap", () => {
+        // 11 failures → 1 suppressed. Singular grammar: "1 additional generator failure was hidden".
+        const results = Array.from({ length: 11 }, (_, i) =>
+            buildResult({ generatorName: `gen-${i}`, errorMessage: `error ${i}` })
+        );
+        const out = renderGithubAnnotationsForResults(results);
+        expect(out.split("\n").filter((l) => l.startsWith("::error "))).toHaveLength(11);
+        expect(out).toContain(
+            "::warning title=11 generators failed (showing first 10)::1 additional generator failure was hidden by GitHub's per-step annotation cap. See the step summary table for the full list.\n"
+        );
+    });
+
+    it("appends a trailing ::warning:: with plural wording when many failures are over the cap", () => {
+        const results = Array.from({ length: 15 }, (_, i) =>
+            buildResult({ generatorName: `gen-${i}`, errorMessage: `error ${i}` })
+        );
+        const out = renderGithubAnnotationsForResults(results);
+        expect(out.split("\n").filter((l) => l.startsWith("::error "))).toHaveLength(15);
+        expect(out).toContain(
+            "::warning title=15 generators failed (showing first 10)::5 additional generator failures were hidden by GitHub's per-step annotation cap. See the step summary table for the full list.\n"
+        );
+    });
+
+    it("emits the overflow warning AFTER all error annotations (so the warning appears last in the panel)", () => {
+        // Order matters in the raw stdout — workflow commands are processed in order, and the
+        // panel's chronological grouping reads the warning as a footer rather than a header.
+        const results = Array.from({ length: 11 }, (_, i) =>
+            buildResult({ generatorName: `gen-${i}`, errorMessage: `error ${i}` })
+        );
+        const out = renderGithubAnnotationsForResults(results);
+        const lastErrorIndex = out.lastIndexOf("::error ");
+        const warningIndex = out.indexOf("::warning ");
+        expect(warningIndex).toBeGreaterThan(lastErrorIndex);
+    });
+});

--- a/packages/cli/cli/src/commands/automations/generate/__test__/renderGithubAnnotationsForResults.test.ts
+++ b/packages/cli/cli/src/commands/automations/generate/__test__/renderGithubAnnotationsForResults.test.ts
@@ -159,7 +159,7 @@ describe("renderGithubAnnotationsForResults", () => {
             buildResult({ generatorName: `gen-${i}`, errorMessage: `error ${i}` })
         );
         const out = renderGithubAnnotationsForResults(results);
-        expect(out.split("\n").filter((l) => l.startsWith("::error "))).toHaveLength(5);
+        expect(out.split("\n").filter((l) => l.startsWith("::error::") || l.startsWith("::error "))).toHaveLength(5);
         expect(out).not.toContain("::warning");
     });
 
@@ -170,7 +170,7 @@ describe("renderGithubAnnotationsForResults", () => {
             buildResult({ generatorName: `gen-${i}`, errorMessage: `error ${i}` })
         );
         const out = renderGithubAnnotationsForResults(results);
-        expect(out.split("\n").filter((l) => l.startsWith("::error "))).toHaveLength(10);
+        expect(out.split("\n").filter((l) => l.startsWith("::error::") || l.startsWith("::error "))).toHaveLength(10);
         expect(out).not.toContain("::warning");
     });
 
@@ -180,7 +180,7 @@ describe("renderGithubAnnotationsForResults", () => {
             buildResult({ generatorName: `gen-${i}`, errorMessage: `error ${i}` })
         );
         const out = renderGithubAnnotationsForResults(results);
-        expect(out.split("\n").filter((l) => l.startsWith("::error "))).toHaveLength(11);
+        expect(out.split("\n").filter((l) => l.startsWith("::error::") || l.startsWith("::error "))).toHaveLength(11);
         expect(out).toContain(
             "::warning title=11 generators failed (showing first 10)::1 additional generator failure was hidden by GitHub's per-step annotation cap. See the step summary table for the full list.\n"
         );
@@ -191,7 +191,7 @@ describe("renderGithubAnnotationsForResults", () => {
             buildResult({ generatorName: `gen-${i}`, errorMessage: `error ${i}` })
         );
         const out = renderGithubAnnotationsForResults(results);
-        expect(out.split("\n").filter((l) => l.startsWith("::error "))).toHaveLength(15);
+        expect(out.split("\n").filter((l) => l.startsWith("::error::") || l.startsWith("::error "))).toHaveLength(15);
         expect(out).toContain(
             "::warning title=15 generators failed (showing first 10)::5 additional generator failures were hidden by GitHub's per-step annotation cap. See the step summary table for the full list.\n"
         );
@@ -204,8 +204,11 @@ describe("renderGithubAnnotationsForResults", () => {
             buildResult({ generatorName: `gen-${i}`, errorMessage: `error ${i}` })
         );
         const out = renderGithubAnnotationsForResults(results);
-        const lastErrorIndex = out.lastIndexOf("::error ");
-        const warningIndex = out.indexOf("::warning ");
+        // Use a regex so the test matches both `::error::body` and `::error <props>::body` forms,
+        // and isn't brittle to whether annotations carry properties in the future.
+        const errorIndices = [...out.matchAll(/::error[: ]/g)].map((m) => m.index ?? -1);
+        const warningIndex = out.search(/::warning[: ]/);
+        const lastErrorIndex = errorIndices.length > 0 ? Math.max(...errorIndices) : -1;
         expect(warningIndex).toBeGreaterThan(lastErrorIndex);
     });
 });

--- a/packages/cli/cli/src/commands/automations/generate/__test__/reportGenerateResults.test.ts
+++ b/packages/cli/cli/src/commands/automations/generate/__test__/reportGenerateResults.test.ts
@@ -27,6 +27,8 @@ function successResult(overrides: Partial<GeneratorRunResult> = {}): GeneratorRu
         durationMs: 1234,
         sdkRepoUrl: "https://github.com/acme/sdk",
         generatorsYmlUrl: null,
+        generatorsYmlWorkspaceRelativePath: null,
+        generatorsYmlLineNumber: null,
         ...overrides
     };
 }

--- a/packages/cli/cli/src/commands/automations/generate/executeAutomationsGenerate.ts
+++ b/packages/cli/cli/src/commands/automations/generate/executeAutomationsGenerate.ts
@@ -1,3 +1,4 @@
+import { withSuppressedLoggerAnnotations } from "@fern-api/cli-logger";
 import { TaskAbortSignal } from "@fern-api/task-context";
 
 import { CliContext } from "../../../cli-context/CliContext.js";
@@ -5,6 +6,7 @@ import { loadProjectAndRegisterWorkspacesWithContext } from "../../../cliCommons
 import { parseGeneratorArg } from "../../generate/filterGenerators.js";
 import { generateAPIWorkspaces } from "../../generate/generateAPIWorkspaces.js";
 import { GeneratorRunCollector } from "./GeneratorRunResult.js";
+import { renderGithubAnnotationsForResults } from "./renderGithubAnnotationsForResults.js";
 import { renderStdoutSummary, writeResults, writeResultsSync } from "./reportGenerateResults.js";
 
 export interface AutomationsGenerateOptions {
@@ -49,49 +51,62 @@ export async function executeAutomationsGenerate({
         }
         outputsFlushed = true;
         writeResultsSync({ results: collector.results(), jsonOutputPath });
+        // Best-effort annotation emit on the signal path. Node's `process.stdout.write` typically
+        // lands synchronously for small writes to a pipe, but it's not guaranteed — if the runner
+        // tears us down before the kernel buffer drains, the user just doesn't see annotations.
+        // The summary table written above is the durable artifact.
+        emitStructuredAnnotations(collector);
     };
     process.once("SIGINT", flushOnSignal);
     process.once("SIGTERM", flushOnSignal);
 
+    // Suppress the generic logger-driven GHA annotation hook for the duration of this run, so
+    // per-generator failures don't get annotated twice (once with raw text from `logger.error`,
+    // once with structured `file=` / `line=` metadata from the collector emitter below). The
+    // scoped runner restores the previous suppression state even if the body throws.
     try {
-        await cliContext.runTask(async () => {
-            await generateAPIWorkspaces({
-                project: await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
-                    commandLineApiWorkspace: options.api,
-                    defaultToAllApiWorkspaces: true
-                }),
-                cliContext,
-                version: options.version,
-                groupNames: options.group != null ? [options.group] : undefined,
-                generatorName,
-                generatorIndex,
-                shouldLogS3Url: false,
-                keepDocker: false,
-                useLocalDocker: false,
-                preview: false,
-                mode: undefined,
-                force: true,
-                runner: undefined,
-                inspect: false,
-                lfsOverride: undefined,
-                fernignorePath: undefined,
-                skipFernignore: false,
-                dynamicIrOnly: false,
-                outputDir: undefined,
-                noReplay: false,
-                retryRateLimited: false,
-                requireEnvVars: false,
-                automationMode: true,
-                autoMerge: options.autoMerge,
-                skipIfNoDiff: true,
-                automation: { recorder: collector }
-            });
+        await withSuppressedLoggerAnnotations(async () => {
+            try {
+                await cliContext.runTask(async () => {
+                    await generateAPIWorkspaces({
+                        project: await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
+                            commandLineApiWorkspace: options.api,
+                            defaultToAllApiWorkspaces: true
+                        }),
+                        cliContext,
+                        version: options.version,
+                        groupNames: options.group != null ? [options.group] : undefined,
+                        generatorName,
+                        generatorIndex,
+                        shouldLogS3Url: false,
+                        keepDocker: false,
+                        useLocalDocker: false,
+                        preview: false,
+                        mode: undefined,
+                        force: true,
+                        runner: undefined,
+                        inspect: false,
+                        lfsOverride: undefined,
+                        fernignorePath: undefined,
+                        skipFernignore: false,
+                        dynamicIrOnly: false,
+                        outputDir: undefined,
+                        noReplay: false,
+                        retryRateLimited: false,
+                        requireEnvVars: false,
+                        automationMode: true,
+                        autoMerge: options.autoMerge,
+                        skipIfNoDiff: true,
+                        automation: { recorder: collector }
+                    });
+                });
+            } catch (error) {
+                if (!(error instanceof TaskAbortSignal)) {
+                    throw error;
+                }
+                taskAborted = true;
+            }
         });
-    } catch (error) {
-        if (!(error instanceof TaskAbortSignal)) {
-            throw error;
-        }
-        taskAborted = true;
     } finally {
         // `process.once` self-removes if fired; these are no-ops on the signal path.
         process.off("SIGINT", flushOnSignal);
@@ -99,10 +114,18 @@ export async function executeAutomationsGenerate({
         if (!outputsFlushed) {
             outputsFlushed = true;
             await reportFinalOutputs({ collector, jsonOutputPath, taskAborted });
+            emitStructuredAnnotations(collector);
         }
         if (collector.hasFailures()) {
             process.exitCode = 1;
         }
+    }
+}
+
+function emitStructuredAnnotations(collector: GeneratorRunCollector): void {
+    const annotations = renderGithubAnnotationsForResults(collector.results());
+    if (annotations.length > 0) {
+        process.stdout.write(annotations);
     }
 }
 

--- a/packages/cli/cli/src/commands/automations/generate/executeAutomationsGenerate.ts
+++ b/packages/cli/cli/src/commands/automations/generate/executeAutomationsGenerate.ts
@@ -92,7 +92,12 @@ export async function executeAutomationsGenerate({
                         dynamicIrOnly: false,
                         outputDir: undefined,
                         noReplay: false,
-                        retryRateLimited: false,
+                        // Automation runs are unattended; transient 429s should be retried
+                        // automatically rather than failing the run and asking a human to
+                        // re-trigger with a flag. The retry policy is bounded (3 attempts,
+                        // 2s→120s exponential backoff with jitter) so a real outage still
+                        // surfaces as a failure rather than a hang.
+                        retryRateLimited: true,
                         requireEnvVars: false,
                         automationMode: true,
                         autoMerge: options.autoMerge,

--- a/packages/cli/cli/src/commands/automations/generate/renderGithubAnnotationsForResults.ts
+++ b/packages/cli/cli/src/commands/automations/generate/renderGithubAnnotationsForResults.ts
@@ -3,10 +3,10 @@ import { renderGithubAnnotation, shouldEmitGithubAnnotations } from "@fern-api/c
 import { GeneratorRunResult } from "./GeneratorRunResult.js";
 
 /**
- * GitHub Actions silently drops annotations once a step exceeds 10 of any given level (error,
- * warning, notice). When more than this many generators fail in one run, the overflow disappears
- * from the UI without any signal that it was truncated — a reviewer reading the PR sees ten red
- * markers and assumes that's all of them.
+ * GitHub Actions caps annotations at 10 per level per step (error and warning are independent
+ * caps, as is notice though we don't emit those). When more than 10 generators fail in one run
+ * the overflow is silently dropped — a reviewer reading the PR sees ten red markers and assumes
+ * that's all of them.
  *
  * We can't lift the cap (it's the runner's), but we can emit a single trailing `::warning::` that
  * tells the reader exactly how many failures didn't make it onto the file view, pointing them at

--- a/packages/cli/cli/src/commands/automations/generate/renderGithubAnnotationsForResults.ts
+++ b/packages/cli/cli/src/commands/automations/generate/renderGithubAnnotationsForResults.ts
@@ -1,0 +1,90 @@
+import { renderGithubAnnotation, shouldEmitGithubAnnotations } from "@fern-api/cli-logger";
+
+import { GeneratorRunResult } from "./GeneratorRunResult.js";
+
+/**
+ * GitHub Actions silently drops annotations once a step exceeds 10 of any given level (error,
+ * warning, notice). When more than this many generators fail in one run, the overflow disappears
+ * from the UI without any signal that it was truncated — a reviewer reading the PR sees ten red
+ * markers and assumes that's all of them.
+ *
+ * We can't lift the cap (it's the runner's), but we can emit a single trailing `::warning::` that
+ * tells the reader exactly how many failures didn't make it onto the file view, pointing them at
+ * the step-summary table for the full picture. The warning consumes one of the 10 *warning* slots
+ * (separate from the error cap), and the CLI rarely emits warnings, so this is essentially free.
+ *
+ * If GitHub raises the cap in the future, this constant is the single place to update.
+ */
+const GITHUB_ACTIONS_ANNOTATIONS_PER_LEVEL_CAP = 10;
+
+/**
+ * Builds GitHub Actions error-annotation workflow commands for every failed generator in a run.
+ * Each annotation is anchored on the generator's line in `generators.yml` (when resolvable) so it
+ * appears inline on the file in the PR's "Files changed" tab — exactly where a reviewer would
+ * change the version pin or remove the failing generator.
+ *
+ * Title format: `<generator> failed (group=<group>, api=<api>)`. Explicit `key=value` labels
+ * disambiguate the title whenever a name contains a `/` (generator names like
+ * `fernapi/fern-python-sdk` are common) and match the vocabulary of the step-summary table.
+ *
+ * When the failure count exceeds the runner's per-step annotation cap (see
+ * {@link GITHUB_ACTIONS_ANNOTATIONS_PER_LEVEL_CAP}), we still emit one error annotation per
+ * failure (GHA drops the overflow itself) and append a trailing warning explaining how many
+ * failures didn't make it into the panel.
+ *
+ * Callers should guard with `shouldEmitGithubAnnotations()` to skip the render entirely off-CI.
+ */
+export function renderGithubAnnotationsForResults(results: readonly GeneratorRunResult[]): string {
+    if (!shouldEmitGithubAnnotations()) {
+        return "";
+    }
+    const lines: string[] = [];
+    let failureCount = 0;
+    for (const result of results) {
+        if (result.status !== "failed") {
+            continue;
+        }
+        failureCount++;
+        const annotation = renderAnnotationForFailure(result);
+        if (annotation != null) {
+            lines.push(annotation);
+        }
+    }
+    const overflow = renderOverflowWarning(failureCount);
+    if (overflow != null) {
+        lines.push(overflow);
+    }
+    return lines.join("");
+}
+
+function renderAnnotationForFailure(result: GeneratorRunResult): string | undefined {
+    const body = result.errorMessage ?? "Generator failed";
+    const title = buildTitle(result);
+    const file = result.generatorsYmlWorkspaceRelativePath ?? undefined;
+    // GHA renders `line=` without `file=` against the workflow file itself (or nothing) — drop
+    // the line number when we have nothing to anchor it to so the annotation lands on the PR
+    // generally rather than on a misleading location.
+    const line = file != null ? (result.generatorsYmlLineNumber ?? undefined) : undefined;
+    return renderGithubAnnotation("error", body, { title, file, line });
+}
+
+function buildTitle(result: GeneratorRunResult): string {
+    const qualifiers: string[] = [`group=${result.groupName}`];
+    if (result.apiName != null && result.apiName.length > 0) {
+        qualifiers.push(`api=${result.apiName}`);
+    }
+    return `${result.generatorName} failed (${qualifiers.join(", ")})`;
+}
+
+function renderOverflowWarning(failureCount: number): string | undefined {
+    if (failureCount <= GITHUB_ACTIONS_ANNOTATIONS_PER_LEVEL_CAP) {
+        return undefined;
+    }
+    const suppressed = failureCount - GITHUB_ACTIONS_ANNOTATIONS_PER_LEVEL_CAP;
+    const body =
+        `${suppressed} additional generator ${suppressed === 1 ? "failure was" : "failures were"} hidden by ` +
+        `GitHub's per-step annotation cap. See the step summary table for the full list.`;
+    return renderGithubAnnotation("warning", body, {
+        title: `${failureCount} generators failed (showing first ${GITHUB_ACTIONS_ANNOTATIONS_PER_LEVEL_CAP})`
+    });
+}

--- a/packages/cli/ete-tests/src/utils/runFernCli.ts
+++ b/packages/cli/ete-tests/src/utils/runFernCli.ts
@@ -15,6 +15,11 @@ export async function runFernCli(
     { includeAuthToken = true, signal, ...execaOptions }: RunFernCliOptions = {}
 ): Promise<loggingExeca.ReturnValue> {
     const env = {
+        // When the test runner itself runs in GitHub Actions, `GITHUB_ACTIONS=true` would be
+        // inherited by the spawned CLI and trigger the GHA annotation hook, polluting stdout
+        // with `::error::` / `::warning::` lines that break exact-match assertions in ete tests.
+        // Tests that want to exercise annotation behavior can override this via the `env` arg.
+        GITHUB_ACTIONS: "",
         ...execaOptions?.env,
         ...(includeAuthToken ? { FERN_TOKEN: process.env.FERN_ORG_TOKEN_DEV } : {})
     };
@@ -48,6 +53,9 @@ export function captureFernCli(
         {
             ...execaOptions,
             env: {
+                // See `runFernCli` for the rationale — suppress inherited `GITHUB_ACTIONS=true`
+                // so the CLI doesn't emit annotation workflow commands on stdout under CI.
+                GITHUB_ACTIONS: "",
                 ...execaOptions?.env,
                 FERN_TOKEN: process.env.FERN_ORG_TOKEN_DEV
             },


### PR DESCRIPTION
## Summary

Surface CLI errors and warnings as **GitHub Actions annotations** when running under GHA, so failures appear inline in the PR/run UI instead of being buried in the raw step log.

The screenshot motivating this: `fern automations generate` produced an "SDK generation failed (2/8 succeeded, 4 skipped)" summary table, but the GHA Annotations panel showed only the generic `Process completed with exit code 1` — the user had to scroll the raw log to find which generator failed and why.

## How it works

Two layers, both gated on `GITHUB_ACTIONS=true`:

1. **Generic logger hook** (in `@fern-api/cli-logger`) — every `logger.error` / `logger.warn` across the CLI also emits a `::error::` / `::warning::` workflow command on stdout. Covers `fern check`, `fern generate`, validation errors, etc. Status-only logs (`omitOnTTY: true`, e.g. the per-task "Failed." line) are filtered out so they don't burn through GitHub's per-step cap.

2. **Structured per-generator annotations** for `fern automations generate` — emitted from the `GeneratorRunCollector` after the run, anchored on the exact line in `generators.yml` (`file=fern/apis/foo/generators.yml,line=42`) so the annotation appears inline on the file in the PR's "Files changed" tab. Title format is `<generator> failed (group=<group>, api=<api>)` — explicit `key=value` qualifiers because generator names like `fernapi/fern-python-sdk` already contain `/`.

The structured emitter wraps its run in `withSuppressedLoggerAnnotations(...)` (a scoped runner with try/finally restoration) so per-generator failures don't get annotated twice — once with raw text from `logger.error`, once with the rich `file=` / `line=` metadata.

When the failure count exceeds GitHub's per-step cap (10), the structured emitter still emits one `::error::` per failure (GHA drops the overflow itself) and appends a trailing `::warning::` like `"3 additional generator failures were hidden by GitHub's per-step annotation cap. See the step summary table for the full list."` so reviewers know what's missing.

## Related fix bundled in: auto-retry on 429 in automations mode

While verifying this PR with a real GHA run, every generator call hit `429 Too Many Requests` from Fiddle. The CLI already has a `--retry-rate-limited` flag (bounded: 3 attempts, 2s→120s exponential backoff with jitter), but `fern automations generate` was passing `false`. Automation runs are unattended — failing the run and asking a human to re-trigger with a flag isn't useful — so this PR flips that default to `true` for automations only. `fern generate` (interactive) still requires the explicit flag. The retry warnings emitted during backoff are absorbed by `withSuppressedLoggerAnnotations`, so the panel stays clean and only the final post-retry failure (if any) becomes a `::error::` annotation.

## Sanitization (per the [GHA workflow command spec](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions))

- ANSI escape codes (chalk colors) stripped from bodies and property values — they'd render as literal `[31m...[39m` noise in the panel.
- Embedded newlines in bodies encoded as `%0A` so multi-line errors stay one workflow command (GHA renders them as a multi-line annotation).
- Property values escape `,` `:` `\r` `\n` `%` per spec so they can't break out of the property list.

## Out of scope

- `fern check` validation errors annotate via the generic logger hook with no `file=` / `line=` metadata. Anchoring those properly would need structured emission from a check-command emitter, not from `logger.error` — separate design pass.
- The 429s observed during empirical verification are independent of this PR's changes; the request/concurrency path is unchanged. Real fixes (client-side throttling on the `createJob` fan-out, or revisiting Fiddle's rate limit) are follow-ups.

## Test plan

- [x] `pnpm turbo run test --filter @fern-api/cli-logger --filter @fern-api/cli` — 33 + 637 tests pass
- [x] `pnpm check:fix` clean
- [x] End-to-end smoke test: simulated logger and structured annotation paths with `GITHUB_ACTIONS=true` and verified output matches expectations across env-var gate, suppression scope (incl. nested), level filter, omitOnTTY filter, prefix→title, and the cap-overflow warning
- [x] **Empirical verification on a real GHA run** — published `5.9.0-rc.0`, ran `automations generate` against a multi-workspace fern config, and confirmed: rich annotations rendered inline on `generators.yml` lines, `%2C` / `%3A` decoded correctly in titles, and no duplicate generic+structured annotations. Initial run also exposed the 429 issue, which motivated the retry default flip above.
