### PR TITLE
chore(changelog): remove `break` from auto-changelog flow

### DIFF
--- a/.claude/release-versioning.md
+++ b/.claude/release-versioning.md
@@ -44,6 +44,6 @@ Pick the narrowest matching **`softwareDirectory`** when several could apply (e.
 2. Use a new filename that describes the change (e.g. `fix-streaming-timeout.yml`).
 3. Each file is a **YAML array** of objects. Only these fields are allowed (see **`fern-changes-yml.schema.json`**):
    - **`summary`**: string (multi-line `|` allowed).
-   - **`type`**: `fix` | `chore` | `feat` | `internal` | `break`
+   - **`type`**: `fix` | `chore` | `feat` | `internal`
 
-Those types drive semver bumps when releases run (`fix`/`chore` → patch, `feat`/`internal` → minor, `break` → major). You do not need to bump versions yourself.
+Those types drive semver bumps when releases run (`fix`/`chore` → patch, `feat`/`internal` → minor). The automated release flow does **not** produce major version bumps. To ship a major release, a human edits the relevant `versions.yml` directly so the breaking change is explicitly acknowledged in review. The validator rejects `type: break` in `unreleased/`.

--- a/fern-changes-yml.schema.json
+++ b/fern-changes-yml.schema.json
@@ -17,7 +17,7 @@
                 },
                 "type": {
                     "$ref": "#/definitions/ChangelogType",
-                    "description": "Type of change determines version bump: fix/chore (patch), feat/internal (minor), break (major)"
+                    "description": "Type of change determines version bump: fix/chore (patch), feat/internal (minor). Major version bumps are not produced by the automated release flow; edit versions.yml directly to ship a major release."
                 },
                 "pre-release": {
                     "$ref": "#/definitions/PreReleaseTag",
@@ -36,11 +36,10 @@
                 "fix",
                 "chore",
                 "feat",
-                "internal",
-                "break"
+                "internal"
             ],
             "title": "Changelog Type",
-            "description": "The type of change: fix/chore → patch, feat/internal → minor, break → major"
+            "description": "The type of change: fix/chore → patch, feat/internal → minor. Major version bumps are not produced by the automated release flow and must be made by editing versions.yml directly."
         },
         "PreReleaseTag": {
             "type": "string",

--- a/generators/csharp/sdk/changes/unreleased/.template.yml
+++ b/generators/csharp/sdk/changes/unreleased/.template.yml
@@ -5,5 +5,5 @@
 - summary: |
     Brief description of your change.
     You can use multiple lines for longer descriptions.
-  type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  type: feat  # Options: fix/chore (patch), feat/internal (minor). Major bumps are not produced by the auto-release flow; edit versions.yml directly to ship a major release.
   # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/go/sdk/changes/unreleased/.template.yml
+++ b/generators/go/sdk/changes/unreleased/.template.yml
@@ -5,5 +5,5 @@
 - summary: |
     Brief description of your change.
     You can use multiple lines for longer descriptions.
-  type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  type: feat  # Options: fix/chore (patch), feat/internal (minor). Major bumps are not produced by the auto-release flow; edit versions.yml directly to ship a major release.
   # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/java/sdk/changes/unreleased/.template.yml
+++ b/generators/java/sdk/changes/unreleased/.template.yml
@@ -5,5 +5,5 @@
 - summary: |
     Brief description of your change.
     You can use multiple lines for longer descriptions.
-  type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  type: feat  # Options: fix/chore (patch), feat/internal (minor). Major bumps are not produced by the auto-release flow; edit versions.yml directly to ship a major release.
   # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/php/sdk/changes/unreleased/.template.yml
+++ b/generators/php/sdk/changes/unreleased/.template.yml
@@ -5,5 +5,5 @@
 - summary: |
     Brief description of your change.
     You can use multiple lines for longer descriptions.
-  type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  type: feat  # Options: fix/chore (patch), feat/internal (minor). Major bumps are not produced by the auto-release flow; edit versions.yml directly to ship a major release.
   # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/python/sdk/changes/unreleased/.template.yml
+++ b/generators/python/sdk/changes/unreleased/.template.yml
@@ -5,5 +5,5 @@
 - summary: |
     Brief description of your change.
     You can use multiple lines for longer descriptions.
-  type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  type: feat  # Options: fix/chore (patch), feat/internal (minor). Major bumps are not produced by the auto-release flow; edit versions.yml directly to ship a major release.
   # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/ruby-v2/sdk/changes/unreleased/.template.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/.template.yml
@@ -5,5 +5,5 @@
 - summary: |
     Brief description of your change.
     You can use multiple lines for longer descriptions.
-  type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  type: feat  # Options: fix/chore (patch), feat/internal (minor). Major bumps are not produced by the auto-release flow; edit versions.yml directly to ship a major release.
   # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/ruby/sdk/changes/unreleased/.template.yml
+++ b/generators/ruby/sdk/changes/unreleased/.template.yml
@@ -5,5 +5,5 @@
 - summary: |
     Brief description of your change.
     You can use multiple lines for longer descriptions.
-  type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  type: feat  # Options: fix/chore (patch), feat/internal (minor). Major bumps are not produced by the auto-release flow; edit versions.yml directly to ship a major release.
   # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/rust/sdk/changes/unreleased/.template.yml
+++ b/generators/rust/sdk/changes/unreleased/.template.yml
@@ -5,5 +5,5 @@
 - summary: |
     Brief description of your change.
     You can use multiple lines for longer descriptions.
-  type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  type: feat  # Options: fix/chore (patch), feat/internal (minor). Major bumps are not produced by the auto-release flow; edit versions.yml directly to ship a major release.
   # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/swift/sdk/changes/unreleased/.template.yml
+++ b/generators/swift/sdk/changes/unreleased/.template.yml
@@ -5,5 +5,5 @@
 - summary: |
     Brief description of your change.
     You can use multiple lines for longer descriptions.
-  type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  type: feat  # Options: fix/chore (patch), feat/internal (minor). Major bumps are not produced by the auto-release flow; edit versions.yml directly to ship a major release.
   # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/typescript/sdk/changes/unreleased/.template.yml
+++ b/generators/typescript/sdk/changes/unreleased/.template.yml
@@ -5,5 +5,5 @@
 - summary: |
     Brief description of your change.
     You can use multiple lines for longer descriptions.
-  type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  type: feat  # Options: fix/chore (patch), feat/internal (minor). Major bumps are not produced by the auto-release flow; edit versions.yml directly to ship a major release.
   # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -138,8 +138,8 @@ Every CLI change (`packages/cli/` tree) **must** include an unreleased changelog
 1. Create a new YAML file under `packages/cli/cli/changes/unreleased/` with a descriptive filename (e.g., `fix-global-headers.yml`). Copy `.template.yml` from that folder as a starting point.
 2. Each file is a YAML array of objects with two fields:
    - `summary`: description of the change (multi-line `|` allowed)
-   - `type`: one of `fix`, `chore`, `feat`, `internal`, `break`
-3. These types drive semver bumps automatically: `fix`/`chore` → patch, `feat`/`internal` → minor, `break` → major.
+   - `type`: one of `fix`, `chore`, `feat`, `internal`
+3. These types drive semver bumps automatically: `fix`/`chore` → patch, `feat`/`internal` → minor. Major version bumps are not produced by the automated release flow; edit `versions.yml` directly to ship a major release.
 
 ```yaml
 # Example: packages/cli/cli/changes/unreleased/fix-global-headers.yml

--- a/packages/cli/cli/changes/unreleased/.template.yml
+++ b/packages/cli/cli/changes/unreleased/.template.yml
@@ -5,5 +5,5 @@
 - summary: |
     Brief description of your change.
     You can use multiple lines for longer descriptions.
-  type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  type: feat  # Options: fix/chore (patch), feat/internal (minor). Major bumps are not produced by the auto-release flow; edit versions.yml directly to ship a major release.
   # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/packages/cli/cli/changes/unreleased/remove-break-changelog-type.yml
+++ b/packages/cli/cli/changes/unreleased/remove-break-changelog-type.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Remove `break` from the supported changelog types so the automated release flow
+    cannot produce a major version bump. Major releases must now be made by editing
+    the relevant `versions.yml` directly so the breaking change is explicitly
+    acknowledged in review. Validation rejects `type: break` in `unreleased/`.
+  type: chore

--- a/packages/seed/src/__test__/validateStagedChanges.test.ts
+++ b/packages/seed/src/__test__/validateStagedChanges.test.ts
@@ -1,0 +1,91 @@
+import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { mkdir, mkdtemp, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+import { validateStagedChanges } from "../commands/validate/validateStagedChanges";
+
+interface RecordingTaskContext {
+    logger: {
+        debug: (msg: string) => void;
+        error: (msg: string) => void;
+    };
+    errors: string[];
+}
+
+function createContext(): RecordingTaskContext {
+    const errors: string[] = [];
+    return {
+        logger: {
+            debug: () => undefined,
+            error: (msg: string) => {
+                errors.push(msg);
+            }
+        },
+        errors
+    };
+}
+
+async function createTempChangelog(): Promise<{ root: string; changelogPath: string }> {
+    const root = await mkdtemp(path.join(tmpdir(), "validate-staged-changes-"));
+    const changelogPath = path.join(root, "CHANGELOG.md");
+    await writeFile(changelogPath, "# changelog\n", "utf-8");
+    return { root, changelogPath };
+}
+
+async function writeChange(root: string, version: string, file: string, contents: string): Promise<void> {
+    const dir = path.join(root, "changes", version);
+    await mkdir(dir, { recursive: true });
+    await writeFile(path.join(dir, file), contents, "utf-8");
+}
+
+describe("validateStagedChanges", () => {
+    it("rejects type: break in unreleased entries", async () => {
+        const { root, changelogPath } = await createTempChangelog();
+        await writeChange(root, "unreleased", "rename-thing.yml", `- summary: |\n    Rename a thing.\n  type: break\n`);
+
+        const context = createContext();
+        const hasErrors = await validateStagedChanges({
+            absolutePathToChangelog: AbsoluteFilePath.of(changelogPath),
+            // biome-ignore lint/suspicious/noExplicitAny: minimal stub for tests
+            context: context as any,
+            label: "test"
+        });
+
+        expect(hasErrors).toBe(true);
+        expect(context.errors.some((err) => err.includes('forbidden type "break"'))).toBe(true);
+    });
+
+    it("allows type: feat in unreleased entries", async () => {
+        const { root, changelogPath } = await createTempChangelog();
+        await writeChange(root, "unreleased", "add-thing.yml", `- summary: |\n    Add a thing.\n  type: feat\n`);
+
+        const context = createContext();
+        const hasErrors = await validateStagedChanges({
+            absolutePathToChangelog: AbsoluteFilePath.of(changelogPath),
+            // biome-ignore lint/suspicious/noExplicitAny: minimal stub for tests
+            context: context as any,
+            label: "test"
+        });
+
+        expect(hasErrors).toBe(false);
+        expect(context.errors).toEqual([]);
+    });
+
+    it("does not reject historical released versions that contain type: break", async () => {
+        const { root, changelogPath } = await createTempChangelog();
+        await writeChange(root, "5.0.0", "rename-thing.yml", `- summary: |\n    Rename a thing.\n  type: break\n`);
+
+        const context = createContext();
+        const hasErrors = await validateStagedChanges({
+            absolutePathToChangelog: AbsoluteFilePath.of(changelogPath),
+            // biome-ignore lint/suspicious/noExplicitAny: minimal stub for tests
+            context: context as any,
+            label: "test"
+        });
+
+        expect(hasErrors).toBe(false);
+        expect(context.errors).toEqual([]);
+    });
+});

--- a/packages/seed/src/commands/validate/validateStagedChanges.ts
+++ b/packages/seed/src/commands/validate/validateStagedChanges.ts
@@ -6,6 +6,9 @@ import yaml from "js-yaml";
 
 import { ChangelogEntry, validateAngleBracketEscaping } from "./angleBracketValidator.js";
 
+const UNRELEASED_DIR_NAME = "unreleased";
+const FORBIDDEN_UNRELEASED_TYPES = new Set(["break"]);
+
 export async function validateStagedChanges({
     absolutePathToChangelog,
     context,
@@ -55,8 +58,37 @@ export async function validateStagedChanges({
                     context.logger.error(chalk.red(`${relPath}: ${error}`));
                 }
             }
+
+            if (versionName === UNRELEASED_DIR_NAME) {
+                const forbiddenTypeErrors = findForbiddenUnreleasedTypes(items);
+                if (forbiddenTypeErrors.length > 0) {
+                    hasErrors = true;
+                    for (const error of forbiddenTypeErrors) {
+                        context.logger.error(chalk.red(`${relPath}: ${error}`));
+                    }
+                }
+            }
         }
     }
 
     return hasErrors;
+}
+
+function findForbiddenUnreleasedTypes(items: unknown[]): string[] {
+    const errors: string[] = [];
+    for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (typeof item !== "object" || item === null) {
+            continue;
+        }
+        const type = (item as { type?: unknown }).type;
+        if (typeof type === "string" && FORBIDDEN_UNRELEASED_TYPES.has(type)) {
+            errors.push(
+                `Entry ${i + 1} uses forbidden type "${type}". ` +
+                    "Major version bumps are not produced by the automated release flow; " +
+                    "to ship a breaking change, edit the relevant versions.yml directly so the major bump is explicitly acknowledged in review."
+            );
+        }
+    }
+    return errors;
 }

--- a/scripts/release-setup.ts
+++ b/scripts/release-setup.ts
@@ -96,7 +96,7 @@ function createChangelogStructure(config: SoftwareConfig): void {
 - summary: |
     Brief description of your change.
     You can use multiple lines for longer descriptions.
-  type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  type: feat  # Options: fix/chore (patch), feat/internal (minor). Major version bumps are not produced by the auto-release flow; edit versions.yml directly to ship a major release.
 `;
     writeFileSync(templatePath, templateContent);
 

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -16,14 +16,16 @@ import { setupSoftware } from "./release-setup.js";
 
 interface ChangelogEntry {
     summary: string;
-    type: "fix" | "chore" | "feat" | "internal" | "break";
+    type: "fix" | "chore" | "feat" | "internal";
     "pre-release"?: string;
 }
 
-const VALID_CHANGELOG_TYPES = new Set(["fix", "chore", "feat", "internal", "break"]);
+const VALID_CHANGELOG_TYPES = new Set(["fix", "chore", "feat", "internal"]);
 const VALID_PRE_RELEASE_TAGS = new Set(["alpha", "beta", "rc"]);
 
-type Severity = "major" | "minor" | "patch";
+// Major version bumps are intentionally not produced by the automated release flow.
+// To ship a major release, a human edits versions.yml directly.
+type Severity = "minor" | "patch";
 
 function getSeverityFromType(type: ChangelogEntry["type"]): Severity {
     switch (type) {
@@ -33,8 +35,6 @@ function getSeverityFromType(type: ChangelogEntry["type"]): Severity {
         case "feat":
         case "internal":
             return "minor";
-        case "break":
-            return "major";
         default: {
             const _exhaustive: never = type;
             throw new Error(`Unknown changelog type: ${_exhaustive}`);
@@ -177,9 +177,7 @@ function determineNextVersion(currentVersion: string, changes: UnreleasedChange[
     for (const change of changes) {
         for (const entry of change.entries) {
             const severity = getSeverityFromType(entry.type);
-            if (severity === "major") {
-                highestSeverity = "major";
-            } else if (severity === "minor" && highestSeverity !== "major") {
+            if (severity === "minor") {
                 highestSeverity = "minor";
             }
         }
@@ -204,18 +202,20 @@ function determineNextVersion(currentVersion: string, changes: UnreleasedChange[
         process.exit(1);
     }
 
-    // Compute the base next version from severity
+    // Compute the base next version from severity. Major bumps are deliberately
+    // unreachable here — they require a human edit to versions.yml.
     let nextBase: string;
     switch (highestSeverity) {
-        case "major":
-            nextBase = `${major + 1}.0.0`;
-            break;
         case "minor":
             nextBase = `${major}.${minor + 1}.0`;
             break;
         case "patch":
             nextBase = isCurrentPreRelease ? `${major}.${minor}.${patch}` : `${major}.${minor}.${patch + 1}`;
             break;
+        default: {
+            const _exhaustive: never = highestSeverity;
+            throw new Error(`Unknown severity: ${_exhaustive}`);
+        }
     }
 
     // If no pre-release tag requested, return the stable version


### PR DESCRIPTION
## Description

Linear ticket: Refs

Removes `break` as a supported changelog entry type so the automated release flow can no longer produce a major version bump. Major releases must now be made by editing the relevant `versions.yml` directly so the breaking change is explicitly acknowledged in review.

This came from the recent unintended v5.0.0 CLI release in [#15583](https://github.com/fern-api/fern/pull/15583): a `break` entry triggered an automatic major bump. Major releases should be human-acknowledged events.

## Changes Made

- `fern-changes-yml.schema.json`: drop `break` from the `ChangelogType` enum and update descriptions to reflect that automation produces only `patch` / `minor` bumps.
- `scripts/release.ts`: remove `break` from the `ChangelogEntry` type, `VALID_CHANGELOG_TYPES`, and `getSeverityFromType`. Drop `"major"` from the `Severity` type and the corresponding case in `determineNextVersion` (auto-release can no longer reach a major bump). The runtime parser now rejects `type: break` with `Invalid "type" field: "break". Expected one of: fix, chore, feat, internal`.
- `packages/seed/src/commands/validate/validateStagedChanges.ts`: add a new check that fails seed validate if any entry in `changes/unreleased/` has `type: break`. Historical released versions (e.g. `packages/cli/cli/changes/5.0.0/rename-og-background-image.yml`) are intentionally left as-is — they're already shipped and recorded in `versions.yml`.
- `packages/seed/src/__test__/validateStagedChanges.test.ts`: add unit tests covering the new rejection.
- All `*/changes/unreleased/.template.yml` files (CLI + 10 generators) and `scripts/release-setup.ts`: update the `type:` comment to drop `break (major)` and add a note that majors require a manual `versions.yml` edit.
- `.claude/release-versioning.md`: update docs to remove `break` from the supported types and explain how major releases work.
- [ ] Updated README.md generator (if applicable) — N/A.

## Testing

- [x] Unit tests added/updated (`packages/seed/src/__test__/validateStagedChanges.test.ts`).
- [x] Full `@fern-api/seed-cli` test suite passes locally (`pnpm turbo run test --filter @fern-api/seed-cli` → 212/212 passing).
- [x] Manual testing: dropped a `type: break` file into `packages/cli/cli/changes/unreleased/` and ran `pnpm seed validate cli`. Validator failed with: ``Entry 1 uses forbidden type "break". Major version bumps are not produced by the automated release flow; to ship a breaking change, edit the relevant versions.yml directly so the major bump is explicitly acknowledged in review.`` Removed the file after the check.
- [x] `pnpm check` (biome) passes; full repo `pnpm format` clean.


Link to Devin session: https://app.devin.ai/sessions/00649b80ad674a21bdd0dc7edde7c2ba
Requested by: @aditya-arolkar-swe
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15685" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->