### PR TITLE
chore(typescript): upgrade oxfmt 0.48.0, oxlint 1.63.0, oxlint-tsgolint 0.22.1

### DIFF
--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -12,10 +12,10 @@ RUN corepack prepare yarn@1.22.22
 
 RUN pnpm add -g typescript@~5.7.2 \
   prettier@3.7.4 \
-  oxfmt@0.42.0 \
+  oxfmt@0.48.0 \
   @biomejs/biome@2.4.3 \
-  oxlint@1.57.0 \
-  oxlint-tsgolint@0.17.4 \
+  oxlint@1.63.0 \
+  oxlint-tsgolint@0.22.1 \
   @types/node@^18.19.70 \
   webpack@^5.97.1 \
   msw@2.11.2 \

--- a/generators/typescript/sdk/changes/unreleased/upgrade-oxc-tools.yml
+++ b/generators/typescript/sdk/changes/unreleased/upgrade-oxc-tools.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Update oxfmt from 0.42.0 to 0.48.0, oxlint from 1.57.0 to 1.63.0, and oxlint-tsgolint from 0.17.4 to 0.22.1.
+  type: chore

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -19,10 +19,10 @@ RUN npm install -g pnpm@10.33.0 --force
 RUN npm install -g yarn@1.22.22 --force
 RUN pnpm add -g typescript@~5.9.3 \
   prettier@3.8.1 \
-  oxfmt@0.42.0 \
+  oxfmt@0.48.0 \
   @biomejs/biome@2.4.10 \
-  oxlint@1.57.0 \
-  oxlint-tsgolint@0.17.4 \
+  oxlint@1.63.0 \
+  oxlint-tsgolint@0.22.1 \
   @types/node@^18.19.70 \
   ts-loader@^9.5.4 \
   webpack@^5.105.4 \

--- a/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
@@ -51,9 +51,9 @@ type COMMON_SCRIPTS = (typeof COMMON_SCRIPTS)[keyof typeof COMMON_SCRIPTS];
 const TOOL_VERSIONS = {
     BIOME: "2.4.10",
     PRETTIER: "3.8.1",
-    OXFMT: "0.42.0",
-    OXLINT: "1.57.0",
-    OXLINT_TSGOLINT: "0.17.4"
+    OXFMT: "0.48.0",
+    OXLINT: "1.63.0",
+    OXLINT_TSGOLINT: "0.22.1"
 } as const;
 
 export abstract class TypescriptProject {

--- a/seed/ts-sdk/simple-api/use-oxc/package.json
+++ b/seed/ts-sdk/simple-api/use-oxc/package.json
@@ -67,9 +67,9 @@
     "devDependencies": {
         "@types/node": "^18.19.70",
         "msw": "2.11.2",
-        "oxfmt": "0.42.0",
-        "oxlint": "1.57.0",
-        "oxlint-tsgolint": "0.17.4",
+        "oxfmt": "0.48.0",
+        "oxlint": "1.63.0",
+        "oxlint-tsgolint": "0.22.1",
         "ts-loader": "^9.5.4",
         "typescript": "~5.9.3",
         "vitest": "^4.1.1",

--- a/seed/ts-sdk/simple-api/use-oxfmt/package.json
+++ b/seed/ts-sdk/simple-api/use-oxfmt/package.json
@@ -68,7 +68,7 @@
         "@biomejs/biome": "2.4.10",
         "@types/node": "^18.19.70",
         "msw": "2.11.2",
-        "oxfmt": "0.42.0",
+        "oxfmt": "0.48.0",
         "ts-loader": "^9.5.4",
         "typescript": "~5.9.3",
         "vitest": "^4.1.1",

--- a/seed/ts-sdk/simple-api/use-oxlint/package.json
+++ b/seed/ts-sdk/simple-api/use-oxlint/package.json
@@ -64,8 +64,8 @@
         "@types/node": "^18.19.70",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10",
-        "oxlint": "1.57.0",
-        "oxlint-tsgolint": "0.17.4"
+        "oxlint": "1.63.0",
+        "oxlint-tsgolint": "0.22.1"
     },
     "browser": {
         "fs": false,


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR -->

Upgrades the oxc toolchain used by the TypeScript SDK generator to the latest versions:

| Package | Old | New |
|---------|-----|-----|
| oxfmt | 0.42.0 | **0.48.0** |
| oxlint | 1.57.0 | **1.63.0** |
| oxlint-tsgolint | 0.17.4 | **0.22.1** |

No breaking changes in any of the three packages across these version ranges. No config changes needed.

**Key improvements included in this upgrade:**

**oxfmt:** Bug fixes (sequence expression in arrow function body, blank line after directive), performance (sort imports during IR construction).

**oxlint:** SARIF formatter, agent output mode, many Jest rules split into separate Vitest rules, new ESLint rules (`require-unicode-regexp`, `no-restricted-properties`, `logical-assignment-operators`), new Vue rules, `jsx-a11y/interactive-supports-focus`, numerous bug fixes.

**oxlint-tsgolint:** Enriched diagnostics for `await-thenable` and `no-unsafe-enum-comparison`, suggestions for `require-await` and `no-unsafe-enum-comparison`, bug fixes for `prefer-optional-chain`, `no-unnecessary-condition`, `no-base-to-string`.

## Changes Made
- Updated `TOOL_VERSIONS` in `TypescriptProject.ts`
- Updated `generators/typescript/sdk/cli/Dockerfile`
- Updated `docker/seed/Dockerfile.ts`
- Updated seed test outputs (`use-oxlint`, `use-oxfmt`, `use-oxc` package.json files)
- Added unreleased changelog entry

## Testing
- [x] Version strings verified across all files (no stale references remain)
- [x] Formatting check passed (`pnpm format`)


Link to Devin session: https://app.devin.ai/sessions/8517f7eec0f5427f8d3835a25515912a
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->