### PR TITLE
chore(deps): bump @fern-api/replay to 0.15.0 in generator-cli

### DIFF
--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -39,7 +39,7 @@
     "@fern-api/cli-ai": "workspace:*",
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
-    "@fern-api/replay": "0.14.1",
+    "@fern-api/replay": "0.15.0",
     "@fern-api/task-context": "workspace:*",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Bump @fern-api/replay to 0.15.0.
+      type: chore
+  createdAt: "2026-05-06"
+  version: 0.9.26
+
+- changelogEntry:
+    - summary: |
         Fix `AutoVersionStep` silently stripping pre-release identifiers on
         bump. A customer on `4.0.0-rc.2` getting a PATCH-classified change
         previously landed on `4.0.1`, demoting their release candidate to a

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7887,8 +7887,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/logging-execa
       '@fern-api/replay':
-        specifier: 0.14.1
-        version: 0.14.1
+        specifier: 0.15.0
+        version: 0.15.0
       '@fern-api/task-context':
         specifier: workspace:*
         version: link:../cli/task-context
@@ -9414,6 +9414,11 @@ packages:
 
   '@fern-api/replay@0.14.1':
     resolution: {integrity: sha512-OBuBJb7HWMkWjhKpd91NW5pfPtpzvAEvkkFPVtN70K9uLPoc8CQm0j/asaEaOjH/tm7cXDAEQZj4Ekn1Rj+XNw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@fern-api/replay@0.15.0':
+    resolution: {integrity: sha512-F5EcUoVLsVYW5qmwag0S87ZAIf7ldc+vlHEbg4MdImd2m4W5WVKIL1vy60DDPucD2QnGTzavDv9Hi6IaOlyYCg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16454,6 +16459,15 @@ snapshots:
       - supports-color
 
   '@fern-api/replay@0.14.1':
+    dependencies:
+      minimatch: 10.2.5
+      node-diff3: 3.2.0
+      simple-git: 3.36.0
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@fern-api/replay@0.15.0':
     dependencies:
       minimatch: 10.2.5
       node-diff3: 3.2.0


### PR DESCRIPTION
## Description
Bumps `@fern-api/replay` from `0.14.1` to `0.15.0` in the generator-cli package, and adds a new generator-cli version entry (`0.9.26`) to trigger publish.

## Changes Made
- Updated `@fern-api/replay` dependency in `packages/generator-cli/package.json` from `0.14.1` to `0.15.0`
- Added version `0.9.26` entry in `packages/generator-cli/versions.yml`
- Updated `pnpm-lock.yaml`

## Testing
- [ ] CI publish of generator-cli `0.9.26` after merge
- [ ] Catalog pin bump PR to follow once published

Link to Devin session: https://app.devin.ai/sessions/cd94ea14c1f14b878b0251f027404829
Requested by: @tstanmay13