### PR TITLE
feat(cli): include fern_run_id and github_run_id on every PostHog event

### DIFF
--- a/packages/cli/cli-telemetry/src/fernRunId.ts
+++ b/packages/cli/cli-telemetry/src/fernRunId.ts
@@ -34,9 +34,11 @@ export function getFernRunId(): string | undefined {
 export function getRunIdProperties(): { fern_run_id?: string; github_run_id?: string } {
     const properties: { fern_run_id?: string; github_run_id?: string } = {};
     const fernRunId = getFernRunId();
-    if (fernRunId != null) {
+
+    if (fernRunId != null && fernRunId.length > 0) {
         properties.fern_run_id = fernRunId;
     }
+
     const githubRunId = process.env.GITHUB_RUN_ID;
     if (githubRunId != null && githubRunId.length > 0) {
         properties.github_run_id = githubRunId;

--- a/packages/cli/cli-telemetry/src/fernRunId.ts
+++ b/packages/cli/cli-telemetry/src/fernRunId.ts
@@ -25,3 +25,21 @@ export function getOrCreateFernRunId(): string {
 export function getFernRunId(): string | undefined {
     return process.env[FERN_RUN_ID_ENV_VAR];
 }
+
+/**
+ * Returns the run-id correlation properties to attach to every PostHog event:
+ * `fern_run_id` (CLI-minted UUID) and `github_run_id` (GitHub Actions run ID,
+ * when running inside a workflow).
+ */
+export function getRunIdProperties(): { fern_run_id?: string; github_run_id?: string } {
+    const properties: { fern_run_id?: string; github_run_id?: string } = {};
+    const fernRunId = getFernRunId();
+    if (fernRunId != null) {
+        properties.fern_run_id = fernRunId;
+    }
+    const githubRunId = process.env.GITHUB_RUN_ID;
+    if (githubRunId != null && githubRunId.length > 0) {
+        properties.github_run_id = githubRunId;
+    }
+    return properties;
+}

--- a/packages/cli/cli-telemetry/src/index.ts
+++ b/packages/cli/cli-telemetry/src/index.ts
@@ -1,2 +1,2 @@
-export { getFernRunId, getOrCreateFernRunId } from "./fernRunId.js";
+export { getFernRunId, getOrCreateFernRunId, getRunIdProperties } from "./fernRunId.js";
 export { setSentryFernRunIdTag, setSentryGithubRunIdTag, setSentryRunIdTags } from "./sentryRunId.js";

--- a/packages/cli/cli-v2/src/telemetry/TelemetryClient.ts
+++ b/packages/cli/cli-v2/src/telemetry/TelemetryClient.ts
@@ -1,4 +1,4 @@
-import { setSentryRunIdTags } from "@fern-api/cli-telemetry";
+import { getRunIdProperties, setSentryRunIdTags } from "@fern-api/cli-telemetry";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { CliError } from "@fern-api/task-context";
 import * as Sentry from "@sentry/node";
@@ -36,7 +36,8 @@ export class TelemetryClient {
             ci: IS_CI,
             os: os.platform(),
             tty: isTTY,
-            usingAccessToken: process.env.FERN_TOKEN != null
+            usingAccessToken: process.env.FERN_TOKEN != null,
+            ...getRunIdProperties()
         };
         this.posthog = apiKey != null && apiKey.length > 0 && isTelemetryEnabled ? new PostHog(apiKey) : undefined;
 

--- a/packages/cli/cli/changes/unreleased/posthog-run-id-properties.yml
+++ b/packages/cli/cli/changes/unreleased/posthog-run-id-properties.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Attach `fern_run_id` and `github_run_id` as PostHog properties on every CLI
+    event so PostHog dashboards can correlate analytics with the FERN_RUN_ID set
+    by the GitHub Actions wrappers and the matching Sentry tags.
+  type: internal

--- a/packages/cli/cli/src/__test__/fernRunId.test.ts
+++ b/packages/cli/cli/src/__test__/fernRunId.test.ts
@@ -1,4 +1,4 @@
-import { getFernRunId, getOrCreateFernRunId } from "@fern-api/cli-telemetry";
+import { getFernRunId, getOrCreateFernRunId, getRunIdProperties } from "@fern-api/cli-telemetry";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("getOrCreateFernRunId", () => {
@@ -48,5 +48,56 @@ describe("getFernRunId", () => {
     it("returns the current FERN_RUN_ID when set", () => {
         process.env.FERN_RUN_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
         expect(getFernRunId()).toBe("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee");
+    });
+});
+
+describe("getRunIdProperties", () => {
+    beforeEach(() => {
+        delete process.env.FERN_RUN_ID;
+        delete process.env.GITHUB_RUN_ID;
+    });
+
+    afterEach(() => {
+        delete process.env.FERN_RUN_ID;
+        delete process.env.GITHUB_RUN_ID;
+    });
+
+    it("returns both fern_run_id and github_run_id when both env vars are set", () => {
+        process.env.FERN_RUN_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+        process.env.GITHUB_RUN_ID = "12345678";
+
+        expect(getRunIdProperties()).toEqual({
+            fern_run_id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            github_run_id: "12345678"
+        });
+    });
+
+    it("omits github_run_id when GITHUB_RUN_ID is not set", () => {
+        process.env.FERN_RUN_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+        expect(getRunIdProperties()).toEqual({
+            fern_run_id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+        });
+    });
+
+    it("omits fern_run_id when FERN_RUN_ID is not set", () => {
+        process.env.GITHUB_RUN_ID = "12345678";
+
+        expect(getRunIdProperties()).toEqual({
+            github_run_id: "12345678"
+        });
+    });
+
+    it("returns an empty object when neither env var is set", () => {
+        expect(getRunIdProperties()).toEqual({});
+    });
+
+    it("omits github_run_id when GITHUB_RUN_ID is empty", () => {
+        process.env.FERN_RUN_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+        process.env.GITHUB_RUN_ID = "";
+
+        expect(getRunIdProperties()).toEqual({
+            fern_run_id: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+        });
     });
 });

--- a/packages/cli/posthog-manager/package.json
+++ b/packages/cli/posthog-manager/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@fern-api/auth": "workspace:*",
+    "@fern-api/cli-telemetry": "workspace:*",
     "@fern-api/core": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/task-context": "workspace:*",

--- a/packages/cli/posthog-manager/src/AccessTokenPosthogManager.ts
+++ b/packages/cli/posthog-manager/src/AccessTokenPosthogManager.ts
@@ -1,3 +1,4 @@
+import { getRunIdProperties } from "@fern-api/cli-telemetry";
 import { PosthogEvent } from "@fern-api/task-context";
 import { PostHog } from "posthog-node";
 
@@ -23,7 +24,8 @@ export class AccessTokenPosthogManager implements PosthogManager {
                     ...event,
                     ...event.properties,
                     version: process.env.CLI_VERSION,
-                    usingAccessToken: true
+                    usingAccessToken: true,
+                    ...getRunIdProperties()
                 }
             });
         }

--- a/packages/cli/posthog-manager/src/UserPosthogManager.ts
+++ b/packages/cli/posthog-manager/src/UserPosthogManager.ts
@@ -1,4 +1,5 @@
 import { FernUserToken, getUserIdFromToken } from "@fern-api/auth";
+import { getRunIdProperties } from "@fern-api/cli-telemetry";
 import { createVenusService } from "@fern-api/core";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { PosthogEvent } from "@fern-api/task-context";
@@ -43,7 +44,8 @@ export class UserPosthogManager implements PosthogManager {
                 ...event,
                 ...event.properties,
                 usingAccessToken: false,
-                ...(userEmail != null ? { userEmail } : {})
+                ...(userEmail != null ? { userEmail } : {}),
+                ...getRunIdProperties()
             }
         });
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6603,6 +6603,9 @@ importers:
       '@fern-api/auth':
         specifier: workspace:*
         version: link:../auth
+      '@fern-api/cli-telemetry':
+        specifier: workspace:*
+        version: link:../cli-telemetry
       '@fern-api/core':
         specifier: workspace:*
         version: link:../../core


### PR DESCRIPTION
## Summary

Adds `getRunIdProperties()` to `@fern-api/cli-telemetry` and wires it into both PostHog code paths so every CLI analytics event carries the run-id correlation properties:

- **v1**: `UserPosthogManager.sendEvent` and `AccessTokenPosthogManager.sendEvent`
- **v2**: `TelemetryClient.baseTags` (inherited by `sendEvent` + `sendLifecycleEvent`)

Property names match the existing Sentry tags (`fern_run_id`, `github_run_id`) so a Sentry issue and a PostHog event for the same run can be cross-referenced without remapping.

The helper omits each key when the corresponding env var is unset, so the returned object is safe to spread regardless of whether the CLI is running in CI.

Closes the PostHog half of [FER-9667](https://linear.app/buildwithfern/issue/FER-9667/wrapper-mints-fern-run-id-cli-inherits-via-env-run-id-contract) (the run_id contract). Sentry tagging and env-precedence behavior were already shipped in prior work; this fills the PostHog gap called out in the ticket comment _"set on telemetry, not propagated to API calls, PR comments yet"_.

## Test plan

- [x] New unit tests in `packages/cli/cli/src/__test__/fernRunId.test.ts` covering `getRunIdProperties` (both vars set, only one set, neither set, empty `GITHUB_RUN_ID`)
- [x] `pnpm turbo run compile --filter @fern-api/cli-telemetry --filter @fern-api/posthog-manager --filter @fern-api/cli-v2 --filter @fern-api/cli` — 94 packages, all clean
- [x] `pnpm turbo run test --filter @fern-api/cli --filter @fern-api/posthog-manager` — 623/623 cli tests pass
- [ ] Manually verify a CLI run with `FERN_RUN_ID=<X>` and `GITHUB_RUN_ID=<Y>` set in env emits PostHog events whose properties include `fern_run_id=X` and `github_run_id=Y`

🤖 Generated with [Claude Code](https://claude.com/claude-code)