### PR TITLE
fix(cli): apply navbar-links overlay in app preview, match skip-slug tabs positionally

### DIFF
--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -841,9 +841,13 @@ export async function runAppPreviewServer({
                 // Apply navigation overlay (translated display-names, titles, etc.)
                 const localeNavOverlay = translationNavigationOverlays?.[locale];
                 let translatedAnnouncement = docsDefinition.config.announcement;
+                let translatedNavbarLinks = docsDefinition.config.navbarLinks;
                 if (localeNavOverlay != null) {
                     updatedRoot = applyTranslatedNavigationOverlays(updatedRoot, localeNavOverlay);
                     translatedAnnouncement = getTranslatedAnnouncement(localeNavOverlay) ?? translatedAnnouncement;
+                    if (localeNavOverlay.navbarLinks != null) {
+                        translatedNavbarLinks = localeNavOverlay.navbarLinks;
+                    }
                 }
 
                 const translatedDefinition: DocsV1Read.DocsDefinition = {
@@ -852,7 +856,8 @@ export async function runAppPreviewServer({
                     config: {
                         ...docsDefinition.config,
                         root: updatedRoot,
-                        announcement: translatedAnnouncement
+                        announcement: translatedAnnouncement,
+                        navbarLinks: translatedNavbarLinks
                     }
                 };
 

--- a/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/applyTranslatedNavigationOverlays.test.ts
@@ -267,6 +267,62 @@ describe("applyTranslatedNavigationOverlays", () => {
         expect(tabs[1]?.title).toBe("APIリファレンス");
     });
 
+    it("applies tab overrides positionally when skip-slug tabs share the same slug", () => {
+        // When tabs use skip-slug:true, they all collapse into the parent's
+        // slug, so slug-based matching can't disambiguate them. The overlay
+        // navigation order is the source of truth — match positionally.
+        const root = {
+            type: "root",
+            child: {
+                type: "unversioned",
+                child: {
+                    type: "tabbed",
+                    children: [
+                        {
+                            type: "tab",
+                            title: "Home",
+                            slug: "platform/v4",
+                            child: { type: "sidebarRoot", children: [] }
+                        },
+                        {
+                            type: "tab",
+                            title: "API Reference",
+                            slug: "platform/v4",
+                            child: { type: "sidebarRoot", children: [] }
+                        },
+                        {
+                            type: "tab",
+                            title: "Changelog",
+                            slug: "platform/v4",
+                            child: { type: "sidebarRoot", children: [] }
+                        }
+                    ]
+                }
+            }
+        };
+        const overlay: docsYml.TranslationNavigationOverlay = {
+            ...emptyOverlay(),
+            tabs: {
+                home: { displayName: "ホーム", slug: undefined },
+                api: { displayName: "API リファレンス", slug: undefined },
+                changelog: { displayName: "チェンジログ", slug: undefined }
+            },
+            navigation: [
+                { type: "tab", tabId: "home", layout: undefined, variants: undefined },
+                { type: "tab", tabId: "api", layout: undefined, variants: undefined },
+                { type: "tab", tabId: "changelog", layout: undefined, variants: undefined }
+            ]
+        };
+
+        const result = applyTranslatedNavigationOverlays(asRoot(root), overlay);
+        const unversioned = (result as unknown as Record<string, unknown>).child as Record<string, unknown>;
+        const tabbed = unversioned.child as Record<string, unknown>;
+        const tabs = tabbed.children as Array<Record<string, unknown>>;
+        expect(tabs[0]?.title).toBe("ホーム");
+        expect(tabs[1]?.title).toBe("API リファレンス");
+        expect(tabs[2]?.title).toBe("チェンジログ");
+    });
+
     it("applies section and page title overrides from navigation overlay", () => {
         const root = {
             type: "root",

--- a/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
+++ b/packages/cli/docs-resolver/src/applyTranslatedNavigationOverlays.ts
@@ -116,16 +116,23 @@ function applyChildOverlays(
         });
     }
 
-    // Tabbed children → match tabs with overlay.tabs and overlay.navigation
+    // Tabbed children → match tabs with overlay.tabs and overlay.navigation.
+    // Track tab position among siblings so we can fall back to positional
+    // matching when slug-based matching fails (e.g. skip-slug tabs that
+    // collapse into the parent slug and therefore all share the same slug).
     if (parentType === "tabbed") {
+        const orderedTabIds = collectOrderedTabIds(overlay);
+        let tabIndex = 0;
         return children.map((child) => {
             const childObj = child as Record<string, unknown> | null;
             if (childObj == null || typeof childObj !== "object") {
                 return walkAndApply(child, overlay);
             }
             if (childObj["type"] === "tab") {
+                const positionalTabId = orderedTabIds[tabIndex];
+                tabIndex++;
                 const walked = walkAndApply(child, overlay) as Record<string, unknown>;
-                return applyTabOverlayToNode(walked, overlay);
+                return applyTabOverlayToNode(walked, overlay, positionalTabId);
             }
             return walkAndApply(child, overlay);
         });
@@ -249,28 +256,42 @@ function applyVersionOverlayToNode(
     return node;
 }
 
-function applyTabOverlayToNode(node: Record<string, unknown>, overlay: docsYml.TranslationNavigationOverlay): unknown {
+function applyTabOverlayToNode(
+    node: Record<string, unknown>,
+    overlay: docsYml.TranslationNavigationOverlay,
+    positionalTabId?: string
+): unknown {
     const tabSlug = extractLastSlugSegment(node["slug"] as string | undefined);
 
-    // Look up tab display-name override from overlay.tabs
+    // Look up tab display-name override from overlay.tabs.
+    // Match precedence: slug-based match → positional fallback (covers
+    // skip-slug tabs that collapse into the parent slug and therefore can't
+    // be disambiguated by slug alone).
+    let appliedTabId: string | undefined;
     if (overlay.tabs != null && tabSlug != null) {
         for (const [tabId, tabOverlay] of Object.entries(overlay.tabs)) {
-            // Match by tab ID (YAML key) against nav tree slug segment, or
-            // by the overlay's explicit slug field against the slug segment
             const isMatch = tabId === tabSlug || (tabOverlay.slug != null && tabOverlay.slug === tabSlug);
             if (isMatch && tabOverlay.displayName != null) {
                 node["title"] = tabOverlay.displayName;
+                appliedTabId = tabId;
                 break;
             }
         }
     }
+    if (appliedTabId == null && positionalTabId != null && overlay.tabs != null) {
+        const tabOverlayEntry = overlay.tabs[positionalTabId];
+        if (tabOverlayEntry?.displayName != null) {
+            node["title"] = tabOverlayEntry.displayName;
+            appliedTabId = positionalTabId;
+        }
+    }
 
     // Find matching tab navigation overlay for child overrides
-    const tabNavOverlay = findTabNavOverlay(tabSlug, overlay);
+    const tabNavOverlay = findTabNavOverlay(tabSlug, overlay, positionalTabId);
 
     if (tabNavOverlay != null) {
         // Apply tab title override from the tabs map if not already applied
-        if (overlay.tabs != null) {
+        if (overlay.tabs != null && appliedTabId == null) {
             const tabOverlayEntry = overlay.tabs[tabNavOverlay.tabId];
             if (tabOverlayEntry?.displayName != null) {
                 node["title"] = tabOverlayEntry.displayName;
@@ -307,7 +328,8 @@ function applyTabOverlayToNode(node: Record<string, unknown>, overlay: docsYml.T
 
 function findTabNavOverlay(
     tabSlug: string | undefined,
-    overlay: docsYml.TranslationNavigationOverlay
+    overlay: docsYml.TranslationNavigationOverlay,
+    positionalTabId?: string
 ): docsYml.NavigationItemOverlay.Tab | undefined {
     if (overlay.navigation == null) {
         return undefined;
@@ -330,7 +352,39 @@ function findTabNavOverlay(
         }
     }
 
+    // Positional fallback: when slug-based matching fails, use the tab's
+    // position among siblings (passed in by `applyChildOverlays`) to find
+    // the corresponding entry in overlay.navigation by tabId.
+    if (positionalTabId != null) {
+        for (const navItem of overlay.navigation) {
+            if (navItem.type === "tab" && navItem.tabId === positionalTabId) {
+                return navItem;
+            }
+        }
+    }
+
     return undefined;
+}
+
+/**
+ * Returns the ordered list of tab IDs from the overlay, preferring the order
+ * declared in `overlay.navigation` (which mirrors the source navigation
+ * ordering). Falls back to the insertion order of `overlay.tabs` if no
+ * navigation is defined.
+ */
+function collectOrderedTabIds(overlay: docsYml.TranslationNavigationOverlay): string[] {
+    if (overlay.navigation != null) {
+        const fromNavigation = overlay.navigation
+            .filter((item): item is docsYml.NavigationItemOverlay.Tab => item.type === "tab")
+            .map((item) => item.tabId);
+        if (fromNavigation.length > 0) {
+            return fromNavigation;
+        }
+    }
+    if (overlay.tabs != null) {
+        return Object.keys(overlay.tabs);
+    }
+    return [];
 }
 
 /**


### PR DESCRIPTION
## Summary

Two related bugs caused translated tabs and navbar CTAs to silently render in the source language even when a properly-formed translation overlay was on disk. Surfaced by Frame.io's docs site after #15681 unblocked the version YAML loading: with versions translated, the next layer up (tabs + navbar CTAs) became visible as still-English.

### Bug 1 — `runAppPreviewServer.ts` dropped the per-locale `navbar-links`

`runPreviewServer.ts` (legacy preview) and `publishDocs.ts` (production publish) both replace `docsDefinition.config.navbarLinks` with `localeNavOverlay.navbarLinks` when the overlay defines them. The default app preview server (the one `fern docs dev` runs without `--legacy`) skipped this step. Result: `fern docs dev` showed English CTAs on `/<lang>/` URLs while a published deploy of the same docs correctly served the translated CTAs — a confusing parity gap.

### Bug 2 — skip-slug tabs couldn't be matched by slug

When tabs use `skip-slug: true`, every tab at that level inherits the parent's slug, so the existing slug-based matching in `applyTabOverlayToNode` / `findTabNavOverlay` matched at most one tab — the only one whose slug retained its own segment. The other siblings stayed in the source language.

Concrete repro from Frame.io's `versions/v4.yml`:

```yaml
tabs:
  api:
    display-name: API Reference
    skip-slug: true
  docs:
    display-name: Docs
  home:
    display-name: Home
    skip-slug: true
  changelog:
    display-name: Changelog
    skip-slug: true
```

With the matching `translations/ja/versions/v4.yml`, only the `docs` tab was getting translated — the other three (home/api/changelog) all rendered as English because they collapsed into `/platform/v4` and the matcher saw `tabSlug = "v4"`, which didn't match any of `home`, `api`, or `changelog`.

This change adds a positional fallback: `applyChildOverlays` for the `tabbed` parent now tracks each tab's index among siblings and threads a `positionalTabId` (taken from the ordered list of `tab:` entries in `overlay.navigation`) into the matcher. Slug-based matching still wins when available; positional matching only fires when the slug-based pass yields no result.

## Test plan

- [x] New unit test covers three skip-slug sibling tabs sharing one slug — all three get their translated `display-name`.
- [x] All 57 docs-resolver tests pass (1 new + 56 prior).
- [ ] Manual smoke against a real `fern docs dev` showing translated CTAs on `/ja/` — left for reviewer; verified locally that with this branch built into the bundle the response from `load-with-url` carries the Japanese navbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)