### PR TITLE
chore(openapi): upgrade ir-sdk to 67.1.0

### DIFF
--- a/generators/openapi/package.json
+++ b/generators/openapi/package.json
@@ -46,7 +46,7 @@
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.0.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@types/js-yaml": "catalog:",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",

--- a/generators/openapi/src/utils/convertAvailability.ts
+++ b/generators/openapi/src/utils/convertAvailability.ts
@@ -5,10 +5,14 @@ import { FernIr } from "@fern-fern/ir-sdk";
  */
 export function convertAvailabilityStatus(status: FernIr.AvailabilityStatus): string | undefined {
     return FernIr.AvailabilityStatus._visit<string | undefined>(status, {
+        alpha: () => "alpha",
+        beta: () => "beta",
         inDevelopment: () => "in-development",
+        preview: () => "preview",
         preRelease: () => "pre-release",
         generalAvailability: () => "generally-available",
         deprecated: () => "deprecated",
+        legacy: () => "legacy",
         _other: () => undefined
     });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1386,8 +1386,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/commons/fs-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.0.0
-        version: 66.0.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@types/js-yaml':
         specifier: 'catalog:'
         version: 4.0.9
@@ -9455,6 +9455,10 @@ packages:
     resolution: {integrity: sha512-BKtpmuyK98GagBSZ5CMe3oAkkwG5l3MId+/VyyyGbUV+HRrqIS+htIBlGmsNBW6fzuKK6hgOGn+Kyb2N4+Mejg==}
     engines: {node: '>=18.0.0'}
 
+  '@fern-fern/ir-sdk@67.1.0':
+    resolution: {integrity: sha512-fkTbqm3ldzx5hUGgIyVliBn+bebNsKoPVvuzc3ZUpoPgXQXJkmWi0TvKKHoyHTqZ0lWLMsjX4ADY3doILrUS3g==}
+    engines: {node: '>=18.0.0'}
+
   '@fern-fern/ir-v53-sdk@1.0.1':
     resolution: {integrity: sha512-SVNbkGBVgE/PkgurqqdFEYkmYBGNZzD2Qh8wF9nApp1NH2Wipte5zbzngl78snGTk/e9DN6+mYHfgQPzv6Pi4w==}
     engines: {node: '>=18.0.0'}
@@ -16529,6 +16533,8 @@ snapshots:
   '@fern-fern/ir-sdk@66.2.0': {}
 
   '@fern-fern/ir-sdk@66.3.0': {}
+
+  '@fern-fern/ir-sdk@67.1.0': {}
 
   '@fern-fern/ir-v53-sdk@1.0.1': {}
 


### PR DESCRIPTION
## Description

Upgrade `@fern-fern/ir-sdk` from 66.0.0 to 67.1.0 in the OpenAPI generator (`generators/openapi/`).

## Changes Made

- Updated `@fern-fern/ir-sdk` version from `66.0.0` to `67.1.0` in `generators/openapi/package.json`
- Updated `pnpm-lock.yaml` via `pnpm install`
- Added missing visitor cases (`alpha`, `beta`, `preview`, `legacy`) in `convertAvailability.ts` to handle new `AvailabilityStatus` variants introduced in IR SDK 67.1.0

## Testing

- [x] `pnpm compile` passes with no errors
- [x] `pnpm format` passes

Link to Devin session: https://app.devin.ai/sessions/7cd4d13f6f8d4e2986e1dff80f5472e0
Requested by: @Swimburger