### PR TITLE
fix(seed): repair broken ts-seed and csharp-seed Dockerfile builds

### DIFF
--- a/docker/seed/Dockerfile.csharp
+++ b/docker/seed/Dockerfile.csharp
@@ -34,7 +34,7 @@ RUN dotnet tool install -g csharpier --version "1.2.6" && \
       <PackageReference Include="PolySharp" Version="1.15.0" /> \
       <PackageReference Include="OneOf" Version="3.0.271" /> \
       <PackageReference Include="OneOf.Extended" Version="3.0.271" /> \
-      <PackageReference Include="System.Text.Json" Version="8.0.5" /> \
+      <PackageReference Include="System.Text.Json" Version="10.0.5" /> \
       <PackageReference Include="System.Net.Http" Version="[4.3.4,)" /> \
       <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" /> \
       <PackageReference Include="Google.Protobuf" Version="3.27.2" /> \
@@ -47,7 +47,7 @@ RUN dotnet tool install -g csharpier --version "1.2.6" && \
       <PackageReference Include="NUnit.Analyzers" Version="4.12.0" /> \
       <PackageReference Include="coverlet.collector" Version="8.0.1" /> \
       <PackageReference Include="WireMock.Net" Version="2.2.0" /> \
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" /> \
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" /> \
       <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" /> \
       <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" /> \
   </ItemGroup> \

--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -5,6 +5,9 @@ ENV YARN_CACHE_FOLDER=/.yarn-cache
 ENV PNPM_HOME=/.pnpm
 ENV PATH=$PNPM_HOME:$PATH
 
+# Update corepack first; the version bundled with node:22.12-slim ships with
+# outdated signing keys and rejects newer pnpm/yarn releases (corepack#612).
+RUN npm install -g corepack@latest
 RUN npm install -g pnpm@10.20.0 --force
 RUN corepack prepare pnpm@10.20.0
 RUN npm install -g yarn@1.22.22 --force


### PR DESCRIPTION
## Description
Linear ticket: N/A

`docker/seed/Dockerfile.ts` and `docker/seed/Dockerfile.csharp` have been failing on `main` since:

- **ts-seed**: 2026-04-01 — every push since then [has failed](https://github.com/fern-api/fern/actions/workflows/seed-dockers.yml?query=branch%3Amain) on `RUN corepack prepare pnpm@10.20.0` with `Internal Error: Cannot find matching keyid` ([nodejs/corepack#612](https://github.com/nodejs/corepack/issues/612)). The version of corepack bundled with `node:22.12-slim` ships with outdated signing keys and rejects newer pnpm/yarn releases.
- **csharp-seed**: 2026-04-01 (PR [#14429](https://github.com/fern-api/fern/pull/14429), `chore(csharp): upgrade WireMock.Net from 1.25.0 to 2.2.0`) — `dotnet restore /dependencies.csproj` fails with NU1605 package downgrade errors:
  - `WireMock.Net 2.2.0 → WireMock.Net.Minimal 2.2.0 → Scriban.Signed 7.0.6 → System.Text.Json (>= 10.0.5)` conflicts with the pinned `8.0.5`.
  - `Grpc.Net.ClientFactory 2.63.0 → Microsoft.Extensions.Http 6.0.0 → Microsoft.Extensions.Logging 10.0.0 → Microsoft.Extensions.Logging.Abstractions (>= 10.0.0)` conflicts with the pinned `8.0.2`.

These two images are referenced from the new grype scan matrix in #15729, where the failures were surfaced again.

## Changes Made
- `docker/seed/Dockerfile.ts`: prepend `RUN npm install -g corepack@latest` so corepack has up-to-date signing keys before `corepack prepare` runs. Added a comment explaining why.
- `docker/seed/Dockerfile.csharp`: bump warmup-cache `dependencies.csproj` versions to satisfy transitive constraints from `WireMock.Net 2.2.0` and `Grpc.Net.ClientFactory 2.63.0`:
  - `System.Text.Json`: `8.0.5` → `10.0.5`
  - `Microsoft.Extensions.Logging.Abstractions`: `8.0.2` → `10.0.0`

## Testing
- [x] Built `docker/seed/Dockerfile.ts` locally — passes (`Successfully tagged fern-ts-seed-test:local`).
- [x] Built `docker/seed/Dockerfile.csharp` locally — passes; `dotnet restore /dependencies.csproj` reports `Restored /dependencies.csproj (in 7.18 sec).` with no NU1605 errors (only a few benign NU1701 netstandard2.0 compatibility warnings, unchanged from before).
- [ ] CI: `Build seed containers` workflow on this PR.

Link to Devin session: https://app.devin.ai/sessions/4363b615bc51422483ddb7d519a4ee12
Requested by: @davidkonigsberg