### PR TITLE
fix(cli): improve 429 rate-limit retry with server hints and more retries

### DIFF
--- a/packages/cli/cli/changes/unreleased/improve-rate-limit-retry.yml
+++ b/packages/cli/cli/changes/unreleased/improve-rate-limit-retry.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Improve 429 rate-limit retry logic for remote generation: increase max retries
+    from 3 to 5, respect the server's retryAfter hint as a minimum delay, and widen
+    jitter (0.2 → 0.5) to reduce thundering-herd retries when many generators run
+    concurrently across multiple API groups.
+  type: fix

--- a/packages/cli/cli/src/commands/automations/generate/executeAutomationsGenerate.ts
+++ b/packages/cli/cli/src/commands/automations/generate/executeAutomationsGenerate.ts
@@ -94,9 +94,10 @@ export async function executeAutomationsGenerate({
                         noReplay: false,
                         // Automation runs are unattended; transient 429s should be retried
                         // automatically rather than failing the run and asking a human to
-                        // re-trigger with a flag. The retry policy is bounded (3 attempts,
-                        // 2s→120s exponential backoff with jitter) so a real outage still
-                        // surfaces as a failure rather than a hang.
+                        // re-trigger with a flag. The retry policy is bounded (5 attempts,
+                        // 2s→120s exponential backoff with jitter, respecting server
+                        // retryAfter hints) so a real outage still surfaces as a failure
+                        // rather than a hang.
                         retryRateLimited: true,
                         requireEnvVars: false,
                         automationMode: true,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/retryWithRateLimit.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/retryWithRateLimit.test.ts
@@ -25,6 +25,16 @@ describe("TooManyRequestsError", () => {
         const error = new TooManyRequestsError();
         expect(error.message).toBe("Received 429 Too Many Requests");
     });
+
+    it("should store retryAfterSeconds when provided", () => {
+        const error = new TooManyRequestsError(30);
+        expect(error.retryAfterSeconds).toBe(30);
+    });
+
+    it("should have undefined retryAfterSeconds when not provided", () => {
+        const error = new TooManyRequestsError();
+        expect(error.retryAfterSeconds).toBeUndefined();
+    });
 });
 
 describe("retryWithRateLimit", () => {
@@ -86,14 +96,14 @@ describe("retryWithRateLimit", () => {
         ).rejects.toThrow("some other error");
     });
 
-    it("should retry up to 3 times on TooManyRequestsError and succeed", async () => {
+    it("should retry up to 5 times on TooManyRequestsError and succeed", async () => {
         const logger = createMockLogger();
         let callCount = 0;
 
         const result = await retryWithRateLimit({
             fn: async () => {
                 callCount++;
-                if (callCount <= 2) {
+                if (callCount <= 4) {
                     throw new TooManyRequestsError();
                 }
                 return "success after retries";
@@ -107,11 +117,11 @@ describe("retryWithRateLimit", () => {
         });
 
         expect(result).toBe("success after retries");
-        expect(callCount).toBe(3);
-        expect(logger.warn).toHaveBeenCalledTimes(2);
+        expect(callCount).toBe(5);
+        expect(logger.warn).toHaveBeenCalledTimes(4);
     });
 
-    it("should throw after exhausting all 3 retries", async () => {
+    it("should throw after exhausting all 5 retries", async () => {
         const logger = createMockLogger();
         let callCount = 0;
 
@@ -130,9 +140,9 @@ describe("retryWithRateLimit", () => {
             })
         ).rejects.toThrow(TooManyRequestsError);
 
-        // 1 initial + 3 retries = 4 total calls
-        expect(callCount).toBe(4);
-        expect(logger.warn).toHaveBeenCalledTimes(3);
+        // 1 initial + 5 retries = 6 total calls
+        expect(callCount).toBe(6);
+        expect(logger.warn).toHaveBeenCalledTimes(5);
     });
 
     it("should rethrow non-429 errors immediately even when retryRateLimited is true", async () => {
@@ -163,7 +173,7 @@ describe("retryWithRateLimit", () => {
         const delays: number[] = [];
         let callCount = 0;
 
-        // Mock Math.random to return 0.5 (no jitter effect: 1 + (0.5 - 0.5) * 0.2 = 1.0)
+        // Mock Math.random to return 0.5 (no jitter effect: 1 + (0.5 - 0.5) * 0.5 = 1.0)
         const originalRandom = Math.random;
         Math.random = () => 0.5;
 
@@ -192,14 +202,16 @@ describe("retryWithRateLimit", () => {
         // Attempt 0: 2000 * 2^0 = 2000ms
         // Attempt 1: 2000 * 2^1 = 4000ms
         // Attempt 2: 2000 * 2^2 = 8000ms
-        expect(delays).toEqual([2000, 4000, 8000]);
+        // Attempt 3: 2000 * 2^3 = 16000ms
+        // Attempt 4: 2000 * 2^4 = 32000ms
+        expect(delays).toEqual([2000, 4000, 8000, 16000, 32000]);
     });
 
     it("should apply jitter to delays", async () => {
         const logger = createMockLogger();
         const delays: number[] = [];
 
-        // Mock Math.random to return 0.0 (minimum jitter: 1 + (0.0 - 0.5) * 0.2 = 0.9)
+        // Mock Math.random to return 0.0 (minimum jitter: 1 + (0.0 - 0.5) * 0.5 = 0.75)
         const originalRandom = Math.random;
         Math.random = () => 0.0;
 
@@ -223,11 +235,13 @@ describe("retryWithRateLimit", () => {
             Math.random = originalRandom;
         }
 
-        // With Math.random = 0.0, jitter = 1 + (0.0 - 0.5) * 0.2 = 0.9
-        // Attempt 0: round(2000 * 0.9) = 1800ms
-        // Attempt 1: round(4000 * 0.9) = 3600ms
-        // Attempt 2: round(8000 * 0.9) = 7200ms
-        expect(delays).toEqual([1800, 3600, 7200]);
+        // With Math.random = 0.0, jitter = 1 + (0.0 - 0.5) * 0.5 = 0.75
+        // Attempt 0: round(2000 * 0.75) = 1500ms
+        // Attempt 1: round(4000 * 0.75) = 3000ms
+        // Attempt 2: round(8000 * 0.75) = 6000ms
+        // Attempt 3: round(16000 * 0.75) = 12000ms
+        // Attempt 4: round(32000 * 0.75) = 24000ms
+        expect(delays).toEqual([1500, 3000, 6000, 12000, 24000]);
     });
 
     it("should cap exponential backoff delay at max retry delay", async () => {
@@ -287,7 +301,80 @@ describe("retryWithRateLimit", () => {
         expect(logger.warn).toHaveBeenCalledTimes(2);
         const firstCall = logger.warn.mock.calls[0]?.[0] as string;
         const secondCall = logger.warn.mock.calls[1]?.[0] as string;
-        expect(firstCall).toContain("attempt 1/3");
-        expect(secondCall).toContain("attempt 2/3");
+        expect(firstCall).toContain("attempt 1/5");
+        expect(secondCall).toContain("attempt 2/5");
+    });
+
+    it("should use server retryAfter hint as minimum delay when provided", async () => {
+        const logger = createMockLogger();
+        const delays: number[] = [];
+        let callCount = 0;
+
+        // Mock Math.random to return 0.5 (no jitter effect)
+        const originalRandom = Math.random;
+        Math.random = () => 0.5;
+
+        try {
+            await retryWithRateLimit({
+                fn: async () => {
+                    callCount++;
+                    if (callCount <= 1) {
+                        // Server says wait 30 seconds
+                        throw new TooManyRequestsError(30);
+                    }
+                    return "success";
+                },
+                retryRateLimited: true,
+                logger,
+                onRateLimitedWithoutRetry: () => {
+                    throw new Error("should not be called");
+                },
+                delayFn: async (ms: number) => {
+                    delays.push(ms);
+                }
+            });
+        } finally {
+            Math.random = originalRandom;
+        }
+
+        // Attempt 0 base delay: 2000ms, server hint: 30000ms → effective: 30000ms
+        // With jitter = 1.0: 30000ms
+        expect(delays).toEqual([30000]);
+    });
+
+    it("should use exponential backoff when it exceeds server retryAfter", async () => {
+        const logger = createMockLogger();
+        const delays: number[] = [];
+        let callCount = 0;
+
+        // Mock Math.random to return 0.5 (no jitter)
+        const originalRandom = Math.random;
+        Math.random = () => 0.5;
+
+        try {
+            await retryWithRateLimit({
+                fn: async () => {
+                    callCount++;
+                    if (callCount <= 1) {
+                        // Server says wait 1 second, but backoff is 2s → use backoff
+                        throw new TooManyRequestsError(1);
+                    }
+                    return "success";
+                },
+                retryRateLimited: true,
+                logger,
+                onRateLimitedWithoutRetry: () => {
+                    throw new Error("should not be called");
+                },
+                delayFn: async (ms: number) => {
+                    delays.push(ms);
+                }
+            });
+        } finally {
+            Math.random = originalRandom;
+        }
+
+        // Server says 1s (1000ms), but backoff base is 2000ms → use 2000ms
+        expect(delays).toEqual([2000]);
     });
 });

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/retryWithRateLimit.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/retryWithRateLimit.test.ts
@@ -342,6 +342,43 @@ describe("retryWithRateLimit", () => {
         expect(delays).toEqual([30000]);
     });
 
+    it("should not let jitter reduce delay below server retryAfter hint", async () => {
+        const logger = createMockLogger();
+        const delays: number[] = [];
+        let callCount = 0;
+
+        // Mock Math.random to return 0.0 (minimum jitter: 1 + (0.0 - 0.5) * 0.5 = 0.75)
+        const originalRandom = Math.random;
+        Math.random = () => 0.0;
+
+        try {
+            await retryWithRateLimit({
+                fn: async () => {
+                    callCount++;
+                    if (callCount <= 1) {
+                        // Server says wait 30 seconds
+                        throw new TooManyRequestsError(30);
+                    }
+                    return "success";
+                },
+                retryRateLimited: true,
+                logger,
+                onRateLimitedWithoutRetry: () => {
+                    throw new Error("should not be called");
+                },
+                delayFn: async (ms: number) => {
+                    delays.push(ms);
+                }
+            });
+        } finally {
+            Math.random = originalRandom;
+        }
+
+        // Without the floor: effectiveBase=30000, jitter=0.75 → 22500ms (below 30s!)
+        // With the floor: max(22500, 30000) = 30000ms
+        expect(delays).toEqual([30000]);
+    });
+
     it("should use exponential backoff when it exceeds server retryAfter", async () => {
         const logger = createMockLogger();
         const delays: number[] = [];

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/createAndStartJob.ts
@@ -217,7 +217,8 @@ async function createJob({
         // biome-ignore lint/suspicious/noExplicitAny: the error shape from the SDK is not well-typed
         const rawError = createResponse.error as any;
         if (rawError?.content?.reason === "status-code" && rawError.content.statusCode === 429) {
-            throw new TooManyRequestsError();
+            const retryAfter = extractRetryAfterSeconds(rawError);
+            throw new TooManyRequestsError(retryAfter);
         }
 
         // GithubAppNotInstalled is not in the SDK's error union for createJobV3, so
@@ -475,6 +476,17 @@ function extractGithubAppNotInstalledMessage(error: any): string | undefined {
         `The Fern GitHub App is not installed on ${repo}. ` +
         "Please install it (https://github.com/apps/fern-api) and try again."
     );
+}
+
+/**
+ * Extracts the retryAfter value (in seconds) from a 429 response body.
+ * Fiddle returns { body: { content: { retryAfter: <seconds> } } } inside
+ * the SDK's status-code error wrapper.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: the error shape from the SDK is not well-typed
+function extractRetryAfterSeconds(rawError: any): number | undefined {
+    const retryAfter = rawError?.content?.body?.content?.retryAfter;
+    return typeof retryAfter === "number" && retryAfter > 0 ? retryAfter : undefined;
 }
 
 // Fiddle's ErrorBody serializes as { error: "<ErrorType>", content: <TypedBody> }.

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/retryWithRateLimit.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/retryWithRateLimit.ts
@@ -3,13 +3,16 @@ import { CliError } from "@fern-api/task-context";
 
 const RATE_LIMIT_INITIAL_RETRY_DELAY_MS = 2_000;
 const RATE_LIMIT_MAX_RETRY_DELAY_MS = 120_000;
-const RATE_LIMIT_MAX_RETRIES = 3;
-const RATE_LIMIT_JITTER_FACTOR = 0.2;
+const RATE_LIMIT_MAX_RETRIES = 5;
+const RATE_LIMIT_JITTER_FACTOR = 0.5;
 
 export class TooManyRequestsError extends Error {
-    constructor() {
+    readonly retryAfterSeconds: number | undefined;
+
+    constructor(retryAfterSeconds?: number) {
         super("Received 429 Too Many Requests");
         Object.setPrototypeOf(this, TooManyRequestsError.prototype);
+        this.retryAfterSeconds = retryAfterSeconds;
     }
 }
 
@@ -19,8 +22,10 @@ export class TooManyRequestsError extends Error {
  * When `retryRateLimited` is false and a TooManyRequestsError is thrown, it calls `onRateLimitedWithoutRetry`
  * to let the caller handle it (e.g. show a helpful message suggesting --retry-rate-limited).
  *
- * When `retryRateLimited` is true, retries up to RATE_LIMIT_MAX_RETRIES times with
- * exponential backoff and jitter (2s initial, 120s max).
+ * When `retryRateLimited` is true, retries up to RATE_LIMIT_MAX_RETRIES times.
+ * If the server provides a retryAfter hint, that value (in seconds) is used as the
+ * minimum delay. Otherwise, exponential backoff with jitter is applied
+ * (2s initial, 120s max, 0.5 jitter factor).
  */
 export async function retryWithRateLimit<T>({
     fn,
@@ -55,8 +60,10 @@ export async function retryWithRateLimit<T>({
                     RATE_LIMIT_INITIAL_RETRY_DELAY_MS * 2 ** attempt,
                     RATE_LIMIT_MAX_RETRY_DELAY_MS
                 );
+                const serverHintMs = error.retryAfterSeconds != null ? error.retryAfterSeconds * 1000 : undefined;
+                const effectiveBase = serverHintMs != null ? Math.max(baseDelay, serverHintMs) : baseDelay;
                 const jitter = 1 + (Math.random() - 0.5) * RATE_LIMIT_JITTER_FACTOR;
-                const delay = Math.round(baseDelay * jitter);
+                const delay = Math.round(Math.min(effectiveBase * jitter, RATE_LIMIT_MAX_RETRY_DELAY_MS));
                 logger.warn(
                     `Received 429 Too Many Requests. Retrying in ${(delay / 1000).toFixed(1)}s (attempt ${attempt + 1}/${RATE_LIMIT_MAX_RETRIES})...`
                 );

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/retryWithRateLimit.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/retryWithRateLimit.ts
@@ -63,7 +63,9 @@ export async function retryWithRateLimit<T>({
                 const serverHintMs = error.retryAfterSeconds != null ? error.retryAfterSeconds * 1000 : undefined;
                 const effectiveBase = serverHintMs != null ? Math.max(baseDelay, serverHintMs) : baseDelay;
                 const jitter = 1 + (Math.random() - 0.5) * RATE_LIMIT_JITTER_FACTOR;
-                const delay = Math.round(Math.min(effectiveBase * jitter, RATE_LIMIT_MAX_RETRY_DELAY_MS));
+                const delay = Math.round(
+                    Math.min(Math.max(effectiveBase * jitter, serverHintMs ?? 0), RATE_LIMIT_MAX_RETRY_DELAY_MS)
+                );
                 logger.warn(
                     `Received 429 Too Many Requests. Retrying in ${(delay / 1000).toFixed(1)}s (attempt ${attempt + 1}/${RATE_LIMIT_MAX_RETRIES})...`
                 );


### PR DESCRIPTION
## Description
Refs: https://github.com/fern-demo/autorelease-demo-fern-config-niels/actions/runs/25393662838/job/74474579600

Fixes 429 Too Many Requests failures during `fern automations generate` when many generators run concurrently across multiple API groups.

## Changes Made
- **Increase max retries from 3 → 5**: Gives more time for the server's leaky bucket to drain when many generators are retrying simultaneously
- **Respect server's `retryAfter` hint**: Parse the `retryAfter` value from fiddle's 429 response body and use it as the minimum delay floor, instead of always using fixed exponential backoff. Jitter can only add time above the server hint, never reduce below it.
- **Increase jitter factor from 0.2 → 0.5**: Wider jitter spreads out retry attempts across generators, reducing the thundering-herd effect where all generators retry at the same time
- **Pass `retryAfterSeconds` through `TooManyRequestsError`**: The error class now carries the server hint from the 429 response so the retry logic can use it
- [x] Updated tests to match new retry parameters (5 retries, 0.5 jitter, retryAfter support, jitter floor enforcement)

**Before**: 3 retries at 2s→4s→8s with ±10% jitter, ignoring server hints → ~14s total wait, frequent exhaustion  
**After**: 5 retries at 2s→4s→8s→16s→32s (or server hint, whichever is larger) with ±25% jitter → ~62s total wait with better spread

A companion PR in fern-api/fiddle ([#732](https://github.com/fern-api/fiddle/pull/732)) increases the server-side burst limit from 10 → 20 generators.

## Testing
- [x] Unit tests added/updated — all 124 tests pass in `@fern-api/remote-workspace-runner`
- [x] Format/lint checks pass
- [x] Devin Review feedback addressed (jitter floor enforcement)

Link to Devin session: https://app.devin.ai/sessions/dc108ecbb9e641d4b8ce8caf275b183d
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->