### PR TITLE
chore(typescript): upgrade dynamic-ir-sdk to 67.1.0

### DIFF
--- a/generators/browser-compatible-base/package.json
+++ b/generators/browser-compatible-base/package.json
@@ -35,7 +35,7 @@
     "@fern-api/casings-generator": "workspace:*",
     "@fern-api/configuration": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "66.1.0",
+    "@fern-api/dynamic-ir-sdk": "67.1.0",
     "@fern-api/fern-definition-schema": "workspace:*",
     "@fern-api/ir-sdk": "workspace:*",
     "@fern-api/logger": "workspace:*",

--- a/generators/typescript-v2/dynamic-snippets/package.json
+++ b/generators/typescript-v2/dynamic-snippets/package.json
@@ -35,7 +35,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "66.1.0",
+    "@fern-api/dynamic-ir-sdk": "67.1.0",
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/typescript-ast": "workspace:*",
     "@fern-api/typescript-browser-compatible-base": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -754,8 +754,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 66.1.0
-        version: 66.1.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-api/fern-definition-schema':
         specifier: workspace:*
         version: link:../../packages/cli/fern-definition/schema
@@ -2560,8 +2560,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 66.1.0
-        version: 66.1.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -9396,6 +9396,10 @@ packages:
 
   '@fern-api/dynamic-ir-sdk@66.3.0':
     resolution: {integrity: sha512-hOfcPPkfhC5vhiZdDVxlsaAPfMQlWdswnpvQoDRhjDN+zGK+ctLiPF7jyKqwIBynG5GyS3SalI2/2r/IgcaFpA==}
+    engines: {node: '>=18.0.0'}
+
+  '@fern-api/dynamic-ir-sdk@67.1.0':
+    resolution: {integrity: sha512-IpvIb0CSc69ItZSTacQay4bGqvv3+CJ1jONhvbDmXeKl4qQN3Jey3pudeR26glA6qg9WBz5EVJAoSYnLClF4Dw==}
     engines: {node: '>=18.0.0'}
 
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28':
@@ -16409,6 +16413,8 @@ snapshots:
   '@fern-api/dynamic-ir-sdk@66.1.0': {}
 
   '@fern-api/dynamic-ir-sdk@66.3.0': {}
+
+  '@fern-api/dynamic-ir-sdk@67.1.0': {}
 
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28': {}
 


### PR DESCRIPTION
## Description

Upgrade `@fern-api/dynamic-ir-sdk` from 66.1.0 to 67.1.0 in the TypeScript v2 generator and browser-compatible-base.

## Changes Made

- Updated `@fern-api/dynamic-ir-sdk` from `66.1.0` to `67.1.0` in `generators/typescript-v2/dynamic-snippets/package.json`
- Updated `@fern-api/dynamic-ir-sdk` from `66.1.0` to `67.1.0` in `generators/browser-compatible-base/package.json`
- Updated `pnpm-lock.yaml`

## Testing

- [x] `pnpm install` completed successfully
- [x] `pnpm compile` — both `@fern-api/browser-compatible-base-generator` and `@fern-api/typescript-dynamic-snippets` compile cleanly with no type errors
- [x] `pnpm format` — no formatting issues

Link to Devin session: https://app.devin.ai/sessions/c0124bcef00a452aae27cc45c1068648
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->