### PR TITLE
chore(java): upgrade ir-sdk and dynamic-ir-sdk to 67.1.0 in java-v2

### DIFF
--- a/generators/java-v2/base/package.json
+++ b/generators/java-v2/base/package.json
@@ -41,7 +41,7 @@
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/java-ast": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
-    "@fern-fern/ir-sdk": "^66.3.0",
+    "@fern-fern/ir-sdk": "^67.1.0",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/generators/java-v2/dynamic-snippets/package.json
+++ b/generators/java-v2/dynamic-snippets/package.json
@@ -35,7 +35,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "66.1.0",
+    "@fern-api/dynamic-ir-sdk": "67.1.0",
     "@fern-api/java-ast": "workspace:*",
     "@fern-api/path-utils": "workspace:*",
     "@types/lodash-es": "catalog:",

--- a/generators/java-v2/sdk/package.json
+++ b/generators/java-v2/sdk/package.json
@@ -49,7 +49,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-fern/generator-cli-sdk": "^0.1.8",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "^66.3.0",
+    "@fern-fern/ir-sdk": "^67.1.0",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
     "lodash-es": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1272,8 +1272,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/logging-execa
       '@fern-fern/ir-sdk':
-        specifier: ^66.3.0
-        version: 66.3.0
+        specifier: ^67.1.0
+        version: 67.1.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17
@@ -1296,8 +1296,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 66.1.0
-        version: 66.1.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-api/java-ast':
         specifier: workspace:*
         version: link:../ast
@@ -1353,8 +1353,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: ^66.3.0
-        version: 66.3.0
+        specifier: ^67.1.0
+        version: 67.1.0
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12
@@ -9398,6 +9398,10 @@ packages:
     resolution: {integrity: sha512-hOfcPPkfhC5vhiZdDVxlsaAPfMQlWdswnpvQoDRhjDN+zGK+ctLiPF7jyKqwIBynG5GyS3SalI2/2r/IgcaFpA==}
     engines: {node: '>=18.0.0'}
 
+  '@fern-api/dynamic-ir-sdk@67.1.0':
+    resolution: {integrity: sha512-IpvIb0CSc69ItZSTacQay4bGqvv3+CJ1jONhvbDmXeKl4qQN3Jey3pudeR26glA6qg9WBz5EVJAoSYnLClF4Dw==}
+    engines: {node: '>=18.0.0'}
+
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28':
     resolution: {integrity: sha512-3qhAAuc4ZJWLaFtyZzaYXfF9OQ5iviNrvLDXtjKScKUNS134fR3v3c3xedCidTq5KedapuBECziUaOmmd6KXVA==}
     engines: {node: '>=18.0.0'}
@@ -9453,6 +9457,10 @@ packages:
 
   '@fern-fern/ir-sdk@66.3.0':
     resolution: {integrity: sha512-BKtpmuyK98GagBSZ5CMe3oAkkwG5l3MId+/VyyyGbUV+HRrqIS+htIBlGmsNBW6fzuKK6hgOGn+Kyb2N4+Mejg==}
+    engines: {node: '>=18.0.0'}
+
+  '@fern-fern/ir-sdk@67.1.0':
+    resolution: {integrity: sha512-fkTbqm3ldzx5hUGgIyVliBn+bebNsKoPVvuzc3ZUpoPgXQXJkmWi0TvKKHoyHTqZ0lWLMsjX4ADY3doILrUS3g==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/ir-v53-sdk@1.0.1':
@@ -16410,6 +16418,8 @@ snapshots:
 
   '@fern-api/dynamic-ir-sdk@66.3.0': {}
 
+  '@fern-api/dynamic-ir-sdk@67.1.0': {}
+
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28': {}
 
   '@fern-api/fdr-sdk@1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)':
@@ -16529,6 +16539,8 @@ snapshots:
   '@fern-fern/ir-sdk@66.2.0': {}
 
   '@fern-fern/ir-sdk@66.3.0': {}
+
+  '@fern-fern/ir-sdk@67.1.0': {}
 
   '@fern-fern/ir-v53-sdk@1.0.1': {}
 


### PR DESCRIPTION
## Description
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
Internal dependency bump for the Java v2 generator.

## Changes Made
- Updated `@fern-fern/ir-sdk` from `^66.3.0` to `^67.1.0` in `generators/java-v2/base/package.json` and `generators/java-v2/sdk/package.json`
- Updated `@fern-api/dynamic-ir-sdk` from `66.1.0` to `67.1.0` in `generators/java-v2/dynamic-snippets/package.json`
- Updated `pnpm-lock.yaml`

## Testing
- [x] `pnpm install` succeeded
- [x] `pnpm turbo run compile` for all java-v2 packages (`@fern-api/java-base`, `@fern-api/java-sdk`, `@fern-api/java-dynamic-snippets`) compiled with no errors
- [x] `pnpm format` passed with no changes needed

Link to Devin session: https://app.devin.ai/sessions/0c29418135744c06a6e5eb822c49caba
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->