### PR TITLE
chore(cli): bump @fern-fern/fiddle-sdk to 1.0.2 and inline replay payload

### DIFF
--- a/packages/cli/cli/changes/unreleased/chore-bump-fiddle-sdk-1.0.2.yml
+++ b/packages/cli/cli/changes/unreleased/chore-bump-fiddle-sdk-1.0.2.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump `@fern-fern/fiddle-sdk` catalog pin to `1.0.2`. The new SDK exposes
+    `replay` on `CreateJobRequestV2`, so the field added to `createJobV3` in
+    PR #15690 stops being silently stripped by the SDK serializer and now
+    actually reaches Fiddle. With this in place, customers setting
+    `replay.enabled: false` in `generators.yml` get the legacy GitHub push/PR
+    path on cloud generation. Final activation step for FER-10343.
+  type: chore

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -175,7 +175,9 @@ async function createJob({
         publishMetadata: generatorInvocation.publishMetadata
     };
 
-    const createResponse = await remoteGenerationService.remoteGen.createJobV3({
+    // Const-typed payload ducks the TS excess-property check; `replay` isn't on
+    // fiddle-sdk's CreateJobRequestV2 yet (FER-10343).
+    const createJobRequest = {
         apiName: workspace.definition.rootApiFile.contents.name,
         version,
         organizationName: organization,
@@ -205,7 +207,8 @@ async function createJob({
         //   runId: process.env.FERN_RUN_ID
         // Fiddle will use these for separate PRs, automerge, run_id correlation,
         // and breaking change handling. (skipIfNoDiff is forwarded above — see fern-api/fiddle#708.)
-    });
+    };
+    const createResponse = await remoteGenerationService.remoteGen.createJobV3(createJobRequest);
 
     if (!createResponse.ok) {
         // Check for 429 Too Many Requests before processing the error through the visitor.

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -175,9 +175,7 @@ async function createJob({
         publishMetadata: generatorInvocation.publishMetadata
     };
 
-    // Const-typed payload ducks the TS excess-property check; `replay` isn't on
-    // fiddle-sdk's CreateJobRequestV2 yet (FER-10343).
-    const createJobRequest = {
+    const createResponse = await remoteGenerationService.remoteGen.createJobV3({
         apiName: workspace.definition.rootApiFile.contents.name,
         version,
         organizationName: organization,
@@ -207,8 +205,7 @@ async function createJob({
         //   runId: process.env.FERN_RUN_ID
         // Fiddle will use these for separate PRs, automerge, run_id correlation,
         // and breaking change handling. (skipIfNoDiff is forwarded above — see fern-api/fiddle#708.)
-    };
-    const createResponse = await remoteGenerationService.remoteGen.createJobV3(createJobRequest);
+    });
 
     if (!createResponse.ok) {
         // Check for 429 Too Many Requests before processing the error through the visitor.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ catalogs:
       specifier: ^0.0.5297
       version: 0.0.5297
     '@fern-fern/fiddle-sdk':
-      specifier: 1.0.1
-      version: 1.0.1
+      specifier: 1.0.2
+      version: 1.0.2
     '@fern-fern/generator-exec-sdk':
       specifier: ^0.0.1167
       version: 0.0.1167
@@ -4436,7 +4436,7 @@ importers:
         version: link:../workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.1
+        version: 1.0.2
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -4855,7 +4855,7 @@ importers:
         version: link:../yaml/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.1
+        version: 1.0.2
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -4985,7 +4985,7 @@ importers:
         version: link:../../commons/path-utils
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.1
+        version: 1.0.2
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -5028,7 +5028,7 @@ importers:
         version: link:../task-context
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.1
+        version: 1.0.2
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -6126,7 +6126,7 @@ importers:
         version: link:../../../workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.1
+        version: 1.0.2
       '@fern-fern/generator-exec-sdk':
         specifier: 'catalog:'
         version: 0.0.1167
@@ -6283,7 +6283,7 @@ importers:
         version: link:../../../workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.1
+        version: 1.0.2
       axios:
         specifier: 'catalog:'
         version: 1.16.0
@@ -7017,7 +7017,7 @@ importers:
         version: link:../../api-importers/v3-importer-commons
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.1
+        version: 1.0.2
       '@open-rpc/meta-schema':
         specifier: 'catalog:'
         version: 1.14.9
@@ -7458,7 +7458,7 @@ importers:
         version: link:../../cli/task-context
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.1
+        version: 1.0.2
       '@redocly/openapi-core':
         specifier: 'catalog:'
         version: 1.34.11
@@ -7860,7 +7860,7 @@ importers:
         version: 0.0.5297
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.1
+        version: 1.0.2
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -8104,7 +8104,7 @@ importers:
         version: link:../cli/workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.1
+        version: 1.0.2
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -9436,8 +9436,8 @@ packages:
   '@fern-fern/fdr-test-sdk@0.0.5297':
     resolution: {integrity: sha512-jrZUZ6oIA64LHtrv77xEq0X7qJhT9xRMGWhKcLjIUArMsD7h6KMWUHVdoB/1MP0Mz/uL/E2xmM31SOgJicpIcA==}
 
-  '@fern-fern/fiddle-sdk@1.0.1':
-    resolution: {integrity: sha512-mGCTFkKBDQulvnx7VijKlrFIiXL+vvxE0N6yfGIJfmgv5/IEPu7klX9/n8oA6nzfZyCYw698ElloGgP1fszxoQ==}
+  '@fern-fern/fiddle-sdk@1.0.2':
+    resolution: {integrity: sha512-xh0ZMAVBvXNRtSJsr+gxANEgZMZgRzchvwO1BDgpYTacou6Th8SWY0JuakAwWpm0hEoNSd+/XSlWeyiKNpjL9g==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/generator-cli-sdk@0.1.8':
@@ -16490,7 +16490,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@fern-fern/fiddle-sdk@1.0.1': {}
+  '@fern-fern/fiddle-sdk@1.0.2': {}
 
   '@fern-fern/generator-cli-sdk@0.1.8':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,7 +65,7 @@ catalog:
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80
   "@fern-fern/fdr-test-sdk": ^0.0.5297
-  "@fern-fern/fiddle-sdk": 1.0.1
+  "@fern-fern/fiddle-sdk": 1.0.2
   "@fern-fern/generator-exec-sdk": ^0.0.1167
   "@fern-fern/generators-sdk": 0.114.0-5745f9e74
   "@fern-fern/ir-v53-sdk": 1.0.1


### PR DESCRIPTION
## Summary

Final activation step for [FER-10343](https://linear.app/buildwithfern/issue/FER-10343/honor-replayenabled-in-cloud-generation-flow).

`@fern-fern/fiddle-sdk@1.0.2` (just published — see [run](https://github.com/fern-api/fiddle/actions/runs/25387249198)) exposes `replay` on `CreateJobRequestV2`, so the field added in [#15690](https://github.com/fern-api/fern/pull/15690) now reaches Fiddle instead of being silently stripped by the SDK serializer. With the SDK type now including `replay`, the const-typed payload workaround introduced in #15690 is no longer needed — collapsed back to a direct inline `createJobV3({...})` call.

## What this enables

- Customer sets `replay.enabled: false` in `generators.yml`
- Runs `fern generate` (cloud)
- Fiddle's `willUseReplayPipeline()` short-circuits → legacy GitHub push/PR path
- Resulting PR contains generator output without replay-applied patches

Verified end-to-end against prod fiddle prior to this PR with a temporary raw-fetch hack ([demo PR #169](https://github.com/fern-demo/fern-replay-testbed-java-sdk/pull/169)). With this catalog bump merged + a CLI release, the same behavior holds via the production code path — no hack.

## Test plan

- [x] `pnpm install` resolved with `1.0.2` and updated `pnpm-lock.yaml`
- [x] `pnpm compile` (159 packages) passes
- [x] `pnpm turbo run test --filter @fern-api/remote-workspace-runner` passes (12 files, 119 tests)
- [x] Inline `createJobV3({ ..., replay, ... })` typechecks against the new SDK schema
- [ ] Post-merge: next CLI release autopublishes; customers with `replay.enabled: false` get the legacy path

## Out of scope

The `Publish Internal SDKs` workflow autoversioner regression (picks `0.0.99` on `push` events instead of bumping past `1.0.x`) is a pre-existing fiddle-side issue, not new to this PR. Worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->