### PR TITLE
fix(generator-cli): use correct GitHub API base URL for GitHub Enterprise self-hosted repos

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-ghe-octokit-baseurl.yml
+++ b/packages/cli/cli/changes/unreleased/fix-ghe-octokit-baseurl.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix GitHub Enterprise support for self-hosted SDK generation. Octokit API calls
+    (signed commits, PR creation, ref updates) now use the correct GHE API base URL
+    derived from the repository URI instead of always hitting api.github.com.
+  type: fix

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -21,7 +21,7 @@ import {
     type PipelineLogger,
     PostGenerationPipeline
 } from "@fern-api/generator-cli/pipeline";
-import { cloneRepository, parseRepository } from "@fern-api/github";
+import { cloneRepository, getGithubApiBaseUrl, parseRepository } from "@fern-api/github";
 import { generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { FernIr, PublishTarget } from "@fern-api/ir-sdk";
 import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
@@ -428,7 +428,8 @@ export async function runLocalGenerationForWorkspace({
                                 skipIfNoDiff,
                                 hasBreakingChanges,
                                 breakingChangesSummary: hasBreakingChanges ? autoVersioningPrDescription : undefined,
-                                runId: process.env.FERN_RUN_ID
+                                runId: process.env.FERN_RUN_ID,
+                                apiBaseUrl: getGithubApiBaseUrl(selfhostedGithubConfig.uri)
                             },
                             cliVersion: workspace.cliVersion ?? "unknown",
                             generatorVersions: {

--- a/packages/commons/github/src/getGithubApiBaseUrl.ts
+++ b/packages/commons/github/src/getGithubApiBaseUrl.ts
@@ -1,0 +1,15 @@
+import { DEFAULT_REMOTE } from "./constants.js";
+import { parseRepository } from "./parseRepository.js";
+
+/**
+ * Derives the GitHub REST API base URL for Octokit from a repository URI.
+ * Returns `undefined` for github.com (Octokit's default), or the GHE API
+ * endpoint (e.g. `https://github.intuit.com/api/v3`) for Enterprise hosts.
+ */
+export function getGithubApiBaseUrl(repositoryUri: string): string | undefined {
+    const { remote } = parseRepository(repositoryUri);
+    if (remote === DEFAULT_REMOTE) {
+        return undefined;
+    }
+    return `https://${remote}/api/v3`;
+}

--- a/packages/commons/github/src/index.ts
+++ b/packages/commons/github/src/index.ts
@@ -3,6 +3,7 @@ export { cloneRepository } from "./cloneRepository.js";
 export { createOrUpdatePullRequest } from "./createOrUpdatePullRequest.js";
 export { deleteBranch } from "./deleteBranch.js";
 export { getFileContent } from "./getFileContent.js";
+export { getGithubApiBaseUrl } from "./getGithubApiBaseUrl.js";
 export { getLatestRelease } from "./getLatestRelease.js";
 export { getOrUpdateBranch } from "./getOrUpdateBranch.js";
 export { parseRepository } from "./parseRepository.js";

--- a/packages/generator-cli/src/github/GitHub.ts
+++ b/packages/generator-cli/src/github/GitHub.ts
@@ -1,5 +1,5 @@
 import { cwd, resolve } from "@fern-api/fs-utils";
-import { ClonedRepository, cloneRepository, parseRepository } from "@fern-api/github";
+import { ClonedRepository, cloneRepository, getGithubApiBaseUrl, parseRepository } from "@fern-api/github";
 import { Octokit } from "@octokit/rest";
 
 import type { FernGeneratorCli } from "../configuration/sdk/index.js";
@@ -92,8 +92,10 @@ export class GitHub {
             await repository.commit("SDK Generation");
             await repository.push();
 
+            const apiBaseUrl = getGithubApiBaseUrl(this.githubConfig.uri);
             const octokit = new Octokit({
-                auth: this.githubConfig.token
+                auth: this.githubConfig.token,
+                ...(apiBaseUrl != null ? { baseUrl: apiBaseUrl } : {})
             });
             // Use octokit directly to create the pull request
             const parsedRepo = parseRepository(this.githubConfig.uri);

--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -103,7 +103,7 @@ export class GithubStep extends BaseStep {
     ): Promise<GithubStepResult> {
         const baseBranch = this.config.branch ?? (await repository.getDefaultBranch());
         const octokit = this.createOctokit();
-        const { owner, repo } = parseRepository(this.config.uri);
+        const { owner, repo, remote } = parseRepository(this.config.uri);
 
         let prBranch: string;
         let isUpdatingExistingPR = false;
@@ -200,8 +200,7 @@ export class GithubStep extends BaseStep {
                 logger: this.logger
             });
             const pushedBranch = await repository.getCurrentBranch();
-            const { remote } = parseRepository(this.config.uri);
-            result.branchUrl = `https://${remote}/${this.config.uri}/tree/${pushedBranch}`;
+            result.branchUrl = `https://${remote}/${owner}/${repo}/tree/${pushedBranch}`;
             this.logger.info(`Pushed branch: ${result.branchUrl}`);
 
             if (generationBaseSha != null) {
@@ -220,7 +219,7 @@ export class GithubStep extends BaseStep {
 
         const headSha = await repository.getHeadSha();
         const changelogUrl = resolved.changelogEntry
-            ? `https://github.com/${this.config.uri}/blob/${headSha}/changelog.md`
+            ? `https://${remote}/${owner}/${repo}/blob/${headSha}/changelog.md`
             : undefined;
         const { prTitle, prBody } = parseCommitMessageForPR(
             resolved.commitMessage,
@@ -347,7 +346,7 @@ export class GithubStep extends BaseStep {
             });
 
             const pushedBranch = await repository.getCurrentBranch();
-            result.branchUrl = `https://${remote}/${this.config.uri}/tree/${pushedBranch}`;
+            result.branchUrl = `https://${remote}/${owner}/${repo}/tree/${pushedBranch}`;
             this.logger.info(`Pushed branch: ${result.branchUrl}`);
         }
 

--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -102,7 +102,7 @@ export class GithubStep extends BaseStep {
         resolved: ResolvedPrFields
     ): Promise<GithubStepResult> {
         const baseBranch = this.config.branch ?? (await repository.getDefaultBranch());
-        const octokit = new Octokit({ auth: this.config.token });
+        const octokit = this.createOctokit();
         const { owner, repo } = parseRepository(this.config.uri);
 
         let prBranch: string;
@@ -200,7 +200,8 @@ export class GithubStep extends BaseStep {
                 logger: this.logger
             });
             const pushedBranch = await repository.getCurrentBranch();
-            result.branchUrl = `https://github.com/${this.config.uri}/tree/${pushedBranch}`;
+            const { remote } = parseRepository(this.config.uri);
+            result.branchUrl = `https://${remote}/${this.config.uri}/tree/${pushedBranch}`;
             this.logger.info(`Pushed branch: ${result.branchUrl}`);
 
             if (generationBaseSha != null) {
@@ -332,8 +333,8 @@ export class GithubStep extends BaseStep {
         };
 
         if (!this.config.previewMode) {
-            const octokit = new Octokit({ auth: this.config.token });
-            const { owner, repo } = parseRepository(this.config.uri);
+            const octokit = this.createOctokit();
+            const { owner, repo, remote } = parseRepository(this.config.uri);
             await pushSignedCommit({
                 repository,
                 octokit,
@@ -346,11 +347,19 @@ export class GithubStep extends BaseStep {
             });
 
             const pushedBranch = await repository.getCurrentBranch();
-            result.branchUrl = `https://github.com/${this.config.uri}/tree/${pushedBranch}`;
+            result.branchUrl = `https://${remote}/${this.config.uri}/tree/${pushedBranch}`;
             this.logger.info(`Pushed branch: ${result.branchUrl}`);
         }
 
         return result;
+    }
+
+    private createOctokit(): Octokit {
+        const opts: ConstructorParameters<typeof Octokit>[0] = { auth: this.config.token };
+        if (this.config.apiBaseUrl != null) {
+            opts.baseUrl = this.config.apiBaseUrl;
+        }
+        return new Octokit(opts);
     }
 
     private async ensureFernignore(): Promise<void> {

--- a/packages/generator-cli/src/pipeline/types.ts
+++ b/packages/generator-cli/src/pipeline/types.ts
@@ -142,6 +142,8 @@ export interface GithubStepConfig {
     breakingChangesSummary?: string;
     /** FERN_RUN_ID for cross-repo correlation (set by GitHub Action) */
     runId?: string;
+    /** GitHub API base URL for GitHub Enterprise (e.g. "https://github.intuit.com/api/v3"). Omit for github.com. */
+    apiBaseUrl?: string;
 }
 
 export interface PipelineResult {


### PR DESCRIPTION
## Description
Refs FER-GHE-support
<!-- Octokit was always defaulting to api.github.com for all GitHub REST API calls, 
causing 401 "Bad credentials" errors when using a GHE PAT with a self-hosted instance -->

When using self-hosted GitHub Enterprise (e.g. `github.intuit.com`) with `generators.yml` `github.uri`, the `pushSignedCommit` flow fails with `HttpError: Bad credentials` because Octokit hits `api.github.com` instead of the GHE API endpoint (`github.intuit.com/api/v3`).

The git CLI operations (clone, checkout, commit) work correctly because `parseRepository()` already extracts the custom remote. But every Octokit API call (signed commits, ref updates, PR creation/listing) was using the default `api.github.com` base URL.

This affects **all generators** equally — the issue is in the shared `generator-cli` package, not language-specific code. Both `push` and `pull-request` modes are affected because `pushSignedCommit()` is used in both flows.

## Changes Made
- Added `getGithubApiBaseUrl()` utility to `@fern-api/github` that derives the GHE API base URL from a repository URI (returns `undefined` for github.com, `https://<host>/api/v3` for Enterprise hosts)
- Added optional `apiBaseUrl` field to `GithubStepConfig` in `generator-cli`
- Updated all Octokit instantiations in `GithubStep.ts` (both `pull-request` and `push` modes) to pass `baseUrl` when targeting a GHE host
- Updated Octokit instantiation in `GitHub.ts` (legacy code path used by generators directly)
- Fixed hardcoded `https://github.com/` branch URL construction to use the actual remote host from the parsed URI
- Wired `apiBaseUrl` through from `runLocalGenerationForWorkspace.ts` pipeline config

## Testing
- [x] `pnpm check` passes (Biome lint)
- [x] `pnpm format` passes
- [ ] Manual testing completed — requires a GHE instance to fully validate end-to-end
- Verified that the fix is backward-compatible: when `apiBaseUrl` is `undefined` (github.com repos), Octokit uses its default base URL as before

Link to Devin session: https://app.devin.ai/sessions/d6f0693ed3d54dc59a04619b58f2a599
Requested by: @iamnamananand996