### PR TITLE
chore(deps): bump @fern-api/generator-cli catalog pin to 0.9.26

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ catalogs:
       specifier: 0.0.6-2ee1b7e28
       version: 0.0.6-2ee1b7e28
     '@fern-api/generator-cli':
-      specifier: 0.9.22
-      version: 0.9.22
+      specifier: 0.9.26
+      version: 0.9.26
     '@fern-api/venus-api-sdk':
       specifier: 0.22.34
       version: 0.22.34
@@ -631,7 +631,7 @@ importers:
         version: link:packages/configs
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.22
+        version: 0.9.26
       '@rolldown/binding-darwin-arm64':
         specifier: 'catalog:'
         version: 1.0.0-rc.5
@@ -700,7 +700,7 @@ importers:
         version: link:../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.22
+        version: 0.9.26
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../packages/ir-sdk
@@ -2440,7 +2440,7 @@ importers:
         version: link:../../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.22
+        version: 0.9.26
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../packages/cli/logger
@@ -9408,13 +9408,8 @@ packages:
   '@fern-api/fdr-sdk@1.2.4-f661387fb2':
     resolution: {integrity: sha512-wlk1lTCIZ7biND4vQf8jvhUw9P/rBQ5pXASCrumv8R96up0B3DY6yiY1C4VmFyHmp/kPhcjzc5T9TvHZZxFdrA==}
 
-  '@fern-api/generator-cli@0.9.22':
-    resolution: {integrity: sha512-War2x7+HMAl8TzferxbIRfp1zgQ5OMdoZW/FsD2H/Ep7t0SWLBDcAm+x7s+mhnwEYYXe9VSdA2+aNZC3pwRalA==}
-    hasBin: true
-
-  '@fern-api/replay@0.14.1':
-    resolution: {integrity: sha512-OBuBJb7HWMkWjhKpd91NW5pfPtpzvAEvkkFPVtN70K9uLPoc8CQm0j/asaEaOjH/tm7cXDAEQZj4Ekn1Rj+XNw==}
-    engines: {node: '>=18'}
+  '@fern-api/generator-cli@0.9.26':
+    resolution: {integrity: sha512-m2ZTOCfMd5FbpWoWtnUQERCGO+sOCvEA7EOnPjhfLMfOkgzMLi/rb/pZwBrNDnQyIP0itDOE7YPO3PKHIfTZAw==}
     hasBin: true
 
   '@fern-api/replay@0.15.0':
@@ -16447,23 +16442,14 @@ snapshots:
       - encoding
       - typescript
 
-  '@fern-api/generator-cli@0.9.22':
+  '@fern-api/generator-cli@0.9.26':
     dependencies:
       '@boundaryml/baml': 0.219.0
-      '@fern-api/replay': 0.14.1
+      '@fern-api/replay': 0.15.0
       '@octokit/rest': 22.0.1
       es-toolkit: 1.45.1
       semver: 7.7.4
       tmp-promise: 3.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@fern-api/replay@0.14.1':
-    dependencies:
-      minimatch: 10.2.5
-      node-diff3: 3.2.0
-      simple-git: 3.36.0
-      yaml: 2.8.3
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,7 +60,7 @@ catalog:
   "@bufbuild/protoplugin": 2.2.5
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.2.4-f661387fb2
-  "@fern-api/generator-cli": 0.9.22
+  "@fern-api/generator-cli": 0.9.26
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Description
Bumps the `@fern-api/generator-cli` catalog pin from `0.9.22` to `0.9.26` in `pnpm-workspace.yaml`.

This follows the merge of #15767 which bumped `@fern-api/replay` to `0.15.0` and published generator-cli `0.9.26`.

## Changes Made
- Updated `@fern-api/generator-cli` catalog pin in `pnpm-workspace.yaml` from `0.9.22` to `0.9.26`
- Updated `pnpm-lock.yaml`

## Testing
- [ ] CI passes
- [ ] Generators pick up the new catalog pin on next rebuild

Link to Devin session: https://app.devin.ai/sessions/cd94ea14c1f14b878b0251f027404829
Requested by: @tstanmay13