### PR TITLE
chore(cli): plumb replay config through remote generation runner

### DIFF
--- a/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
@@ -133,6 +133,7 @@ export class LegacyRemoteGenerationRunner {
                 skipFernignore: args.skipFernignore,
                 absolutePathToPreview,
                 whitelabel: undefined,
+                replay: fernWorkspace.generatorsConfiguration?.replay,
                 dynamicIrOnly: false,
                 retryRateLimited: false,
                 requireEnvVars: args.requireEnvVars ?? true

--- a/packages/cli/cli/changes/unreleased/chore-plumb-replay-to-remote-runner.yml
+++ b/packages/cli/cli/changes/unreleased/chore-plumb-replay-to-remote-runner.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Plumb the top-level `replay` block from `generators.yml` through the remote
+    generation runner to the createJobV3 wire boundary, so cloud generation can
+    honor `replay.enabled` once Fiddle exposes the field.
+  type: chore

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -180,6 +180,7 @@ export async function generateWorkspace({
                         shouldLogS3Url,
                         token,
                         whitelabel: workspace.generatorsConfiguration?.whitelabel,
+                        replay,
                         absolutePathToPreview,
                         mode,
                         fernignorePath,

--- a/packages/cli/cli/src/commands/sdk-preview/sdkPreview.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/sdkPreview.ts
@@ -291,6 +291,7 @@ export async function sdkPreview({
                         shouldLogS3Url: false,
                         token,
                         whitelabel: workspace.generatorsConfiguration?.whitelabel,
+                        replay: workspace.generatorsConfiguration?.replay,
                         mode: undefined as "pull-request" | undefined,
                         fernignorePath: undefined as string | undefined,
                         skipFernignore: false,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -32,6 +32,7 @@ export async function createAndStartJob({
     shouldLogS3Url,
     token,
     whitelabel,
+    replay,
     irVersionOverride,
     absolutePathToPreview,
     fiddlePreview,
@@ -54,6 +55,7 @@ export async function createAndStartJob({
     shouldLogS3Url: boolean;
     token: FernToken;
     whitelabel: FernFiddle.WhitelabelConfig | undefined;
+    replay: generatorsYml.ReplayConfigSchema | undefined;
     irVersionOverride: string | undefined;
     absolutePathToPreview: AbsoluteFilePath | undefined;
     /** When provided, overrides the `preview` flag sent to Fiddle. When omitted, falls back to absolutePathToPreview != null. */
@@ -101,6 +103,7 @@ export async function createAndStartJob({
                 shouldLogS3Url,
                 token,
                 whitelabel,
+                replay,
                 absolutePathToPreview,
                 fiddlePreview,
                 pushPreviewBranch,
@@ -149,6 +152,7 @@ async function createJob({
     shouldLogS3Url: boolean;
     token: FernToken;
     whitelabel: FernFiddle.WhitelabelConfig | undefined;
+    replay: generatorsYml.ReplayConfigSchema | undefined;
     absolutePathToPreview: AbsoluteFilePath | undefined;
     /** When provided, overrides the `preview` flag sent to Fiddle. When omitted, falls back to absolutePathToPreview != null. */
     fiddlePreview?: boolean;

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
@@ -32,6 +32,7 @@ export async function runRemoteGenerationForAPIWorkspace({
     shouldLogS3Url,
     token,
     whitelabel,
+    replay,
     absolutePathToPreview,
     isPreview,
     fiddlePreview,
@@ -59,6 +60,7 @@ export async function runRemoteGenerationForAPIWorkspace({
     shouldLogS3Url: boolean;
     token: FernToken;
     whitelabel: FernFiddle.WhitelabelConfig | undefined;
+    replay: generatorsYml.ReplayConfigSchema | undefined;
     absolutePathToPreview: AbsoluteFilePath | undefined;
     /** Controls CLI-side behavior (lenient env vars, skip version check). Falls back to absolutePathToPreview != null. */
     isPreview?: boolean;
@@ -133,6 +135,7 @@ export async function runRemoteGenerationForAPIWorkspace({
                     shouldLogS3Url,
                     token,
                     whitelabel,
+                    replay,
                     absolutePathToPreview,
                     isPreview,
                     fiddlePreview,
@@ -186,6 +189,7 @@ async function generateOne({
     shouldLogS3Url,
     token,
     whitelabel,
+    replay,
     absolutePathToPreview,
     isPreview,
     fiddlePreview,
@@ -217,6 +221,7 @@ async function generateOne({
     shouldLogS3Url: boolean;
     token: FernToken;
     whitelabel: FernFiddle.WhitelabelConfig | undefined;
+    replay: generatorsYml.ReplayConfigSchema | undefined;
     absolutePathToPreview: AbsoluteFilePath | undefined;
     isPreview: boolean | undefined;
     fiddlePreview: boolean | undefined;
@@ -300,6 +305,7 @@ async function generateOne({
             shouldLogS3Url,
             token,
             whitelabel,
+            replay,
             readme: generatorInvocation.readme,
             irVersionOverride: generatorInvocation.irVersionOverride,
             absolutePathToPreview,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -38,6 +38,7 @@ export async function runRemoteGenerationForGenerator({
     shouldLogS3Url,
     token,
     whitelabel,
+    replay,
     irVersionOverride,
     absolutePathToPreview,
     isPreview: isPreviewOverride,
@@ -64,6 +65,7 @@ export async function runRemoteGenerationForGenerator({
     shouldLogS3Url: boolean;
     token: FernToken;
     whitelabel: FernFiddle.WhitelabelConfig | undefined;
+    replay: generatorsYml.ReplayConfigSchema | undefined;
     irVersionOverride: string | undefined;
     absolutePathToPreview: AbsoluteFilePath | undefined;
     /** Controls CLI-side behavior (lenient env vars, skip version check). Falls back to absolutePathToPreview != null. */
@@ -308,6 +310,7 @@ export async function runRemoteGenerationForGenerator({
         shouldLogS3Url,
         token,
         whitelabel: whitelabel != null ? substituteEnvVars(whitelabel) : undefined,
+        replay,
         irVersionOverride,
         absolutePathToPreview,
         fiddlePreview,


### PR DESCRIPTION
## Summary

- Plumb the top-level `replay` block from `generators.yml` through `runRemoteGenerationForAPIWorkspace` → `runRemoteGenerationForGenerator` → `createAndStartJob`, mirroring the existing `whitelabel` wire-through.
- Sets up the rails for cloud generation to honor `replay.enabled` once Fiddle's `CreateJobRequestV2` schema exposes a `replay` field.
- Field is plumbed all the way to the `createJobV3` wire boundary but not yet sent — fiddle-sdk 1.0.1 has no `replay` member on `CreateJobRequestV2`.
- Resolves: [FER-10343](https://linear.app/buildwithfern/issue/FER-10343/honor-replayenabled-in-cloud-generation-flow) (rails portion; full resolution waits on the fiddle-side schema PR).

## Test plan

- [x] `pnpm compile` (159 packages) passes
- [x] `pnpm turbo run test --filter @fern-api/remote-workspace-runner` passes (12 files, 119 tests)
- [ ] After fiddle ships `replay` on `CreateJobRequestV2`, follow-up PR will bump the SDK pin in `pnpm-workspace.yaml` and add `replay: replay != null ? { enabled: replay.enabled } : undefined,` to the `createJobV3` call in `createAndStartJob.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15689" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->