### PR TITLE
chore(ci): use sparse checkout to skip seed/ in non-test CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            /*
+            !seed
+            !seed-remote-local
+          sparse-checkout-cone-mode: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -77,6 +83,12 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            /*
+            !seed
+            !seed-remote-local
+          sparse-checkout-cone-mode: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -91,6 +103,12 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            /*
+            !seed
+            !seed-remote-local
+          sparse-checkout-cone-mode: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -105,6 +123,12 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            /*
+            !seed
+            !seed-remote-local
+          sparse-checkout-cone-mode: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -119,6 +143,12 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            /*
+            !seed
+            !seed-remote-local
+          sparse-checkout-cone-mode: false
 
       - name: Install
         uses: ./.github/actions/install
@@ -147,6 +177,12 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            /*
+            !seed
+            !seed-remote-local
+          sparse-checkout-cone-mode: false
 
       - name: Install
         uses: ./.github/actions/install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
             /*
             !seed
             !seed-remote-local
+            packages/seed/**
+            docker/seed/**
           sparse-checkout-cone-mode: false
 
       - name: Install
@@ -88,6 +90,8 @@ jobs:
             /*
             !seed
             !seed-remote-local
+            packages/seed/**
+            docker/seed/**
           sparse-checkout-cone-mode: false
 
       - name: Install
@@ -108,6 +112,8 @@ jobs:
             /*
             !seed
             !seed-remote-local
+            packages/seed/**
+            docker/seed/**
           sparse-checkout-cone-mode: false
 
       - name: Install
@@ -128,6 +134,8 @@ jobs:
             /*
             !seed
             !seed-remote-local
+            packages/seed/**
+            docker/seed/**
           sparse-checkout-cone-mode: false
 
       - name: Install
@@ -148,6 +156,8 @@ jobs:
             /*
             !seed
             !seed-remote-local
+            packages/seed/**
+            docker/seed/**
           sparse-checkout-cone-mode: false
 
       - name: Install
@@ -182,6 +192,8 @@ jobs:
             /*
             !seed
             !seed-remote-local
+            packages/seed/**
+            docker/seed/**
           sparse-checkout-cone-mode: false
 
       - name: Install


### PR DESCRIPTION
## Description

The `fern` repo has **138,308 tracked files**, of which **119,314 (86%) are in `seed/`**. A full checkout takes ~5 minutes just for filesystem I/O on CI runners, even with a shallow clone — the bottleneck is creating 138K files on disk, not the git transfer (~75 MB pack).

This PR adds sparse checkout to 6 CI jobs that never read `seed/` files, reducing their checkout from ~138K files to ~19K files.

## Changes Made

Added `sparse-checkout` with `sparse-checkout-cone-mode: false` to exclude `seed/` and `seed-remote-local/` in these jobs:

- **compile** — only compiles TS packages in `packages/` and `generators/`
- **boundaries** — checks turbo task boundaries between packages
- **depcheck** — checks unused deps via knip
- **validate-cli-dependencies** — reads only `packages/cli/cli/package.json`
- **lint** — stylelint on `packages/**/*.scss`, biome format (seed excluded in `biome.jsonc`), `fern:build`, `jsonschema`, `docs:generate`
- **biome** — biome check (seed excluded in `biome.jsonc`)

**Unchanged jobs** (need seed/ for snapshot tests or are uncertain):
- `test`, `test-ete`, `live-test-dev`, `generate-docs-test-windows`, `live-test-dev-windows`

### Why these jobs are safe

- `pnpm-workspace.yaml` only includes `packages/**` and `generators/**` — `seed/` is not a workspace member, so `pnpm install` works without it
- `biome.jsonc` already excludes `seed` (line 101)
- `.prettierignore` already excludes `seed/` (line 20)
- `stylelint` only targets `packages/**/src/**/*.scss`
- The repo already has `scripts/sparse-checkout.sh` using the same exclusion patterns
- `packages/seed/**` and `docker/seed/**` are re-included after the `!seed` exclusion (since non-cone mode patterns match at any directory level)

## Testing

- [x] CI on this PR validates that all 6 modified jobs pass with sparse checkout

Link to Devin session: https://app.devin.ai/sessions/4e17dc695e9c4e25bca7a2b9b66cfd6b
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15686" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->