### PR TITLE
chore(cli): add changelog entry for #15699

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-translation-navbar-and-skip-slug-tabs.yml
+++ b/packages/cli/cli/changes/unreleased/fix-translation-navbar-and-skip-slug-tabs.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Apply per-locale `navbar-links` overlays in the default `fern docs dev` app
+    preview server (the legacy preview and production publish already did this,
+    so dev was the odd one out and showed English CTAs on `/<lang>/` URLs).
+    Also matches translation overrides for skip-slug sibling tabs positionally
+    when slug-based matching can't disambiguate them — without this, only the
+    one tab whose slug retained its own segment got translated.
+  type: fix


### PR DESCRIPTION
## Summary

#15699 was merged without a `changes/unreleased/*.yml` file, so the auto-release flow has no entry to roll into the next CLI release. This adds the changelog entry as a `fix` so the next release picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)