### PR TITLE
feat(internal): add ADR framework and retroactive release management ADRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,46 @@ When creating pull requests in this repository:
 3. **Description**: Follow the PR template in `.github/pull_request_template.md`
 4. **Testing**: Ensure all tests pass before marking PR as ready for review
 
+## Architecture Decision Records (ADRs)
+
+ADRs live in `docs/adr/` and are numbered sequentially (`0001-`, `0002-`, …).
+
+**Create an ADR when a change is cross-cutting — i.e., it affects how multiple components of the repo work together or sets a convention that all contributors must follow:**
+- A new repo-wide system or workflow (release pipelines, CI frameworks, build tooling)
+- A design decision that governs the IR or the contract between the CLI and generators broadly
+- A new architectural pattern or abstraction adopted across several packages
+- A policy change that constrains how all (or many) generators/packages must behave
+
+**Do NOT create an ADR for:**
+- Changes scoped to a single generator or package, even significant ones (new features, output format changes, config additions)
+- Bug fixes at any level
+- Dependency version bumps
+- Refactors that don't change observable behavior
+- IR additions that are additive and don't change existing generator contracts
+
+### ADR format
+
+```markdown
+# ADR NNNN: <Title>
+
+## Status
+Accepted — merged #<PR> on <date>.
+
+## Context
+Why this change was needed and what constraints shaped the design.
+
+## Decision
+What was decided and the key implementation details.
+
+## Alternatives Considered
+Other approaches evaluated and why they were rejected.
+
+## Consequences
+Trade-offs, limitations, and follow-on implications.
+```
+
+After writing the ADR, number it by finding the highest existing `docs/adr/NNNN-*.md` and incrementing by one.
+
 ## Troubleshooting
 
 ### Quick Fixes by Issue Type

--- a/docs/adr/0001-unified-release-management.md
+++ b/docs/adr/0001-unified-release-management.md
@@ -1,0 +1,68 @@
+# ADR 0001: Unified Release Management System
+
+## Status
+
+Accepted — merged [#12149](https://github.com/fern-api/fern/pull/12149) on 2025-11-15.
+Partially superseded by [ADR 0002](./0002-remove-major-version-from-auto-release.md): `break` type and major version bumps were removed from the automated flow.
+
+## Context
+
+The Fern monorepo hosts many independently-versioned software components (CLI, TypeScript SDK generator, Python SDK generator, etc.), each with its own `versions.yml`, changelog workflow, and CI validation. Over time this produced:
+
+- Separate, bespoke CI workflows per component (`cli-release.yml`, `validate-changelog.yml`, etc.) that diverged in behavior
+- Manual severity fields on changelog entries that were easy to get wrong and inconsistent
+- No standard way to onboard a new component into the release system — each addition required copying and adapting existing scripts
+- Release commits hardcoded to `main`, making break-glass releases from other branches impossible
+- Changelog validation scattered across per-component scripts with no shared logic
+
+The goal was a single, consistent release system that works for any component in the monorepo without per-component customization.
+
+## Decision
+
+Implement a TypeScript-based unified release system with a central registry:
+
+- **`release-config.json`** — central registry mapping short identifiers (e.g., `cli`, `python-sdk`) to full component metadata (name, path to `versions.yml`, changelog folder, software directory). All CI workflows read from this file dynamically so adding a new component requires only a single config entry.
+
+- **`pnpm release <software>`** — single entry point that routes to interactive setup (for new components) or the release workflow (for existing ones). Setup prompts for config values and creates the changelog directory structure including a `.template.yml` with a dynamic `$schema` pointer.
+
+- **Type-derived version bumps** — changelog entries declare a `type` (`fix`, `chore`, `feat`, `internal`, `break`). Severity is computed automatically: `fix`/`chore` → patch, `feat`/`internal` → minor, `break` → major. The manual `severity` field is eliminated.
+
+- **Branch-agnostic release script** — `release.ts` detects the current branch via `git rev-parse --abbrev-ref HEAD` rather than hardcoding `main`. The CI workflow (`release-software.yml`) controls which branch is checked out, keeping the script reusable for break-glass releases via `workflow_dispatch`.
+
+- **Unified CI validation** — a single `validate-changelogs.yml` workflow reads `release-config.json` to discover all components, then checks only the components whose files appear in the PR diff. This replaces the per-component validation scripts.
+
+- **Loop prevention** — `release-software.yml` matches commit subjects against `^chore\(.+\): release .+` to skip triggering on the release commits themselves, avoiding infinite CI loops.
+
+### Key files
+
+| File | Purpose |
+|------|---------|
+| `release-config.json` | Component registry |
+| `release-config.schema.json` | JSON schema for IDE validation of the registry |
+| `fern-changes-yml.schema.json` | JSON schema for changelog entry files |
+| `scripts/release.ts` | Main entry point |
+| `scripts/release-setup.ts` | Interactive setup for new components |
+| `scripts/release-config.ts` | Shared config load/save utilities |
+| `scripts/release-workflow.ts` | Non-interactive batch release for CI |
+| `scripts/validate-changelogs.ts` | PR changelog validation |
+| `.github/workflows/validate-changelogs.yml` | Unified PR validation |
+| `.github/workflows/release-software.yml` | Auto-release on merge to main |
+
+## Alternatives Considered
+
+**Keep per-component scripts and workflows** — Rejected. Every new component (e.g., a new language SDK) would require copying and adapting 3–4 files. Divergence was already visible between the CLI workflow and prototype generator workflows; adding more components would multiply the maintenance burden.
+
+**Use an existing release tool (semantic-release, changesets, release-please)** — Considered but rejected. The monorepo has an existing `versions.yml`-based convention tied to Fern's own changelog format and IR version compatibility checks. Adopting an external tool would require migrating all components off that convention or maintaining two parallel systems. The bespoke system is ~500 LOC and fits the existing conventions exactly.
+
+**Store severity explicitly on changelog entries** — The original design required authors to write `severity: minor` alongside `type: feat`. Rejected because type already determines severity unambiguously, making the field redundant. Authors were regularly inconsistent (writing `type: feat, severity: patch`), and the duplication was a source of confusion. Auto-deriving severity from type removes the class of errors entirely.
+
+**Hardcode branch to `main` in the release script** — The original implementation checked out `main` unconditionally. Rejected in favor of detecting the current branch so that the CI workflow controls the target branch. This allows future `workflow_dispatch`-triggered releases from non-main branches without changing the script.
+
+## Consequences
+
+- **Adding a new component to the release system** is now a single `pnpm release <new-component>` invocation that writes a config entry and creates the changelog directory — no CI workflow changes needed.
+- **Changelog entries are simpler** — authors write only `summary` and `type`; severity is derived automatically.
+- **`validate-changelogs.yml` now runs `pnpm install`** on every PR, adding latency to changelog validation. Mitigated by Turbo's caching, but a path filter could be added if it becomes a bottleneck.
+- **Release loop prevention relies on commit subject regex** — if a release commit subject drifts from `^chore\(.+\): release .+`, the workflow could trigger itself. This is detectable and low-risk but worth monitoring.
+- **`ACTIONS_PAT` secret must have main-branch bypass** — the release script pushes directly to main. If the secret is misconfigured, releases will fail silently at the push step.
+- **No automated tests for `validateChangelogEntry()`** — the runtime validation logic has no unit tests. Edge cases (missing fields, invalid types) should be covered before this becomes the sole gating mechanism.

--- a/docs/adr/0002-remove-major-version-from-auto-release.md
+++ b/docs/adr/0002-remove-major-version-from-auto-release.md
@@ -1,0 +1,49 @@
+# ADR 0002: Remove Major Version Bumps from Automated Release Flow
+
+## Status
+
+Accepted — merged [#15685](https://github.com/fern-api/fern/pull/15685) on 2026-05-06.
+
+## Context
+
+ADR 0001 established a unified release system where changelog entry `type` determines the version bump automatically: `fix`/`chore` → patch, `feat`/`internal` → minor, `break` → major. This worked as designed but created a dangerous footgun: any engineer merging a PR with a `type: break` changelog entry would silently trigger a major version release for that component.
+
+This surfaced as an incident in [#15583](https://github.com/fern-api/fern/pull/15583): a `break` entry for the CLI removal of `og:background-image` caused the automated system to cut CLI v5.0.0 without any explicit human acknowledgment that a major release was happening. Major version bumps for a widely-used CLI and SDK generators are customer-visible breaking events — they break pinned installs, require migration guides, and should never happen as a side-effect of a routine changelog entry.
+
+The root problem: major releases carry a different weight than patch or minor releases. They require deliberate human intent, not just a correctly-typed changelog entry.
+
+## Decision
+
+Remove `break` as a valid changelog entry type. The automated release flow can now only produce patch or minor bumps. Major releases require a direct edit to the relevant `versions.yml` file, making the major bump an explicit, reviewable code change rather than a computed side-effect.
+
+### Changes
+
+- **`fern-changes-yml.schema.json`**: `break` dropped from the `ChangelogType` enum. IDE autocompletion and validation no longer suggest it.
+- **`scripts/release.ts`**: `break` removed from `VALID_CHANGELOG_TYPES`, `getSeverityFromType`, `ChangelogEntry`, and `Severity`. The runtime parser rejects `type: break` with a clear error: `Invalid "type" field: "break". Expected one of: fix, chore, feat, internal`.
+- **`packages/seed/src/commands/validate/validateStagedChanges.ts`**: `seed validate` now fails if any file in `changes/unreleased/` has `type: break`, catching it before the release script runs.
+- **All `.template.yml` files** (CLI + 10 generators): `break (major)` removed from the type comment; a note added explaining that majors require a manual `versions.yml` edit.
+- **`.claude/release-versioning.md`**: documentation updated to remove `break` and explain the manual major release path.
+
+Historical changelog files that already contain `type: break` (e.g., entries under `changes/5.0.0/`) are left unchanged — they are already shipped and recorded in `versions.yml`.
+
+### How to ship a major release now
+
+Edit the relevant `versions.yml` directly to set the next version to the intended major (e.g., `6.0.0`). The diff in the PR makes the major bump explicit and reviewable by teammates and the release on-call.
+
+## Alternatives Considered
+
+**Require an explicit confirmation flag on `break` entries** — e.g., `confirm-major: true` alongside `type: break`. Rejected because it adds friction without adding safety: anyone can write the flag without understanding the implications, and the automation still fires automatically on merge. It does not change the fundamental problem that the major bump is a side-effect rather than an intentional act.
+
+**Require a separate approval step in the release workflow for major bumps** — add a manual CI gate (GitHub environment protection rule or a `workflow_dispatch` approval) before pushing a major release. Rejected as operationally complex: it would require configuring environment secrets per component, adds async latency to the release, and is hard to audit. A `versions.yml` edit achieves the same gate with zero infrastructure.
+
+**Keep `break` but send an alert/notification before releasing** — notify a Slack channel or require an issue to be filed before proceeding. Rejected because notifications are easy to miss and don't prevent the release from proceeding. Hard enforcement (rejecting the changelog entry) is strictly safer.
+
+**Rate-limit major releases** (e.g., only allow one per calendar quarter) — Rejected as overly prescriptive. The goal is explicit acknowledgment, not frequency control.
+
+## Consequences
+
+- **Major releases are now always intentional**: the only path to a major version bump is a `versions.yml` edit that appears in a PR diff, making the decision visible and reviewable.
+- **`break` entries in historical changelogs remain valid**: the validator only rejects files in `changes/unreleased/`, so the released history is untouched.
+- **Authors lose a changelog type**: engineers writing truly breaking changes must either use `feat` (if the bump should be minor) or open a separate PR that manually bumps `versions.yml`. The template files explain this.
+- **`seed validate` is now the enforcement point**: the check lives in the validator so it fires in CI before any release logic runs. A misconfigured or skipped validator could let a `break` entry reach the release script, where it is also rejected — two layers of defense.
+- **The original v5.0.0 incident cannot recur**: there is no code path from a changelog entry to a major version bump.


### PR DESCRIPTION
## Context

Architectural decisions in this repo have historically lived only in PR descriptions, with no durable home. When the next contributor asks why the release system works the way it does — why `break` was removed as a changelog type, or why major bumps require a manual `versions.yml` edit — the only trace is buried in a merged PR. This PR establishes a lightweight ADR practice so those decisions are findable where developers look: in the repo itself.

It also adds two retroactive ADRs for the release system decisions made in PRs #12149 and #15685, which are the most consequential cross-cutting decisions in recent history.

## What's Changed

- Added `docs/adr/` directory with:
  - `0001-unified-release-management.md` — retroactive ADR for the unified release system introduced in #12149: central `release-config.json` registry, type-derived version bumps, branch-agnostic release script, unified CI validation
  - `0002-remove-major-version-from-auto-release.md` — retroactive ADR for the removal of `break` type and major version bumps from the automated flow (#15685), driven by the unintended v5.0.0 CLI release incident
- Updated `CLAUDE.md` with an "Architecture Decision Records" section covering:
  - When to write an ADR: cross-cutting decisions affecting multiple components or setting repo-wide conventions — NOT changes scoped to a single generator or package, even significant ones
  - The standard ADR format (Status, Context, Decision, Alternatives Considered, Consequences)
  - Numbering convention (`NNNN-` prefix, sequential)

## Testing

- Verified `CLAUDE.md` renders correctly with the new section in the right place
- Confirmed both ADR files follow the agreed format
- Pre-commit hook passed cleanly