### PR TITLE
fix(cli): support broken links checks with scoped api

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-check-broken-links-with-api-flag.yml
+++ b/packages/cli/cli/changes/unreleased/fix-check-broken-links-with-api-flag.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix `fern check --api <name>` failing when broken-links validation is enabled
+    and `docs.yml` references multiple APIs. The docs validator now always sees
+    the full set of API workspaces (so the `valid-markdown-links` rule can resolve
+    every API referenced from the docs navigation), while the `--api` filter is
+    still applied to API-level validation only.
+  type: fix

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -1287,16 +1287,27 @@ function addValidateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     default: false
                 }),
         async (argv) => {
+            // Docs validation may reference APIs outside `--api`; apply the filter
+            // only to API-level validation.
+            const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
+                commandLineApiWorkspace: undefined,
+                defaultToAllApiWorkspaces: true
+            });
+
+            if (argv.api != null && !project.apiWorkspaces.some((ws) => ws.workspaceName === argv.api)) {
+                cliContext.failAndThrow(`API does not exist: ${argv.api}`, undefined, {
+                    code: CliError.Code.ConfigError
+                });
+            }
+
             await validateWorkspaces({
-                project: await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
-                    commandLineApiWorkspace: argv.api,
-                    defaultToAllApiWorkspaces: true
-                }),
+                project,
                 cliContext,
                 logWarnings: argv.warnings,
                 brokenLinks: argv.brokenLinks,
                 errorOnBrokenLinks: argv.strictBrokenLinks,
-                directFromOpenapi: argv.fromOpenapi
+                directFromOpenapi: argv.fromOpenapi,
+                commandLineApiWorkspace: argv.api
             });
         }
     );

--- a/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
+++ b/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
@@ -17,7 +17,8 @@ export async function validateWorkspaces({
     brokenLinks,
     errorOnBrokenLinks,
     isLocal,
-    directFromOpenapi
+    directFromOpenapi,
+    commandLineApiWorkspace
 }: {
     project: Project;
     cliContext: CliContext;
@@ -26,10 +27,22 @@ export async function validateWorkspaces({
     errorOnBrokenLinks: boolean;
     isLocal?: boolean;
     directFromOpenapi?: boolean;
+    /**
+     * Optional `--api` filter. When provided, only the named API workspace is validated
+     * for API-level rules. Docs validation always runs against the full set of API
+     * workspaces because `docs.yml` may reference any/all APIs in the project (e.g. the
+     * `valid-markdown-links` rule resolves an API definition for every `apiSection`).
+     */
+    commandLineApiWorkspace?: string;
 }): Promise<void> {
     const apiResults: ApiValidationResult[] = [];
     let docsResult: DocsValidationResult | undefined;
     let hasAnyErrors = false;
+
+    const apiWorkspacesToValidate =
+        commandLineApiWorkspace != null
+            ? project.apiWorkspaces.filter((workspace) => workspace.workspaceName === commandLineApiWorkspace)
+            : project.apiWorkspaces;
 
     // Collect docs violations first (using runTaskForWorkspace to preserve [docs]: prefix for fatal errors)
     const docsWorkspace = project.docsWorkspaces;
@@ -63,7 +76,7 @@ export async function validateWorkspaces({
 
     // Collect API violations (using runTaskForWorkspace to preserve [api]: prefix for fatal errors)
     await Promise.all(
-        project.apiWorkspaces.map(async (workspace) => {
+        apiWorkspacesToValidate.map(async (workspace) => {
             if (workspace.generatorsConfiguration?.groups.length === 0 && workspace.type !== "fern") {
                 return;
             }

--- a/packages/cli/ete-tests/src/tests/validate/validate.test.ts
+++ b/packages/cli/ete-tests/src/tests/validate/validate.test.ts
@@ -2,15 +2,84 @@ import { rm } from "fs/promises";
 import path from "path";
 import stripAnsi from "strip-ansi";
 
+import { createTempFixture } from "../../utils/createTempFixture.js";
 import { runFernCli } from "../../utils/runFernCli.js";
 
 const FIXTURES_DIR = path.join(__dirname, "fixtures");
+const FERN_CONFIG_JSON = `{
+  "version": "*",
+  "organization": "fern"
+}
+`;
+const DOCS_WITH_MULTIPLE_APIS = `instances:
+  - url: test.docs.buildwithfern.com
+
+check:
+  rules:
+    broken-links: error
+
+navigation:
+  - page: Home
+    path: home.mdx
+  - api: First API
+    api-name: first
+  - api: Second API
+    api-name: second
+`;
+const API_GENERATORS_YML = `api:
+  specs:
+    - openapi: openapi.yml
+groups: {}
+`;
+const OPENAPI_YML = `openapi: 3.0.3
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /health:
+    get:
+      operationId: healthCheck
+      responses:
+        "200":
+          description: OK
+`;
 
 describe("validate", () => {
     itFixture("simple");
     itFixture("docs");
     itFixture("no-api");
     itFixture("no-generator");
+
+    it("check with --api resolves all APIs referenced by docs", async ({ signal }) => {
+        const fixture = await createTempFixture({
+            "fern/fern.config.json": FERN_CONFIG_JSON,
+            "fern/docs.yml": DOCS_WITH_MULTIPLE_APIS,
+            "fern/home.mdx": "# Home\n",
+            "fern/apis/first/generators.yml": API_GENERATORS_YML,
+            "fern/apis/first/openapi.yml": OPENAPI_YML,
+            "fern/apis/second/generators.yml": API_GENERATORS_YML,
+            "fern/apis/second/openapi.yml": OPENAPI_YML
+        });
+
+        try {
+            const checkAll = await runFernCli(["check"], {
+                cwd: fixture.path,
+                reject: false,
+                signal
+            });
+            const checkScoped = await runFernCli(["check", "--api", "first"], {
+                cwd: fixture.path,
+                reject: false,
+                signal
+            });
+
+            expect(checkAll.exitCode).toBe(0);
+            expect(checkScoped.exitCode).toBe(0);
+            expect(stripAnsi(checkScoped.stdout)).not.toContain('Rule "valid-markdown-links" failed to initialize');
+        } finally {
+            await fixture.cleanup();
+        }
+    }, 90_000);
 });
 
 function itFixture(fixtureName: string) {


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-9770 

Fixes `fern check --api <name>` when docs broken-links validation is enabled and `docs.yml` references multiple APIs.

Previously, `--api` scoped the loaded project to a single API workspace before docs validation ran. The `valid-markdown-links` rule resolves every API section referenced by docs navigation, so it failed to initialize when another referenced API was not loaded.

## Changes Made
- Load all API workspaces for `fern check` so docs validation can resolve every API referenced from `docs.yml`.
- Apply the `--api` filter only to API-level validation.
- Preserve the existing invalid API error for unknown `--api` values.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

Manual testing:
- Ran `pnpm fern:build`.
- Verified `fern check --api <name>` against several customer docs projects where broken-links validation is enabled and `docs.yml` references multiple APIs.
- Confirmed scoped checks no longer fail during broken-links rule initialization and correctly proceed to report actual docs validation results.
- Verified valid `--api` values work as expected across these projects.
- Verified `check --api nonexistent` still fails with `API does not exist: nonexistent`.
- Ran `pnpm test` in `packages/cli/cli`; all 618 tests passed.