### PR TITLE
fix(cli): respect `x-fern-ignore` in duplicate SDK method validation

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-fern-ignore-duplicate-overrides.yml
+++ b/packages/cli/cli/changes/unreleased/fix-fern-ignore-duplicate-overrides.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix `fern check` to respect `x-fern-ignore` when validating duplicate SDK method names. Operations marked with `x-fern-ignore: true` are now excluded from the duplicate override check.
+  type: fix

--- a/packages/cli/workspace/oss-validator/src/rules/no-duplicate-overrides/__test__/fixtures/fern-ignore/fern.config.json
+++ b/packages/cli/workspace/oss-validator/src/rules/no-duplicate-overrides/__test__/fixtures/fern-ignore/fern.config.json
@@ -1,0 +1,4 @@
+{
+    "organization": "test",
+    "version": "0.44.11"
+}

--- a/packages/cli/workspace/oss-validator/src/rules/no-duplicate-overrides/__test__/fixtures/fern-ignore/generators.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-duplicate-overrides/__test__/fixtures/fern-ignore/generators.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: ./openapi/openapi.yml
+      overrides: ./openapi/openapi-overrides.yml

--- a/packages/cli/workspace/oss-validator/src/rules/no-duplicate-overrides/__test__/fixtures/fern-ignore/openapi/openapi-overrides.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-duplicate-overrides/__test__/fixtures/fern-ignore/openapi/openapi-overrides.yml
@@ -1,0 +1,17 @@
+paths:
+  /v1/categories:
+    get:
+      x-fern-sdk-group-name: categories
+      x-fern-sdk-method-name: list
+  /v1/categories/{id}:
+    get:
+      x-fern-sdk-group-name: categories
+      x-fern-sdk-method-name: retrieve
+  /v1/connect/categories:
+    get:
+      x-fern-sdk-group-name: categories
+      x-fern-sdk-method-name: list
+  /v1/connect/categories/{id}:
+    get:
+      x-fern-sdk-group-name: categories
+      x-fern-sdk-method-name: retrieve

--- a/packages/cli/workspace/oss-validator/src/rules/no-duplicate-overrides/__test__/fixtures/fern-ignore/openapi/openapi.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-duplicate-overrides/__test__/fixtures/fern-ignore/openapi/openapi.yml
@@ -1,0 +1,63 @@
+openapi: 3.1.0
+info:
+  title: Sample API
+  version: 1.0.0
+paths:
+  /v1/categories:
+    get:
+      summary: List categories (deprecated)
+      operationId: list-categories-deprecated
+      x-fern-ignore: true
+      responses:
+        "200":
+          description: Successful retrieval
+          content:
+            application/json:
+              schema:
+                type: string
+  /v1/categories/{id}:
+    get:
+      summary: Retrieve category (deprecated)
+      operationId: retrieve-category-deprecated
+      x-fern-ignore: true
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful retrieval
+          content:
+            application/json:
+              schema:
+                type: string
+  /v1/connect/categories:
+    get:
+      summary: List categories
+      operationId: list-categories
+      responses:
+        "200":
+          description: Successful retrieval
+          content:
+            application/json:
+              schema:
+                type: string
+  /v1/connect/categories/{id}:
+    get:
+      summary: Retrieve category
+      operationId: retrieve-category
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful retrieval
+          content:
+            application/json:
+              schema:
+                type: string

--- a/packages/cli/workspace/oss-validator/src/rules/no-duplicate-overrides/__test__/no-duplicate-overrides.test.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-duplicate-overrides/__test__/no-duplicate-overrides.test.ts
@@ -134,6 +134,20 @@ describe("no-duplicate-overrides", () => {
         expect(violations).toEqual([]);
     }, 10_000);
 
+    it("x-fern-ignore - no conflict", async () => {
+        const violations = await getViolationsForRule({
+            rule: NoDuplicateOverridesRule,
+            absolutePathToWorkspace: join(
+                AbsoluteFilePath.of(__dirname),
+                RelativeFilePath.of("fixtures"),
+                RelativeFilePath.of("fern-ignore")
+            ),
+            cliVersion: "0.1.3-rc0"
+        });
+
+        expect(violations).toEqual([]);
+    }, 10_000);
+
     it("same namespace - conflict", async () => {
         const violations = await getViolationsForRule({
             rule: NoDuplicateOverridesRule,

--- a/packages/cli/workspace/oss-validator/src/rules/no-duplicate-overrides/no-duplicate-overrides.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-duplicate-overrides/no-duplicate-overrides.ts
@@ -27,7 +27,12 @@ export const NoDuplicateOverridesRule: Rule = {
                             "x-fern-sdk-group-name"?: string | string[];
                             "x-fern-sdk-method-name"?: string;
                             "x-fern-audiences"?: string | string[];
+                            "x-fern-ignore"?: boolean;
                         };
+
+                        if (operationObj?.["x-fern-ignore"] === true) {
+                            continue;
+                        }
                         const rawSdkGroupName = operationObj?.["x-fern-sdk-group-name"];
                         const sdkGroupName = Array.isArray(rawSdkGroupName)
                             ? rawSdkGroupName.join(".")


### PR DESCRIPTION
## Description

Fixes a bug where `fern check` (and `fern generate` validation) did not respect the `x-fern-ignore: true` extension when checking for duplicate SDK method names. Operations marked with `x-fern-ignore` should be excluded from generation entirely, but the `NoDuplicateOverridesRule` was still counting them, causing false-positive "SDK method already exists" errors.

**Customer impact:** Users with OpenAPI specs containing deprecated endpoints marked `x-fern-ignore: true` alongside newer replacement endpoints with the same SDK group/method names were unable to run `fern generate` on newer CLI versions.

## Changes Made
- Updated `NoDuplicateOverridesRule` to skip operations with `x-fern-ignore: true` before checking for duplicate SDK method names
- Added `fern-ignore` test fixture with an OpenAPI spec that has duplicate SDK method names where the deprecated operations are marked `x-fern-ignore: true`
- Added test case verifying no violations are reported when duplicates are resolved by `x-fern-ignore`

## Testing
- [x] Unit tests added/updated — new "x-fern-ignore - no conflict" test case
- [x] All 27 existing tests pass (6 test files)
- [x] Lint checks pass

Link to Devin session: https://app.devin.ai/sessions/6aac99d204df41188f85d0036db901f0
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->