### PR TITLE
chore(cli): make @boundaryml/baml an optional dependency

### DIFF
--- a/packages/cli/ai/package.json
+++ b/packages/cli/ai/package.json
@@ -33,8 +33,10 @@
     "test:update": "vitest --run -u"
   },
   "dependencies": {
-    "@boundaryml/baml": "catalog:",
     "@fern-api/configuration": "workspace:*"
+  },
+  "optionalDependencies": {
+    "@boundaryml/baml": "catalog:"
   },
   "devDependencies": {
     "@fern-api/configs": "workspace:*",

--- a/packages/cli/ai/src/__test__/loader.test.ts
+++ b/packages/cli/ai/src/__test__/loader.test.ts
@@ -12,6 +12,7 @@ describe("loadBamlDependencies", () => {
             "@boundaryml/baml is required for AI features (auto-versioning, sdk-diff)."
         );
         await expect(loadBamlDependencies()).rejects.toThrow("pnpm add @boundaryml/baml");
+        await expect(loadBamlDependencies()).rejects.toThrow("Original error:");
 
         vi.doUnmock("@boundaryml/baml");
     });

--- a/packages/cli/ai/src/__test__/loader.test.ts
+++ b/packages/cli/ai/src/__test__/loader.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("loadBamlDependencies", () => {
+    it("throws with install instructions when @boundaryml/baml is not available", async () => {
+        vi.doMock("@boundaryml/baml", () => {
+            throw new Error("Cannot find module '@boundaryml/baml'");
+        });
+
+        const { loadBamlDependencies } = await import("../loader.js");
+
+        await expect(loadBamlDependencies()).rejects.toThrow(
+            "@boundaryml/baml is required for AI features (auto-versioning, sdk-diff)."
+        );
+        await expect(loadBamlDependencies()).rejects.toThrow("pnpm add @boundaryml/baml");
+
+        vi.doUnmock("@boundaryml/baml");
+    });
+
+    it("resolves successfully when @boundaryml/baml is installed", async () => {
+        const { loadBamlDependencies } = await import("../loader.js");
+
+        const deps = await loadBamlDependencies();
+        expect(deps).toBeDefined();
+        expect(deps.ClientRegistry).toBeDefined();
+        expect(deps.BamlClient).toBeDefined();
+        expect(deps.configureBamlClient).toBeDefined();
+        expect(typeof deps.configureBamlClient).toBe("function");
+    });
+});

--- a/packages/cli/ai/src/index.ts
+++ b/packages/cli/ai/src/index.ts
@@ -1,3 +1,3 @@
-export * from "./types.js";
-export { loadBamlDependencies } from "./loader.js";
 export type { BamlClientInstance, BamlDependencies, ClientRegistryInstance } from "./loader.js";
+export { loadBamlDependencies } from "./loader.js";
+export * from "./types.js";

--- a/packages/cli/ai/src/index.ts
+++ b/packages/cli/ai/src/index.ts
@@ -1,2 +1,3 @@
-export * from "./baml_client/index.js";
-export * from "./configureBamlClient.js";
+export * from "./types.js";
+export { loadBamlDependencies } from "./loader.js";
+export type { BamlClientInstance, BamlDependencies, ClientRegistryInstance } from "./loader.js";

--- a/packages/cli/ai/src/loader.ts
+++ b/packages/cli/ai/src/loader.ts
@@ -1,0 +1,62 @@
+import { generatorsYml } from "@fern-api/configuration";
+
+import type { AnalyzeCommitDiffResponse, ConsolidateChangelogResponse } from "./types.js";
+
+export interface BamlClientInstance {
+    AnalyzeSdkDiff(
+        diff: string,
+        language: string,
+        previousVersion: string,
+        priorChangelog: string,
+        specCommitMessage: string
+    ): Promise<AnalyzeCommitDiffResponse>;
+    ConsolidateChangelog(
+        rawEntries: string,
+        bestBump: string,
+        language: string,
+        previousVersion: string,
+        projectedVersion: string
+    ): Promise<ConsolidateChangelogResponse>;
+    withOptions(options: { clientRegistry?: unknown }): BamlClientInstance;
+}
+
+export interface BamlDependencies {
+    ClientRegistry: new () => ClientRegistryInstance;
+    BamlClient: BamlClientInstance;
+    configureBamlClient: (config: generatorsYml.AiServicesSchema) => ClientRegistryInstance;
+}
+
+export interface ClientRegistryInstance {
+    addLlmClient(name: string, provider: string, options: Record<string, unknown>): void;
+    setPrimary(name: string): void;
+}
+
+const INSTALL_MESSAGE =
+    "@boundaryml/baml is required for AI features (auto-versioning, sdk-diff).\n" +
+    "Install it with:\n" +
+    "  npm install @boundaryml/baml\n" +
+    "  pnpm add @boundaryml/baml";
+
+/**
+ * Lazily loads BAML dependencies at runtime.
+ *
+ * This uses dynamic import() so that @boundaryml/baml is only resolved when
+ * AI features are actually invoked. Users who never use auto-versioning or
+ * sdk-diff will not need the package installed.
+ */
+export async function loadBamlDependencies(): Promise<BamlDependencies> {
+    try {
+        const [baml, bamlClient, config] = await Promise.all([
+            import("@boundaryml/baml"),
+            import("./baml_client/index.js"),
+            import("./configureBamlClient.js")
+        ]);
+        return {
+            ClientRegistry: baml.ClientRegistry,
+            BamlClient: bamlClient.b as BamlClientInstance,
+            configureBamlClient: config.configureBamlClient
+        };
+    } catch {
+        throw new Error(INSTALL_MESSAGE);
+    }
+}

--- a/packages/cli/ai/src/loader.ts
+++ b/packages/cli/ai/src/loader.ts
@@ -56,7 +56,8 @@ export async function loadBamlDependencies(): Promise<BamlDependencies> {
             BamlClient: bamlClient.b as BamlClientInstance,
             configureBamlClient: config.configureBamlClient
         };
-    } catch {
-        throw new Error(INSTALL_MESSAGE);
+    } catch (error) {
+        const original = error instanceof Error ? error.message : String(error);
+        throw new Error(`${INSTALL_MESSAGE}\n\nOriginal error: ${original}`);
     }
 }

--- a/packages/cli/ai/src/types.ts
+++ b/packages/cli/ai/src/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Standalone type definitions for the CLI AI package.
+ *
+ * These mirror the BAML-generated types in ./baml_client/types.ts but have no
+ * runtime dependency on @boundaryml/baml, so they can be imported without
+ * requiring the (optional) BAML package to be installed.
+ */
+
+export enum VersionBump {
+    MAJOR = "MAJOR",
+    MINOR = "MINOR",
+    PATCH = "PATCH",
+    NO_CHANGE = "NO_CHANGE"
+}
+
+export interface AnalyzeCommitDiffResponse {
+    message: string;
+    changelog_entry: string;
+    version_bump: VersionBump;
+    version_bump_reason: string;
+}
+
+export interface ConsolidateChangelogResponse {
+    consolidated_changelog: string;
+    pr_description: string;
+    version_bump_reason: string;
+}

--- a/packages/cli/cli-v2/build-utils.mjs
+++ b/packages/cli/cli-v2/build-utils.mjs
@@ -15,7 +15,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * This ensures we don't miss runtime dependencies regardless of where they're declared.
  */
 function getDependencyVersion(packageName) {
-    return packageJson.dependencies?.[packageName] ?? packageJson.devDependencies?.[packageName];
+    return packageJson.dependencies?.[packageName] ?? packageJson.devDependencies?.[packageName] ?? packageJson.optionalDependencies?.[packageName];
 }
 
 /**

--- a/packages/cli/cli-v2/build-utils.mjs
+++ b/packages/cli/cli-v2/build-utils.mjs
@@ -1,14 +1,28 @@
 import { exec } from "child_process";
-import { writeFile } from "fs/promises";
+import { readFile, writeFile } from "fs/promises";
 import path from "path";
 import tsup from "tsup";
 import { fileURLToPath } from "url";
 import { promisify } from "util";
+import { parse as parseYaml } from "yaml";
 import packageJson from "./package.json" with { type: "json" };
 
 const execAsync = promisify(exec);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+
+let _catalogCache = null;
+async function loadCatalog() {
+    if (_catalogCache) {
+        return _catalogCache;
+    }
+    const wsPath = path.join(REPO_ROOT, "pnpm-workspace.yaml");
+    const raw = await readFile(wsPath, "utf8");
+    const ws = parseYaml(raw);
+    _catalogCache = ws.catalog ?? {};
+    return _catalogCache;
+}
 
 /**
  * Get a dependency version from package.json, preferring dependencies over devDependencies.
@@ -20,6 +34,18 @@ function getDependencyVersion(packageName) {
         packageJson.devDependencies?.[packageName] ??
         packageJson.optionalDependencies?.[packageName]
     );
+}
+
+async function resolveVersion(packageName, version) {
+    if (version === "catalog:" || version === "catalog:default") {
+        const catalog = await loadCatalog();
+        const resolved = catalog[packageName];
+        if (!resolved) {
+            throw new Error(`Could not resolve catalog version for ${packageName}`);
+        }
+        return resolved;
+    }
+    return version;
 }
 
 /**
@@ -95,7 +121,7 @@ export async function buildCli(config) {
     for (const dep of runtimeDependencies) {
         const version = getDependencyVersion(dep);
         if (version) {
-            dependencies[dep] = version;
+            dependencies[dep] = await resolveVersion(dep, version);
         }
     }
 

--- a/packages/cli/cli-v2/build-utils.mjs
+++ b/packages/cli/cli-v2/build-utils.mjs
@@ -15,7 +15,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * This ensures we don't miss runtime dependencies regardless of where they're declared.
  */
 function getDependencyVersion(packageName) {
-    return packageJson.dependencies?.[packageName] ?? packageJson.devDependencies?.[packageName] ?? packageJson.optionalDependencies?.[packageName];
+    return (
+        packageJson.dependencies?.[packageName] ??
+        packageJson.devDependencies?.[packageName] ??
+        packageJson.optionalDependencies?.[packageName]
+    );
 }
 
 /**

--- a/packages/cli/cli-v2/package.json
+++ b/packages/cli/cli-v2/package.json
@@ -38,8 +38,10 @@
     "test:debug": "pnpm run test --inspect --no-file-parallelism",
     "test:update": "vitest --passWithNoTests --run -u"
   },
+  "optionalDependencies": {
+    "@boundaryml/baml": "catalog:"
+  },
   "devDependencies": {
-    "@boundaryml/baml": "catalog:",
     "@fern-api/api-workspace-commons": "workspace:*",
     "@fern-api/api-workspace-validator": "workspace:*",
     "@fern-api/auth": "workspace:*",

--- a/packages/cli/cli/build-utils.mjs
+++ b/packages/cli/cli/build-utils.mjs
@@ -52,7 +52,11 @@ async function rewriteSourceMapSources(absOutDir) {
  * This ensures we don't miss runtime dependencies regardless of where they're declared.
  */
 function getDependencyVersion(packageName) {
-    return packageJson.dependencies?.[packageName] ?? packageJson.devDependencies?.[packageName] ?? packageJson.optionalDependencies?.[packageName];
+    return (
+        packageJson.dependencies?.[packageName] ??
+        packageJson.devDependencies?.[packageName] ??
+        packageJson.optionalDependencies?.[packageName]
+    );
 }
 
 /**

--- a/packages/cli/cli/build-utils.mjs
+++ b/packages/cli/cli/build-utils.mjs
@@ -52,7 +52,7 @@ async function rewriteSourceMapSources(absOutDir) {
  * This ensures we don't miss runtime dependencies regardless of where they're declared.
  */
 function getDependencyVersion(packageName) {
-    return packageJson.dependencies?.[packageName] ?? packageJson.devDependencies?.[packageName];
+    return packageJson.dependencies?.[packageName] ?? packageJson.devDependencies?.[packageName] ?? packageJson.optionalDependencies?.[packageName];
 }
 
 /**
@@ -91,6 +91,7 @@ export const PRODUCTION_TSUP_OVERRIDES = {
  * @param {boolean} config.minify - Whether to minify the output
  * @param {Object} config.env - Environment variables to inject
  * @param {string[]} [config.runtimeDependencies] - List of runtime dependencies to include in package.json
+ * @param {string[]} [config.optionalRuntimeDependencies] - List of optional runtime dependencies to include in package.json
  * @param {Object} [config.packageJsonOverrides] - Overrides for the generated package.json
  * @param {Object} [config.tsupOverrides] - Additional tsup configuration options
  */
@@ -99,7 +100,8 @@ export async function buildCli(config) {
         outDir,
         minify,
         env,
-        runtimeDependencies = ["@boundaryml/baml"],
+        runtimeDependencies = [],
+        optionalRuntimeDependencies = ["@boundaryml/baml"],
         packageJsonOverrides = {},
         tsupOverrides = {}
     } = config;
@@ -153,12 +155,22 @@ export async function buildCli(config) {
         );
     }
 
+    // Collect optional runtime dependencies
+    const optionalDependencies = {};
+    for (const dep of optionalRuntimeDependencies) {
+        const version = getDependencyVersion(dep);
+        if (version) {
+            optionalDependencies[dep] = version;
+        }
+    }
+
     // Write package.json
     const outputPackageJson = {
         version,
         repository: packageJson.repository,
         files: ["cli.cjs"],
-        dependencies,
+        ...(Object.keys(dependencies).length > 0 && { dependencies }),
+        ...(Object.keys(optionalDependencies).length > 0 && { optionalDependencies }),
         ...packageJsonOverrides
     };
 

--- a/packages/cli/cli/build-utils.mjs
+++ b/packages/cli/cli/build-utils.mjs
@@ -5,12 +5,26 @@ import path from "path";
 import tsup from "tsup";
 import { fileURLToPath } from "url";
 import { promisify } from "util";
+import { parse as parseYaml } from "yaml";
 import packageJson from "./package.json" with { type: "json" };
 
 const execAsync = promisify(exec);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "../../..");
+
+/** Lazily loaded pnpm catalog map (package name → version range). */
+let _catalogCache = null;
+async function loadCatalog() {
+    if (_catalogCache) {
+        return _catalogCache;
+    }
+    const wsPath = path.join(REPO_ROOT, "pnpm-workspace.yaml");
+    const raw = await readFile(wsPath, "utf8");
+    const ws = parseYaml(raw);
+    _catalogCache = ws.catalog ?? {};
+    return _catalogCache;
+}
 
 /**
  * Rewrite every .map file in absOutDir so each entry in `sources` is a clean
@@ -57,6 +71,22 @@ function getDependencyVersion(packageName) {
         packageJson.devDependencies?.[packageName] ??
         packageJson.optionalDependencies?.[packageName]
     );
+}
+
+/**
+ * Resolve a version string, replacing the pnpm `catalog:` protocol with the
+ * actual version range from pnpm-workspace.yaml.
+ */
+async function resolveVersion(packageName, version) {
+    if (version === "catalog:" || version === "catalog:default") {
+        const catalog = await loadCatalog();
+        const resolved = catalog[packageName];
+        if (!resolved) {
+            throw new Error(`Could not resolve catalog version for ${packageName}`);
+        }
+        return resolved;
+    }
+    return version;
 }
 
 /**
@@ -146,7 +176,7 @@ export async function buildCli(config) {
     for (const dep of runtimeDependencies) {
         const version = getDependencyVersion(dep);
         if (version) {
-            dependencies[dep] = version;
+            dependencies[dep] = await resolveVersion(dep, version);
         }
     }
 
@@ -164,7 +194,7 @@ export async function buildCli(config) {
     for (const dep of optionalRuntimeDependencies) {
         const version = getDependencyVersion(dep);
         if (version) {
-            optionalDependencies[dep] = version;
+            optionalDependencies[dep] = await resolveVersion(dep, version);
         }
     }
 

--- a/packages/cli/cli/build.dev.mjs
+++ b/packages/cli/cli/build.dev.mjs
@@ -23,7 +23,7 @@ buildCli({
         CLI_NAME: "fern-dev",
         CLI_PACKAGE_NAME: "@fern-api/fern-api-dev"
     },
-    runtimeDependencies: ["@boundaryml/baml"],
+
     packageJsonOverrides: {
         name: "@fern-api/fern-api-dev",
         bin: { "fern-dev": "cli.cjs" }

--- a/packages/cli/cli/build.local.mjs
+++ b/packages/cli/cli/build.local.mjs
@@ -24,7 +24,7 @@ buildCli({
         CLI_NAME: "fern-local",
         CLI_PACKAGE_NAME: "fern-api"
     },
-    runtimeDependencies: ["@boundaryml/baml"],
+
     packageJsonOverrides: {
         name: "fern-api",
         bin: { fern: "cli.cjs" }

--- a/packages/cli/cli/build.prod-unminified.mjs
+++ b/packages/cli/cli/build.prod-unminified.mjs
@@ -22,7 +22,7 @@ buildCli({
         CLI_NAME: "fern",
         CLI_PACKAGE_NAME: "fern-api"
     },
-    runtimeDependencies: ["@boundaryml/baml"],
+
     packageJsonOverrides: {
         name: "fern-api",
         bin: { fern: "cli.cjs" }

--- a/packages/cli/cli/build.prod.mjs
+++ b/packages/cli/cli/build.prod.mjs
@@ -23,7 +23,7 @@ buildCli({
         CLI_NAME: "fern",
         CLI_PACKAGE_NAME: "fern-api"
     },
-    runtimeDependencies: ["@boundaryml/baml"],
+
     packageJsonOverrides: {
         name: "fern-api",
         bin: { fern: "cli.cjs" }

--- a/packages/cli/cli/changes/unreleased/optional-baml-dep.yml
+++ b/packages/cli/cli/changes/unreleased/optional-baml-dep.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Make @boundaryml/baml an optional dependency. The CLI no longer requires BAML
+    to be installed unless AI features (auto-versioning, sdk-diff) are used.
+    Users who invoke AI features without BAML installed will see a clear error
+    message with installation instructions.
+  type: chore

--- a/packages/cli/cli/package.json
+++ b/packages/cli/cli/package.json
@@ -46,8 +46,10 @@
     "test:debug": "pnpm run test --inspect --no-file-parallelism",
     "test:update": "vitest --passWithNoTests --run -u"
   },
+  "optionalDependencies": {
+    "@boundaryml/baml": "catalog:"
+  },
   "devDependencies": {
-    "@boundaryml/baml": "catalog:",
     "@bufbuild/protobuf": "catalog:",
     "@fern-api/api-workspace-commons": "workspace:*",
     "@fern-api/api-workspace-validator": "workspace:*",

--- a/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
+++ b/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
@@ -6,8 +6,8 @@
  * - A version bump recommendation (major/minor/patch)
  */
 
-import { ClientRegistry } from "@boundaryml/baml";
-import { AnalyzeCommitDiffResponse, b as BamlClient, configureBamlClient, VersionBump } from "@fern-api/cli-ai";
+import type { AnalyzeCommitDiffResponse, BamlClientInstance, ClientRegistryInstance } from "@fern-api/cli-ai";
+import { loadBamlDependencies, VersionBump } from "@fern-api/cli-ai";
 import { loadGeneratorsConfiguration } from "@fern-api/configuration-loader";
 import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, cwd, doesPathExist, resolve } from "@fern-api/fs-utils";
@@ -28,7 +28,7 @@ import { CliContext } from "../../cli-context/CliContext.js";
 
 const execAsync = promisify(exec);
 
-async function getClientRegistry(context: CliContext, project: Project): Promise<ClientRegistry> {
+async function getClientRegistry(context: CliContext, project: Project): Promise<ClientRegistryInstance> {
     // Get the first API workspace (or we could make this configurable)
     const workspace = project.apiWorkspaces[0];
     if (workspace == null) {
@@ -60,6 +60,7 @@ async function getClientRegistry(context: CliContext, project: Project): Promise
     }
 
     context.logger.debug(`Using AI service: ${generatorsConfig.ai.provider} with model ${generatorsConfig.ai.model}`);
+    const { configureBamlClient } = await loadBamlDependencies();
     return configureBamlClient(generatorsConfig.ai);
 }
 
@@ -96,6 +97,7 @@ export async function sdkDiffCommand({
         throw new TaskAbortSignal();
     }
 
+    const { BamlClient } = await loadBamlDependencies();
     const clientRegistry = await getClientRegistry(context, project);
 
     // Generate git diff between the two directories
@@ -144,7 +146,7 @@ export async function sdkDiffCommand({
     // Analyze the diff using LLM with the configured client
     context.logger.info("Analyzing diff with LLM...");
     try {
-        const bamlClient = BamlClient.withOptions({ clientRegistry });
+        const bamlClient: BamlClientInstance = BamlClient.withOptions({ clientRegistry });
 
         if (cappedChunks.length <= 1) {
             // Single chunk — standard path

--- a/packages/cli/generation/local-generation/local-workspace-runner/package.json
+++ b/packages/cli/generation/local-generation/local-workspace-runner/package.json
@@ -33,7 +33,6 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@boundaryml/baml": "catalog:",
     "@fern-api/api-workspace-commons": "workspace:*",
     "@fern-api/api-workspace-validator": "workspace:*",
     "@fern-api/auth": "workspace:*",

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -1,5 +1,5 @@
-import { ClientRegistry } from "@boundaryml/baml";
-import { b as BamlClient, configureBamlClient, VersionBump } from "@fern-api/cli-ai";
+import type { BamlClientInstance, ClientRegistryInstance } from "@fern-api/cli-ai";
+import { loadBamlDependencies, VersionBump } from "@fern-api/cli-ai";
 import { FERNIGNORE_FILENAME, generatorsYml, getFernIgnorePaths } from "@fern-api/configuration";
 import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
@@ -426,6 +426,7 @@ export class LocalTaskHandler {
                                     previousVersion,
                                     bestBump as VersionBump
                                 );
+                                const { BamlClient } = await loadBamlDependencies();
                                 const rollup = await BamlClient.withOptions({
                                     clientRegistry: await this.getClientRegistry()
                                 }).ConsolidateChangelog(
@@ -565,7 +566,8 @@ export class LocalTaskHandler {
     ): Promise<CachedAnalysis | null> {
         const doAnalysis = async (): Promise<CachedAnalysis | null> => {
             const clientRegistry = await this.getClientRegistry();
-            const bamlClient = BamlClient.withOptions({ clientRegistry });
+            const { BamlClient } = await loadBamlDependencies();
+            const bamlClient: BamlClientInstance = BamlClient.withOptions({ clientRegistry });
             const analysis = await bamlClient.AnalyzeSdkDiff(
                 cleanedDiff,
                 language,
@@ -707,7 +709,7 @@ export class LocalTaskHandler {
      * Gets the BAML client registry for AI analysis.
      * This method is adapted from sdkDiffCommand.ts but needs project configuration.
      */
-    private async getClientRegistry(): Promise<ClientRegistry> {
+    private async getClientRegistry(): Promise<ClientRegistryInstance> {
         if (this.ai == null) {
             throw new CliError({
                 message:
@@ -718,6 +720,7 @@ export class LocalTaskHandler {
         }
 
         this.context.logger.debug(`Using AI service: ${this.ai.provider} with model ${this.ai.model}`);
+        const { configureBamlClient } = await loadBamlDependencies();
         return configureBamlClient(this.ai);
     }
 

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/LocalTaskHandler.behavioral.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/LocalTaskHandler.behavioral.test.ts
@@ -80,10 +80,13 @@ vi.mock("@fern-api/cli-ai", async () => {
     const actual = await vi.importActual("@fern-api/cli-ai");
     return {
         ...actual,
-        b: {
-            withOptions: mockWithOptions
-        },
-        configureBamlClient: vi.fn().mockReturnValue({})
+        loadBamlDependencies: vi.fn().mockResolvedValue({
+            BamlClient: {
+                withOptions: mockWithOptions
+            },
+            configureBamlClient: vi.fn().mockReturnValue({}),
+            ClientRegistry: class ClientRegistry {}
+        })
     };
 });
 

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/LocalTaskHandler.fallback.test.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/__test__/LocalTaskHandler.fallback.test.ts
@@ -87,10 +87,13 @@ vi.mock("@fern-api/cli-ai", async () => {
     const actual = await vi.importActual("@fern-api/cli-ai");
     return {
         ...actual,
-        b: {
-            withOptions: mockWithOptions
-        },
-        configureBamlClient: vi.fn().mockReturnValue({})
+        loadBamlDependencies: vi.fn().mockResolvedValue({
+            BamlClient: {
+                withOptions: mockWithOptions
+            },
+            configureBamlClient: vi.fn().mockReturnValue({}),
+            ClientRegistry: class ClientRegistry {}
+        })
     };
 });
 

--- a/packages/generator-cli/src/__test__/auto-version-step.execute.test.ts
+++ b/packages/generator-cli/src/__test__/auto-version-step.execute.test.ts
@@ -12,13 +12,16 @@ const mockConsolidateChangelog = vi.fn();
 const mockConfigureBamlClient = vi.fn(() => ({}));
 
 vi.mock("@fern-api/cli-ai", () => ({
-    b: {
-        withOptions: () => ({
-            AnalyzeSdkDiff: mockAnalyzeSdkDiff,
-            ConsolidateChangelog: mockConsolidateChangelog
-        })
-    },
-    configureBamlClient: mockConfigureBamlClient,
+    loadBamlDependencies: vi.fn().mockResolvedValue({
+        BamlClient: {
+            withOptions: () => ({
+                AnalyzeSdkDiff: mockAnalyzeSdkDiff,
+                ConsolidateChangelog: mockConsolidateChangelog
+            })
+        },
+        configureBamlClient: mockConfigureBamlClient,
+        ClientRegistry: class ClientRegistry {}
+    }),
     VersionBump: { MAJOR: "MAJOR", MINOR: "MINOR", PATCH: "PATCH", NO_CHANGE: "NO_CHANGE" }
 }));
 

--- a/packages/generator-cli/src/pipeline/steps/AutoVersionStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/AutoVersionStep.ts
@@ -1,4 +1,4 @@
-import type { configureBamlClient as ConfigureBamlClient, VersionBump as VersionBumpEnum } from "@fern-api/cli-ai";
+import type { VersionBump as VersionBumpEnum } from "@fern-api/cli-ai";
 import { execFileSync } from "child_process";
 import { existsSync } from "fs";
 import { readFile, writeFile } from "fs/promises";
@@ -560,17 +560,18 @@ export class AutoVersionStep extends BaseStep {
      * commands never reach this method, so dynamic import keeps them unaffected.
      */
     private async loadBaml(): Promise<{
-        client: ReturnType<typeof import("@fern-api/cli-ai").b.withOptions>;
+        client: import("@fern-api/cli-ai").BamlClientInstance;
         VersionBump: typeof import("@fern-api/cli-ai").VersionBump;
     }> {
         if (this.config.ai == null) {
             throw new Error("AutoVersionStep: ai config is missing. Set autoVersion.ai to a BAML provider+model pair.");
         }
-        const cliAi = await import("@fern-api/cli-ai");
-        const registry = cliAi.configureBamlClient(this.config.ai as Parameters<typeof ConfigureBamlClient>[0]);
+        const { loadBamlDependencies, VersionBump } = await import("@fern-api/cli-ai");
+        const { BamlClient, configureBamlClient } = await loadBamlDependencies();
+        const registry = configureBamlClient(this.config.ai as Parameters<typeof configureBamlClient>[0]);
         return {
-            client: cliAi.b.withOptions({ clientRegistry: registry }),
-            VersionBump: cliAi.VersionBump
+            client: BamlClient.withOptions({ clientRegistry: registry }),
+            VersionBump
         };
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3667,9 +3667,6 @@ importers:
 
   packages/cli/ai:
     dependencies:
-      '@boundaryml/baml':
-        specifier: 'catalog:'
-        version: 0.219.0
       '@fern-api/configuration':
         specifier: workspace:*
         version: link:../configuration
@@ -3686,6 +3683,10 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+    optionalDependencies:
+      '@boundaryml/baml':
+        specifier: 'catalog:'
+        version: 0.219.0
 
   packages/cli/api-importers/asyncapi-to-ir:
     dependencies:
@@ -4271,9 +4272,6 @@ importers:
 
   packages/cli/cli:
     devDependencies:
-      '@boundaryml/baml':
-        specifier: 'catalog:'
-        version: 0.219.0
       '@bufbuild/protobuf':
         specifier: 2.2.5
         version: 2.2.5
@@ -4571,6 +4569,10 @@ importers:
       yargs:
         specifier: ^17.4.1
         version: 17.7.2
+    optionalDependencies:
+      '@boundaryml/baml':
+        specifier: 'catalog:'
+        version: 0.219.0
 
   packages/cli/cli-logger:
     dependencies:
@@ -4737,9 +4739,6 @@ importers:
         specifier: 'catalog:'
         version: 3.0.3
     devDependencies:
-      '@boundaryml/baml':
-        specifier: 'catalog:'
-        version: 0.219.0
       '@fern-api/api-workspace-commons':
         specifier: workspace:*
         version: link:../../commons/api-workspace-commons
@@ -4944,6 +4943,10 @@ importers:
       yargs:
         specifier: ^17.4.1
         version: 17.7.2
+    optionalDependencies:
+      '@boundaryml/baml':
+        specifier: 'catalog:'
+        version: 0.219.0
 
   packages/cli/config:
     devDependencies:
@@ -6019,9 +6022,6 @@ importers:
 
   packages/cli/generation/local-generation/local-workspace-runner:
     dependencies:
-      '@boundaryml/baml':
-        specifier: 'catalog:'
-        version: 0.219.0
       '@fern-api/api-workspace-commons':
         specifier: workspace:*
         version: link:../../../../commons/api-workspace-commons


### PR DESCRIPTION
## Description

Makes `@boundaryml/baml` an optional dependency so users who don't use AI features (auto-versioning, `sdk-diff`) don't need the ~59MB native binary package installed. When AI features are invoked without BAML, a clear error message with install instructions is shown.

## Changes Made

- Created standalone type definitions (`types.ts`) that mirror BAML-generated types without runtime BAML dependency
- Created lazy loader (`loader.ts`) with `loadBamlDependencies()` using dynamic `import()` — preserves original errors for debugging version mismatches
- Moved `@boundaryml/baml` from `dependencies` to `optionalDependencies` in all relevant `package.json` files
- Updated `sdkDiffCommand.ts`, `LocalTaskHandler.ts`, and `AutoVersionStep.ts` to use lazy loader pattern
- Added catalog protocol resolution in `build-utils.mjs` so dist `package.json` contains actual semver ranges (not pnpm `catalog:`)
- Added `optionalRuntimeDependencies` support in CLI build configs
- Updated all test mocks to match new `loadBamlDependencies` interface

## Testing

- [x] Unit tests added/updated — `loader.test.ts` verifies error when BAML missing + success when installed
- [x] All 16 tests in `@fern-api/cli-ai` pass
- [x] All 368 tests in `@fern-api/generator-cli` pass
- [x] All 121 tests in `@fern-api/local-workspace-runner` pass
- [x] CLI builds successfully with resolved `optionalDependencies` (`^0.219.0`)
- [x] Biome lint/format pass

Link to Devin session: https://app.devin.ai/sessions/c5bd2ebb9cfc4c199c5d94db120834be
Requested by: @thesandlord
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->