### PR TITLE
feat(csharp): support OAuth token override

### DIFF
--- a/generators/csharp/sdk/changes/unreleased/oauth-token-override.yml
+++ b/generators/csharp/sdk/changes/unreleased/oauth-token-override.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    OAuth client credentials APIs now accept a pre-fetched bearer token in addition to clientId/clientSecret.
+    Callers can pass `token: "..."` to bypass the OAuth client credentials flow, or continue passing
+    `clientId`/`clientSecret` (or rely on env-var fallbacks) to have the SDK fetch and refresh tokens
+    automatically. The constructor performs a runtime check ensuring at least one valid auth combination
+    is provided. The README also documents both authentication options.
+  type: feat

--- a/generators/csharp/sdk/features.yml
+++ b/generators/csharp/sdk/features.yml
@@ -4,6 +4,11 @@ features:
     description: |
       Instantiate and use the client with the following:
 
+  - id: AUTHENTICATION
+    description: |
+      The SDK supports authenticating via the OAuth client credentials flow (clientId + clientSecret) or by
+      providing a pre-fetched bearer token. Choose whichever option fits your environment:
+
   - id: ENVIRONMENTS
     description: |
       This SDK allows you to configure different environments for API requests.

--- a/generators/csharp/sdk/src/options/ClientOptionsGenerator.ts
+++ b/generators/csharp/sdk/src/options/ClientOptionsGenerator.ts
@@ -232,7 +232,9 @@ export class ClientOptionsGenerator extends FileGenerator<CSharpFile, SdkGenerat
             const name = this.case.pascalSafe(header.name);
             if (!seenNames.has(name)) {
                 seenNames.add(name);
-                const type = this.context.csharpTypeMapper.convert({ reference: header.valueType });
+                const type = this.context.csharpTypeMapper.convert({
+                    reference: header.valueType
+                });
                 const isOptional =
                     header.valueType.type === "container" && header.valueType.container.type === "optional";
                 const field: UnifiedField = {
@@ -299,26 +301,31 @@ export class ClientOptionsGenerator extends FileGenerator<CSharpFile, SdkGenerat
             return [
                 {
                     name: this.case.pascalSafe(scheme.name),
-                    type: this.context.csharpTypeMapper.convert({ reference: scheme.valueType }),
+                    type: this.context.csharpTypeMapper.convert({
+                        reference: scheme.valueType
+                    }),
                     docs: scheme.docs ?? `The ${this.case.camelSafe(scheme.name)} to use for authentication.`,
                     isOptional,
                     hasEnvironmentVariable: scheme.headerEnvVar != null
                 }
             ];
         } else if (scheme.type === "oauth") {
+            // OAuth supports two auth modes: client credentials or a pre-fetched bearer token.
+            // All three fields are optional at the API surface; a runtime check in the
+            // generated root client constructor enforces that one valid combination is provided.
             const fields: UnifiedField[] = [
                 {
                     name: "ClientId",
                     type: this.Primitive.string,
                     docs: "The clientId to use for authentication.",
-                    isOptional,
+                    isOptional: true,
                     hasEnvironmentVariable: scheme.configuration.clientIdEnvVar != null
                 },
                 {
                     name: "ClientSecret",
                     type: this.Primitive.string,
                     docs: "The clientSecret to use for authentication.",
-                    isOptional,
+                    isOptional: true,
                     hasEnvironmentVariable: scheme.configuration.clientSecretEnvVar != null
                 }
             ];
@@ -339,9 +346,15 @@ export class ClientOptionsGenerator extends FileGenerator<CSharpFile, SdkGenerat
                     name: this.case.pascalSafe(customProperty.property.name),
                     type: typeRef,
                     docs: `The ${this.case.camelSafe(customProperty.property.name)} for OAuth authentication.`,
-                    isOptional
+                    isOptional: true
                 });
             }
+            fields.push({
+                name: "Token",
+                type: this.Primitive.string,
+                docs: "A pre-fetched bearer token. When provided, the OAuth client credentials flow is bypassed.",
+                isOptional: true
+            });
             return fields;
         } else if (scheme.type === "inferred") {
             // Inferred auth credentials become fields on ClientOptions

--- a/generators/csharp/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/csharp/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -135,7 +135,39 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
             snippets[ReadmeSnippetBuilder.FORWARD_COMPATIBLE_ENUMS_FEATURE_ID] =
                 this.buildForwardCompatibleEnumSnippets();
         }
+        if (this.hasOAuthClientCredentials()) {
+            snippets[FernGeneratorCli.StructuredFeatureId.Authentication] = this.buildOAuthAuthenticationSnippets();
+        }
         return snippets;
+    }
+
+    private hasOAuthClientCredentials(): boolean {
+        return this.context.ir.auth.schemes.some((scheme) => scheme.type === "oauth");
+    }
+
+    private buildOAuthAuthenticationSnippets(): string[] {
+        const rootClientName = this.Types.RootClient.name;
+        const clientOptionsName = this.Types.ClientOptions.name;
+        const unified = this.context.settings.unifiedClientOptions;
+        const credentialsConstructor = unified
+            ? `var client = new ${rootClientName}(new ${clientOptionsName} { ClientId = "client_id", ClientSecret = "client_secret" });`
+            : `var client = new ${rootClientName}(clientId: "client_id", clientSecret: "client_secret");`;
+        const tokenConstructor = unified
+            ? `var client = new ${rootClientName}(new ${clientOptionsName} { Token = "my-pre-generated-bearer-token" });`
+            : `var client = new ${rootClientName}(token: "my-pre-generated-bearer-token");`;
+        const credentialsSnippet = this.writeCode(`
+using ${this.namespaces.root};
+
+// Option 1: OAuth client credentials flow (the SDK fetches and refreshes tokens automatically)
+${credentialsConstructor}
+`);
+        const tokenSnippet = this.writeCode(`
+using ${this.namespaces.root};
+
+// Option 2: Pre-fetched bearer token (the SDK skips the OAuth flow)
+${tokenConstructor}
+`);
+        return [credentialsSnippet, tokenSnippet];
     }
 
     private buildUsageSnippets(): string[] {

--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -975,20 +975,6 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                 // or a pre-fetched bearer token. Both paths are wired up in the constructor;
                 // a runtime check enforces that the caller provides one valid combination.
                 // All three params are therefore optional at the C# API layer.
-                //
-                // Guard against a (rare) collision with a sibling bearer scheme whose token
-                // identifier also resolves to `token`. Without this, the dedup in
-                // `getConstructorParameters` would silently drop one of the two `token` params,
-                // breaking either the OAuth token override or the bearer auth header.
-                const collidingBearer = this.context.ir.auth.schemes.find(
-                    (s) => s.type === "bearer" && this.case.camelSafe(s.token) === "token"
-                );
-                if (collidingBearer != null) {
-                    throw new Error(
-                        "OAuth token override parameter `token` collides with a bearer auth scheme " +
-                            "whose token also resolves to `token`. Rename the bearer token in the IR to disambiguate."
-                    );
-                }
                 const tokenAccess = this.settings.unifiedClientOptions ? "clientOptions.Token" : "token";
                 const envVarFallbackCondition = `${tokenAccess} == null`;
                 return [

--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -416,15 +416,26 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                                 continue;
                             }
                             const target = paramAccess(param);
-                            innerWriter.writeLine(`${target} ??= ${GetFromEnvironmentOrThrow}(`);
-                            innerWriter.indent();
-                            innerWriter.writeNode(this.csharp.string_({ string: param.environmentVariable }));
-                            innerWriter.writeLine(",");
-                            innerWriter.writeLine(
-                                `"Please pass in ${escapeForCSharpString(param.name)} or set the environment variable ${escapeForCSharpString(param.environmentVariable)}."`
-                            );
-                            innerWriter.dedent();
-                            innerWriter.writeLine(");");
+                            // When a fallback condition is set (e.g. OAuth credentials are only
+                            // required if no token was provided), use the non-throwing
+                            // Environment.GetEnvironmentVariable so a missing env var falls through
+                            // to a downstream validation that surfaces the full set of auth options
+                            // (e.g. "provide either a token or both clientId and clientSecret").
+                            if (group.condition != null) {
+                                innerWriter.write(`${target} ??= Environment.GetEnvironmentVariable(`);
+                                innerWriter.writeNode(this.csharp.string_({ string: param.environmentVariable }));
+                                innerWriter.writeLine(");");
+                            } else {
+                                innerWriter.writeLine(`${target} ??= ${GetFromEnvironmentOrThrow}(`);
+                                innerWriter.indent();
+                                innerWriter.writeNode(this.csharp.string_({ string: param.environmentVariable }));
+                                innerWriter.writeLine(",");
+                                innerWriter.writeLine(
+                                    `"Please pass in ${escapeForCSharpString(param.name)} or set the environment variable ${escapeForCSharpString(param.environmentVariable)}."`
+                                );
+                                innerWriter.dedent();
+                                innerWriter.writeLine(");");
+                            }
                         }
                         if (group.condition != null) {
                             innerWriter.endControlFlow();
@@ -964,6 +975,20 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                 // or a pre-fetched bearer token. Both paths are wired up in the constructor;
                 // a runtime check enforces that the caller provides one valid combination.
                 // All three params are therefore optional at the C# API layer.
+                //
+                // Guard against a (rare) collision with a sibling bearer scheme whose token
+                // identifier also resolves to `token`. Without this, the dedup in
+                // `getConstructorParameters` would silently drop one of the two `token` params,
+                // breaking either the OAuth token override or the bearer auth header.
+                const collidingBearer = this.context.ir.auth.schemes.find(
+                    (s) => s.type === "bearer" && this.case.camelSafe(s.token) === "token"
+                );
+                if (collidingBearer != null) {
+                    throw new Error(
+                        "OAuth token override parameter `token` collides with a bearer auth scheme " +
+                            "whose token also resolves to `token`. Rename the bearer token in the IR to disambiguate."
+                    );
+                }
                 const tokenAccess = this.settings.unifiedClientOptions ? "clientOptions.Token" : "token";
                 const envVarFallbackCondition = `${tokenAccess} == null`;
                 return [

--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -48,6 +48,17 @@ interface ConstructorParameter {
      * When present, the parameter is optional and uses this value as fallback.
      */
     clientDefault?: Literal;
+    /**
+     * If true, this parameter is omitted from generated example snippets.
+     * Used for the OAuth `token` override parameter so example snippets continue
+     * to demonstrate the credentials flow by default.
+     */
+    skipInSnippets?: boolean;
+    /**
+     * If set, the env var fallback for this parameter is wrapped in `if (<condition>) { ... }`.
+     * Used to skip OAuth client-credentials env var lookups when the user has provided a token.
+     */
+    envVarFallbackCondition?: string;
 }
 
 interface LiteralParameter {
@@ -270,7 +281,10 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
         // when the same key is added twice, so we dedup here. Earlier entries
         // win; we preserve the IR-established ordering of required > optional
         // > literal so the most specific / required scheme takes precedence.
-        const authHeaderCandidates: { headerName: string; entry: ast.Dictionary.MapEntry }[] = [];
+        const authHeaderCandidates: {
+            headerName: string;
+            entry: ast.Dictionary.MapEntry;
+        }[] = [];
 
         for (const param of [...requiredParameters, ...optionalParameters]) {
             if (param.header != null) {
@@ -374,8 +388,33 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                         );
                     }
 
-                    for (const param of optionalParameters) {
-                        if (param.environmentVariable != null) {
+                    // Group env var fallbacks by their fallback condition so that
+                    // params sharing a condition (e.g. OAuth credentials when no token was passed)
+                    // emit inside a single `if` block.
+                    const envVarParams = optionalParameters.filter((p) => p.environmentVariable != null);
+                    const envVarGroups: {
+                        condition: string | undefined;
+                        params: ConstructorParameter[];
+                    }[] = [];
+                    for (const param of envVarParams) {
+                        const last = envVarGroups[envVarGroups.length - 1];
+                        if (last != null && last.condition === param.envVarFallbackCondition) {
+                            last.params.push(param);
+                        } else {
+                            envVarGroups.push({
+                                condition: param.envVarFallbackCondition,
+                                params: [param]
+                            });
+                        }
+                    }
+                    for (const group of envVarGroups) {
+                        if (group.condition != null) {
+                            innerWriter.controlFlow("if", this.csharp.codeblock(group.condition));
+                        }
+                        for (const param of group.params) {
+                            if (param.environmentVariable == null) {
+                                continue;
+                            }
                             const target = paramAccess(param);
                             innerWriter.writeLine(`${target} ??= ${GetFromEnvironmentOrThrow}(`);
                             innerWriter.indent();
@@ -386,6 +425,9 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                             );
                             innerWriter.dedent();
                             innerWriter.writeLine(");");
+                        }
+                        if (group.condition != null) {
+                            innerWriter.endControlFlow();
                         }
                     }
 
@@ -530,6 +572,27 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                             this.oauth.configuration.tokenEndpoint.endpointReference.serviceId
                         );
 
+                        const tokenAccess = unified ? "clientOptions.Token" : "token";
+                        const clientIdAccess = unified ? "clientOptions.ClientId" : "clientId";
+                        const clientSecretAccess = unified ? "clientOptions.ClientSecret" : "clientSecret";
+
+                        // Token override path: use the pre-fetched bearer token directly.
+                        innerWriter.controlFlow("if", this.csharp.codeblock(`${tokenAccess} != null`));
+                        innerWriter.writeTextStatement(
+                            `clientOptionsWithAuth.Headers["Authorization"] = $"Bearer {${tokenAccess}}"`
+                        );
+                        innerWriter.alternativeControlFlow("else");
+
+                        // Runtime validation: when no token is provided, both credentials are required.
+                        innerWriter.controlFlow(
+                            "if",
+                            this.csharp.codeblock(`${clientIdAccess} == null || ${clientSecretAccess} == null`)
+                        );
+                        innerWriter.writeTextStatement(
+                            "throw new ArgumentException(\"Please provide either a 'token' or both 'clientId' and 'clientSecret'.\")"
+                        );
+                        innerWriter.endControlFlow();
+
                         // Use clientOptions (platform headers only) for OAuth token requests
                         const arguments_ = [
                             this.generation.Types.RawClient.new({
@@ -537,10 +600,11 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                             })
                         ];
                         const oauthAdditionalParams = this.getOAuthAdditionalParamNames();
-                        const clientIdAccess = unified ? "clientOptions.ClientId" : "clientId";
-                        const clientSecretAccess = unified ? "clientOptions.ClientSecret" : "clientSecret";
+                        // Property accesses can't be tracked through nullable flow analysis,
+                        // so silence the warning with `!` after the explicit null check above.
+                        const credentialSuffix = unified ? "!" : "";
                         innerWriter.write(
-                            `var tokenProvider = new OAuthTokenProvider(${clientIdAccess}, ${clientSecretAccess}, `
+                            `var tokenProvider = new OAuthTokenProvider(${clientIdAccess}${credentialSuffix}, ${clientSecretAccess}${credentialSuffix}, `
                         );
                         for (const param of oauthAdditionalParams) {
                             const paramRef = unified ? `clientOptions.${this.toPascalCase(param)}` : param;
@@ -558,6 +622,7 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                         innerWriter.writeTextStatement(
                             `clientOptionsWithAuth.Headers["Authorization"] = new Func<global::System.Threading.Tasks.ValueTask<string>>(async () => await tokenProvider.${this.names.methods.getAccessTokenAsync}().ConfigureAwait(false))`
                         );
+                        innerWriter.endControlFlow();
                     }
 
                     if (this.inferred != null) {
@@ -677,9 +742,15 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
 
         if (this.settings.unifiedClientOptions) {
             // In unified mode, auth params become named properties inside ClientOptions
-            const clientOptionsFields: Array<{ name: string; assignment: ast.CodeBlock | ast.AstNode }> = [];
+            const clientOptionsFields: Array<{
+                name: string;
+                assignment: ast.CodeBlock | ast.AstNode;
+            }> = [];
 
             for (const param of allParameters) {
+                if (param.skipInSnippets) {
+                    continue;
+                }
                 if (param.environmentVariable != null && !includeEnvVarArguments) {
                     continue;
                 }
@@ -718,6 +789,9 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
             }
         } else {
             for (const param of allParameters) {
+                if (param.skipInSnippets) {
+                    continue;
+                }
                 // Skip parameters with environment variables unless explicitly including them
                 if (param.environmentVariable != null && !includeEnvVarArguments) {
                     continue;
@@ -886,11 +960,17 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
             }
         } else if (scheme.type === "oauth") {
             if (this.oauth !== null) {
+                // OAuth supports two auth modes: client credentials (clientId + clientSecret)
+                // or a pre-fetched bearer token. Both paths are wired up in the constructor;
+                // a runtime check enforces that the caller provides one valid combination.
+                // All three params are therefore optional at the C# API layer.
+                const tokenAccess = this.settings.unifiedClientOptions ? "clientOptions.Token" : "token";
+                const envVarFallbackCondition = `${tokenAccess} == null`;
                 return [
                     {
                         name: "clientId",
                         docs: "The clientId to use for authentication.",
-                        isOptional,
+                        isOptional: true,
                         typeReference: FernIr.TypeReference.primitive({
                             v1: FernIr.PrimitiveTypeV1.String,
                             v2: FernIr.PrimitiveTypeV2.string({
@@ -900,12 +980,13 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                         }),
                         type: this.Primitive.string,
                         environmentVariable: scheme.configuration.clientIdEnvVar,
+                        envVarFallbackCondition,
                         exampleValue: "client_id"
                     },
                     {
                         name: "clientSecret",
                         docs: "The clientSecret to use for authentication.",
-                        isOptional,
+                        isOptional: true,
                         typeReference: FernIr.TypeReference.primitive({
                             v1: FernIr.PrimitiveTypeV1.String,
                             v2: FernIr.PrimitiveTypeV2.string({
@@ -915,9 +996,27 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                         }),
                         type: this.Primitive.string,
                         environmentVariable: scheme.configuration.clientSecretEnvVar,
+                        envVarFallbackCondition,
                         exampleValue: "client_secret"
                     },
-                    ...this.getOAuthAdditionalConstructorParams(scheme, isOptional)
+                    ...this.getOAuthAdditionalConstructorParams(scheme, true).map((p) => ({
+                        ...p,
+                        envVarFallbackCondition: p.environmentVariable != null ? envVarFallbackCondition : undefined
+                    })),
+                    {
+                        name: "token",
+                        docs: "A pre-fetched bearer token. When provided, the OAuth client credentials flow is bypassed.",
+                        isOptional: true,
+                        typeReference: FernIr.TypeReference.primitive({
+                            v1: FernIr.PrimitiveTypeV1.String,
+                            v2: FernIr.PrimitiveTypeV2.string({
+                                default: undefined,
+                                validation: undefined
+                            })
+                        }),
+                        type: this.Primitive.string,
+                        skipInSnippets: true
+                    }
                 ];
             } else {
                 this.context.logger.warn(

--- a/seed/csharp-sdk/any-auth/README.md
+++ b/seed/csharp-sdk/any-auth/README.md
@@ -11,6 +11,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
 - [Installation](#installation)
 - [Reference](#reference)
 - [Usage](#usage)
+- [Authentication](#authentication)
 - [Exception Handling](#exception-handling)
 - [Advanced](#advanced)
   - [Retries](#retries)
@@ -51,6 +52,25 @@ await client.Auth.GetTokenAsync(
         GrantType = "client_credentials",
     }
 );
+```
+
+## Authentication
+
+The SDK supports authenticating via the OAuth client credentials flow (clientId + clientSecret) or by
+providing a pre-fetched bearer token. Choose whichever option fits your environment:
+
+```csharp
+using SeedAnyAuth;
+
+// Option 1: OAuth client credentials flow (the SDK fetches and refreshes tokens automatically)
+var client = new SeedAnyAuthClient(clientId: "client_id", clientSecret: "client_secret");
+```
+
+```csharp
+using SeedAnyAuth;
+
+// Option 2: Pre-fetched bearer token (the SDK skips the OAuth flow)
+var client = new SeedAnyAuthClient(token: "my-pre-generated-bearer-token");
 ```
 
 ## Exception Handling

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/SeedAnyAuthClient.cs
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/SeedAnyAuthClient.cs
@@ -24,14 +24,11 @@ public partial class SeedAnyAuthClient : ISeedAnyAuthClient
             "MY_API_KEY",
             "Please pass in apiKey or set the environment variable MY_API_KEY."
         );
-        clientId ??= GetFromEnvironmentOrThrow(
-            "MY_CLIENT_ID",
-            "Please pass in clientId or set the environment variable MY_CLIENT_ID."
-        );
-        clientSecret ??= GetFromEnvironmentOrThrow(
-            "MY_CLIENT_SECRET",
-            "Please pass in clientSecret or set the environment variable MY_CLIENT_SECRET."
-        );
+        if (token == null)
+        {
+            clientId ??= Environment.GetEnvironmentVariable("MY_CLIENT_ID");
+            clientSecret ??= Environment.GetEnvironmentVariable("MY_CLIENT_SECRET");
+        }
         username ??= GetFromEnvironmentOrThrow(
             "MY_USERNAME",
             "Please pass in username or set the environment variable MY_USERNAME."

--- a/seed/csharp-sdk/endpoint-security-auth/README.md
+++ b/seed/csharp-sdk/endpoint-security-auth/README.md
@@ -11,6 +11,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
 - [Installation](#installation)
 - [Reference](#reference)
 - [Usage](#usage)
+- [Authentication](#authentication)
 - [Exception Handling](#exception-handling)
 - [Advanced](#advanced)
   - [Retries](#retries)
@@ -58,6 +59,25 @@ await client.Auth.GetTokenAsync(
         GrantType = "client_credentials",
     }
 );
+```
+
+## Authentication
+
+The SDK supports authenticating via the OAuth client credentials flow (clientId + clientSecret) or by
+providing a pre-fetched bearer token. Choose whichever option fits your environment:
+
+```csharp
+using SeedEndpointSecurityAuth;
+
+// Option 1: OAuth client credentials flow (the SDK fetches and refreshes tokens automatically)
+var client = new SeedEndpointSecurityAuthClient(clientId: "client_id", clientSecret: "client_secret");
+```
+
+```csharp
+using SeedEndpointSecurityAuth;
+
+// Option 2: Pre-fetched bearer token (the SDK skips the OAuth flow)
+var client = new SeedEndpointSecurityAuthClient(token: "my-pre-generated-bearer-token");
 ```
 
 ## Exception Handling

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuthClient.cs
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuthClient.cs
@@ -24,14 +24,11 @@ public partial class SeedEndpointSecurityAuthClient : ISeedEndpointSecurityAuthC
             "MY_API_KEY",
             "Please pass in apiKey or set the environment variable MY_API_KEY."
         );
-        clientId ??= GetFromEnvironmentOrThrow(
-            "MY_CLIENT_ID",
-            "Please pass in clientId or set the environment variable MY_CLIENT_ID."
-        );
-        clientSecret ??= GetFromEnvironmentOrThrow(
-            "MY_CLIENT_SECRET",
-            "Please pass in clientSecret or set the environment variable MY_CLIENT_SECRET."
-        );
+        if (token == null)
+        {
+            clientId ??= Environment.GetEnvironmentVariable("MY_CLIENT_ID");
+            clientSecret ??= Environment.GetEnvironmentVariable("MY_CLIENT_SECRET");
+        }
         username ??= GetFromEnvironmentOrThrow(
             "MY_USERNAME",
             "Please pass in username or set the environment variable MY_USERNAME."

--- a/seed/csharp-sdk/oauth-client-credentials-custom/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-custom/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/README.md
@@ -11,6 +11,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
 - [Installation](#installation)
 - [Reference](#reference)
 - [Usage](#usage)
+- [Authentication](#authentication)
 - [Exception Handling](#exception-handling)
 - [Advanced](#advanced)
   - [Retries](#retries)
@@ -54,6 +55,25 @@ await client.Auth.GetTokenWithClientCredentialsAsync(
         Scope = "scope",
     }
 );
+```
+
+## Authentication
+
+The SDK supports authenticating via the OAuth client credentials flow (clientId + clientSecret) or by
+providing a pre-fetched bearer token. Choose whichever option fits your environment:
+
+```csharp
+using SeedOauthClientCredentials;
+
+// Option 1: OAuth client credentials flow (the SDK fetches and refreshes tokens automatically)
+var client = new SeedOauthClientCredentialsClient(clientId: "client_id", clientSecret: "client_secret");
+```
+
+```csharp
+using SeedOauthClientCredentials;
+
+// Option 2: Pre-fetched bearer token (the SDK skips the OAuth flow)
+var client = new SeedOauthClientCredentialsClient(token: "my-pre-generated-bearer-token");
 ```
 
 ## Exception Handling

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
@@ -9,10 +9,11 @@ public partial class SeedOauthClientCredentialsClient : ISeedOauthClientCredenti
     private readonly RawClient _client;
 
     public SeedOauthClientCredentialsClient(
-        string clientId,
-        string clientSecret,
-        string entityId,
-        string scp,
+        string? clientId = null,
+        string? clientSecret = null,
+        string? entityId = null,
+        string? scp = null,
+        string? token = null,
         ClientOptions? clientOptions = null
     )
     {
@@ -34,17 +35,30 @@ public partial class SeedOauthClientCredentialsClient : ISeedOauthClientCredenti
             }
         }
         var clientOptionsWithAuth = clientOptions.Clone();
-        var tokenProvider = new OAuthTokenProvider(
-            clientId,
-            clientSecret,
-            entityId,
-            scp,
-            new AuthClient(new RawClient(clientOptions))
-        );
-        clientOptionsWithAuth.Headers["Authorization"] =
-            new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
-                await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+        if (token != null)
+        {
+            clientOptionsWithAuth.Headers["Authorization"] = $"Bearer {token}";
+        }
+        else
+        {
+            if (clientId == null || clientSecret == null)
+            {
+                throw new ArgumentException(
+                    "Please provide either a 'token' or both 'clientId' and 'clientSecret'."
+                );
+            }
+            var tokenProvider = new OAuthTokenProvider(
+                clientId,
+                clientSecret,
+                entityId,
+                scp,
+                new AuthClient(new RawClient(clientOptions))
             );
+            clientOptionsWithAuth.Headers["Authorization"] =
+                new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
+                    await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+                );
+        }
         _client = new RawClient(clientOptionsWithAuth);
         Auth = new AuthClient(_client);
         NestedNoAuth = new NestedNoAuthClient(_client);

--- a/seed/csharp-sdk/oauth-client-credentials-default/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-default/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-default/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-default/README.md
@@ -11,6 +11,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
 - [Installation](#installation)
 - [Reference](#reference)
 - [Usage](#usage)
+- [Authentication](#authentication)
 - [Exception Handling](#exception-handling)
 - [Advanced](#advanced)
   - [Retries](#retries)
@@ -50,6 +51,25 @@ await client.Auth.GetTokenAsync(
         GrantType = "client_credentials",
     }
 );
+```
+
+## Authentication
+
+The SDK supports authenticating via the OAuth client credentials flow (clientId + clientSecret) or by
+providing a pre-fetched bearer token. Choose whichever option fits your environment:
+
+```csharp
+using SeedOauthClientCredentialsDefault;
+
+// Option 1: OAuth client credentials flow (the SDK fetches and refreshes tokens automatically)
+var client = new SeedOauthClientCredentialsDefaultClient(clientId: "client_id", clientSecret: "client_secret");
+```
+
+```csharp
+using SeedOauthClientCredentialsDefault;
+
+// Option 2: Pre-fetched bearer token (the SDK skips the OAuth flow)
+var client = new SeedOauthClientCredentialsDefaultClient(token: "my-pre-generated-bearer-token");
 ```
 
 ## Exception Handling

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefaultClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefaultClient.cs
@@ -10,8 +10,9 @@ public partial class SeedOauthClientCredentialsDefaultClient
     private readonly RawClient _client;
 
     public SeedOauthClientCredentialsDefaultClient(
-        string clientId,
-        string clientSecret,
+        string? clientId = null,
+        string? clientSecret = null,
+        string? token = null,
         ClientOptions? clientOptions = null
     )
     {
@@ -33,15 +34,28 @@ public partial class SeedOauthClientCredentialsDefaultClient
             }
         }
         var clientOptionsWithAuth = clientOptions.Clone();
-        var tokenProvider = new OAuthTokenProvider(
-            clientId,
-            clientSecret,
-            new AuthClient(new RawClient(clientOptions))
-        );
-        clientOptionsWithAuth.Headers["Authorization"] =
-            new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
-                await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+        if (token != null)
+        {
+            clientOptionsWithAuth.Headers["Authorization"] = $"Bearer {token}";
+        }
+        else
+        {
+            if (clientId == null || clientSecret == null)
+            {
+                throw new ArgumentException(
+                    "Please provide either a 'token' or both 'clientId' and 'clientSecret'."
+                );
+            }
+            var tokenProvider = new OAuthTokenProvider(
+                clientId,
+                clientSecret,
+                new AuthClient(new RawClient(clientOptions))
             );
+            clientOptionsWithAuth.Headers["Authorization"] =
+                new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
+                    await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+                );
+        }
         _client = new RawClient(clientOptionsWithAuth);
         Auth = new AuthClient(_client);
         NestedNoAuth = new NestedNoAuthClient(_client);

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/README.md
@@ -11,6 +11,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
 - [Installation](#installation)
 - [Reference](#reference)
 - [Usage](#usage)
+- [Authentication](#authentication)
 - [Exception Handling](#exception-handling)
 - [Advanced](#advanced)
   - [Retries](#retries)
@@ -52,6 +53,25 @@ await client.Auth.GetTokenWithClientCredentialsAsync(
         Scope = "scope",
     }
 );
+```
+
+## Authentication
+
+The SDK supports authenticating via the OAuth client credentials flow (clientId + clientSecret) or by
+providing a pre-fetched bearer token. Choose whichever option fits your environment:
+
+```csharp
+using SeedOauthClientCredentialsEnvironmentVariables;
+
+// Option 1: OAuth client credentials flow (the SDK fetches and refreshes tokens automatically)
+var client = new SeedOauthClientCredentialsEnvironmentVariablesClient(clientId: "client_id", clientSecret: "client_secret");
+```
+
+```csharp
+using SeedOauthClientCredentialsEnvironmentVariables;
+
+// Option 2: Pre-fetched bearer token (the SDK skips the OAuth flow)
+var client = new SeedOauthClientCredentialsEnvironmentVariablesClient(token: "my-pre-generated-bearer-token");
 ```
 
 ## Exception Handling

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariablesClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariablesClient.cs
@@ -12,17 +12,21 @@ public partial class SeedOauthClientCredentialsEnvironmentVariablesClient
     public SeedOauthClientCredentialsEnvironmentVariablesClient(
         string? clientId = null,
         string? clientSecret = null,
+        string? token = null,
         ClientOptions? clientOptions = null
     )
     {
-        clientId ??= GetFromEnvironmentOrThrow(
-            "CLIENT_ID",
-            "Please pass in clientId or set the environment variable CLIENT_ID."
-        );
-        clientSecret ??= GetFromEnvironmentOrThrow(
-            "CLIENT_SECRET",
-            "Please pass in clientSecret or set the environment variable CLIENT_SECRET."
-        );
+        if (token == null)
+        {
+            clientId ??= GetFromEnvironmentOrThrow(
+                "CLIENT_ID",
+                "Please pass in clientId or set the environment variable CLIENT_ID."
+            );
+            clientSecret ??= GetFromEnvironmentOrThrow(
+                "CLIENT_SECRET",
+                "Please pass in clientSecret or set the environment variable CLIENT_SECRET."
+            );
+        }
         clientOptions ??= new ClientOptions();
         var platformHeaders = new Headers(
             new Dictionary<string, string>()
@@ -41,15 +45,28 @@ public partial class SeedOauthClientCredentialsEnvironmentVariablesClient
             }
         }
         var clientOptionsWithAuth = clientOptions.Clone();
-        var tokenProvider = new OAuthTokenProvider(
-            clientId,
-            clientSecret,
-            new AuthClient(new RawClient(clientOptions))
-        );
-        clientOptionsWithAuth.Headers["Authorization"] =
-            new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
-                await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+        if (token != null)
+        {
+            clientOptionsWithAuth.Headers["Authorization"] = $"Bearer {token}";
+        }
+        else
+        {
+            if (clientId == null || clientSecret == null)
+            {
+                throw new ArgumentException(
+                    "Please provide either a 'token' or both 'clientId' and 'clientSecret'."
+                );
+            }
+            var tokenProvider = new OAuthTokenProvider(
+                clientId,
+                clientSecret,
+                new AuthClient(new RawClient(clientOptions))
             );
+            clientOptionsWithAuth.Headers["Authorization"] =
+                new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
+                    await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+                );
+        }
         _client = new RawClient(clientOptionsWithAuth);
         Auth = new AuthClient(_client);
         NestedNoAuth = new NestedNoAuthClient(_client);

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariablesClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariablesClient.cs
@@ -18,14 +18,8 @@ public partial class SeedOauthClientCredentialsEnvironmentVariablesClient
     {
         if (token == null)
         {
-            clientId ??= GetFromEnvironmentOrThrow(
-                "CLIENT_ID",
-                "Please pass in clientId or set the environment variable CLIENT_ID."
-            );
-            clientSecret ??= GetFromEnvironmentOrThrow(
-                "CLIENT_SECRET",
-                "Please pass in clientSecret or set the environment variable CLIENT_SECRET."
-            );
+            clientId ??= Environment.GetEnvironmentVariable("CLIENT_ID");
+            clientSecret ??= Environment.GetEnvironmentVariable("CLIENT_SECRET");
         }
         clientOptions ??= new ClientOptions();
         var platformHeaders = new Headers(

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/README.md
@@ -11,6 +11,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
 - [Installation](#installation)
 - [Reference](#reference)
 - [Usage](#usage)
+- [Authentication](#authentication)
 - [Exception Handling](#exception-handling)
 - [Advanced](#advanced)
   - [Retries](#retries)
@@ -52,6 +53,25 @@ await client.Auth.GetTokenWithClientCredentialsAsync(
         Scope = "read:users",
     }
 );
+```
+
+## Authentication
+
+The SDK supports authenticating via the OAuth client credentials flow (clientId + clientSecret) or by
+providing a pre-fetched bearer token. Choose whichever option fits your environment:
+
+```csharp
+using SeedOauthClientCredentialsMandatoryAuth;
+
+// Option 1: OAuth client credentials flow (the SDK fetches and refreshes tokens automatically)
+var client = new SeedOauthClientCredentialsMandatoryAuthClient(clientId: "client_id", clientSecret: "client_secret");
+```
+
+```csharp
+using SeedOauthClientCredentialsMandatoryAuth;
+
+// Option 2: Pre-fetched bearer token (the SDK skips the OAuth flow)
+var client = new SeedOauthClientCredentialsMandatoryAuthClient(token: "my-pre-generated-bearer-token");
 ```
 
 ## Exception Handling

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuthClient.cs
@@ -9,8 +9,9 @@ public partial class SeedOauthClientCredentialsMandatoryAuthClient
     private readonly RawClient _client;
 
     public SeedOauthClientCredentialsMandatoryAuthClient(
-        string clientId,
-        string clientSecret,
+        string? clientId = null,
+        string? clientSecret = null,
+        string? token = null,
         ClientOptions? clientOptions = null
     )
     {
@@ -32,15 +33,28 @@ public partial class SeedOauthClientCredentialsMandatoryAuthClient
             }
         }
         var clientOptionsWithAuth = clientOptions.Clone();
-        var tokenProvider = new OAuthTokenProvider(
-            clientId,
-            clientSecret,
-            new AuthClient(new RawClient(clientOptions))
-        );
-        clientOptionsWithAuth.Headers["Authorization"] =
-            new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
-                await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+        if (token != null)
+        {
+            clientOptionsWithAuth.Headers["Authorization"] = $"Bearer {token}";
+        }
+        else
+        {
+            if (clientId == null || clientSecret == null)
+            {
+                throw new ArgumentException(
+                    "Please provide either a 'token' or both 'clientId' and 'clientSecret'."
+                );
+            }
+            var tokenProvider = new OAuthTokenProvider(
+                clientId,
+                clientSecret,
+                new AuthClient(new RawClient(clientOptions))
             );
+            clientOptionsWithAuth.Headers["Authorization"] =
+                new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
+                    await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+                );
+        }
         _client = new RawClient(clientOptionsWithAuth);
         Auth = new AuthClient(_client);
         Nested = new NestedClient(_client);

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/.fern/metadata.json
@@ -6,8 +6,7 @@
     "unified-client-options": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/README.md
@@ -11,6 +11,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
 - [Installation](#installation)
 - [Reference](#reference)
 - [Usage](#usage)
+- [Authentication](#authentication)
 - [Exception Handling](#exception-handling)
 - [Advanced](#advanced)
   - [Retries](#retries)
@@ -54,6 +55,25 @@ await client.Auth.GetTokenWithClientCredentialsAsync(
         Scope = "read:users",
     }
 );
+```
+
+## Authentication
+
+The SDK supports authenticating via the OAuth client credentials flow (clientId + clientSecret) or by
+providing a pre-fetched bearer token. Choose whichever option fits your environment:
+
+```csharp
+using SeedOauthClientCredentialsMandatoryAuth;
+
+// Option 1: OAuth client credentials flow (the SDK fetches and refreshes tokens automatically)
+var client = new SeedOauthClientCredentialsMandatoryAuthClient(new ClientOptions { ClientId = "client_id", ClientSecret = "client_secret" });
+```
+
+```csharp
+using SeedOauthClientCredentialsMandatoryAuth;
+
+// Option 2: Pre-fetched bearer token (the SDK skips the OAuth flow)
+var client = new SeedOauthClientCredentialsMandatoryAuthClient(new ClientOptions { Token = "my-pre-generated-bearer-token" });
 ```
 
 ## Exception Handling

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/Core/Public/ClientOptions.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/Core/Public/ClientOptions.cs
@@ -19,6 +19,7 @@ public partial class ClientOptions
         AdditionalHeaders = other.AdditionalHeaders;
         ClientId = other.ClientId;
         ClientSecret = other.ClientSecret;
+        Token = other.Token;
     }
 
     /// <summary>
@@ -85,7 +86,7 @@ public partial class ClientOptions
     /// <summary>
     /// The clientId to use for authentication.
     /// </summary>
-    public required string ClientId { get;
+    public string? ClientId { get;
 #if NET5_0_OR_GREATER
         init;
 #else
@@ -96,7 +97,18 @@ public partial class ClientOptions
     /// <summary>
     /// The clientSecret to use for authentication.
     /// </summary>
-    public required string ClientSecret { get;
+    public string? ClientSecret { get;
+#if NET5_0_OR_GREATER
+        init;
+#else
+        set;
+#endif
+    }
+
+    /// <summary>
+    /// A pre-fetched bearer token. When provided, the OAuth client credentials flow is bypassed.
+    /// </summary>
+    public string? Token { get;
 #if NET5_0_OR_GREATER
         init;
 #else

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuthClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuthClient.cs
@@ -27,15 +27,28 @@ public partial class SeedOauthClientCredentialsMandatoryAuthClient
             }
         }
         var clientOptionsWithAuth = clientOptions.Clone();
-        var tokenProvider = new OAuthTokenProvider(
-            clientOptions.ClientId,
-            clientOptions.ClientSecret,
-            new AuthClient(new RawClient(clientOptions))
-        );
-        clientOptionsWithAuth.Headers["Authorization"] =
-            new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
-                await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+        if (clientOptions.Token != null)
+        {
+            clientOptionsWithAuth.Headers["Authorization"] = $"Bearer {clientOptions.Token}";
+        }
+        else
+        {
+            if (clientOptions.ClientId == null || clientOptions.ClientSecret == null)
+            {
+                throw new ArgumentException(
+                    "Please provide either a 'token' or both 'clientId' and 'clientSecret'."
+                );
+            }
+            var tokenProvider = new OAuthTokenProvider(
+                clientOptions.ClientId!,
+                clientOptions.ClientSecret!,
+                new AuthClient(new RawClient(clientOptions))
             );
+            clientOptionsWithAuth.Headers["Authorization"] =
+                new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
+                    await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+                );
+        }
         _client = new RawClient(clientOptionsWithAuth);
         Auth = new AuthClient(_client);
         Nested = new NestedClient(_client);

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/README.md
@@ -11,6 +11,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
 - [Installation](#installation)
 - [Reference](#reference)
 - [Usage](#usage)
+- [Authentication](#authentication)
 - [Exception Handling](#exception-handling)
 - [Advanced](#advanced)
   - [Retries](#retries)
@@ -53,6 +54,25 @@ await client.Auth.GetTokenAsync(
         Scope = "scope",
     }
 );
+```
+
+## Authentication
+
+The SDK supports authenticating via the OAuth client credentials flow (clientId + clientSecret) or by
+providing a pre-fetched bearer token. Choose whichever option fits your environment:
+
+```csharp
+using SeedOauthClientCredentials;
+
+// Option 1: OAuth client credentials flow (the SDK fetches and refreshes tokens automatically)
+var client = new SeedOauthClientCredentialsClient(clientId: "client_id", clientSecret: "client_secret");
+```
+
+```csharp
+using SeedOauthClientCredentials;
+
+// Option 2: Pre-fetched bearer token (the SDK skips the OAuth flow)
+var client = new SeedOauthClientCredentialsClient(token: "my-pre-generated-bearer-token");
 ```
 
 ## Exception Handling

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
@@ -10,8 +10,9 @@ public partial class SeedOauthClientCredentialsClient : ISeedOauthClientCredenti
     private readonly RawClient _client;
 
     public SeedOauthClientCredentialsClient(
-        string clientId,
-        string clientSecret,
+        string? clientId = null,
+        string? clientSecret = null,
+        string? token = null,
         ClientOptions? clientOptions = null
     )
     {
@@ -33,15 +34,28 @@ public partial class SeedOauthClientCredentialsClient : ISeedOauthClientCredenti
             }
         }
         var clientOptionsWithAuth = clientOptions.Clone();
-        var tokenProvider = new OAuthTokenProvider(
-            clientId,
-            clientSecret,
-            new AuthClient(new RawClient(clientOptions))
-        );
-        clientOptionsWithAuth.Headers["Authorization"] =
-            new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
-                await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+        if (token != null)
+        {
+            clientOptionsWithAuth.Headers["Authorization"] = $"Bearer {token}";
+        }
+        else
+        {
+            if (clientId == null || clientSecret == null)
+            {
+                throw new ArgumentException(
+                    "Please provide either a 'token' or both 'clientId' and 'clientSecret'."
+                );
+            }
+            var tokenProvider = new OAuthTokenProvider(
+                clientId,
+                clientSecret,
+                new AuthClient(new RawClient(clientOptions))
             );
+            clientOptionsWithAuth.Headers["Authorization"] =
+                new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
+                    await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+                );
+        }
         _client = new RawClient(clientOptionsWithAuth);
         Auth = new AuthClient(_client);
         NestedNoAuth = new NestedNoAuthClient(_client);

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/README.md
@@ -11,6 +11,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
 - [Installation](#installation)
 - [Reference](#reference)
 - [Usage](#usage)
+- [Authentication](#authentication)
 - [Exception Handling](#exception-handling)
 - [Advanced](#advanced)
   - [Retries](#retries)
@@ -45,6 +46,25 @@ var client = new SeedApiClient("client_id", "client_secret");
 await client.Identity.GetTokenAsync(
     new GetTokenIdentityRequest { Username = "username", Password = "password" }
 );
+```
+
+## Authentication
+
+The SDK supports authenticating via the OAuth client credentials flow (clientId + clientSecret) or by
+providing a pre-fetched bearer token. Choose whichever option fits your environment:
+
+```csharp
+using SeedApi;
+
+// Option 1: OAuth client credentials flow (the SDK fetches and refreshes tokens automatically)
+var client = new SeedApiClient(clientId: "client_id", clientSecret: "client_secret");
+```
+
+```csharp
+using SeedApi;
+
+// Option 2: Pre-fetched bearer token (the SDK skips the OAuth flow)
+var client = new SeedApiClient(token: "my-pre-generated-bearer-token");
 ```
 
 ## Exception Handling

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi/SeedApiClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi/SeedApiClient.cs
@@ -6,7 +6,12 @@ public partial class SeedApiClient : ISeedApiClient
 {
     private readonly RawClient _client;
 
-    public SeedApiClient(string clientId, string clientSecret, ClientOptions? clientOptions = null)
+    public SeedApiClient(
+        string? clientId = null,
+        string? clientSecret = null,
+        string? token = null,
+        ClientOptions? clientOptions = null
+    )
     {
         clientOptions ??= new ClientOptions();
         var platformHeaders = new Headers(
@@ -26,15 +31,28 @@ public partial class SeedApiClient : ISeedApiClient
             }
         }
         var clientOptionsWithAuth = clientOptions.Clone();
-        var tokenProvider = new OAuthTokenProvider(
-            clientId,
-            clientSecret,
-            new IdentityClient(new RawClient(clientOptions))
-        );
-        clientOptionsWithAuth.Headers["Authorization"] =
-            new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
-                await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+        if (token != null)
+        {
+            clientOptionsWithAuth.Headers["Authorization"] = $"Bearer {token}";
+        }
+        else
+        {
+            if (clientId == null || clientSecret == null)
+            {
+                throw new ArgumentException(
+                    "Please provide either a 'token' or both 'clientId' and 'clientSecret'."
+                );
+            }
+            var tokenProvider = new OAuthTokenProvider(
+                clientId,
+                clientSecret,
+                new IdentityClient(new RawClient(clientOptions))
             );
+            clientOptionsWithAuth.Headers["Authorization"] =
+                new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
+                    await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+                );
+        }
         _client = new RawClient(clientOptionsWithAuth);
         Identity = new IdentityClient(_client);
         Plants = new PlantsClient(_client);

--- a/seed/csharp-sdk/oauth-client-credentials-reference/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-reference/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/README.md
@@ -11,6 +11,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
 - [Installation](#installation)
 - [Reference](#reference)
 - [Usage](#usage)
+- [Authentication](#authentication)
 - [Exception Handling](#exception-handling)
 - [Advanced](#advanced)
   - [Retries](#retries)
@@ -45,6 +46,25 @@ var client = new SeedOauthClientCredentialsReferenceClient("client_id", "client_
 await client.Auth.GetTokenAsync(
     new GetTokenRequest { ClientId = "client_id", ClientSecret = "client_secret" }
 );
+```
+
+## Authentication
+
+The SDK supports authenticating via the OAuth client credentials flow (clientId + clientSecret) or by
+providing a pre-fetched bearer token. Choose whichever option fits your environment:
+
+```csharp
+using SeedOauthClientCredentialsReference;
+
+// Option 1: OAuth client credentials flow (the SDK fetches and refreshes tokens automatically)
+var client = new SeedOauthClientCredentialsReferenceClient(clientId: "client_id", clientSecret: "client_secret");
+```
+
+```csharp
+using SeedOauthClientCredentialsReference;
+
+// Option 2: Pre-fetched bearer token (the SDK skips the OAuth flow)
+var client = new SeedOauthClientCredentialsReferenceClient(token: "my-pre-generated-bearer-token");
 ```
 
 ## Exception Handling

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReferenceClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReferenceClient.cs
@@ -8,8 +8,9 @@ public partial class SeedOauthClientCredentialsReferenceClient
     private readonly RawClient _client;
 
     public SeedOauthClientCredentialsReferenceClient(
-        string clientId,
-        string clientSecret,
+        string? clientId = null,
+        string? clientSecret = null,
+        string? token = null,
         ClientOptions? clientOptions = null
     )
     {
@@ -31,15 +32,28 @@ public partial class SeedOauthClientCredentialsReferenceClient
             }
         }
         var clientOptionsWithAuth = clientOptions.Clone();
-        var tokenProvider = new OAuthTokenProvider(
-            clientId,
-            clientSecret,
-            new AuthClient(new RawClient(clientOptions))
-        );
-        clientOptionsWithAuth.Headers["Authorization"] =
-            new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
-                await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+        if (token != null)
+        {
+            clientOptionsWithAuth.Headers["Authorization"] = $"Bearer {token}";
+        }
+        else
+        {
+            if (clientId == null || clientSecret == null)
+            {
+                throw new ArgumentException(
+                    "Please provide either a 'token' or both 'clientId' and 'clientSecret'."
+                );
+            }
+            var tokenProvider = new OAuthTokenProvider(
+                clientId,
+                clientSecret,
+                new AuthClient(new RawClient(clientOptions))
             );
+            clientOptionsWithAuth.Headers["Authorization"] =
+                new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
+                    await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+                );
+        }
         _client = new RawClient(clientOptionsWithAuth);
         Auth = new AuthClient(_client);
         Simple = new SimpleClient(_client);

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/README.md
@@ -11,6 +11,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
 - [Installation](#installation)
 - [Reference](#reference)
 - [Usage](#usage)
+- [Authentication](#authentication)
 - [Exception Handling](#exception-handling)
 - [Advanced](#advanced)
   - [Retries](#retries)
@@ -52,6 +53,25 @@ await client.Auth.GetTokenWithClientCredentialsAsync(
         Scope = "scope",
     }
 );
+```
+
+## Authentication
+
+The SDK supports authenticating via the OAuth client credentials flow (clientId + clientSecret) or by
+providing a pre-fetched bearer token. Choose whichever option fits your environment:
+
+```csharp
+using SeedOauthClientCredentialsWithVariables;
+
+// Option 1: OAuth client credentials flow (the SDK fetches and refreshes tokens automatically)
+var client = new SeedOauthClientCredentialsWithVariablesClient(clientId: "client_id", clientSecret: "client_secret");
+```
+
+```csharp
+using SeedOauthClientCredentialsWithVariables;
+
+// Option 2: Pre-fetched bearer token (the SDK skips the OAuth flow)
+var client = new SeedOauthClientCredentialsWithVariablesClient(token: "my-pre-generated-bearer-token");
 ```
 
 ## Exception Handling

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariablesClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariablesClient.cs
@@ -10,8 +10,9 @@ public partial class SeedOauthClientCredentialsWithVariablesClient
     private readonly RawClient _client;
 
     public SeedOauthClientCredentialsWithVariablesClient(
-        string clientId,
-        string clientSecret,
+        string? clientId = null,
+        string? clientSecret = null,
+        string? token = null,
         ClientOptions? clientOptions = null
     )
     {
@@ -33,15 +34,28 @@ public partial class SeedOauthClientCredentialsWithVariablesClient
             }
         }
         var clientOptionsWithAuth = clientOptions.Clone();
-        var tokenProvider = new OAuthTokenProvider(
-            clientId,
-            clientSecret,
-            new AuthClient(new RawClient(clientOptions))
-        );
-        clientOptionsWithAuth.Headers["Authorization"] =
-            new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
-                await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+        if (token != null)
+        {
+            clientOptionsWithAuth.Headers["Authorization"] = $"Bearer {token}";
+        }
+        else
+        {
+            if (clientId == null || clientSecret == null)
+            {
+                throw new ArgumentException(
+                    "Please provide either a 'token' or both 'clientId' and 'clientSecret'."
+                );
+            }
+            var tokenProvider = new OAuthTokenProvider(
+                clientId,
+                clientSecret,
+                new AuthClient(new RawClient(clientOptions))
             );
+            clientOptionsWithAuth.Headers["Authorization"] =
+                new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
+                    await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+                );
+        }
         _client = new RawClient(clientOptionsWithAuth);
         Auth = new AuthClient(_client);
         NestedNoAuth = new NestedNoAuthClient(_client);

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/.fern/metadata.json
@@ -6,8 +6,7 @@
     "include-exception-handler": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/README.md
@@ -11,6 +11,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
 - [Installation](#installation)
 - [Reference](#reference)
 - [Usage](#usage)
+- [Authentication](#authentication)
 - [Exception Handling](#exception-handling)
 - [Advanced](#advanced)
   - [Retries](#retries)
@@ -52,6 +53,25 @@ await client.Auth.GetTokenWithClientCredentialsAsync(
         Scope = "read:users",
     }
 );
+```
+
+## Authentication
+
+The SDK supports authenticating via the OAuth client credentials flow (clientId + clientSecret) or by
+providing a pre-fetched bearer token. Choose whichever option fits your environment:
+
+```csharp
+using SeedOauthClientCredentials;
+
+// Option 1: OAuth client credentials flow (the SDK fetches and refreshes tokens automatically)
+var client = new SeedOauthClientCredentialsClient(clientId: "client_id", clientSecret: "client_secret");
+```
+
+```csharp
+using SeedOauthClientCredentials;
+
+// Option 2: Pre-fetched bearer token (the SDK skips the OAuth flow)
+var client = new SeedOauthClientCredentialsClient(token: "my-pre-generated-bearer-token");
 ```
 
 ## Exception Handling

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
@@ -9,8 +9,9 @@ public partial class SeedOauthClientCredentialsClient : ISeedOauthClientCredenti
     private readonly RawClient _client;
 
     public SeedOauthClientCredentialsClient(
-        string clientId,
-        string clientSecret,
+        string? clientId = null,
+        string? clientSecret = null,
+        string? token = null,
         ClientOptions? clientOptions = null
     )
     {
@@ -37,15 +38,28 @@ public partial class SeedOauthClientCredentialsClient : ISeedOauthClientCredenti
                 }
             }
             var clientOptionsWithAuth = clientOptions.Clone();
-            var tokenProvider = new OAuthTokenProvider(
-                clientId,
-                clientSecret,
-                new AuthClient(new RawClient(clientOptions))
-            );
-            clientOptionsWithAuth.Headers["Authorization"] =
-                new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
-                    await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+            if (token != null)
+            {
+                clientOptionsWithAuth.Headers["Authorization"] = $"Bearer {token}";
+            }
+            else
+            {
+                if (clientId == null || clientSecret == null)
+                {
+                    throw new ArgumentException(
+                        "Please provide either a 'token' or both 'clientId' and 'clientSecret'."
+                    );
+                }
+                var tokenProvider = new OAuthTokenProvider(
+                    clientId,
+                    clientSecret,
+                    new AuthClient(new RawClient(clientOptions))
                 );
+                clientOptionsWithAuth.Headers["Authorization"] =
+                    new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
+                        await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+                    );
+            }
             _client = new RawClient(clientOptionsWithAuth);
             Auth = new AuthClient(_client);
             NestedNoAuth = new NestedNoAuthClient(_client);

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/.fern/metadata.json
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/.fern/metadata.json
@@ -4,8 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {},
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/README.md
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/README.md
@@ -11,6 +11,7 @@ The Seed C# library provides convenient access to the Seed APIs from C#.
 - [Installation](#installation)
 - [Reference](#reference)
 - [Usage](#usage)
+- [Authentication](#authentication)
 - [Exception Handling](#exception-handling)
 - [Advanced](#advanced)
   - [Retries](#retries)
@@ -52,6 +53,25 @@ await client.Auth.GetTokenWithClientCredentialsAsync(
         Scope = "read:users",
     }
 );
+```
+
+## Authentication
+
+The SDK supports authenticating via the OAuth client credentials flow (clientId + clientSecret) or by
+providing a pre-fetched bearer token. Choose whichever option fits your environment:
+
+```csharp
+using SeedOauthClientCredentials;
+
+// Option 1: OAuth client credentials flow (the SDK fetches and refreshes tokens automatically)
+var client = new SeedOauthClientCredentialsClient(clientId: "client_id", clientSecret: "client_secret");
+```
+
+```csharp
+using SeedOauthClientCredentials;
+
+// Option 2: Pre-fetched bearer token (the SDK skips the OAuth flow)
+var client = new SeedOauthClientCredentialsClient(token: "my-pre-generated-bearer-token");
 ```
 
 ## Exception Handling

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/SeedOauthClientCredentialsClient.cs
@@ -9,8 +9,9 @@ public partial class SeedOauthClientCredentialsClient : ISeedOauthClientCredenti
     private readonly RawClient _client;
 
     public SeedOauthClientCredentialsClient(
-        string clientId,
-        string clientSecret,
+        string? clientId = null,
+        string? clientSecret = null,
+        string? token = null,
         ClientOptions? clientOptions = null
     )
     {
@@ -32,15 +33,28 @@ public partial class SeedOauthClientCredentialsClient : ISeedOauthClientCredenti
             }
         }
         var clientOptionsWithAuth = clientOptions.Clone();
-        var tokenProvider = new OAuthTokenProvider(
-            clientId,
-            clientSecret,
-            new AuthClient(new RawClient(clientOptions))
-        );
-        clientOptionsWithAuth.Headers["Authorization"] =
-            new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
-                await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+        if (token != null)
+        {
+            clientOptionsWithAuth.Headers["Authorization"] = $"Bearer {token}";
+        }
+        else
+        {
+            if (clientId == null || clientSecret == null)
+            {
+                throw new ArgumentException(
+                    "Please provide either a 'token' or both 'clientId' and 'clientSecret'."
+                );
+            }
+            var tokenProvider = new OAuthTokenProvider(
+                clientId,
+                clientSecret,
+                new AuthClient(new RawClient(clientOptions))
             );
+            clientOptionsWithAuth.Headers["Authorization"] =
+                new Func<global::System.Threading.Tasks.ValueTask<string>>(async () =>
+                    await tokenProvider.GetAccessTokenAsync().ConfigureAwait(false)
+                );
+        }
         _client = new RawClient(clientOptionsWithAuth);
         Auth = new AuthClient(_client);
         NestedNoAuth = new NestedNoAuthClient(_client);

--- a/seed/csharp-sdk/seed.yml
+++ b/seed/csharp-sdk/seed.yml
@@ -428,7 +428,6 @@ allowedFailures:
   - literal:no-custom-config
   - literal:readonly-constants
   - mixed-case
-  - oauth-client-credentials-custom
   - package-yml
   - pagination-uri-path
   - property-access


### PR DESCRIPTION
## Description
Linear ticket: Refs

Adds OAuth token override support to the C# SDK generator, mirroring the pattern already used by the Go, Python, Java, and TypeScript generators. When an API uses OAuth client credentials, the generated C# client now accepts either:
- `clientId` + `clientSecret` (existing behavior — the SDK fetches and refreshes tokens automatically), or
- `token` (new — the caller provides a pre-fetched bearer token, bypassing the OAuth flow).

All three parameters are optional. The constructor performs a runtime check that throws `ArgumentException` when neither valid auth combination is supplied. Environment-variable fallbacks for `clientId` / `clientSecret` are now skipped when a token is passed, so users who supply a token never trigger an env-var lookup.

## Changes Made
- **`generators/csharp/sdk/src/root-client/RootClientGenerator.ts`** — emits `clientId`, `clientSecret`, and `token` as optional constructor parameters; the constructor first checks for a token (and uses it directly), otherwise validates and runs the existing `OAuthTokenProvider` path. Env-var fallbacks for OAuth credentials are wrapped in `if (token == null)`. The new `token` parameter is excluded from generated example snippets so the credentials path remains the default in usage examples.
- **`generators/csharp/sdk/src/options/ClientOptionsGenerator.ts`** — adds `Token` alongside `ClientId` / `ClientSecret` for unified `ClientOptions` and makes all three optional. The existing copy constructor logic copies `Token` automatically.
- **`generators/csharp/sdk/src/readme/ReadmeSnippetBuilder.ts`** — emits an `Authentication` section for OAuth APIs showing both auth options (works for unified and non-unified modes).
- **`generators/csharp/sdk/features.yml`** — adds the `AUTHENTICATION` feature description shown above the snippets.
- **`generators/csharp/sdk/changes/unreleased/oauth-token-override.yml`** — `feat` changelog entry.
- **`seed/csharp-sdk/seed.yml`** — removes `oauth-client-credentials-custom` from `allowedFailures` (it now passes).
- **Regenerated seed fixtures** under `seed/csharp-sdk/oauth-client-credentials*` for all 11 variants.
- [x] Updated README.md generator

## Testing
- [x] Lint: `pnpm check` passes (biome).
- [x] Compile: `pnpm turbo run compile --filter @fern-api/fern-csharp-sdk` passes.
- [x] Seed regeneration: all 11 oauth-client-credentials* fixtures regenerated and pass.
- [x] Manual `dotnet build` of representative regenerated fixtures (`oauth-client-credentials-mandatory-auth/no-custom-config` and `unified-client-options`) succeeds with no new warnings.

### Sample regenerated client (non-unified mode)
```csharp
public SeedOauthClientCredentialsClient(
    string? clientId = null,
    string? clientSecret = null,
    string? token = null,
    ClientOptions? clientOptions = null
)
{
    // ... platform headers ...
    var clientOptionsWithAuth = clientOptions.Clone();
    if (token != null)
    {
        clientOptionsWithAuth.Headers["Authorization"] = $"Bearer {token}";
    }
    else
    {
        if (clientId == null || clientSecret == null)
        {
            throw new ArgumentException(
                "Please provide either a 'token' or both 'clientId' and 'clientSecret'."
            );
        }
        var tokenProvider = new OAuthTokenProvider(
            clientId,
            clientSecret,
            new AuthClient(new RawClient(clientOptions))
        );
        clientOptionsWithAuth.Headers["Authorization"] = /* lazy token fetch */;
    }
    // ...
}
```

### Sample generated README section
```
## Authentication

The SDK supports authenticating via the OAuth client credentials flow (clientId + clientSecret) or by
providing a pre-fetched bearer token. Choose whichever option fits your environment:

```csharp
using SeedOauthClientCredentials;

// Option 1: OAuth client credentials flow (the SDK fetches and refreshes tokens automatically)
var client = new SeedOauthClientCredentialsClient(clientId: "client_id", clientSecret: "client_secret");
```

```csharp
using SeedOauthClientCredentials;

// Option 2: Pre-fetched bearer token (the SDK skips the OAuth flow)
var client = new SeedOauthClientCredentialsClient(token: "my-pre-generated-bearer-token");
```
```


Link to Devin session: https://app.devin.ai/sessions/23808e58ed2b48deab9bd9a24284c8a6
Requested by: @jsklan