### PR TITLE
fix(cli): respect FERN_FDR_ORIGIN for publish

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-fdr-origin-ledger.yml
+++ b/packages/cli/cli/changes/unreleased/fix-fdr-origin-ledger.yml
@@ -1,3 +1,3 @@
 - summary: |
-    Fix docs-ledger deploy to respect FERN_FDR_ORIGIN environment variable override.
+    Fix publish to respect FERN_FDR_ORIGIN environment variable override.
   type: fix

--- a/packages/cli/cli/changes/unreleased/fix-fdr-origin-ledger.yml
+++ b/packages/cli/cli/changes/unreleased/fix-fdr-origin-ledger.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix docs-ledger deploy to respect FERN_FDR_ORIGIN environment variable override.
+  type: fix

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -181,7 +181,11 @@ export async function publishDocs({
     loginCommand?: string;
     multiSource?: boolean;
 }): Promise<string> {
-    const fdrOrigin = process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
+    const fdrOrigin =
+        process.env.FERN_FDR_ORIGIN ??
+        process.env.OVERRIDE_FDR_ORIGIN ??
+        process.env.DEFAULT_FDR_ORIGIN ??
+        "https://registry.buildwithfern.com";
     const isAirGapped = await detectAirGappedMode(`${fdrOrigin}/health`, context.logger);
     if (isAirGapped) {
         context.logger.debug("Detected air-gapped environment - skipping external FDR service calls");


### PR DESCRIPTION
## Description

The `fdrOrigin` variable in `publishDocs.ts` was using only the build-time-inlined `DEFAULT_FDR_ORIGIN`, ignoring the runtime `FERN_FDR_ORIGIN` override. This caused the new docs-ledger code path to always hit the production FDR, even when `FERN_FDR_ORIGIN` was set (e.g. for local testing or self-hosted deployments).

## Changes Made

- Updated `publishDocs.ts` to check `FERN_FDR_ORIGIN` and `OVERRIDE_FDR_ORIGIN` before falling back to the build-time `DEFAULT_FDR_ORIGIN`, aligning with the existing `createFdrService` resolution order in `packages/core/src/services/fdr.ts`.
- Added unreleased changelog entry.

## Testing

- [x] Manual review: confirmed the new resolution order matches `createFdrService`
- [x] Linting passes (`biome lint` + `biome format`)

Link to Devin session: https://app.devin.ai/sessions/f71adf85aa2b478f80b180c36414ab7b
Requested by: @broady