### PR TITLE
fix(internal): detect any SemVer prerelease in CLI publish routing

### DIFF
--- a/packages/seed/src/__test__/publishRouting.test.ts
+++ b/packages/seed/src/__test__/publishRouting.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { getPublishType } from "../utils/publishRouting.js";
+
+describe("getPublishType", () => {
+    it("routes plain GA version to ga", () => {
+        expect(getPublishType({ version: "5.9.0", isDevRelease: undefined })).toBe("ga");
+        expect(getPublishType({ version: "5.9.0", isDevRelease: false })).toBe("ga");
+        expect(getPublishType({ version: "1.0.0", isDevRelease: undefined })).toBe("ga");
+        expect(getPublishType({ version: "0.1.0", isDevRelease: undefined })).toBe("ga");
+    });
+
+    it("routes rc prerelease to prerelease", () => {
+        expect(getPublishType({ version: "5.9.0-rc.0", isDevRelease: undefined })).toBe("prerelease");
+        expect(getPublishType({ version: "5.9.0-rc.1", isDevRelease: false })).toBe("prerelease");
+        expect(getPublishType({ version: "1.0.0-rc.42", isDevRelease: undefined })).toBe("prerelease");
+    });
+
+    it("routes alpha prerelease to prerelease", () => {
+        expect(getPublishType({ version: "5.9.0-alpha.0", isDevRelease: undefined })).toBe("prerelease");
+        expect(getPublishType({ version: "5.9.0-alpha.3", isDevRelease: false })).toBe("prerelease");
+    });
+
+    it("routes beta prerelease to prerelease", () => {
+        expect(getPublishType({ version: "5.9.0-beta.0", isDevRelease: undefined })).toBe("prerelease");
+        expect(getPublishType({ version: "5.9.0-beta.3", isDevRelease: false })).toBe("prerelease");
+    });
+
+    it("routes named prereleases to prerelease", () => {
+        expect(getPublishType({ version: "5.9.0-next.42", isDevRelease: undefined })).toBe("prerelease");
+        expect(getPublishType({ version: "5.9.0-next.20240501", isDevRelease: undefined })).toBe("prerelease");
+        expect(getPublishType({ version: "2.0.0-canary.1", isDevRelease: undefined })).toBe("prerelease");
+        expect(getPublishType({ version: "1.0.0-preview.5", isDevRelease: undefined })).toBe("prerelease");
+    });
+
+    it("routes dev release to dev regardless of version", () => {
+        expect(getPublishType({ version: "5.9.0", isDevRelease: true })).toBe("dev");
+        expect(getPublishType({ version: "5.9.0-rc.0", isDevRelease: true })).toBe("dev");
+        expect(getPublishType({ version: "5.9.0-alpha.0", isDevRelease: true })).toBe("dev");
+        expect(getPublishType({ version: "1.0.0-beta.3", isDevRelease: true })).toBe("dev");
+    });
+
+    it("returns ga for malformed versions that semver cannot parse", () => {
+        expect(getPublishType({ version: "not-a-version", isDevRelease: undefined })).toBe("ga");
+        expect(getPublishType({ version: "1.2", isDevRelease: undefined })).toBe("ga");
+    });
+});

--- a/packages/seed/src/commands/publish/publishCli.ts
+++ b/packages/seed/src/commands/publish/publishCli.ts
@@ -4,6 +4,7 @@ import path from "path";
 
 import { PublishCommand } from "../../config/api/index.js";
 import { loadCliWorkspace } from "../../loadGeneratorWorkspaces.js";
+import { getPublishType } from "../../utils/publishRouting.js";
 import { runCommands, subVersion } from "../../utils/publishUtilities.js";
 import { getNewCliVersion, VersionFilePair } from "../../utils/versionUtilities.js";
 
@@ -46,16 +47,23 @@ export async function publishCli({
 
     context.logger.info(`Publishing CLI@${publishVersion}...`);
 
+    const publishType = getPublishType({ version: publishVersion, isDevRelease });
+
     let publishConfig: PublishCommand;
-    if (isDevRelease) {
-        context.logger.info(`Publishing CLI@${publishVersion} as a dev release...`);
-        publishConfig = cliWorkspace.workspaceConfig.publishDev;
-    } else if (publishVersion.includes("rc")) {
-        context.logger.info(`Publishing CLI@${publishVersion} as a pre-release...`);
-        publishConfig = cliWorkspace.workspaceConfig.publishRc;
-    } else {
-        context.logger.info(`Publishing CLI@${publishVersion} as a production release...`);
-        publishConfig = cliWorkspace.workspaceConfig.publishGa;
+    switch (publishType) {
+        case "dev":
+            context.logger.info(`Publishing CLI@${publishVersion} as a dev release...`);
+            publishConfig = cliWorkspace.workspaceConfig.publishDev;
+            break;
+        case "prerelease":
+            context.logger.info(`Publishing CLI@${publishVersion} as a pre-release...`);
+            // publishRc is named for historical reasons; it handles all prerelease identifiers.
+            publishConfig = cliWorkspace.workspaceConfig.publishRc;
+            break;
+        case "ga":
+            context.logger.info(`Publishing CLI@${publishVersion} as a production release...`);
+            publishConfig = cliWorkspace.workspaceConfig.publishGa;
+            break;
     }
 
     // Instance of PublishCommand configuration, leverage these commands outright

--- a/packages/seed/src/commands/publish/publishCli.ts
+++ b/packages/seed/src/commands/publish/publishCli.ts
@@ -1,3 +1,4 @@
+import { assertNever } from "@fern-api/core-utils";
 import { AbsoluteFilePath, RelativeFilePath } from "@fern-api/fs-utils";
 import { TaskContext } from "@fern-api/task-context";
 import path from "path";
@@ -64,6 +65,8 @@ export async function publishCli({
             context.logger.info(`Publishing CLI@${publishVersion} as a production release...`);
             publishConfig = cliWorkspace.workspaceConfig.publishGa;
             break;
+        default:
+            assertNever(publishType);
     }
 
     // Instance of PublishCommand configuration, leverage these commands outright

--- a/packages/seed/src/utils/publishRouting.ts
+++ b/packages/seed/src/utils/publishRouting.ts
@@ -1,0 +1,32 @@
+import semver from "semver";
+
+export type PublishType = "dev" | "prerelease" | "ga";
+
+/**
+ * Determines the publish type for a CLI version.
+ *
+ * - "dev" when explicitly flagged as a dev release
+ * - "prerelease" for any SemVer prerelease (e.g. 5.9.0-rc.0, 5.9.0-alpha.0, 5.9.0-beta.3, 5.9.0-next.42)
+ * - "ga" for stable releases (e.g. 5.9.0)
+ *
+ * NOTE: The "prerelease" type maps to the `publishRc` config key in seed.yml.
+ * The key is named `publishRc` for historical reasons but handles all prerelease identifiers.
+ */
+export function getPublishType({
+    version,
+    isDevRelease
+}: {
+    version: string;
+    isDevRelease: boolean | undefined;
+}): PublishType {
+    if (isDevRelease) {
+        return "dev";
+    }
+
+    const parsed = semver.parse(version);
+    if (parsed != null && parsed.prerelease.length > 0) {
+        return "prerelease";
+    }
+
+    return "ga";
+}


### PR DESCRIPTION
## Description

Fixes a bug where `publishCli.ts` only checked for the substring `"rc"` in the version string to determine prerelease routing. Any other prerelease identifier (e.g., `alpha`, `beta`, `next`, `canary`, `preview`) would fall through to the GA publish path, which uses npm's `latest` dist-tag. This means publishing `5.9.0-alpha.0` would set `latest` to an alpha — any user running `npm install fern-api` would silently get a prerelease.

## Changes Made

- **Extracted `getPublishType()` helper** (`packages/seed/src/utils/publishRouting.ts`): Uses the `semver` package (already a dependency) to properly detect any SemVer prerelease identifier. Returns `"dev"`, `"prerelease"`, or `"ga"`.
- **Updated `publishCli.ts`**: Replaced `publishVersion.includes("rc")` with `getPublishType()`. Uses a `switch` statement for exhaustive routing. Added a comment explaining the historical `publishRc` config key name.
- **Did not rename `publishRc`**: Renaming to `publishPrerelease` would require changing `seed/fern-cli/seed.yml` (out of scope), the Fern API definition in `config.yml`, and the auto-generated types. Left the name as-is with an explanatory comment.
- **`publishGenerator.ts` is not affected**: It uses a single `publish` config (no GA/RC routing split).
- **Added unit tests** (`packages/seed/src/__test__/publishRouting.test.ts`): Covers plain GA (`5.9.0`), rc (`5.9.0-rc.0`), alpha (`5.9.0-alpha.0`), beta (`5.9.0-beta.3`), named prereleases (`5.9.0-next.42`, `canary`, `preview`), dev override (`isDevRelease: true` always → `"dev"` regardless of version), and malformed versions (fall through to `"ga"`).

## Testing

- [x] Unit tests added (`publishRouting.test.ts` — 7 test cases)
- [x] `pnpm turbo run test --filter @fern-api/seed-cli` — all 216 tests pass (7 test files)
- [x] `pnpm check` (Biome) passes with no errors

Link to Devin session: https://app.devin.ai/sessions/5390368bff134af98d66841b1983d4b4
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->