### PR TITLE
chore(csharp): upgrade ir-sdk and dynamic-ir-sdk to 67.1.0

### DIFF
--- a/generators/csharp/base/package.json
+++ b/generators/csharp/base/package.json
@@ -37,7 +37,7 @@
     "@fern-api/csharp-codegen": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
     "eta": "^4.5.1",

--- a/generators/csharp/codegen/package.json
+++ b/generators/csharp/codegen/package.json
@@ -33,8 +33,8 @@
   "dependencies": {
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "66.1.0",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-api/dynamic-ir-sdk": "67.1.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "domhandler": "catalog:",
     "htmlparser2": "catalog:",
     "zod": "catalog:"

--- a/generators/csharp/dynamic-snippets/package.json
+++ b/generators/csharp/dynamic-snippets/package.json
@@ -36,7 +36,7 @@
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/csharp-codegen": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "66.1.0",
+    "@fern-api/dynamic-ir-sdk": "67.1.0",
     "@fern-api/path-utils": "workspace:*",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",

--- a/generators/csharp/model/package.json
+++ b/generators/csharp/model/package.json
@@ -46,7 +46,7 @@
     "@fern-api/csharp-codegen": "workspace:*",
     "@fern-api/csharp-formatter": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/generators/csharp/sdk/package.json
+++ b/generators/csharp/sdk/package.json
@@ -50,7 +50,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-fern/generator-cli-sdk": "^0.1.5",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@types/node": "catalog:",
     "@types/url-join": "4.0.1",
     "typescript": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -806,8 +806,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/logging-execa
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12
@@ -836,11 +836,11 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 66.1.0
-        version: 66.1.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       domhandler:
         specifier: 'catalog:'
         version: 5.0.3
@@ -879,8 +879,8 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@fern-api/dynamic-ir-sdk':
-        specifier: 66.1.0
-        version: 66.1.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -949,8 +949,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/fs-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17
@@ -997,8 +997,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17
@@ -9398,6 +9398,10 @@ packages:
     resolution: {integrity: sha512-hOfcPPkfhC5vhiZdDVxlsaAPfMQlWdswnpvQoDRhjDN+zGK+ctLiPF7jyKqwIBynG5GyS3SalI2/2r/IgcaFpA==}
     engines: {node: '>=18.0.0'}
 
+  '@fern-api/dynamic-ir-sdk@67.1.0':
+    resolution: {integrity: sha512-IpvIb0CSc69ItZSTacQay4bGqvv3+CJ1jONhvbDmXeKl4qQN3Jey3pudeR26glA6qg9WBz5EVJAoSYnLClF4Dw==}
+    engines: {node: '>=18.0.0'}
+
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28':
     resolution: {integrity: sha512-3qhAAuc4ZJWLaFtyZzaYXfF9OQ5iviNrvLDXtjKScKUNS134fR3v3c3xedCidTq5KedapuBECziUaOmmd6KXVA==}
     engines: {node: '>=18.0.0'}
@@ -9453,6 +9457,10 @@ packages:
 
   '@fern-fern/ir-sdk@66.3.0':
     resolution: {integrity: sha512-BKtpmuyK98GagBSZ5CMe3oAkkwG5l3MId+/VyyyGbUV+HRrqIS+htIBlGmsNBW6fzuKK6hgOGn+Kyb2N4+Mejg==}
+    engines: {node: '>=18.0.0'}
+
+  '@fern-fern/ir-sdk@67.1.0':
+    resolution: {integrity: sha512-fkTbqm3ldzx5hUGgIyVliBn+bebNsKoPVvuzc3ZUpoPgXQXJkmWi0TvKKHoyHTqZ0lWLMsjX4ADY3doILrUS3g==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/ir-v53-sdk@1.0.1':
@@ -16410,6 +16418,8 @@ snapshots:
 
   '@fern-api/dynamic-ir-sdk@66.3.0': {}
 
+  '@fern-api/dynamic-ir-sdk@67.1.0': {}
+
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28': {}
 
   '@fern-api/fdr-sdk@1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)':
@@ -16529,6 +16539,8 @@ snapshots:
   '@fern-fern/ir-sdk@66.2.0': {}
 
   '@fern-fern/ir-sdk@66.3.0': {}
+
+  '@fern-fern/ir-sdk@67.1.0': {}
 
   '@fern-fern/ir-v53-sdk@1.0.1': {}
 


### PR DESCRIPTION
## Description

Upgrade `@fern-fern/ir-sdk` from 66.3.0 to 67.1.0 and `@fern-api/dynamic-ir-sdk` from 66.1.0 to 67.1.0 in the C# generator packages.

## Changes Made

- Updated `@fern-fern/ir-sdk` to `67.1.0` in `generators/csharp/base/package.json`, `generators/csharp/codegen/package.json`, `generators/csharp/model/package.json`, `generators/csharp/sdk/package.json`
- Updated `@fern-api/dynamic-ir-sdk` to `67.1.0` in `generators/csharp/codegen/package.json`, `generators/csharp/dynamic-snippets/package.json`
- Updated `pnpm-lock.yaml`

## Testing

- [x] `pnpm install` completed successfully
- [x] `pnpm compile` for all C# generator packages passed with no errors

Link to Devin session: https://app.devin.ai/sessions/193d85547da14c1b82903d15449d2cd3
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->