### PR TITLE
fix(cli): replay org_id from fern.config.json organization, not venus

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-replay-org-id-source.yml
+++ b/packages/cli/cli/changes/unreleased/fix-replay-org-id-source.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Source `org_id` on the replay PostHog event from `fern.config.json` (the project organization slug, like every other CLI flow), not from a Venus token lookup.
+  type: fix

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -483,17 +483,17 @@ export async function runLocalGenerationForWorkspace({
                                     previewMode: selfhostedGithubConfig.previewMode === true,
                                     durationMs: pipelineDurationMs
                                 });
-                                // `surface: "cli"` mirrors the cloud emitter's `surface: "fiddle"`
-                                // so dashboards can split between CLI-local and Fiddle paths
-                                // without coalescing NULLs. Set as a final overlay so the local
-                                // helper itself stays surface-agnostic.
-                                const propsWithSurface = { ...replayTelemetryProps, surface: "cli" as const };
+                                const propsWithOverlay = {
+                                    ...replayTelemetryProps,
+                                    surface: "cli" as const,
+                                    org_id: projectConfig.organization
+                                };
                                 interactiveTaskContext.instrumentPostHogEvent({
                                     command: "replay",
-                                    properties: propsWithSurface
+                                    properties: propsWithOverlay
                                 });
                                 interactiveTaskContext.logger.debug(
-                                    `[telemetry] replay event sent: ${JSON.stringify(propsWithSurface)}`
+                                    `[telemetry] replay event sent: ${JSON.stringify(propsWithOverlay)}`
                                 );
                             } catch (error) {
                                 interactiveTaskContext.logger.debug(

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/RemoteTaskHandler.ts
@@ -56,6 +56,7 @@ export declare namespace RemoteTaskHandler {
     }
     export interface ReplayTelemetryContext {
         cliVersion: string | undefined;
+        orgId: string;
         automationMode: boolean;
         autoMerge: boolean;
         skipIfNoDiff: boolean;
@@ -317,13 +318,16 @@ export class RemoteTaskHandler {
                 durationMs: Date.now() - this.taskStartedAtMs
             });
 
+            const propsWithOverlay = {
+                ...props,
+                surface: "fiddle" as const,
+                org_id: this.telemetryContext.orgId
+            };
             this.context.instrumentPostHogEvent({
                 command: "replay",
-                properties: { ...props, surface: "fiddle" }
+                properties: propsWithOverlay
             });
-            this.context.logger.debug(
-                `[telemetry] replay event sent: ${JSON.stringify({ ...props, surface: "fiddle" })}`
-            );
+            this.context.logger.debug(`[telemetry] replay event sent: ${JSON.stringify(propsWithOverlay)}`);
             this.replayEventEmitted = true;
         } catch (error) {
             this.context.logger.debug(`[telemetry] failed to send replay event: ${String(error)}`);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/RemoteTaskHandler.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/RemoteTaskHandler.test.ts
@@ -179,6 +179,7 @@ describe("RemoteTaskHandler.processUpdate — replay PostHog emission", () => {
     function makeBaseTelemetryContext(): RemoteTaskHandler.ReplayTelemetryContext {
         return {
             cliVersion: "5.12.0",
+            orgId: "acme",
             automationMode: false,
             autoMerge: false,
             skipIfNoDiff: false,
@@ -256,7 +257,8 @@ describe("RemoteTaskHandler.processUpdate — replay PostHog emission", () => {
             github_mode: "pull-request",
             replay_config_enabled: true,
             no_replay_flag: false,
-            automation_mode: false
+            automation_mode: false,
+            org_id: "acme"
         });
         // Hashed (sha256/16) — no raw repo path leaks
         expect(event.properties?.repo_uri_hash).toMatch(/^[0-9a-f]{16}$/);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -353,6 +353,7 @@ export async function runRemoteGenerationForGenerator({
         absolutePathToPreview,
         telemetryContext: {
             cliVersion: workspace.cliVersion,
+            orgId: projectConfig.organization,
             automationMode: automationMode === true,
             autoMerge: autoMerge === true,
             skipIfNoDiff: skipIfNoDiff === true,

--- a/packages/cli/posthog-manager/src/UserPosthogManager.ts
+++ b/packages/cli/posthog-manager/src/UserPosthogManager.ts
@@ -34,9 +34,7 @@ export class UserPosthogManager implements PosthogManager {
     }
 
     public async sendEvent(event: PosthogEvent): Promise<void> {
-        // Resolve email + primary org in parallel — both are venus calls that
-        // happen at most once per CLI process (cached after first miss).
-        const [userEmail, orgId] = await Promise.all([this.getUserEmail(), this.getPrimaryOrgId()]);
+        const userEmail = await this.getUserEmail();
         this.posthog.capture({
             distinctId: this.userId ?? (await this.getPersistedDistinctId()),
             event: "CLI",
@@ -45,8 +43,7 @@ export class UserPosthogManager implements PosthogManager {
                 ...event,
                 ...event.properties,
                 usingAccessToken: false,
-                ...(userEmail != null ? { userEmail } : {}),
-                ...(orgId != null ? { org_id: orgId } : {})
+                ...(userEmail != null ? { userEmail } : {})
             }
         });
     }
@@ -81,44 +78,6 @@ export class UserPosthogManager implements PosthogManager {
             // Silently fail - email is optional for analytics
         }
         this.userEmail = null;
-        return undefined;
-    }
-
-    /**
-     * Cached primary `OrganizationId` for the current user. `null` is the
-     * "tried and gave up" sentinel — distinct from `undefined` (not yet tried)
-     * so subsequent `sendEvent` calls don't repeatedly hit venus when the user
-     * has no orgs or the call failed.
-     *
-     * Picks the first org returned by `getOrgIdsFromToken`. Multi-org users
-     * appear under their first org for adoption metrics — accurate enough for
-     * dashboards, and matches autopilot's distinct-id pattern.
-     */
-    private orgId: string | undefined | null;
-    private async getPrimaryOrgId(): Promise<string | undefined> {
-        if (this.orgId === null) {
-            return undefined;
-        }
-        if (this.orgId != null) {
-            return this.orgId;
-        }
-        if (this.token == null) {
-            this.orgId = null;
-            return undefined;
-        }
-        try {
-            const response = await createVenusService({ token: this.token.value }).organization.getOrgIdsFromToken();
-            if (response.ok && response.body.length > 0) {
-                const first = response.body[0];
-                if (first != null) {
-                    this.orgId = first;
-                    return this.orgId;
-                }
-            }
-        } catch {
-            // Silently fail — org tagging is optional for analytics.
-        }
-        this.orgId = null;
         return undefined;
     }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #15717 (G3 enrichment). The original implementation tagged the `replay` PostHog event's `org_id` via a venus lookup (`venus.organization.getOrgIdsFromToken()`, picking `[0]`). That diverges from how every other CLI flow handles "org" — they all use `project.config.organization` (the slug from `fern.config.json`).

For multi-org users — common on Fern team / support — venus's first-org-returned can be unrelated to the project being generated. My own runs landed under `org_id: "test-snippet-issue"` instead of `"fern"` because that's what venus returned at index 0 for my token.

This PR switches the source to `projectConfig.organization` at both emit sites (local + cloud) and removes the venus helper.

## Why this is the right convention

Surveyed every "org" reference in the CLI — every existing flow uses `project.config.organization`:

| Caller | Field set |
|---|---|
| `generateAPIWorkspaces.ts:114` | `orgId: project.config.organization` |
| `mockServer.ts:21` | `orgId: project.config.organization` |
| `testOutput.ts:25` | `orgId: project.config.organization` |
| `devDocsWorkspace.ts:41,89` | `orgId: project.config.organization` |
| `generateLibraryDocs.ts:313` | `orgId: opts.orgId` (also project) |
| `generateDocsWorkspace.ts:168` | `orgId: project.config.organization` |
| `cli.ts:598` (token cmd) | defaults to project's organization |

Same string already drives Fiddle auth, FDR routing, and docs-preview domains. Replay telemetry should be consistent with that.

## What changes

* **`UserPosthogManager.ts`** — revert `getPrimaryOrgId()` and its call from `sendEvent()`. No more venus call per CLI process.
* **`runLocalGenerationForWorkspace.ts`** — overlay `org_id: projectConfig.organization` on the local emit's properties.
* **`RemoteTaskHandler.ts`** — add `orgId` to `ReplayTelemetryContext`, overlay on cloud emit's properties.
* **`runRemoteGenerationForGenerator.ts`** — populate `telemetryContext.orgId` from `projectConfig.organization`.
* **Test fixture** — `makeBaseTelemetryContext()` now includes `orgId: "acme"`; assertion checks `org_id: "acme"`.

## Verification

End-to-end against the fern testbed (using the locally-built CLI with PostHog key baked in):

```
# Cloud — Python SDK regen
[telemetry] replay event sent: {..., "surface":"fiddle", "org_id":"fern"}

# Local --local --preview — TS SDK
[telemetry] replay event sent: {..., "surface":"cli", "org_id":"fern"}
```

Both surfaces emit `org_id: "fern"` (matches `fern.config.json organization: "fern"`).

For comparison, the same testbed with the venus-lookup version emitted `org_id: "test-snippet-issue"` (my user's first venus org).

## Schema implications

For any existing `replay` events already in PostHog, the `org_id` field will keep its old venus-derived value (e.g. `"test-snippet-issue"`). Going forward, every event tags with the project slug (e.g. `"fern"`, customer's slug). Easy enough to bucket in queries (`org_id IN ('fern')` for known internal, or filter out test-snippet-issue values).

The dashboard panels keep working — same property name (`properties.org_id`), just a more useful value.

## Test plan

- [x] `pnpm turbo run test --filter @fern-api/posthog-manager --filter @fern-api/local-workspace-runner --filter @fern-api/remote-workspace-runner --filter @fern-api/cli` — all green
- [x] `pnpm turbo run compile` clean
- [x] End-to-end Python cloud regen against testbed → `org_id: "fern"` confirmed in `[telemetry]` debug line
- [x] Local TS preview against testbed → `org_id: "fern"` confirmed
- [ ] Post-merge: confirm event lands in PostHog with `properties.org_id = "fern"` for testbed runs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->