### PR TITLE
fix(cli): pass correct apiId and irVersions to dynamic IR upload URLs endpoint

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-dynamic-ir-upload-urls.yml
+++ b/packages/cli/cli/changes/unreleased/fix-dynamic-ir-upload-urls.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix dynamic IR upload URLs request passing empty apiId and irVersions parameters, which caused 500 errors from FDR during SDK generation.
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -1185,8 +1185,8 @@ async function checkAndDownloadExistingSdkDynamicIRs({
     try {
         const response = await fdr.api.register.checkSdkDynamicIrExists({
             orgId: CjsFdrSdk.OrgId(organization),
-            apiId: "",
-            irVersions: []
+            apiId: workspace.definition.rootApiFile.contents.name,
+            irVersions: Object.keys(snippetConfigWithVersions)
         });
 
         const existingDynamicIrs = response.existingDynamicIrs ?? {};

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -483,12 +483,13 @@ async function uploadDynamicIRForSdkGeneration({
     try {
         uploadUrlsResponse = await fdr.api.register.getSdkDynamicIrUploadUrls({
             orgId: FdrAPI.OrgId(organization),
-            apiId: "",
-            irVersions: []
+            apiId: getOriginalName(ir.apiName),
+            irVersions: [language]
         });
     } catch (error) {
-        // Log warning but don't fail the generation - dynamic IR upload is optional
-        context.logger.warn(`Failed to get dynamic IR upload URLs: ${error}`);
+        context.logger.warn(
+            `Failed to get dynamic IR upload URLs (non-fatal, dynamic snippets may be stale): ${error}`
+        );
         return;
     }
 


### PR DESCRIPTION
## Description

Fixes the "Failed to get dynamic IR upload URLs: Error: Internal server error" 500 error that occurs during SDK generation when the CLI tries to upload dynamic IR.

## Changes Made

**Root Cause:** During the FDR SDK upgrade (PR #13920), the `getSdkDynamicIrUploadUrls` and `checkSdkDynamicIrExists` calls were migrated from the v1 API to the new oRPC-based SDK with placeholder empty values (`apiId: ""`, `irVersions: []`). The old v1 API used different parameters (`version` + `snippetConfiguration`), and the migration didn't map them correctly to the new contract.

The empty `apiId` causes the FDR server to return a 500 Internal Server Error when trying to generate presigned S3 upload URLs.

**Fix:**
- `getSdkDynamicIrUploadUrls`: pass `getOriginalName(ir.apiName)` as `apiId` (matching how `registerApiDefinition` is called) and `[language]` as `irVersions`
- `checkSdkDynamicIrExists`: pass the workspace API name as `apiId` and the configured snippet languages as `irVersions`
- Improved error message to clarify that this failure is non-fatal (dynamic snippets may be stale but SDK generation still succeeds)

**Context:** Dynamic IR upload is an optional post-generation step that enables dynamic code snippets in docs. The generation itself completes successfully even when this step fails. The error was always non-fatal (logged as a warning), but it was confusing/noisy in CI logs.

- [ ] Updated README.md generator (if applicable) — N/A

## Testing
- [x] Verified formatting passes (`pnpm format`)
- [x] The fix is straightforward parameter correction — the values match how the same API is called in `registerApiDefinition`
- [x] The error handling remains non-fatal (warn-level logging, no generation failure)

Link to Devin session: https://app.devin.ai/sessions/e8f9618a96dd4602bc0c3baec6a9c436
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->