### PR TITLE
feat(cli): support `branch` on `mode: release` in generators.yml

### DIFF
--- a/fern-generators.schema.json
+++ b/fern-generators.schema.json
@@ -932,6 +932,9 @@
         "repository": {
           "type": "string"
         },
+        "branch": {
+          "type": "string"
+        },
         "license": {
           "$ref": "#/definitions/license.GithubLicenseSchema"
         },

--- a/fern/apis/generators-yml/definition/group.yml
+++ b/fern/apis/generators-yml/definition/group.yml
@@ -164,6 +164,9 @@ types:
   GithubCommitAndReleaseSchema:
     properties:
       repository: string
+      branch:
+        type: optional<string>
+        docs: If specified, commits and tags the release on this branch instead of the default branch. The branch must exist.
       license: optional<license.GithubLicenseSchema>
       mode: optional<GithubCommitAndReleaseMode>
       # Add properties for commit and release configuration

--- a/generators-yml.schema.json
+++ b/generators-yml.schema.json
@@ -3899,6 +3899,16 @@
         "repository": {
           "type": "string"
         },
+        "branch": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "license": {
           "oneOf": [
             {

--- a/packages/cli/cli-v2/src/migrator/__test__/convertGitOutput.test.ts
+++ b/packages/cli/cli-v2/src/migrator/__test__/convertGitOutput.test.ts
@@ -44,6 +44,12 @@ describe("convertGitOutput", () => {
         expect(result.gitOutput?.branch).toBe("main");
     });
 
+    it("preserves branch field on release mode", () => {
+        const result = convertGitOutput({ repository: "acme/sdk", mode: "release", branch: "v2" });
+        expect(result.gitOutput?.mode).toBe("release");
+        expect(result.gitOutput?.branch).toBe("v2");
+    });
+
     it("omits branch when not set", () => {
         const result = convertGitOutput({ repository: "acme/sdk", mode: "pull-request" });
         expect(result.gitOutput?.branch).toBeUndefined();

--- a/packages/cli/cli-v2/src/sdk/adapter/LegacyGeneratorInvocationAdapter.ts
+++ b/packages/cli/cli-v2/src/sdk/adapter/LegacyGeneratorInvocationAdapter.ts
@@ -129,6 +129,7 @@ export class LegacyGeneratorInvocationAdapter {
                     FernFiddle.GithubOutputModeV2.commitAndRelease({
                         owner: repository.owner,
                         repo: repository.repo,
+                        branch: git.branch,
                         license,
                         publishInfo,
                         downloadSnippets: undefined

--- a/packages/cli/cli/changes/unreleased/add-release-mode-branch.yml
+++ b/packages/cli/cli/changes/unreleased/add-release-mode-branch.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Accept `branch` under `github` when `mode` is `release` in `generators.yml`. This
+    allows users to configure a non-default branch for release mode in preparation for
+    wiring the field through to the remote generation service.
+  type: feat

--- a/packages/cli/cli/src/commands/sdk-preview/__test__/overrideOutputForPreview.test.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/__test__/overrideOutputForPreview.test.ts
@@ -422,6 +422,24 @@ describe("overrideGroupOutputForDiffBranch", () => {
         expect(result.generators[0]?.outputMode.type).toBe("githubV2");
     });
 
+    it("extracts owner/repo from githubV2 commitAndRelease with branch", () => {
+        const generator = makeGenerator(
+            FernFiddle.OutputMode.githubV2(
+                FernFiddle.GithubOutputModeV2.commitAndRelease({
+                    owner: "my-org",
+                    repo: "my-sdk",
+                    branch: "v2"
+                })
+            )
+        );
+        const group = makeGroup([generator]);
+
+        const result = overrideGroupOutputForDiffBranch({ group });
+
+        expect(result.generators).toHaveLength(1);
+        expect(result.generators[0]?.outputMode.type).toBe("githubV2");
+    });
+
     it("excludes generators without github config (publishV2)", () => {
         const generator = makeGenerator(
             FernFiddle.OutputMode.publishV2(

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -831,16 +831,19 @@ async function convertOutputMode({
         const mode = generator.github.mode ?? "release";
         switch (mode) {
             case "commit":
-            case "release":
+            case "release": {
+                const releaseConfig = generator.github as generatorsYml.GithubCommitAndReleaseSchema;
                 return FernFiddle.OutputMode.githubV2(
                     FernFiddle.GithubOutputModeV2.commitAndRelease({
                         owner,
                         repo,
+                        branch: releaseConfig.branch,
                         license,
                         publishInfo,
                         downloadSnippets
                     })
                 );
+            }
             case "pull-request": {
                 const pullRequestConfig = generator.github as generatorsYml.GithubPullRequestSchema;
                 const reviewers = _getReviewers({

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubCommitAndReleaseSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/group/types/GithubCommitAndReleaseSchema.ts
@@ -4,6 +4,8 @@ import type * as GeneratorsYml from "../../../index.js";
 
 export interface GithubCommitAndReleaseSchema {
     repository: string;
+    /** If specified, commits and tags the release on this branch instead of the default branch. The branch must exist. */
+    branch?: string;
     license?: GeneratorsYml.GithubLicenseSchema;
     mode?: GeneratorsYml.GithubCommitAndReleaseMode;
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubCommitAndReleaseSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/group/types/GithubCommitAndReleaseSchema.ts
@@ -11,6 +11,7 @@ export const GithubCommitAndReleaseSchema: core.serialization.ObjectSchema<
     GeneratorsYml.GithubCommitAndReleaseSchema
 > = core.serialization.object({
     repository: core.serialization.string(),
+    branch: core.serialization.string().optional(),
     license: GithubLicenseSchema.optional(),
     mode: GithubCommitAndReleaseMode.optional(),
 });
@@ -18,6 +19,7 @@ export const GithubCommitAndReleaseSchema: core.serialization.ObjectSchema<
 export declare namespace GithubCommitAndReleaseSchema {
     export interface Raw {
         repository: string;
+        branch?: string | null;
         license?: GithubLicenseSchema.Raw | null;
         mode?: GithubCommitAndReleaseMode.Raw | null;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ catalogs:
       specifier: ^0.0.5297
       version: 0.0.5297
     '@fern-fern/fiddle-sdk':
-      specifier: 0.0.85
-      version: 0.0.85
+      specifier: 1.0.1
+      version: 1.0.1
     '@fern-fern/generator-exec-sdk':
       specifier: ^0.0.1167
       version: 0.0.1167
@@ -4438,7 +4438,7 @@ importers:
         version: link:../workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.85
+        version: 1.0.1
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -4856,7 +4856,7 @@ importers:
         version: link:../yaml/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.85
+        version: 1.0.1
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -4982,7 +4982,7 @@ importers:
         version: link:../../commons/path-utils
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.85
+        version: 1.0.1
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -5025,7 +5025,7 @@ importers:
         version: link:../task-context
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.85
+        version: 1.0.1
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -6126,7 +6126,7 @@ importers:
         version: link:../../../workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.85
+        version: 1.0.1
       '@fern-fern/generator-exec-sdk':
         specifier: 'catalog:'
         version: 0.0.1167
@@ -6283,7 +6283,7 @@ importers:
         version: link:../../../workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.85
+        version: 1.0.1
       axios:
         specifier: 'catalog:'
         version: 1.15.0
@@ -7017,7 +7017,7 @@ importers:
         version: link:../../api-importers/v3-importer-commons
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.85
+        version: 1.0.1
       '@open-rpc/meta-schema':
         specifier: 'catalog:'
         version: 1.14.9
@@ -7458,7 +7458,7 @@ importers:
         version: link:../../cli/task-context
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.85
+        version: 1.0.1
       '@redocly/openapi-core':
         specifier: 'catalog:'
         version: 1.34.11
@@ -7860,7 +7860,7 @@ importers:
         version: 0.0.5297
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.85
+        version: 1.0.1
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -8104,7 +8104,7 @@ importers:
         version: link:../cli/workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 0.0.85
+        version: 1.0.1
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -9436,8 +9436,8 @@ packages:
   '@fern-fern/fdr-test-sdk@0.0.5297':
     resolution: {integrity: sha512-jrZUZ6oIA64LHtrv77xEq0X7qJhT9xRMGWhKcLjIUArMsD7h6KMWUHVdoB/1MP0Mz/uL/E2xmM31SOgJicpIcA==}
 
-  '@fern-fern/fiddle-sdk@0.0.85':
-    resolution: {integrity: sha512-+Lqha8blDhUlb0vsEpMoZ5pXS3C94dTMvpacCmkL97Bbcs1RdA1F4I1sKE3ube+piMPMA3K9RdFNI7eGEsnVsA==}
+  '@fern-fern/fiddle-sdk@1.0.1':
+    resolution: {integrity: sha512-mGCTFkKBDQulvnx7VijKlrFIiXL+vvxE0N6yfGIJfmgv5/IEPu7klX9/n8oA6nzfZyCYw698ElloGgP1fszxoQ==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/generator-cli-sdk@0.1.8':
@@ -16490,7 +16490,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@fern-fern/fiddle-sdk@0.0.85': {}
+  '@fern-fern/fiddle-sdk@1.0.1': {}
 
   '@fern-fern/generator-cli-sdk@0.1.8':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,7 +65,7 @@ catalog:
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80
   "@fern-fern/fdr-test-sdk": ^0.0.5297
-  "@fern-fern/fiddle-sdk": 0.0.85
+  "@fern-fern/fiddle-sdk": 1.0.1
   "@fern-fern/generator-exec-sdk": ^0.0.1167
   "@fern-fern/generators-sdk": 0.114.0-5745f9e74
   "@fern-fern/ir-v53-sdk": 1.0.1


### PR DESCRIPTION
## Description

Threads the `branch` field on `mode: release` (`GithubCommitAndRelease`) end-to-end from `generators.yml` through to fiddle. Supersedes #15298 (which was schema-only): now that `@fern-fern/fiddle-sdk@1.0.1` exposes `branch` on `GithubCommitAndReleaseMode`, we can land the wire-through and the schema in one PR rather than risk a silent-failure window where the schema accepts `branch` but the CLI drops it.

End-to-end behavior with this PR + fiddle@0.121.8 (already deployed to prod):

```yaml
github:
  repository: acme/sdk
  mode: release
  branch: v2
```

→ fern CLI sends `branch: v2` in the `commitAndRelease` payload → fiddle clones `acme/sdk` on `v2`, validates the branch exists (else `BranchDoesNotExist`), commits + tags the release on `v2`. Existing release-mode users (no `branch`) are unaffected — branch falls back to the default branch as before.

## Changes Made

- **Bumps `@fern-fern/fiddle-sdk`** from `0.0.85` to `1.0.1` in `pnpm-workspace.yaml` (and `pnpm-lock.yaml`). 1.0.1 was published from fiddle main post-merge of fern-api/fiddle#713 with the new `branch` field on `GithubCommitAndReleaseMode`.
- **Wire-through**:
  - `packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts` — passes `releaseConfig.branch` into `commitAndRelease({ ..., branch })` for the `commit`/`release` cases.
  - `packages/cli/cli-v2/src/sdk/adapter/LegacyGeneratorInvocationAdapter.ts` — passes `git.branch` into `commitAndRelease({ ..., branch })` for the `release` case.
- **Schema** (subsumes #15298):
  - `fern/apis/generators-yml/definition/group.yml` — adds `branch: optional<string>` on `GithubCommitAndReleaseSchema` with docs.
  - `packages/cli/configuration/src/generators-yml/schemas/api/.../GithubCommitAndReleaseSchema.ts` and the matching `serialization/...` sibling — `branch: core.serialization.string().optional()` and `branch?: string | null` on `Raw`. Hand-patched to mirror the existing `GithubPushSchema` shape; running `fern generate` rewrites unrelated files due to a newer codegen, so this avoids churn.
  - `generators-yml.schema.json` — regenerated via `pnpm generators-yml:jsonschema`.
  - `fern-generators.schema.json` — manual `branch` entry mirroring the existing push/PR `branch` entries.
- **Tests**:
  - `packages/cli/cli-v2/src/migrator/__test__/convertGitOutput.test.ts` — adds `preserves branch field on release mode`.
  - `packages/cli/cli/src/commands/sdk-preview/__test__/overrideOutputForPreview.test.ts` — adds a commitAndRelease branch variant.
- **Changelog**: `packages/cli/cli/changes/unreleased/add-release-mode-branch.yml` (`feat`).

## Testing

- [x] Unit tests added/updated — `convertGitOutput.test.ts` and `overrideOutputForPreview.test.ts` cover the new `branch` plumbing on commitAndRelease.
- [x] `pnpm compile` — clean for `@fern-api/cli`, `@fern-api/cli-v2`, `@fern-api/configuration`, `@fern-api/configuration-loader`.
- [x] `pnpm lint:biome` and `pnpm check` — clean.
- [x] Targeted vitest for the two test files — pass.
- [ ] **Prod smoke test** — pending. Plan: build prod CLI from this branch, point a test SDK repo at it with `mode: release, branch: v2`, run against prod fiddle, verify the commit lands on `v2` and the release tag points at the v2 SHA. Negative case: `branch: does-not-exist` → expect `BranchDoesNotExist`. I'll attach the smoke test output as a comment once done.

### Notes

- This PR closes #15298 (schema-only predecessor); the schema diff there is included here verbatim plus the wire-through. I'll close #15298 as duplicate once this is approved.
- fern-api/fiddle#713 (the server-side coordinator change) is already merged and deployed to prod (fiddle@0.121.8).
- fern-api/docs#5115 documents the new field; safe to merge after this PR.


Link to Devin session: https://app.devin.ai/sessions/11840acb772748b294bc5001ab3f7d81
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->