### PR TITLE
fix(cli): pass correct field names for dynamic IR endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
       "minimatch": ">=10.2.3",
       "qs": "6.15.0",
       "url-join": "^4.0.1",
-      "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+      "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
       "form-data": "^4.0.4",
       "@fern-api/ui-core-utils": "0.145.12-b50d999d1",
       "vite": "^7.3.2",

--- a/packages/cli/api-importers/graphql/package.json
+++ b/packages/cli/api-importers/graphql/package.json
@@ -31,7 +31,7 @@
     "test:update": "vitest --run -u --passWithNoTests"
   },
   "dependencies": {
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/task-context": "workspace:*",
     "graphql": "catalog:"

--- a/packages/cli/cli/changes/unreleased/fix-dynamic-ir-client-params.yml
+++ b/packages/cli/cli/changes/unreleased/fix-dynamic-ir-client-params.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix dynamic IR upload and check endpoints to pass correct field names (version, snippetConfiguration) matching the FDR server contract, resolving 500 errors during SDK generation.
+  type: fix

--- a/packages/cli/cli/package.json
+++ b/packages/cli/cli/package.json
@@ -70,7 +70,7 @@
     "@fern-api/docs-preview": "workspace:*",
     "@fern-api/docs-resolver": "workspace:*",
     "@fern-api/docs-validator": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/fern-definition-formatter": "workspace:*",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/fern-definition-validator": "workspace:*",

--- a/packages/cli/configuration-loader/package.json
+++ b/packages/cli/configuration-loader/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/github": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",

--- a/packages/cli/configuration/package.json
+++ b/packages/cli/configuration/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/path-utils": "workspace:*",
     "@fern-fern/fiddle-sdk": "catalog:",

--- a/packages/cli/docs-importers/commons/package.json
+++ b/packages/cli/docs-importers/commons/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/configuration": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/task-context": "workspace:*",
     "js-yaml": "catalog:"

--- a/packages/cli/docs-importers/mintlify/package.json
+++ b/packages/cli/docs-importers/mintlify/package.json
@@ -35,7 +35,7 @@
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-importer-commons": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/task-context": "workspace:*",

--- a/packages/cli/docs-importers/readme/package.json
+++ b/packages/cli/docs-importers/readme/package.json
@@ -35,7 +35,7 @@
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-importer-commons": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-api/task-context": "workspace:*",

--- a/packages/cli/docs-markdown-utils/package.json
+++ b/packages/cli/docs-markdown-utils/package.json
@@ -32,7 +32,7 @@
     "test:update": "vitest --run -u"
   },
   "dependencies": {
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/task-context": "workspace:*",
     "estree-walker": "catalog:",

--- a/packages/cli/docs-preview/package.json
+++ b/packages/cli/docs-preview/package.json
@@ -35,7 +35,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-markdown-utils": "workspace:*",
     "@fern-api/docs-resolver": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/ir-sdk": "workspace:*",
     "@fern-api/ir-utils": "workspace:*",

--- a/packages/cli/ete-tests/package.json
+++ b/packages/cli/ete-tests/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@fern-api/configuration": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/lazy-fern-workspace": "workspace:*",
     "@fern-api/logger": "workspace:*",

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/package.json
@@ -42,7 +42,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-resolver": "workspace:*",
     "@fern-api/fai-sdk": "catalog:",
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/ir-generator": "workspace:*",
     "@fern-api/ir-migrations": "workspace:*",

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -1189,9 +1189,10 @@ async function checkAndDownloadExistingSdkDynamicIRs({
                 { packageName: info.packageName, version: info.version }
             ])
         );
-        // @ts-expect-error -- SDK types will be updated once fern-platform#10550 publishes new @fern-api/fdr-sdk
-        // biome-ignore format: single line required for @ts-expect-error suppression
-        const response = await fdr.api.register.checkSdkDynamicIrExists({ orgId: CjsFdrSdk.OrgId(organization), snippetConfiguration: snippetConfig });
+        const response = await fdr.api.register.checkSdkDynamicIrExists({
+            orgId: CjsFdrSdk.OrgId(organization),
+            snippetConfiguration: snippetConfig
+        });
 
         const existingDynamicIrs = response.existingDynamicIrs ?? {};
 

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -1183,15 +1183,14 @@ async function checkAndDownloadExistingSdkDynamicIRs({
     }
 
     try {
-        const response = await fdr.api.register.checkSdkDynamicIrExists({
-            orgId: CjsFdrSdk.OrgId(organization),
-            snippetConfiguration: Object.fromEntries(
-                Object.entries(snippetConfigWithVersions).map(([lang, info]) => [
-                    lang,
-                    { packageName: info.packageName, version: info.version }
-                ])
-            )
-        });
+        const snippetConfig = Object.fromEntries(
+            Object.entries(snippetConfigWithVersions).map(([lang, info]) => [
+                lang,
+                { packageName: info.packageName, version: info.version }
+            ])
+        );
+        // @ts-expect-error -- SDK types will be updated once fern-platform#10550 publishes new @fern-api/fdr-sdk
+        const response = await fdr.api.register.checkSdkDynamicIrExists({ orgId: CjsFdrSdk.OrgId(organization), snippetConfiguration: snippetConfig });
 
         const existingDynamicIrs = response.existingDynamicIrs ?? {};
 

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -1185,8 +1185,12 @@ async function checkAndDownloadExistingSdkDynamicIRs({
     try {
         const response = await fdr.api.register.checkSdkDynamicIrExists({
             orgId: CjsFdrSdk.OrgId(organization),
-            apiId: workspace.definition.rootApiFile.contents.name,
-            irVersions: Object.keys(snippetConfigWithVersions)
+            snippetConfiguration: Object.fromEntries(
+                Object.entries(snippetConfigWithVersions).map(([lang, info]) => [
+                    lang,
+                    { packageName: info.packageName, version: info.version }
+                ])
+            )
         });
 
         const existingDynamicIrs = response.existingDynamicIrs ?? {};

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -1190,6 +1190,7 @@ async function checkAndDownloadExistingSdkDynamicIRs({
             ])
         );
         // @ts-expect-error -- SDK types will be updated once fern-platform#10550 publishes new @fern-api/fdr-sdk
+        // biome-ignore format: single line required for @ts-expect-error suppression
         const response = await fdr.api.register.checkSdkDynamicIrExists({ orgId: CjsFdrSdk.OrgId(organization), snippetConfiguration: snippetConfig });
 
         const existingDynamicIrs = response.existingDynamicIrs ?? {};

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -483,8 +483,8 @@ async function uploadDynamicIRForSdkGeneration({
     try {
         uploadUrlsResponse = await fdr.api.register.getSdkDynamicIrUploadUrls({
             orgId: FdrAPI.OrgId(organization),
-            apiId: getOriginalName(ir.apiName),
-            irVersions: [language]
+            version,
+            snippetConfiguration: { [language]: packageName }
         });
     } catch (error) {
         context.logger.warn(

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -481,11 +481,8 @@ async function uploadDynamicIRForSdkGeneration({
     // Get presigned upload URLs from FDR
     let uploadUrlsResponse;
     try {
-        uploadUrlsResponse = await fdr.api.register.getSdkDynamicIrUploadUrls({
-            orgId: FdrAPI.OrgId(organization),
-            version,
-            snippetConfiguration: { [language]: packageName }
-        });
+        // @ts-expect-error -- SDK types will be updated once fern-platform#10550 publishes new @fern-api/fdr-sdk
+        uploadUrlsResponse = await fdr.api.register.getSdkDynamicIrUploadUrls({ orgId: FdrAPI.OrgId(organization), version, snippetConfiguration: { [language]: packageName } });
     } catch (error) {
         context.logger.warn(
             `Failed to get dynamic IR upload URLs (non-fatal, dynamic snippets may be stale): ${error}`

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -481,9 +481,11 @@ async function uploadDynamicIRForSdkGeneration({
     // Get presigned upload URLs from FDR
     let uploadUrlsResponse;
     try {
-        // @ts-expect-error -- SDK types will be updated once fern-platform#10550 publishes new @fern-api/fdr-sdk
-        // biome-ignore format: single line required for @ts-expect-error suppression
-        uploadUrlsResponse = await fdr.api.register.getSdkDynamicIrUploadUrls({ orgId: FdrAPI.OrgId(organization), version, snippetConfiguration: { [language]: packageName } });
+        uploadUrlsResponse = await fdr.api.register.getSdkDynamicIrUploadUrls({
+            orgId: FdrAPI.OrgId(organization),
+            version,
+            snippetConfiguration: { [language]: packageName }
+        });
     } catch (error) {
         context.logger.warn(
             `Failed to get dynamic IR upload URLs (non-fatal, dynamic snippets may be stale): ${error}`

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -482,6 +482,7 @@ async function uploadDynamicIRForSdkGeneration({
     let uploadUrlsResponse;
     try {
         // @ts-expect-error -- SDK types will be updated once fern-platform#10550 publishes new @fern-api/fdr-sdk
+        // biome-ignore format: single line required for @ts-expect-error suppression
         uploadUrlsResponse = await fdr.api.register.getSdkDynamicIrUploadUrls({ orgId: FdrAPI.OrgId(organization), version, snippetConfiguration: { [language]: packageName } });
     } catch (error) {
         context.logger.warn(

--- a/packages/cli/register/package.json
+++ b/packages/cli/register/package.json
@@ -38,7 +38,7 @@
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/ir-generator": "workspace:*",
     "@fern-api/ir-sdk": "workspace:*",

--- a/packages/cli/workspace/browser-compatible-fern-workspace/package.json
+++ b/packages/cli/workspace/browser-compatible-fern-workspace/package.json
@@ -37,7 +37,7 @@
     "@fern-api/asyncapi-to-ir": "workspace:*",
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/ir-sdk": "workspace:*",
     "@fern-api/openapi-ir": "workspace:*",
     "@fern-api/openapi-ir-parser": "workspace:*",

--- a/packages/cli/workspace/lazy-fern-workspace/package.json
+++ b/packages/cli/workspace/lazy-fern-workspace/package.json
@@ -41,7 +41,7 @@
     "@fern-api/conjure-to-fern": "workspace:*",
     "@fern-api/core": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/graphql-to-fdr": "workspace:*",

--- a/packages/cli/yaml/docs-validator/package.json
+++ b/packages/cli/yaml/docs-validator/package.json
@@ -40,7 +40,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/docs-markdown-utils": "workspace:*",
     "@fern-api/docs-resolver": "workspace:*",
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/ir-generator": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-api/fdr-sdk": "1.2.0-1d73d2e141",
+    "@fern-api/fdr-sdk": "1.2.4-f661387fb2",
     "@fern-api/venus-api-sdk": "catalog:",
     "@fern-fern/fdr-test-sdk": "catalog:",
     "@fern-fern/fiddle-sdk": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,7 +594,7 @@ overrides:
   minimatch: '>=10.2.3'
   qs: 6.15.0
   url-join: ^4.0.1
-  '@fern-api/fdr-sdk': 1.2.0-1d73d2e141
+  '@fern-api/fdr-sdk': 1.2.4-f661387fb2
   form-data: ^4.0.4
   '@fern-api/ui-core-utils': 0.145.12-b50d999d1
   vite: ^7.3.2
@@ -3845,8 +3845,8 @@ importers:
   packages/cli/api-importers/graphql:
     dependencies:
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -4333,8 +4333,8 @@ importers:
         specifier: workspace:*
         version: link:../yaml/docs-validator
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-formatter':
         specifier: workspace:*
         version: link:../fern-definition/formatter
@@ -4963,8 +4963,8 @@ importers:
         specifier: workspace:*
         version: link:../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../fern-definition/schema
@@ -5000,8 +5000,8 @@ importers:
         specifier: workspace:*
         version: link:../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5079,8 +5079,8 @@ importers:
         specifier: workspace:*
         version: link:../../configuration
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -5119,8 +5119,8 @@ importers:
         specifier: workspace:*
         version: link:../commons
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -5159,8 +5159,8 @@ importers:
         specifier: workspace:*
         version: link:../commons
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../commons/fs-utils
@@ -5226,8 +5226,8 @@ importers:
   packages/cli/docs-markdown-utils:
     dependencies:
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5314,8 +5314,8 @@ importers:
         specifier: workspace:*
         version: link:../docs-resolver
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5429,8 +5429,8 @@ importers:
         specifier: workspace:*
         version: link:../docs-markdown-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -5532,8 +5532,8 @@ importers:
         specifier: workspace:*
         version: link:../configuration
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -6231,8 +6231,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.6-2ee1b7e28
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../../../commons/fs-utils
@@ -6444,8 +6444,8 @@ importers:
   packages/cli/library-docs-generator:
     dependencies:
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/task-context':
         specifier: workspace:*
         version: link:../task-context
@@ -6678,8 +6678,8 @@ importers:
         specifier: workspace:*
         version: link:../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fs-utils':
         specifier: workspace:*
         version: link:../../commons/fs-utils
@@ -6874,8 +6874,8 @@ importers:
         specifier: workspace:*
         version: link:../../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../../ir-sdk
@@ -6959,8 +6959,8 @@ importers:
         specifier: workspace:*
         version: link:../../../commons/core-utils
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../../fern-definition/schema
@@ -7199,8 +7199,8 @@ importers:
         specifier: workspace:*
         version: link:../../docs-resolver
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../../fern-definition/schema
@@ -7838,8 +7838,8 @@ importers:
   packages/core:
     dependencies:
       '@fern-api/fdr-sdk':
-        specifier: 1.2.0-1d73d2e141
-        version: 1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)
+        specifier: 1.2.4-f661387fb2
+        version: 1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
         version: 0.22.34
@@ -9399,8 +9399,8 @@ packages:
     resolution: {integrity: sha512-3qhAAuc4ZJWLaFtyZzaYXfF9OQ5iviNrvLDXtjKScKUNS134fR3v3c3xedCidTq5KedapuBECziUaOmmd6KXVA==}
     engines: {node: '>=18.0.0'}
 
-  '@fern-api/fdr-sdk@1.2.0-1d73d2e141':
-    resolution: {integrity: sha512-MEFE1wOThaUz9IK3bgIkTAQKvLJgt8ccHvXehK9HIvBvxl6EdHNrXrZAlFS5TxLd9yd1AtM9M8LmzzMIzoHfGQ==}
+  '@fern-api/fdr-sdk@1.2.4-f661387fb2':
+    resolution: {integrity: sha512-wlk1lTCIZ7biND4vQf8jvhUw9P/rBQ5pXASCrumv8R96up0B3DY6yiY1C4VmFyHmp/kPhcjzc5T9TvHZZxFdrA==}
 
   '@fern-api/generator-cli@0.9.22':
     resolution: {integrity: sha512-War2x7+HMAl8TzferxbIRfp1zgQ5OMdoZW/FsD2H/Ep7t0SWLBDcAm+x7s+mhnwEYYXe9VSdA2+aNZC3pwRalA==}
@@ -16409,7 +16409,7 @@ snapshots:
 
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28': {}
 
-  '@fern-api/fdr-sdk@1.2.0-1d73d2e141(@opentelemetry/api@1.9.1)(typescript@5.9.3)':
+  '@fern-api/fdr-sdk@1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)':
     dependencies:
       '@fern-api/ui-core-utils': 0.145.12-b50d999d1
       '@orpc/client': 1.13.9(@opentelemetry/api@1.9.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,7 +59,7 @@ catalog:
   "@bufbuild/protobuf": ^2.2.5
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
-  "@fern-api/fdr-sdk": 1.2.0-1d73d2e141
+  "@fern-api/fdr-sdk": 1.2.4-f661387fb2
   "@fern-api/generator-cli": 0.9.22
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34


### PR DESCRIPTION
## Description

Fixes the `Failed to get dynamic IR upload URLs: Error: Internal server error` issue during SDK generation.

**Root Cause:** The FDR SDK client contract defined input schemas using `{ orgId, apiId, irVersions }`, but the FDR server handler expects `{ orgId, version, snippetConfiguration }`. This oRPC contract mismatch caused Zod validation failures → 500 Internal Server Error on every call to `/registry/api/sdk-dynamic-ir-upload-urls` and `/registry/api/check-sdk-dynamic-ir`.

## Changes Made

- Upgraded `@fern-api/fdr-sdk` from `1.2.0-1d73d2e141` to `1.2.4-f661387fb2` (includes contract fix from fern-platform PR #10550)
- Updated `getSdkDynamicIrUploadUrls` call to pass `{ orgId, version, snippetConfiguration: { [language]: packageName } }`
- Updated `checkSdkDynamicIrExists` call to pass `{ orgId, snippetConfiguration: { [lang]: { packageName, version } } }`
- [ ] Updated README.md generator (if applicable) — N/A

**Related:**
- fern-platform PR #10550 (merged): Fixed oRPC contract definition in `@fern-api/fdr-sdk`
- fern PR #15713 (merged): Initial parameter fix (superseded by this PR)

## Testing

- [x] Verified end-to-end against local FDR stack:
  - Correct params → 200 OK with pre-signed S3 upload URL
  - Old params (`apiId`, `irVersions`) → 500 (confirming the bug)
- [x] TypeScript compilation succeeds with new SDK types (no `@ts-expect-error` needed)
- [x] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/e8f9618a96dd4602bc0c3baec6a9c436
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->