### PR TITLE
fix(seed): overlay containerd v2.3.0 in php-seed to clear upstream Go-module CVEs

### DIFF
--- a/docker/seed/Dockerfile.php
+++ b/docker/seed/Dockerfile.php
@@ -5,11 +5,47 @@ RUN apk add --no-cache curl && \
     curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
     crane pull wiremock/wiremock:3.9.1 /wiremock.tar
 
-# Stage 2: Build the seed image
+# Stage 2: Download a newer containerd build to address CVEs in the Go-module
+# deps baked into docker:29.4.1-dind-alpine3.23 (which ships containerd v2.2.3).
+#
+# containerd v2.3.0 bumps grpc v1.78.0 -> v1.80.0, otel v1.38.0 -> v1.43.0,
+# otel/sdk v1.38.0 -> v1.43.0, go-jose v4.1.3 -> v4.1.4 in the /usr/local/bin
+# containerd / ctr / containerd-shim-runc-v2 binaries. The dockerd binary in
+# 29.4.1 talks to containerd over the stable gRPC plugin protocol so newer
+# minor versions of containerd are wire-compatible.
+#
+# We use the `containerd-static-*` archive (statically linked) because the
+# default release tarball is dynamically linked against glibc and won't run
+# on Alpine's musl libc.
+#
+# We deliberately do NOT overlay runc here: the upstream runc v1.4.2 release
+# was built with go1.25.8, which has unfixed stdlib CVEs (CVE-2026-27143 et
+# al.), while the runc v1.3.5 already shipped in the base image was built
+# with the patched go1.26.2 toolchain. Bumping runc would trade two
+# golang.org/x/net findings for several Critical/High stdlib findings, which
+# is a regression.
+FROM alpine:3.23 AS overlay-binaries
+ARG CONTAINERD_VERSION=2.3.0
+RUN apk add --no-cache curl tar && \
+    ARCH=$(uname -m) && \
+    case "$ARCH" in \
+      x86_64) GOARCH=amd64 ;; \
+      aarch64) GOARCH=arm64 ;; \
+      *) echo "Unsupported arch: $ARCH"; exit 1 ;; \
+    esac && \
+    mkdir -p /overlay/usr/local/bin && \
+    curl -fsSL "https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-static-${CONTAINERD_VERSION}-linux-${GOARCH}.tar.gz" \
+      | tar -xz -C /overlay/usr/local --no-same-owner \
+        bin/containerd bin/containerd-shim-runc-v2 bin/ctr
+
+# Stage 3: Build the seed image
 FROM docker:29.4.1-dind-alpine3.23
 
 # Apply latest security patches to base image packages (libssl3, libcrypto3, libcurl, etc.)
 RUN apk upgrade --no-cache
+
+# Overlay newer containerd binaries (see overlay-binaries stage above).
+COPY --from=overlay-binaries /overlay/ /
 
 # Copy pre-pulled wiremock image
 COPY --from=wiremock-pull /wiremock.tar /wiremock.tar


### PR DESCRIPTION
## Description
Linear ticket: Refs (none)

Follow-up to #15731. The php-seed image was bumped to `docker:29.4.1-dind-alpine3.23` (the latest published DinD release) but several CVEs remain in the Go-module deps of the `containerd` / `ctr` / `containerd-shim-runc-v2` binaries that ship with that base image (containerd v2.2.3, depending on `grpc v1.78.0`, `otel v1.38.0`, `otel/sdk v1.38.0`, `go-jose v4.1.3`).

This PR overlays the **statically linked** `containerd v2.3.0` binaries on top of the base image. v2.3.0 bumps:

| dep | v2.2.3 (base) | v2.3.0 (overlay) | fix |
| --- | --- | --- | --- |
| `google.golang.org/grpc` | v1.78.0 | v1.80.0 | GHSA-p77j-4mvh-x3m3 (CVE-2026-33186) — **Critical** |
| `github.com/go-jose/go-jose/v4` | v4.1.3 | v4.1.4 | GHSA-78h2-9frx-2jm8 — **High** |
| `go.opentelemetry.io/otel` | v1.38.0 | v1.43.0 | GHSA-mh2q-q3fh-2475 (containerd path) |
| `go.opentelemetry.io/otel/sdk` | v1.38.0 | v1.43.0 | GHSA-9h8m-3fm2-qjrq — **High** |

The static archive (`containerd-static-2.3.0-linux-${ARCH}.tar.gz`) is required because the default `containerd-2.3.0-linux-${ARCH}.tar.gz` is dynamically linked against glibc and won't run on Alpine's musl libc. dockerd talks to containerd over the stable gRPC plugin protocol, so a newer minor of containerd is wire-compatible with the bundled `dockerd 29.4.1`.

I deliberately **did not** overlay `runc`. The latest published `runc v1.4.2` is built with `go1.25.8`, which has the same unfixed stdlib CVEs (CVE-2026-27143 et al.) that already affect docker-buildx / docker-compose. The `runc v1.3.5` already in the base image is built with the patched `go1.26.2` toolchain. Bumping runc would trade two `golang.org/x/net` Mediums for several Critical/High stdlib findings — a net regression. The local grype scan in this PR confirmed that.

## Changes Made
- `docker/seed/Dockerfile.php`: added an `overlay-binaries` Alpine stage that downloads `containerd-static-${CONTAINERD_VERSION}-linux-${GOARCH}.tar.gz` and extracts `containerd`, `ctr`, and `containerd-shim-runc-v2` into `/overlay/usr/local/bin/`. The final stage `COPY --from=overlay-binaries`s those binaries on top of the existing dind layout. `${ARCH}` detection mirrors the existing `wiremock-pull` stage so both `linux/amd64` and `linux/arm64` builds work.
- [ ] Updated README.md generator (if applicable) — N/A

## Testing
- [ ] Unit tests added/updated — N/A (Dockerfile-only change)
- [x] Manual testing completed:
  - `docker build -f docker/seed/Dockerfile.php -t fernapi/php-seed:devin-overlay .` succeeds.
  - Inside the resulting image: `containerd --version` reports `v2.3.0`, `runc --version` still reports `v1.3.5` (with `go: go1.26.2`), all four binaries are statically linked.
  - Booting the image with `--privileged` brings up `dockerd 29.4.1` cleanly; `docker info` reports `containerd version: 2976f38ccbfcda5ef1364d63d60b0a304e4bf94a` (= containerd v2.3.0) and `runc version: v1.3.5-0-g488fc13`.
  - The pre-loaded wiremock image is still loaded successfully on entrypoint.
- [x] grype scan before/after on `fernapi/php-seed`:

| | unique fixable CVEs | Critical | High | Medium |
| --- | --- | --- | --- | --- |
| Before (current `main`) | 19 | 2 | 10 | 7 |
| After (this PR) | 16 | 1 | 8 | 7 |

  CVEs eliminated: **CVE-2026-33186** (gRPC, Critical), **GHSA-78h2-9frx-2jm8** (go-jose, High), **GHSA-9h8m-3fm2-qjrq** (otel/sdk, High).

  The remaining 16 unique findings all live in `/usr/local/libexec/docker/cli-plugins/docker-buildx`, `/usr/local/libexec/docker/cli-plugins/docker-compose`, and `/usr/local/bin/runc`. Those binaries are at their latest upstream releases (`buildx v0.33.0`, `compose v5.1.3`, `runc v1.3.5`) and have no fix available yet — they're blocked on new releases of those projects rebuilt against the patched `go1.25.9` / `go1.26.2` toolchains and updated otel / spdystream / sigstore deps.

Link to Devin session: https://app.devin.ai/sessions/b0a7f148f63c4950b7ac0cb942559fdd
Requested by: @davidkonigsberg