### PR TITLE
feat(cli): send replay.enabled to Fiddle via createJobV3

### DIFF
--- a/packages/cli/cli/changes/unreleased/feat-send-replay-to-fiddle.yml
+++ b/packages/cli/cli/changes/unreleased/feat-send-replay-to-fiddle.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Forward the top-level `replay` block from `generators.yml` to Fiddle's
+    `createJobV3` call so cloud generation honors `replay.enabled: false` and
+    skips the replay pipeline when a customer opts out. Activates once the
+    `@fern-fern/fiddle-sdk` catalog pin advances to a version that exposes
+    `replay` on `CreateJobRequestV2` (schema landed in fern-api/fiddle#729).
+  type: feat

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -175,12 +175,8 @@ async function createJob({
         publishMetadata: generatorInvocation.publishMetadata
     };
 
-    // Assigned to a const before the createJobV3 call so TypeScript skips the excess-property
-    // check — `replay` is not yet present on @fern-fern/fiddle-sdk's CreateJobRequestV2 type
-    // (schema landed in fern-api/fiddle#729; FER-10343). Until a fiddle-sdk version exposing
-    // `replay` is pinned in pnpm-workspace.yaml, the SDK serializer drops the field at runtime,
-    // so behavior matches today; once the pin moves forward, the field reaches Fiddle and the
-    // server-side gate honors `replay.enabled: false`.
+    // Const-typed payload ducks the TS excess-property check; `replay` isn't on
+    // fiddle-sdk's CreateJobRequestV2 yet (FER-10343).
     const createJobRequest = {
         apiName: workspace.definition.rootApiFile.contents.name,
         version,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -136,6 +136,7 @@ async function createJob({
     shouldLogS3Url,
     token,
     whitelabel,
+    replay,
     absolutePathToPreview,
     fiddlePreview,
     pushPreviewBranch,
@@ -174,7 +175,13 @@ async function createJob({
         publishMetadata: generatorInvocation.publishMetadata
     };
 
-    const createResponse = await remoteGenerationService.remoteGen.createJobV3({
+    // Assigned to a const before the createJobV3 call so TypeScript skips the excess-property
+    // check — `replay` is not yet present on @fern-fern/fiddle-sdk's CreateJobRequestV2 type
+    // (schema landed in fern-api/fiddle#729; FER-10343). Until a fiddle-sdk version exposing
+    // `replay` is pinned in pnpm-workspace.yaml, the SDK serializer drops the field at runtime,
+    // so behavior matches today; once the pin moves forward, the field reaches Fiddle and the
+    // server-side gate honors `replay.enabled: false`.
+    const createJobRequest = {
         apiName: workspace.definition.rootApiFile.contents.name,
         version,
         organizationName: organization,
@@ -186,6 +193,7 @@ async function createJob({
             shouldLogS3Url
         }),
         whitelabel,
+        replay: replay != null ? { enabled: replay.enabled } : undefined,
         // fiddlePreview overrides what we send to Fiddle as `preview`.
         // For sdk preview: fiddlePreview=false so Fiddle doesn't set dryRun=true
         //   (Fiddle uses `dryRun = generatePreview`, so preview=false → actual publish).
@@ -203,7 +211,8 @@ async function createJob({
         //   runId: process.env.FERN_RUN_ID
         // Fiddle will use these for separate PRs, automerge, run_id correlation,
         // and breaking change handling. (skipIfNoDiff is forwarded above — see fern-api/fiddle#708.)
-    });
+    };
+    const createResponse = await remoteGenerationService.remoteGen.createJobV3(createJobRequest);
 
     if (!createResponse.ok) {
         // Check for 429 Too Many Requests before processing the error through the visitor.


### PR DESCRIPTION
## Summary

Forwards the top-level `replay` block from `generators.yml` into the `createJobV3` payload so cloud generation honors `replay.enabled: false` and skips the server-side replay pipeline when a customer opts out. Pairs with [fern-api/fiddle#729](https://github.com/fern-api/fiddle/pull/729) (schema + backend, already merged + deployed to prod).

The field is plumbed via a const-typed payload to duck TypeScript's excess-property check — `replay` isn't yet on `@fern-fern/fiddle-sdk@1.0.1`'s `CreateJobRequestV2` type.

Resolves: [FER-10343](https://linear.app/buildwithfern/issue/FER-10343/honor-replayenabled-in-cloud-generation-flow).

## How to verify it activates

Fully takes effect only once the `@fern-fern/fiddle-sdk` catalog pin in `pnpm-workspace.yaml:67` advances to a version that exposes `replay` on `CreateJobRequestV2`. Until then the SDK's runtime serializer silently strips `replay` from the request body — so behavior matches today (back-compat preserved).

The fiddle-side `Publish Internal SDKs` workflow currently fails on `push` events because the autoversioner picks `0.0.99` (already published on a parallel track from the manually-published `1.0.x` line). Manual `workflow_dispatch` with an explicit version (e.g. `1.0.2`) will publish a fiddle-sdk that exposes `replay`. After that, follow up with a tiny PR bumping the catalog pin.

## End-to-end verification (already done)

Tested locally against the prod fiddle deployment with a temporary raw-fetch hack that bypassed the SDK serializer. Both branches behaved correctly:

| Config | Server behavior | Resulting PR |
|---|---|---|
| `replay.enabled: false` | replay pipeline skipped, legacy GitHub push path | [#169](https://github.com/fern-demo/fern-replay-testbed-java-sdk/pull/169) — `Pushed branch: fern-bot/...` |
| `replay.enabled: true` | replay pipeline runs (org allowlist permits) | [#169](https://github.com/fern-demo/fern-replay-testbed-java-sdk/pull/169) — `Pipeline replay: patches detected=...` |

The raw-fetch hack is **not** in this PR — only the clean SDK call. The hack stays in my local-only branch and gets dropped once a real fiddle-sdk version lands.

## Test plan

- [x] `pnpm compile` (159 packages) passes
- [x] `pnpm turbo run test --filter @fern-api/remote-workspace-runner` passes (12 files, 119 tests)
- [x] End-to-end against prod fiddle (see table above)
- [ ] After fiddle-sdk publishes a version with `replay`, follow-up PR bumps `pnpm-workspace.yaml:67` and the field starts reaching Fiddle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->