### PR TITLE
chore(swift): upgrade ir-sdk and dynamic-ir-sdk to 67.1.0

### DIFF
--- a/generators/swift/base/package.json
+++ b/generators/swift/base/package.json
@@ -36,7 +36,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/swift-codegen": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/generators/swift/dynamic-snippets/package.json
+++ b/generators/swift/dynamic-snippets/package.json
@@ -35,7 +35,7 @@
     "@fern-api/browser-compatible-base-generator": "workspace:*",
     "@fern-api/configs": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/dynamic-ir-sdk": "66.1.0",
+    "@fern-api/dynamic-ir-sdk": "67.1.0",
     "@fern-api/path-utils": "workspace:*",
     "@fern-api/swift-codegen": "workspace:*",
     "@types/lodash-es": "catalog:",

--- a/generators/swift/model/package.json
+++ b/generators/swift/model/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/swift-base": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "lodash-es": "catalog:"
   },
   "devDependencies": {

--- a/generators/swift/sdk/package.json
+++ b/generators/swift/sdk/package.json
@@ -48,7 +48,7 @@
     "@fern-api/test-utils": "workspace:*",
     "@fern-fern/generator-cli-sdk": "^0.1.5",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
     "lodash-es": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2293,8 +2293,8 @@ importers:
         specifier: workspace:*
         version: link:../codegen
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17
@@ -2354,8 +2354,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/commons/core-utils
       '@fern-api/dynamic-ir-sdk':
-        specifier: 66.1.0
-        version: 66.1.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-api/path-utils':
         specifier: workspace:*
         version: link:../../../packages/commons/path-utils
@@ -2387,8 +2387,8 @@ importers:
         specifier: workspace:*
         version: link:../base
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       lodash-es:
         specifier: 'catalog:'
         version: 4.18.1
@@ -2466,8 +2466,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12
@@ -9398,6 +9398,10 @@ packages:
     resolution: {integrity: sha512-hOfcPPkfhC5vhiZdDVxlsaAPfMQlWdswnpvQoDRhjDN+zGK+ctLiPF7jyKqwIBynG5GyS3SalI2/2r/IgcaFpA==}
     engines: {node: '>=18.0.0'}
 
+  '@fern-api/dynamic-ir-sdk@67.1.0':
+    resolution: {integrity: sha512-IpvIb0CSc69ItZSTacQay4bGqvv3+CJ1jONhvbDmXeKl4qQN3Jey3pudeR26glA6qg9WBz5EVJAoSYnLClF4Dw==}
+    engines: {node: '>=18.0.0'}
+
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28':
     resolution: {integrity: sha512-3qhAAuc4ZJWLaFtyZzaYXfF9OQ5iviNrvLDXtjKScKUNS134fR3v3c3xedCidTq5KedapuBECziUaOmmd6KXVA==}
     engines: {node: '>=18.0.0'}
@@ -9453,6 +9457,10 @@ packages:
 
   '@fern-fern/ir-sdk@66.3.0':
     resolution: {integrity: sha512-BKtpmuyK98GagBSZ5CMe3oAkkwG5l3MId+/VyyyGbUV+HRrqIS+htIBlGmsNBW6fzuKK6hgOGn+Kyb2N4+Mejg==}
+    engines: {node: '>=18.0.0'}
+
+  '@fern-fern/ir-sdk@67.1.0':
+    resolution: {integrity: sha512-fkTbqm3ldzx5hUGgIyVliBn+bebNsKoPVvuzc3ZUpoPgXQXJkmWi0TvKKHoyHTqZ0lWLMsjX4ADY3doILrUS3g==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/ir-v53-sdk@1.0.1':
@@ -16410,6 +16418,8 @@ snapshots:
 
   '@fern-api/dynamic-ir-sdk@66.3.0': {}
 
+  '@fern-api/dynamic-ir-sdk@67.1.0': {}
+
   '@fern-api/fai-sdk@0.0.6-2ee1b7e28': {}
 
   '@fern-api/fdr-sdk@1.2.4-f661387fb2(@opentelemetry/api@1.9.1)(typescript@5.9.3)':
@@ -16529,6 +16539,8 @@ snapshots:
   '@fern-fern/ir-sdk@66.2.0': {}
 
   '@fern-fern/ir-sdk@66.3.0': {}
+
+  '@fern-fern/ir-sdk@67.1.0': {}
 
   '@fern-fern/ir-v53-sdk@1.0.1': {}
 


### PR DESCRIPTION
## Description

Internal dependency bump for the Swift generator packages.

## Changes Made
- Updated `@fern-fern/ir-sdk` from `66.3.0` to `67.1.0` in `generators/swift/base/package.json`, `generators/swift/model/package.json`, and `generators/swift/sdk/package.json`
- Updated `@fern-api/dynamic-ir-sdk` from `66.1.0` to `67.1.0` in `generators/swift/dynamic-snippets/package.json`
- Updated `pnpm-lock.yaml`

## Testing
- [x] `pnpm install` completed successfully
- [x] `pnpm compile` passes for all Swift packages (base, model, sdk, dynamic-snippets)
- [x] `pnpm format` passes with no changes needed

Link to Devin session: https://app.devin.ai/sessions/f16177f4782a4fc48849a00594b87e31
Requested by: @Swimburger