### PR TITLE
chore(internal): remove tracked tsconfig.tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ packages/**/build
 packages/**/lib
 packages/**/dist
 packages/**/tsconfig*tsbuildinfo
+tsconfig.tsbuildinfo
 packages/**/out
 
 # generators


### PR DESCRIPTION
## Description

Remove the root `tsconfig.tsbuildinfo` file from git tracking and add it to `.gitignore`. This file is a 20 MB TypeScript build cache that changes on every build and shouldn't be committed.

## Changes Made
- Removed `tsconfig.tsbuildinfo` from git tracking via `git rm --cached`
- Added `tsconfig.tsbuildinfo` to `.gitignore` (the nested `packages/**/tsconfig*tsbuildinfo` pattern was already ignored, but the root file was not)

## Testing
- [x] Verified root `tsconfig.tsbuildinfo` was previously tracked (`git ls-files`)
- [x] Confirmed nested patterns in `.gitignore` already covered subdirectory tsbuildinfo files
- [x] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/109dfcbd47b040a78a51b88589d51c3c
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->