### PR TITLE
chore(deps): upgrade turbo from 2.9.5 to 2.9.9

### DIFF
--- a/packages/generator-cli/turbo.jsonc
+++ b/packages/generator-cli/turbo.jsonc
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://turborepo.dev/schema.json",
+    "$schema": "https://v2-9-9.turborepo.dev/schema.json",
     "extends": ["//"],
     "tasks": {
         "test": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,8 +535,8 @@ catalogs:
       specifier: ^4.21.0
       version: 4.21.0
     turbo:
-      specifier: ^2.9.1
-      version: 2.9.5
+      specifier: ^2.9.9
+      version: 2.9.9
     typescript:
       specifier: 5.9.3
       version: 5.9.3
@@ -673,7 +673,7 @@ importers:
         version: 4.21.0
       turbo:
         specifier: 'catalog:'
-        version: 2.9.5
+        version: 2.9.9
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -10739,33 +10739,33 @@ packages:
   '@ts-morph/common@0.28.1':
     resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
 
-  '@turbo/darwin-64@2.9.5':
-    resolution: {integrity: sha512-qPxhKsLMQP+9+dsmPgAGidi5uNifD4AoAOnEnljab3Qgn0QZRR31Hp+/CgW3Ia5AanWj6JuLLTBYvuQj4mqTWg==}
+  '@turbo/darwin-64@2.9.9':
+    resolution: {integrity: sha512-hTEiNu2ABZZOO1qbjnKASI8eF3BdOOzU6iKv5w5uGOK65DDMc10cS40N1kqM99YT0uSAGUwNu6GdFctRPeEeVA==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.5':
-    resolution: {integrity: sha512-vkF/9F/l3aWd4bHxTui5Hh0F5xrTZ4e3rbBsc57zA6O8gNbmHN3B6eZ5psAIP2CnJRZ8ZxRjV3WZHeNXMXkPBw==}
+  '@turbo/darwin-arm64@2.9.9':
+    resolution: {integrity: sha512-MinO40EEcP5mJiTVpfjtEulsEBhVeryfq21QhYtJZ8hQJLHGgy459rcmDVAY8/JERe4dkVU4KW+zoLF22o01EA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.5':
-    resolution: {integrity: sha512-z/Get5NUaUxm5HSGFqVMICDRjFNsCUhSc4wnFa/PP1QD0NXCjr7bu9a2EM6md/KMCBW0Qe393Ac+UM7/ryDDTw==}
+  '@turbo/linux-64@2.9.9':
+    resolution: {integrity: sha512-7JNLw88Isk+gMlbsC8pulLDkrqe2B827ZsKFEHilb17AC6Xn/62pzH7afjY7fEU6Ayp4XP/vGhlRWOzqBvBvIQ==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.5':
-    resolution: {integrity: sha512-jyBifaNoI5/NheyswomiZXJvjdAdvT7hDRYzQ4meP0DKGvpXUjnqsD+4/J2YSDQ34OHxFkL30FnSCUIVOh2PHw==}
+  '@turbo/linux-arm64@2.9.9':
+    resolution: {integrity: sha512-0pnXDwPw1rHii98JZPRg7SvsjIzy7jrhkwGU9Jy5fVYoMdYd3P2vbtLfII+OJ0Mm4Ar5yykdHDTz3RWiRI1o9g==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.5':
-    resolution: {integrity: sha512-ph24K5uPtvo7UfuyDXnBiB/8XvrO+RQWbbw5zkA/bVNoy9HDiNoIJJj3s62MxT9tjEb6DnPje5PXSz1UR7QAyg==}
+  '@turbo/windows-64@2.9.9':
+    resolution: {integrity: sha512-vjDQycz4gQVvIq4n2rPtiiIESwJlAc406qtkiZlqyL+fHZEd9SxYNlBIFYtc5cuMuwrk+sIKrhN7XvwjmvS9YQ==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.5':
-    resolution: {integrity: sha512-6c5RccT/+iR39SdT1G5HyZaD2n57W77o+l0TTfxG/cVlhV94Acyg2gTQW7zUOhW1BeQpBjHzu9x8yVBZwrHh7g==}
+  '@turbo/windows-arm64@2.9.9':
+    resolution: {integrity: sha512-V6NiH43oCctepbOdQFp7UjqLyK8p6Tt824QA+G4TE+B1BBHu80A0W8OCL+H7uBJ3XZjAj/hvPDw3k3l65DoDGw==}
     cpu: [arm64]
     os: [win32]
 
@@ -14686,8 +14686,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  turbo@2.9.5:
-    resolution: {integrity: sha512-JXNkRe6H6MjSlk5UQRTjyoKX5YN2zlc2632xcSlSFBao5yvbMWTpv9SNolOZlZmUlcDOHuszPLItbKrvcXnnZA==}
+  turbo@2.9.9:
+    resolution: {integrity: sha512-3xfzXE/yTjhh0S5dIWlE+3E+J9A09REpLI1ZqVh2+HrNZoVzZn0pkvjiRgVK/Ev3PF9XnaTwCntTx+CADWXcyA==}
     hasBin: true
 
   type-check@0.4.0:
@@ -17777,22 +17777,22 @@ snapshots:
       path-browserify: 1.0.1
       tinyglobby: 0.2.16
 
-  '@turbo/darwin-64@2.9.5':
+  '@turbo/darwin-64@2.9.9':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.5':
+  '@turbo/darwin-arm64@2.9.9':
     optional: true
 
-  '@turbo/linux-64@2.9.5':
+  '@turbo/linux-64@2.9.9':
     optional: true
 
-  '@turbo/linux-arm64@2.9.5':
+  '@turbo/linux-arm64@2.9.9':
     optional: true
 
-  '@turbo/windows-64@2.9.5':
+  '@turbo/windows-64@2.9.9':
     optional: true
 
-  '@turbo/windows-arm64@2.9.5':
+  '@turbo/windows-arm64@2.9.9':
     optional: true
 
   '@tybys/wasm-util@0.10.1':
@@ -22521,14 +22521,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo@2.9.5:
+  turbo@2.9.9:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.5
-      '@turbo/darwin-arm64': 2.9.5
-      '@turbo/linux-64': 2.9.5
-      '@turbo/linux-arm64': 2.9.5
-      '@turbo/windows-64': 2.9.5
-      '@turbo/windows-arm64': 2.9.5
+      '@turbo/darwin-64': 2.9.9
+      '@turbo/darwin-arm64': 2.9.9
+      '@turbo/linux-64': 2.9.9
+      '@turbo/linux-arm64': 2.9.9
+      '@turbo/windows-64': 2.9.9
+      '@turbo/windows-arm64': 2.9.9
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -235,7 +235,7 @@ catalog:
   tsdown: 0.20.1
   tsup: ^8.5.1
   tsx: ^4.21.0
-  turbo: ^2.9.1
+  turbo: ^2.9.9
   typescript: 5.9.3
   ua-parser-js: ^1.0.37
   undici: ^6.24.0

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://turborepo.dev/schema.json",
+    "$schema": "https://v2-9-9.turborepo.dev/schema.json",
     "globalDependencies": [
         ".npmrc",
         ".prettierrc.json",


### PR DESCRIPTION
## Description

Upgrades Turbo from 2.9.5 to 2.9.9 using `npx @turbo/codemod upgrade`. No codemods were required.

## Changes Made

- Updated `turbo` version in `pnpm-workspace.yaml` catalog from `^2.9.1` to `^2.9.9`
- Updated `$schema` in `turbo.jsonc` and `packages/generator-cli/turbo.jsonc` to versioned format (`https://v2-9-9.turborepo.dev/schema.json`)
- Updated `pnpm-lock.yaml`

### Changelog highlights (2.9.6 → 2.9.9)

**2.9.6** (Apr 10):
- fix: Mention `turbo.json` in concurrency error message
- fix: Surface actionable message when remote cache is requested but not linked
- fix: Load custom CA certificates in fast webpki-only HTTP client

**2.9.7** (May 1):
- feat: Graceful shutdown
- fix: Support two-dot git ranges in filter selectors
- fix: Support pnpm v11 multi-document lockfiles
- fix: Ignore `SIGINT` in shim after spawning local `turbo`
- fix: Preserve graceful shutdown exit code / PTY semantics
- feat: Move Vercel auth to standard OAuth/device flows

**2.9.8** (May 3):
- fix: Preserve concrete dependency precedence
- fix: Resolve Yarn catalog affected packages
- fix: Preserve Bun prune lockfile validity
- fix: Create prune docker bin stubs
- fix: Keep tbx shell connections stable
- perf: Reduce `turbo watch` hash memory spikes
- fix: Reduce parent-death watchdog CPU usage

**2.9.9** (May 4):
- fix: Remove Unix parent death watchdogs
- fix: Scope repo index prefixes to Git root
- fix: Preserve lockfiles during dry-run conversion
- Security hardening across CI and release workflows

## Testing
- [x] Ran `npx @turbo/codemod upgrade` — completed successfully, no codemods needed
- [x] Ran `pnpm format` — no issues
- [x] Verified `pnpm turbo --version` outputs `2.9.9`

Link to Devin session: https://app.devin.ai/sessions/ba8695bd70d24e6c9661b7eca1c9d5cd
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15747" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->