### PR TITLE
fix(cli): autoversion preserves pre-release suffix on bump

### DIFF
--- a/packages/generator-cli/src/__test__/auto-version-step.execute.test.ts
+++ b/packages/generator-cli/src/__test__/auto-version-step.execute.test.ts
@@ -439,8 +439,6 @@ describe("AutoVersionStep.execute() — pre-release version handling", () => {
     beforeEach(async () => {
         mockAnalyzeSdkDiff.mockReset();
         mockConsolidateChangelog.mockReset();
-        // The previous on-disk version is irrelevant when baseVersion is provided —
-        // resolvePreviousVersion short-circuits on a valid baseVersion.
         repo = await setupTwoGenerations({
             previousVersion: "0.0.1",
             featureFile: {
@@ -482,10 +480,6 @@ describe("AutoVersionStep.execute() — pre-release version handling", () => {
         };
         return pkg.version;
     }
-
-    // Real bumps stay in the pre-release line; promotion to stable is never inferred.
-    // NO_CHANGE preserves the version verbatim. Build metadata is dropped on real
-    // bumps (matching semver.inc) and preserved on NO_CHANGE.
 
     it("PATCH on 4.0.0-beta.2 advances the prerelease counter (4.0.0-beta.3)", async () => {
         const result = await runWithBaseVersionAndBump("4.0.0-beta.2", "PATCH");
@@ -549,6 +543,14 @@ describe("AutoVersionStep.execute() — pre-release version handling", () => {
         expect(result.previousVersion).toBe("4.0.0-0");
         expect(result.version).toBe("4.0.0-1");
         expect(packageJsonVersion()).toBe("4.0.0-1");
+    });
+
+    it("PATCH on 1.0.0-alpha.beta.1 (multi-segment prerelease) preserves all earlier segments (1.0.0-alpha.beta.2)", async () => {
+        const result = await runWithBaseVersionAndBump("1.0.0-alpha.beta.1", "PATCH");
+        expect(result.success).toBe(true);
+        expect(result.previousVersion).toBe("1.0.0-alpha.beta.1");
+        expect(result.version).toBe("1.0.0-alpha.beta.2");
+        expect(packageJsonVersion()).toBe("1.0.0-alpha.beta.2");
     });
 });
 

--- a/packages/generator-cli/src/__test__/auto-version-step.execute.test.ts
+++ b/packages/generator-cli/src/__test__/auto-version-step.execute.test.ts
@@ -433,6 +433,125 @@ describe("AutoVersionStep.execute() — pipeline baseVersion overrides diff extr
     });
 });
 
+describe("AutoVersionStep.execute() — pre-release version handling", () => {
+    let repo: TwoGenerations;
+
+    beforeEach(async () => {
+        mockAnalyzeSdkDiff.mockReset();
+        mockConsolidateChangelog.mockReset();
+        // The previous on-disk version is irrelevant when baseVersion is provided —
+        // resolvePreviousVersion short-circuits on a valid baseVersion.
+        repo = await setupTwoGenerations({
+            previousVersion: "0.0.1",
+            featureFile: {
+                path: "src/newFeature.ts",
+                content: "export function newFeature(): number {\n    return 42;\n}\n"
+            }
+        });
+    });
+
+    afterEach(async () => {
+        await repo.cleanup();
+    });
+
+    async function runWithBaseVersionAndBump(
+        baseVersion: string,
+        versionBump: "MAJOR" | "MINOR" | "PATCH" | "NO_CHANGE"
+    ) {
+        mockAnalyzeSdkDiff.mockResolvedValue({
+            version_bump: versionBump,
+            message: versionBump === "NO_CHANGE" ? "" : "feat: change",
+            changelog_entry: versionBump === "NO_CHANGE" ? "" : "### Added\n- change",
+            version_bump_reason: "test"
+        });
+        const step = new AutoVersionStep(repo.repoPath, makeLogger(), {
+            ...baseConfig,
+            baseVersion
+        });
+        const prepared = fakePreparedReplay({
+            outputDir: repo.repoPath,
+            previousGenerationSha: repo.previousSha,
+            currentGenerationSha: repo.currentSha
+        });
+        return step.execute(makeContext(prepared));
+    }
+
+    function packageJsonVersion(): string {
+        const pkg = JSON.parse(readFileSync(join(repo.repoPath, "package.json"), "utf-8")) as {
+            version: string;
+        };
+        return pkg.version;
+    }
+
+    // Pre-fix baseline: real bumps strip the pre-release suffix, silently
+    // demoting a customer's release candidate to a "stable" version.
+    // These assertions document the bug; stage 4 flips them to correct values.
+
+    it("PATCH on 4.0.0-beta.2 strips prerelease (current bug — silently demotes beta to stable)", async () => {
+        const result = await runWithBaseVersionAndBump("4.0.0-beta.2", "PATCH");
+        expect(result.success).toBe(true);
+        expect(result.previousVersion).toBe("4.0.0-beta.2");
+        expect(result.version).toBe("4.0.1");
+        expect(packageJsonVersion()).toBe("4.0.1");
+    });
+
+    it("MINOR on 4.0.0-beta.2 strips prerelease (current bug)", async () => {
+        const result = await runWithBaseVersionAndBump("4.0.0-beta.2", "MINOR");
+        expect(result.success).toBe(true);
+        expect(result.previousVersion).toBe("4.0.0-beta.2");
+        expect(result.version).toBe("4.1.0");
+        expect(packageJsonVersion()).toBe("4.1.0");
+    });
+
+    it("MAJOR on 4.0.0-beta.2 strips prerelease (current bug)", async () => {
+        const result = await runWithBaseVersionAndBump("4.0.0-beta.2", "MAJOR");
+        expect(result.success).toBe(true);
+        expect(result.previousVersion).toBe("4.0.0-beta.2");
+        expect(result.version).toBe("5.0.0");
+        expect(packageJsonVersion()).toBe("5.0.0");
+    });
+
+    it("NO_CHANGE on 4.0.0-beta.2 preserves prerelease (already correct via finalizeNoChange path)", async () => {
+        const result = await runWithBaseVersionAndBump("4.0.0-beta.2", "NO_CHANGE");
+        expect(result.success).toBe(true);
+        expect(result.previousVersion).toBe("4.0.0-beta.2");
+        expect(result.version).toBe("4.0.0-beta.2");
+        expect(packageJsonVersion()).toBe("4.0.0-beta.2");
+    });
+
+    it("PATCH on 4.0.0-rc.0 strips prerelease (current bug)", async () => {
+        const result = await runWithBaseVersionAndBump("4.0.0-rc.0", "PATCH");
+        expect(result.success).toBe(true);
+        expect(result.previousVersion).toBe("4.0.0-rc.0");
+        expect(result.version).toBe("4.0.1");
+        expect(packageJsonVersion()).toBe("4.0.1");
+    });
+
+    it("PATCH on 4.0.0+build.123 drops build metadata (matches semver.inc behavior — not the bug)", async () => {
+        const result = await runWithBaseVersionAndBump("4.0.0+build.123", "PATCH");
+        expect(result.success).toBe(true);
+        expect(result.previousVersion).toBe("4.0.0+build.123");
+        expect(result.version).toBe("4.0.1");
+        expect(packageJsonVersion()).toBe("4.0.1");
+    });
+
+    it("PATCH on 4.0.0-rc.2+build.5 strips both prerelease and build (current bug — drops rc)", async () => {
+        const result = await runWithBaseVersionAndBump("4.0.0-rc.2+build.5", "PATCH");
+        expect(result.success).toBe(true);
+        expect(result.previousVersion).toBe("4.0.0-rc.2+build.5");
+        expect(result.version).toBe("4.0.1");
+        expect(packageJsonVersion()).toBe("4.0.1");
+    });
+
+    it("PATCH on 4.0.0-0 (numeric prerelease) strips prerelease (current bug)", async () => {
+        const result = await runWithBaseVersionAndBump("4.0.0-0", "PATCH");
+        expect(result.success).toBe(true);
+        expect(result.previousVersion).toBe("4.0.0-0");
+        expect(result.version).toBe("4.0.1");
+        expect(packageJsonVersion()).toBe("4.0.1");
+    });
+});
+
 describe("AutoVersionStep.execute() — first generation", () => {
     let tmpDir: tmp.DirectoryResult;
     let repoPath: string;

--- a/packages/generator-cli/src/__test__/auto-version-step.execute.test.ts
+++ b/packages/generator-cli/src/__test__/auto-version-step.execute.test.ts
@@ -483,35 +483,35 @@ describe("AutoVersionStep.execute() — pre-release version handling", () => {
         return pkg.version;
     }
 
-    // Pre-fix baseline: real bumps strip the pre-release suffix, silently
-    // demoting a customer's release candidate to a "stable" version.
-    // These assertions document the bug; stage 4 flips them to correct values.
+    // Real bumps stay in the pre-release line; promotion to stable is never inferred.
+    // NO_CHANGE preserves the version verbatim. Build metadata is dropped on real
+    // bumps (matching semver.inc) and preserved on NO_CHANGE.
 
-    it("PATCH on 4.0.0-beta.2 strips prerelease (current bug — silently demotes beta to stable)", async () => {
+    it("PATCH on 4.0.0-beta.2 advances the prerelease counter (4.0.0-beta.3)", async () => {
         const result = await runWithBaseVersionAndBump("4.0.0-beta.2", "PATCH");
         expect(result.success).toBe(true);
         expect(result.previousVersion).toBe("4.0.0-beta.2");
-        expect(result.version).toBe("4.0.1");
-        expect(packageJsonVersion()).toBe("4.0.1");
+        expect(result.version).toBe("4.0.0-beta.3");
+        expect(packageJsonVersion()).toBe("4.0.0-beta.3");
     });
 
-    it("MINOR on 4.0.0-beta.2 strips prerelease (current bug)", async () => {
+    it("MINOR on 4.0.0-beta.2 stays in the beta line (4.0.0-beta.3)", async () => {
         const result = await runWithBaseVersionAndBump("4.0.0-beta.2", "MINOR");
         expect(result.success).toBe(true);
         expect(result.previousVersion).toBe("4.0.0-beta.2");
-        expect(result.version).toBe("4.1.0");
-        expect(packageJsonVersion()).toBe("4.1.0");
+        expect(result.version).toBe("4.0.0-beta.3");
+        expect(packageJsonVersion()).toBe("4.0.0-beta.3");
     });
 
-    it("MAJOR on 4.0.0-beta.2 strips prerelease (current bug)", async () => {
+    it("MAJOR on 4.0.0-beta.2 stays in the beta line (4.0.0-beta.3) — promotion is never inferred", async () => {
         const result = await runWithBaseVersionAndBump("4.0.0-beta.2", "MAJOR");
         expect(result.success).toBe(true);
         expect(result.previousVersion).toBe("4.0.0-beta.2");
-        expect(result.version).toBe("5.0.0");
-        expect(packageJsonVersion()).toBe("5.0.0");
+        expect(result.version).toBe("4.0.0-beta.3");
+        expect(packageJsonVersion()).toBe("4.0.0-beta.3");
     });
 
-    it("NO_CHANGE on 4.0.0-beta.2 preserves prerelease (already correct via finalizeNoChange path)", async () => {
+    it("NO_CHANGE on 4.0.0-beta.2 preserves the version verbatim", async () => {
         const result = await runWithBaseVersionAndBump("4.0.0-beta.2", "NO_CHANGE");
         expect(result.success).toBe(true);
         expect(result.previousVersion).toBe("4.0.0-beta.2");
@@ -519,15 +519,15 @@ describe("AutoVersionStep.execute() — pre-release version handling", () => {
         expect(packageJsonVersion()).toBe("4.0.0-beta.2");
     });
 
-    it("PATCH on 4.0.0-rc.0 strips prerelease (current bug)", async () => {
+    it("PATCH on 4.0.0-rc.0 advances rc counter (4.0.0-rc.1)", async () => {
         const result = await runWithBaseVersionAndBump("4.0.0-rc.0", "PATCH");
         expect(result.success).toBe(true);
         expect(result.previousVersion).toBe("4.0.0-rc.0");
-        expect(result.version).toBe("4.0.1");
-        expect(packageJsonVersion()).toBe("4.0.1");
+        expect(result.version).toBe("4.0.0-rc.1");
+        expect(packageJsonVersion()).toBe("4.0.0-rc.1");
     });
 
-    it("PATCH on 4.0.0+build.123 drops build metadata (matches semver.inc behavior — not the bug)", async () => {
+    it("PATCH on 4.0.0+build.123 drops build metadata and bumps patch (4.0.1)", async () => {
         const result = await runWithBaseVersionAndBump("4.0.0+build.123", "PATCH");
         expect(result.success).toBe(true);
         expect(result.previousVersion).toBe("4.0.0+build.123");
@@ -535,20 +535,20 @@ describe("AutoVersionStep.execute() — pre-release version handling", () => {
         expect(packageJsonVersion()).toBe("4.0.1");
     });
 
-    it("PATCH on 4.0.0-rc.2+build.5 strips both prerelease and build (current bug — drops rc)", async () => {
+    it("PATCH on 4.0.0-rc.2+build.5 drops build metadata and advances rc (4.0.0-rc.3)", async () => {
         const result = await runWithBaseVersionAndBump("4.0.0-rc.2+build.5", "PATCH");
         expect(result.success).toBe(true);
         expect(result.previousVersion).toBe("4.0.0-rc.2+build.5");
-        expect(result.version).toBe("4.0.1");
-        expect(packageJsonVersion()).toBe("4.0.1");
+        expect(result.version).toBe("4.0.0-rc.3");
+        expect(packageJsonVersion()).toBe("4.0.0-rc.3");
     });
 
-    it("PATCH on 4.0.0-0 (numeric prerelease) strips prerelease (current bug)", async () => {
+    it("PATCH on 4.0.0-0 (numeric prerelease) advances the trailing counter (4.0.0-1)", async () => {
         const result = await runWithBaseVersionAndBump("4.0.0-0", "PATCH");
         expect(result.success).toBe(true);
         expect(result.previousVersion).toBe("4.0.0-0");
-        expect(result.version).toBe("4.0.1");
-        expect(packageJsonVersion()).toBe("4.0.1");
+        expect(result.version).toBe("4.0.0-1");
+        expect(packageJsonVersion()).toBe("4.0.0-1");
     });
 });
 

--- a/packages/generator-cli/src/autoversion/VersionUtils.ts
+++ b/packages/generator-cli/src/autoversion/VersionUtils.ts
@@ -147,26 +147,8 @@ export function isValidSemver(version: string): boolean {
     return SEMVER_PATTERN.test(version);
 }
 
-/**
- * Increments a semantic version based on the version bump type.
- *
- * Pre-release semantics: when `currentVersion` has a pre-release suffix
- * (e.g. "4.0.0-beta.2", "4.0.0-rc.0"), every real bump (MAJOR/MINOR/PATCH)
- * advances the pre-release counter and stays in the same line — the customer
- * never gets silently promoted to a stable version. NO_CHANGE preserves
- * the version verbatim. Promotion to stable (e.g. 4.0.0-rc.2 -> 4.0.0)
- * is a deliberate decision the customer must make explicitly via baseVersion;
- * autoversion never infers it from FAI's bump signal because the BAML prompt
- * is silent on pre-release lines (it only describes API-surface impact).
- *
- * Build metadata (`+build.5`) is informational and is dropped on real bumps,
- * matching `semver.inc` semantics. NO_CHANGE preserves it.
- *
- * @param currentVersion The current version (e.g., "1.2.3", "v1.2.3", "4.0.0-rc.2")
- * @param versionBump The type of version bump (MAJOR, MINOR, PATCH, NO_CHANGE)
- * @return The incremented version
- * @throws AutoVersioningException if version parsing fails or unknown bump type
- */
+// Pre-release lines stay in line: any real bump advances the prerelease counter.
+// Promotion to stable (4.0.0-rc.2 → 4.0.0) requires an explicit baseVersion. See FER-10378.
 export function incrementVersion(currentVersion: string, versionBump: VersionBump): string {
     const matcher = currentVersion.match(SEMVER_PATTERN);
     if (!matcher) {
@@ -178,22 +160,12 @@ export function incrementVersion(currentVersion: string, versionBump: VersionBum
     const preRelease = matcher[5];
 
     if (versionBump === VersionBump.NO_CHANGE) {
-        // Preserve the version verbatim, including any pre-release/build metadata.
         return currentVersion;
     }
 
     let bumped: string | null;
     if (preRelease != null) {
-        // Stay in the pre-release line. The identifier is the leading
-        // non-numeric segment (e.g. "beta" from "beta.2", "rc" from "rc.0").
-        // Pure-numeric prereleases (e.g. "-0") pass undefined so semver bumps
-        // the trailing counter to "-1" without inserting a new identifier.
-        const head = preRelease.split(".")[0];
-        const identifier = head != null && head.length > 0 && !/^\d+$/.test(head) ? head : undefined;
-        bumped =
-            identifier != null
-                ? semver.inc(versionWithoutPrefix, "prerelease", identifier)
-                : semver.inc(versionWithoutPrefix, "prerelease");
+        bumped = semver.inc(versionWithoutPrefix, "prerelease");
     } else if (versionBump === VersionBump.MAJOR) {
         bumped = semver.inc(versionWithoutPrefix, "major");
     } else if (versionBump === VersionBump.MINOR) {

--- a/packages/generator-cli/src/autoversion/VersionUtils.ts
+++ b/packages/generator-cli/src/autoversion/VersionUtils.ts
@@ -1,3 +1,5 @@
+import semver from "semver";
+
 import { AutoVersioningException } from "./AutoVersioningService.js";
 
 /**
@@ -148,8 +150,20 @@ export function isValidSemver(version: string): boolean {
 /**
  * Increments a semantic version based on the version bump type.
  *
- * @param currentVersion The current version (e.g., "1.2.3" or "v1.2.3")
- * @param versionBump The type of version bump (MAJOR, MINOR, PATCH)
+ * Pre-release semantics: when `currentVersion` has a pre-release suffix
+ * (e.g. "4.0.0-beta.2", "4.0.0-rc.0"), every real bump (MAJOR/MINOR/PATCH)
+ * advances the pre-release counter and stays in the same line — the customer
+ * never gets silently promoted to a stable version. NO_CHANGE preserves
+ * the version verbatim. Promotion to stable (e.g. 4.0.0-rc.2 -> 4.0.0)
+ * is a deliberate decision the customer must make explicitly via baseVersion;
+ * autoversion never infers it from FAI's bump signal because the BAML prompt
+ * is silent on pre-release lines (it only describes API-surface impact).
+ *
+ * Build metadata (`+build.5`) is informational and is dropped on real bumps,
+ * matching `semver.inc` semantics. NO_CHANGE preserves it.
+ *
+ * @param currentVersion The current version (e.g., "1.2.3", "v1.2.3", "4.0.0-rc.2")
+ * @param versionBump The type of version bump (MAJOR, MINOR, PATCH, NO_CHANGE)
  * @return The incremented version
  * @throws AutoVersioningException if version parsing fails or unknown bump type
  */
@@ -159,43 +173,42 @@ export function incrementVersion(currentVersion: string, versionBump: VersionBum
         throw new AutoVersioningException("Invalid semantic version format: " + currentVersion);
     }
 
-    const prefix = matcher[1] || "";
-    let major = parseInt(matcher[2] ?? "0", 10);
-    let minor = parseInt(matcher[3] ?? "0", 10);
-    let patch = parseInt(matcher[4] ?? "0", 10);
+    const prefix = matcher[1] ?? "";
+    const versionWithoutPrefix = currentVersion.slice(prefix.length);
     const preRelease = matcher[5];
-    const buildMetadata = matcher[6];
 
-    let preserveMetadata = false;
+    if (versionBump === VersionBump.NO_CHANGE) {
+        // Preserve the version verbatim, including any pre-release/build metadata.
+        return currentVersion;
+    }
 
-    if (versionBump === VersionBump.MAJOR) {
-        major++;
-        minor = 0;
-        patch = 0;
+    let bumped: string | null;
+    if (preRelease != null) {
+        // Stay in the pre-release line. The identifier is the leading
+        // non-numeric segment (e.g. "beta" from "beta.2", "rc" from "rc.0").
+        // Pure-numeric prereleases (e.g. "-0") pass undefined so semver bumps
+        // the trailing counter to "-1" without inserting a new identifier.
+        const head = preRelease.split(".")[0];
+        const identifier = head != null && head.length > 0 && !/^\d+$/.test(head) ? head : undefined;
+        bumped =
+            identifier != null
+                ? semver.inc(versionWithoutPrefix, "prerelease", identifier)
+                : semver.inc(versionWithoutPrefix, "prerelease");
+    } else if (versionBump === VersionBump.MAJOR) {
+        bumped = semver.inc(versionWithoutPrefix, "major");
     } else if (versionBump === VersionBump.MINOR) {
-        minor++;
-        patch = 0;
+        bumped = semver.inc(versionWithoutPrefix, "minor");
     } else if (versionBump === VersionBump.PATCH) {
-        patch++;
-    } else if (versionBump === VersionBump.NO_CHANGE) {
-        preserveMetadata = true;
+        bumped = semver.inc(versionWithoutPrefix, "patch");
     } else {
         throw new AutoVersioningException("Unknown version bump type: " + versionBump);
     }
 
-    let newVersion = `${prefix}${major}.${minor}.${patch}`;
-
-    if (preserveMetadata) {
-        if (preRelease) {
-            newVersion += `-${preRelease}`;
-        }
-
-        if (buildMetadata) {
-            newVersion += `+${buildMetadata}`;
-        }
+    if (bumped === null) {
+        throw new AutoVersioningException("Failed to increment version: " + currentVersion);
     }
 
-    return newVersion;
+    return `${prefix}${bumped}`;
 }
 
 /**

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,18 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix `AutoVersionStep` silently stripping pre-release identifiers on
+        bump. A customer on `4.0.0-rc.2` getting a PATCH-classified change
+        previously landed on `4.0.1`, demoting their release candidate to a
+        "stable" version. `incrementVersion` now stays in the pre-release line
+        (e.g. `4.0.0-rc.2` → `4.0.0-rc.3`) for any real bump; promotion to
+        stable must be done explicitly by setting `baseVersion`.
+      type: fix
+  createdAt: "2026-05-06"
+  version: 0.9.25
+
+- changelogEntry:
+    - summary: |
         Fix `AutoVersionStep` silently regressing the SDK version when a customer
         manually bumped between generations. `resolvePreviousVersion` now prefers
         the pipeline-supplied `baseVersion` over the `[fern-generated]` diff.


### PR DESCRIPTION
## Summary

Customer on `4.0.0-rc.2` triggers a regen, FAI returns PATCH, autoversion silently produces `4.0.1` — RC demoted to "stable" with no warning. `incrementVersion` parsed the pre-release suffix but only re-attached it on `NO_CHANGE`; every real bump dropped it.

When the previous version has a pre-release suffix, MAJOR/MINOR/PATCH now advance the trailing prerelease counter via `semver.inc(v, "prerelease")`, staying in the same line (`4.0.0-rc.2 → 4.0.0-rc.3`, `1.0.0-alpha.beta.1 → 1.0.0-alpha.beta.2`). NO_CHANGE preserves the suffix verbatim. Promotion to stable must be done explicitly via `baseVersion`.

[FER-10378](https://linear.app/buildwithfern/issue/FER-10378).

## Design note (deliberate; flagged for review)

While the customer is in a pre-release line, FAI's magnitude signal collapses to "advance the counter" — MAJOR, MINOR, and PATCH all produce the same output. The alternative (`semver.inc` with `"premajor"`/`"preminor"`) would preserve magnitude inside the line (`4.0.0-rc.2 + MINOR → 4.1.0-rc.0`) but the BAML prompt at `packages/cli/ai/baml_src/diff_analyzer.baml` is silent on what "minor inside a prerelease line" means. Going conservative — open to widening if the BAML contract is updated. Discussion logged on FER-10378.

## Scope

`pnpm-workspace.yaml` catalog pin and CLI changelog entry intentionally **not** in this PR — follow-up, mirroring #15723.

## Test plan

- [x] 9 input cases covered (8 + multi-segment regression for `1.0.0-alpha.beta.1`).
- [x] All 393 tests in `@fern-api/generator-cli` green.
- [x] Compile clean.