### PR TITLE
chore(typescript): upgrade ir-sdk to 67.1.0

### DIFF
--- a/generators/typescript/model/type-generator/package.json
+++ b/generators/typescript/model/type-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/union-generator": "workspace:*",

--- a/generators/typescript/model/type-generator/src/__test__/GeneratedUnionTypeImpl.test.ts
+++ b/generators/typescript/model/type-generator/src/__test__/GeneratedUnionTypeImpl.test.ts
@@ -388,7 +388,8 @@ describe("GeneratedUnionTypeImpl", () => {
                         docs: undefined,
                         availability: undefined,
                         v2Examples: undefined,
-                        propertyAccess: undefined
+                        propertyAccess: undefined,
+                        defaultValue: undefined
                     }
                 ]
             });
@@ -414,7 +415,8 @@ describe("GeneratedUnionTypeImpl", () => {
                         docs: undefined,
                         availability: undefined,
                         v2Examples: undefined,
-                        propertyAccess: undefined
+                        propertyAccess: undefined,
+                        defaultValue: undefined
                     }
                 ],
                 extends: [withNameType]
@@ -868,7 +870,8 @@ describe("GeneratedUnionTypeImpl", () => {
                         docs: undefined,
                         availability: undefined,
                         v2Examples: undefined,
-                        propertyAccess: undefined
+                        propertyAccess: undefined,
+                        defaultValue: undefined
                     }
                 ]
             });

--- a/generators/typescript/model/type-reference-converters/package.json
+++ b/generators/typescript/model/type-reference-converters/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/model/type-reference-example-generator/package.json
+++ b/generators/typescript/model/type-reference-example-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/model/type-schema-generator/package.json
+++ b/generators/typescript/model/type-schema-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/model/type-schema-generator/src/__test__/TypeSchemaGenerator.test.ts
+++ b/generators/typescript/model/type-schema-generator/src/__test__/TypeSchemaGenerator.test.ts
@@ -237,7 +237,8 @@ function createObjectProperty(
         docs: undefined,
         availability: undefined,
         v2Examples: undefined,
-        propertyAccess: undefined
+        propertyAccess: undefined,
+        defaultValue: undefined
     };
 }
 

--- a/generators/typescript/model/union-generator/package.json
+++ b/generators/typescript/model/union-generator/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/model/union-schema-generator/package.json
+++ b/generators/typescript/model/union-schema-generator/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/cli/package.json
+++ b/generators/typescript/sdk/cli/package.json
@@ -39,7 +39,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-api/typescript-ast": "workspace:*",
     "@fern-api/typescript-base": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/abstract-generator-cli": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/client-class-generator/package.json
+++ b/generators/typescript/sdk/client-class-generator/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/resolvers": "workspace:*",

--- a/generators/typescript/sdk/client-class-generator/src/__test__/BaseClientTypeGenerator.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/BaseClientTypeGenerator.test.ts
@@ -43,6 +43,7 @@ function createHeader(opts: {
         availability: undefined,
         docs: undefined,
         clientDefault: undefined,
+        defaultValue: undefined,
         v2Examples: undefined
     };
 }
@@ -366,6 +367,7 @@ describe("BaseClientTypeGenerator", () => {
                                             availability: undefined,
                                             docs: undefined,
                                             propertyAccess: undefined,
+                                            defaultValue: undefined,
                                             v2Examples: undefined
                                         })
                                     },
@@ -377,6 +379,7 @@ describe("BaseClientTypeGenerator", () => {
                                             availability: undefined,
                                             docs: undefined,
                                             propertyAccess: undefined,
+                                            defaultValue: undefined,
                                             v2Examples: undefined
                                         })
                                     },
@@ -392,6 +395,7 @@ describe("BaseClientTypeGenerator", () => {
                                             availability: undefined,
                                             docs: undefined,
                                             propertyAccess: undefined,
+                                            defaultValue: undefined,
                                             v2Examples: undefined
                                         }
                                     },
@@ -441,6 +445,7 @@ describe("BaseClientTypeGenerator", () => {
                                             availability: undefined,
                                             docs: undefined,
                                             propertyAccess: undefined,
+                                            defaultValue: undefined,
                                             v2Examples: undefined
                                         })
                                     },
@@ -452,6 +457,7 @@ describe("BaseClientTypeGenerator", () => {
                                             availability: undefined,
                                             docs: undefined,
                                             propertyAccess: undefined,
+                                            defaultValue: undefined,
                                             v2Examples: undefined
                                         })
                                     },
@@ -467,6 +473,7 @@ describe("BaseClientTypeGenerator", () => {
                                             availability: undefined,
                                             docs: undefined,
                                             propertyAccess: undefined,
+                                            defaultValue: undefined,
                                             v2Examples: undefined
                                         }
                                     },
@@ -830,6 +837,7 @@ describe("BaseClientTypeGenerator", () => {
                                             availability: undefined,
                                             docs: undefined,
                                             propertyAccess: undefined,
+                                            defaultValue: undefined,
                                             v2Examples: undefined
                                         })
                                     },
@@ -841,6 +849,7 @@ describe("BaseClientTypeGenerator", () => {
                                             availability: undefined,
                                             docs: undefined,
                                             propertyAccess: undefined,
+                                            defaultValue: undefined,
                                             v2Examples: undefined
                                         })
                                     },
@@ -856,6 +865,7 @@ describe("BaseClientTypeGenerator", () => {
                                             availability: undefined,
                                             docs: undefined,
                                             propertyAccess: undefined,
+                                            defaultValue: undefined,
                                             v2Examples: undefined
                                         }
                                     },

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedDefaultEndpointImplementation.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedDefaultEndpointImplementation.test.ts
@@ -725,6 +725,7 @@ function createCursorPagination(): FernIr.Pagination {
                 docs: undefined,
                 availability: undefined,
                 propertyAccess: undefined,
+                defaultValue: undefined,
                 v2Examples: undefined
             })
         },
@@ -738,6 +739,7 @@ function createCursorPagination(): FernIr.Pagination {
                 docs: undefined,
                 availability: undefined,
                 propertyAccess: undefined,
+                defaultValue: undefined,
                 v2Examples: undefined
             }
         },
@@ -751,6 +753,7 @@ function createCursorPagination(): FernIr.Pagination {
                 docs: undefined,
                 availability: undefined,
                 propertyAccess: undefined,
+                defaultValue: undefined,
                 v2Examples: undefined
             }
         }

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedEndpointResponse.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedEndpointResponse.test.ts
@@ -24,6 +24,7 @@ function createResponseProperty(name: string, valueType?: FernIr.TypeReference):
             availability: undefined,
             docs: undefined,
             propertyAccess: undefined,
+            defaultValue: undefined,
             v2Examples: undefined
         },
         propertyPath: []
@@ -38,6 +39,7 @@ function createRequestProperty(name: string, valueType?: FernIr.TypeReference): 
             availability: undefined,
             docs: undefined,
             propertyAccess: undefined,
+            defaultValue: undefined,
             v2Examples: undefined
         }),
         propertyPath: []

--- a/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/GeneratedSdkClientClassImpl.test.ts
@@ -812,7 +812,8 @@ describe("GeneratedSdkClientClassImpl", () => {
                         docs: undefined,
                         availability: undefined,
                         v2Examples: undefined,
-                        clientDefault: undefined
+                        clientDefault: undefined,
+                        defaultValue: undefined
                     }
                 ],
                 authRequirement: "ALL",
@@ -897,6 +898,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                                             docs: undefined,
                                             availability: undefined,
                                             propertyAccess: undefined,
+                                            defaultValue: undefined,
                                             v2Examples: undefined
                                         })
                                     },
@@ -908,6 +910,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                                             docs: undefined,
                                             availability: undefined,
                                             propertyAccess: undefined,
+                                            defaultValue: undefined,
                                             v2Examples: undefined
                                         })
                                     },
@@ -923,6 +926,7 @@ describe("GeneratedSdkClientClassImpl", () => {
                                             docs: undefined,
                                             availability: undefined,
                                             propertyAccess: undefined,
+                                            defaultValue: undefined,
                                             v2Examples: undefined
                                         }
                                     },

--- a/generators/typescript/sdk/client-class-generator/src/__test__/RequestParameters.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/RequestParameters.test.ts
@@ -390,7 +390,8 @@ describe("FileUploadRequestParameter", () => {
             availability: undefined,
             docs: undefined,
             v2Examples: undefined,
-            clientDefault: undefined
+            clientDefault: undefined,
+            defaultValue: undefined
         };
         const ref = param.getReferenceToNonLiteralHeader(header, context);
         expect(getTextOfTsNode(ref)).toContain(".");
@@ -414,7 +415,8 @@ describe("FileUploadRequestParameter", () => {
             availability: undefined,
             docs: undefined,
             v2Examples: undefined,
-            clientDefault: undefined
+            clientDefault: undefined,
+            defaultValue: undefined
         };
         const ref = param.getReferenceToNonLiteralHeader(header, context);
         const text = getTextOfTsNode(ref);
@@ -455,7 +457,8 @@ describe("FileUploadRequestParameter", () => {
             docs: undefined,
             availability: undefined,
             v2Examples: undefined,
-            propertyAccess: undefined
+            propertyAccess: undefined,
+            defaultValue: undefined
         };
         const ref = param.getReferenceToBodyProperty(bodyProp, context);
         expect(getTextOfTsNode(ref)).toContain("data");

--- a/generators/typescript/sdk/client-class-generator/src/__test__/isLiteralHeader.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/isLiteralHeader.test.ts
@@ -25,7 +25,8 @@ function createHeader(valueType?: FernIr.TypeReference): FernIr.HttpHeader {
         availability: undefined,
         docs: undefined,
         v2Examples: undefined,
-        clientDefault: undefined
+        clientDefault: undefined,
+        defaultValue: undefined
     };
 }
 

--- a/generators/typescript/sdk/endpoint-error-union-generator/package.json
+++ b/generators/typescript/sdk/endpoint-error-union-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/resolvers": "workspace:*",

--- a/generators/typescript/sdk/environments-generator/package.json
+++ b/generators/typescript/sdk/environments-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/sdk/generator/package.json
+++ b/generators/typescript/sdk/generator/package.json
@@ -39,7 +39,7 @@
     "@fern-api/typescript-ast": "workspace:*",
     "@fern-fern/generator-cli-sdk": "^0.5.0",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "@fern-typescript/endpoint-error-union-generator": "workspace:*",

--- a/generators/typescript/sdk/request-wrapper-generator/package.json
+++ b/generators/typescript/sdk/request-wrapper-generator/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "ts-morph": "catalog:"

--- a/generators/typescript/sdk/request-wrapper-generator/src/__test__/GeneratedRequestWrapperExampleImpl.test.ts
+++ b/generators/typescript/sdk/request-wrapper-generator/src/__test__/GeneratedRequestWrapperExampleImpl.test.ts
@@ -512,6 +512,7 @@ describe("GeneratedRequestWrapperExampleImpl", () => {
                         availability: undefined,
                         v2Examples: undefined,
                         propertyAccess: undefined,
+                        defaultValue: undefined,
                         contentType: undefined,
                         style: undefined
                     })

--- a/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
+++ b/generators/typescript/sdk/sdk-endpoint-type-schemas-generator/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@fern-api/base-generator": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/sdk-error-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-generator/package.json
@@ -32,7 +32,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/abstract-error-class-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/sdk-error-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-error-schema-generator/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
+++ b/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/package.json
@@ -32,7 +32,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/src/__test__/SdkInlinedRequestBodySchemaGenerator.test.ts
+++ b/generators/typescript/sdk/sdk-inlined-request-body-schema-generator/src/__test__/SdkInlinedRequestBodySchemaGenerator.test.ts
@@ -119,7 +119,8 @@ function createInlinedRequestProperty(
         docs: undefined,
         availability: undefined,
         v2Examples: undefined,
-        propertyAccess: undefined
+        propertyAccess: undefined,
+        defaultValue: undefined
     };
 }
 

--- a/generators/typescript/sdk/test-utils/package.json
+++ b/generators/typescript/sdk/test-utils/package.json
@@ -35,11 +35,11 @@
     "ts-morph": "catalog:"
   },
   "peerDependencies": {
-    "@fern-fern/ir-sdk": "66.3.0"
+    "@fern-fern/ir-sdk": "67.1.0"
   },
   "devDependencies": {
     "@fern-api/configs": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/generators/typescript/sdk/test-utils/src/ir-factories.ts
+++ b/generators/typescript/sdk/test-utils/src/ir-factories.ts
@@ -167,7 +167,8 @@ export function createQueryParameter(
         docs: undefined,
         availability: undefined,
         explode: undefined,
-        clientDefault: undefined
+        clientDefault: undefined,
+        defaultValue: undefined
     };
 }
 
@@ -216,7 +217,8 @@ export function createHttpHeader(
         v2Examples: undefined,
         docs: opts?.docs,
         availability: undefined,
-        clientDefault: undefined
+        clientDefault: undefined,
+        defaultValue: undefined
     };
 }
 
@@ -234,7 +236,8 @@ export function createInlinedRequestBodyProperty(
         docs: opts?.docs,
         availability: undefined,
         v2Examples: undefined,
-        propertyAccess: undefined
+        propertyAccess: undefined,
+        defaultValue: undefined
     };
 }
 
@@ -372,7 +375,8 @@ export function createObjectProperty(
         docs: opts?.docs,
         availability: undefined,
         v2Examples: undefined,
-        propertyAccess: undefined
+        propertyAccess: undefined,
+        defaultValue: undefined
     };
 }
 

--- a/generators/typescript/sdk/websocket-type-schema-generator/package.json
+++ b/generators/typescript/sdk/websocket-type-schema-generator/package.json
@@ -32,7 +32,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/abstract-schema-generator": "workspace:*",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",

--- a/generators/typescript/utils/abstract-generator-cli/package.json
+++ b/generators/typescript/utils/abstract-generator-cli/package.json
@@ -37,7 +37,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/commons": "workspace:*",
     "@fern-typescript/contexts": "workspace:*",
     "tmp-promise": "catalog:"

--- a/generators/typescript/utils/commons/package.json
+++ b/generators/typescript/utils/commons/package.json
@@ -38,7 +38,7 @@
     "@fern-api/logger": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
     "@fern-api/typescript-base": "workspace:*",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "decompress": "catalog:",
     "esutils": "catalog:",
     "eta": "^4.5.1",

--- a/generators/typescript/utils/contexts/package.json
+++ b/generators/typescript/utils/contexts/package.json
@@ -35,7 +35,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/logger": "workspace:*",
     "@fern-fern/generator-exec-sdk": "catalog:",
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/commons": "workspace:*",
     "ts-morph": "catalog:"
   },

--- a/generators/typescript/utils/resolvers/package.json
+++ b/generators/typescript/utils/resolvers/package.json
@@ -31,7 +31,7 @@
     "test:update": "vitest --passWithNoTests --run -u"
   },
   "dependencies": {
-    "@fern-fern/ir-sdk": "66.3.0",
+    "@fern-fern/ir-sdk": "67.1.0",
     "@fern-typescript/commons": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2612,8 +2612,8 @@ importers:
         specifier: workspace:*
         version: link:../../../base
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2652,8 +2652,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2689,8 +2689,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2726,8 +2726,8 @@ importers:
         specifier: workspace:*
         version: link:../../../base
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -2772,8 +2772,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2803,8 +2803,8 @@ importers:
         specifier: workspace:*
         version: link:../../../base
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -2858,8 +2858,8 @@ importers:
         specifier: workspace:*
         version: link:../../../typescript-v2/base
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/abstract-generator-cli':
         specifier: workspace:*
         version: link:../../utils/abstract-generator-cli
@@ -2888,8 +2888,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2937,8 +2937,8 @@ importers:
         specifier: workspace:*
         version: link:../../../base
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -2980,8 +2980,8 @@ importers:
         specifier: workspace:*
         version: link:../../../base
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3035,8 +3035,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3160,8 +3160,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../../utils/commons
@@ -3200,8 +3200,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3243,8 +3243,8 @@ importers:
   generators/typescript/sdk/sdk-error-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/abstract-error-class-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-error-class-generator
@@ -3283,8 +3283,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/commons/core-utils
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3320,8 +3320,8 @@ importers:
   generators/typescript/sdk/sdk-inlined-request-body-schema-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3373,8 +3373,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/configs
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.17
@@ -3388,8 +3388,8 @@ importers:
   generators/typescript/sdk/websocket-type-schema-generator:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/abstract-schema-generator':
         specifier: workspace:*
         version: link:../../utils/abstract-schema-generator
@@ -3471,8 +3471,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../commons
@@ -3542,8 +3542,8 @@ importers:
         specifier: workspace:*
         version: link:../../../typescript-v2/base
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       decompress:
         specifier: 'catalog:'
         version: 4.2.1
@@ -3621,8 +3621,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1167
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../commons
@@ -3646,8 +3646,8 @@ importers:
   generators/typescript/utils/resolvers:
     dependencies:
       '@fern-fern/ir-sdk':
-        specifier: 66.3.0
-        version: 66.3.0
+        specifier: 67.1.0
+        version: 67.1.0
       '@fern-typescript/commons':
         specifier: workspace:*
         version: link:../commons
@@ -9453,6 +9453,10 @@ packages:
 
   '@fern-fern/ir-sdk@66.3.0':
     resolution: {integrity: sha512-BKtpmuyK98GagBSZ5CMe3oAkkwG5l3MId+/VyyyGbUV+HRrqIS+htIBlGmsNBW6fzuKK6hgOGn+Kyb2N4+Mejg==}
+    engines: {node: '>=18.0.0'}
+
+  '@fern-fern/ir-sdk@67.1.0':
+    resolution: {integrity: sha512-fkTbqm3ldzx5hUGgIyVliBn+bebNsKoPVvuzc3ZUpoPgXQXJkmWi0TvKKHoyHTqZ0lWLMsjX4ADY3doILrUS3g==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/ir-v53-sdk@1.0.1':
@@ -16529,6 +16533,8 @@ snapshots:
   '@fern-fern/ir-sdk@66.2.0': {}
 
   '@fern-fern/ir-sdk@66.3.0': {}
+
+  '@fern-fern/ir-sdk@67.1.0': {}
 
   '@fern-fern/ir-v53-sdk@1.0.1': {}
 


### PR DESCRIPTION
## Description

Upgrade `@fern-fern/ir-sdk` dependency from 66.3.0 to 67.1.0 across all packages in `generators/typescript/`.

## Changes Made

- Updated all 22 `package.json` files under `generators/typescript/` that reference `@fern-fern/ir-sdk` from `66.3.0` to `67.1.0`
- Updated `pnpm-lock.yaml` accordingly
- Fixed compilation errors caused by new required `defaultValue` field added to `QueryParameter`, `HttpHeader`, `InlinedRequestBodyProperty`, `ObjectProperty`, and `FileUploadBodyProperty` IR types — set to `undefined` in all test factory functions and inline test object literals

## Testing

- [x] `pnpm install` completed successfully
- [x] `pnpm --filter "@fern-typescript/*" compile` passes with zero errors
- [x] `pnpm format` applied

Link to Devin session: https://app.devin.ai/sessions/6f502da9110e4cb69fb9ff76d957d029
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->