### PR TITLE
fix(java): scope @JsonIgnore on query getters to inlined-body wrappers

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/WrappedRequestGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/WrappedRequestGenerator.java
@@ -232,8 +232,45 @@ public final class WrappedRequestGenerator extends AbstractFileGenerator {
                 .addAllProperties(queryParameterObjectProperties)
                 .addAllProperties(objectProperties)
                 .build();
-        Set<ObjectProperty> allQueryParameterProperties = new HashSet<>(queryParameterObjectProperties);
-        allQueryParameterProperties.addAll(queryParameterAllowMultipleObjectProperties);
+        // Only mark query parameters as @JsonIgnore when the wrapped request itself is JSON-serialized
+        // as the body (i.e. the body is inlined alongside the query params). For pure-query, referenced-body,
+        // file-upload, and bytes endpoints the wrapped request is never written via JSON_MAPPER, so
+        // marking query params as @JsonIgnore would silently break toString()/stringify without fixing
+        // any leak.
+        boolean bodyIsInlined = httpEndpoint
+                .getRequestBody()
+                .map(body -> body.visit(new HttpRequestBody.Visitor<Boolean>() {
+                    @Override
+                    public Boolean visitInlinedRequestBody(InlinedRequestBody inlinedRequestBody) {
+                        return true;
+                    }
+
+                    @Override
+                    public Boolean visitReference(HttpRequestBodyReference reference) {
+                        return false;
+                    }
+
+                    @Override
+                    public Boolean visitFileUpload(FileUploadRequest fileUpload) {
+                        return false;
+                    }
+
+                    @Override
+                    public Boolean visitBytes(BytesRequest bytes) {
+                        return false;
+                    }
+
+                    @Override
+                    public Boolean _visitUnknown(Object unknownType) {
+                        return false;
+                    }
+                }))
+                .orElse(false);
+        Set<ObjectProperty> allQueryParameterProperties = new HashSet<>();
+        if (bodyIsInlined) {
+            allQueryParameterProperties.addAll(queryParameterObjectProperties);
+            allQueryParameterProperties.addAll(queryParameterAllowMultipleObjectProperties);
+        }
         ObjectGenerator objectGenerator = new ObjectGenerator(
                 objectTypeDeclaration,
                 Optional.empty(),

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.8.2
+  changelogEntry:
+    - summary: |
+        Only apply `@JsonIgnore` to query-parameter getters when the wrapped request has an
+        inlined body. The 4.0.4 fix applied `@JsonIgnore` to every query getter, which made
+        `toString()` / `ObjectMappers.stringify()` return `{}` for pure-query GETs and for
+        referenced/file-upload/bytes bodies — none of which serialize the wrapped request.
+      type: fix
+  createdAt: "2026-05-06"
+  irVersion: 66
 - version: 4.8.1
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/allof-inline/src/main/java/com/seed/api/requests/SearchRuleTypesRequest.java
+++ b/seed/java-sdk/allof-inline/src/main/java/com/seed/api/requests/SearchRuleTypesRequest.java
@@ -5,9 +5,9 @@ package com.seed.api.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -29,7 +29,7 @@ public final class SearchRuleTypesRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public Optional<String> getQuery() {
         return query;
     }

--- a/seed/java-sdk/allof/src/main/java/com/seed/api/requests/SearchRuleTypesRequest.java
+++ b/seed/java-sdk/allof/src/main/java/com/seed/api/requests/SearchRuleTypesRequest.java
@@ -5,9 +5,9 @@ package com.seed.api.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -29,7 +29,7 @@ public final class SearchRuleTypesRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public Optional<String> getQuery() {
         return query;
     }

--- a/seed/java-sdk/audiences/src/main/java/com/seed/audiences/resources/foldera/service/requests/GetDirectThreadRequest.java
+++ b/seed/java-sdk/audiences/src/main/java/com/seed/audiences/resources/foldera/service/requests/GetDirectThreadRequest.java
@@ -5,9 +5,9 @@ package com.seed.audiences.resources.foldera.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,12 +34,12 @@ public final class GetDirectThreadRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("ids")
     public List<String> getIds() {
         return ids;
     }
 
-    @JsonIgnore
+    @JsonProperty("tags")
     public List<String> getTags() {
         return tags;
     }

--- a/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/resources/service/requests/UploadWithQueryParamsRequest.java
+++ b/seed/java-sdk/bytes-upload/src/main/java/com/seed/bytesUpload/resources/service/requests/UploadWithQueryParamsRequest.java
@@ -5,7 +5,6 @@ package com.seed.bytesUpload.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -41,7 +40,7 @@ public final class UploadWithQueryParamsRequest {
     /**
      * @return The model to use for processing
      */
-    @JsonIgnore
+    @JsonProperty("model")
     public String getModel() {
         return model;
     }
@@ -49,7 +48,7 @@ public final class UploadWithQueryParamsRequest {
     /**
      * @return The language of the content
      */
-    @JsonIgnore
+    @JsonProperty("language")
     public Optional<String> getLanguage() {
         return language;
     }

--- a/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/GetClientRequest.java
+++ b/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/GetClientRequest.java
@@ -5,9 +5,9 @@ package com.seed.clientSideParams.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class GetClientRequest {
     /**
      * @return Comma-separated list of fields to include
      */
-    @JsonIgnore
+    @JsonProperty("fields")
     public Optional<String> getFields() {
         return fields;
     }
@@ -44,7 +44,7 @@ public final class GetClientRequest {
     /**
      * @return Whether specified fields are included or excluded
      */
-    @JsonIgnore
+    @JsonProperty("include_fields")
     public Optional<Boolean> getIncludeFields() {
         return includeFields;
     }

--- a/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/GetConnectionRequest.java
+++ b/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/GetConnectionRequest.java
@@ -5,9 +5,9 @@ package com.seed.clientSideParams.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -32,7 +32,7 @@ public final class GetConnectionRequest {
     /**
      * @return Comma-separated list of fields to include
      */
-    @JsonIgnore
+    @JsonProperty("fields")
     public Optional<String> getFields() {
         return fields;
     }

--- a/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/GetResourceRequest.java
+++ b/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/GetResourceRequest.java
@@ -5,9 +5,9 @@ package com.seed.clientSideParams.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class GetResourceRequest {
     /**
      * @return Include metadata in response
      */
-    @JsonIgnore
+    @JsonProperty("include_metadata")
     public Optional<Boolean> getIncludeMetadata() {
         return includeMetadata;
     }
@@ -44,7 +44,7 @@ public final class GetResourceRequest {
     /**
      * @return Response format
      */
-    @JsonIgnore
+    @JsonProperty("format")
     public Optional<String> getFormat() {
         return format;
     }

--- a/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/GetUserRequest.java
+++ b/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/GetUserRequest.java
@@ -5,9 +5,9 @@ package com.seed.clientSideParams.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class GetUserRequest {
     /**
      * @return Comma-separated list of fields to include or exclude
      */
-    @JsonIgnore
+    @JsonProperty("fields")
     public Optional<String> getFields() {
         return fields;
     }
@@ -44,7 +44,7 @@ public final class GetUserRequest {
     /**
      * @return true to include the fields specified, false to exclude them
      */
-    @JsonIgnore
+    @JsonProperty("include_fields")
     public Optional<Boolean> getIncludeFields() {
         return includeFields;
     }

--- a/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/ListClientsRequest.java
+++ b/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/ListClientsRequest.java
@@ -5,9 +5,9 @@ package com.seed.clientSideParams.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -63,7 +63,7 @@ public final class ListClientsRequest {
     /**
      * @return Comma-separated list of fields to include
      */
-    @JsonIgnore
+    @JsonProperty("fields")
     public Optional<String> getFields() {
         return fields;
     }
@@ -71,7 +71,7 @@ public final class ListClientsRequest {
     /**
      * @return Whether specified fields are included or excluded
      */
-    @JsonIgnore
+    @JsonProperty("include_fields")
     public Optional<Boolean> getIncludeFields() {
         return includeFields;
     }
@@ -79,7 +79,7 @@ public final class ListClientsRequest {
     /**
      * @return Page number (zero-based)
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -87,7 +87,7 @@ public final class ListClientsRequest {
     /**
      * @return Number of results per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Integer> getPerPage() {
         return perPage;
     }
@@ -95,7 +95,7 @@ public final class ListClientsRequest {
     /**
      * @return Include total count in response
      */
-    @JsonIgnore
+    @JsonProperty("include_totals")
     public Optional<Boolean> getIncludeTotals() {
         return includeTotals;
     }
@@ -103,7 +103,7 @@ public final class ListClientsRequest {
     /**
      * @return Filter by global clients
      */
-    @JsonIgnore
+    @JsonProperty("is_global")
     public Optional<Boolean> getIsGlobal() {
         return isGlobal;
     }
@@ -111,7 +111,7 @@ public final class ListClientsRequest {
     /**
      * @return Filter by first party clients
      */
-    @JsonIgnore
+    @JsonProperty("is_first_party")
     public Optional<Boolean> getIsFirstParty() {
         return isFirstParty;
     }
@@ -119,7 +119,7 @@ public final class ListClientsRequest {
     /**
      * @return Filter by application type (spa, native, regular_web, non_interactive)
      */
-    @JsonIgnore
+    @JsonProperty("app_type")
     public Optional<List<String>> getAppType() {
         return appType;
     }

--- a/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/ListConnectionsRequest.java
+++ b/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/ListConnectionsRequest.java
@@ -5,9 +5,9 @@ package com.seed.clientSideParams.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -42,7 +42,7 @@ public final class ListConnectionsRequest {
     /**
      * @return Filter by strategy type (e.g., auth0, google-oauth2, samlp)
      */
-    @JsonIgnore
+    @JsonProperty("strategy")
     public Optional<String> getStrategy() {
         return strategy;
     }
@@ -50,7 +50,7 @@ public final class ListConnectionsRequest {
     /**
      * @return Filter by connection name
      */
-    @JsonIgnore
+    @JsonProperty("name")
     public Optional<String> getName() {
         return name;
     }
@@ -58,7 +58,7 @@ public final class ListConnectionsRequest {
     /**
      * @return Comma-separated list of fields to include
      */
-    @JsonIgnore
+    @JsonProperty("fields")
     public Optional<String> getFields() {
         return fields;
     }

--- a/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/ListResourcesRequest.java
+++ b/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/ListResourcesRequest.java
@@ -5,9 +5,9 @@ package com.seed.clientSideParams.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -58,7 +58,7 @@ public final class ListResourcesRequest {
     /**
      * @return Zero-indexed page number
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public int getPage() {
         return page;
     }
@@ -66,7 +66,7 @@ public final class ListResourcesRequest {
     /**
      * @return Number of items per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Integer> getPerPage() {
         return perPage;
     }
@@ -74,7 +74,7 @@ public final class ListResourcesRequest {
     /**
      * @return Sort field
      */
-    @JsonIgnore
+    @JsonProperty("sort")
     public Optional<String> getSort() {
         return sort;
     }
@@ -82,7 +82,7 @@ public final class ListResourcesRequest {
     /**
      * @return Sort order (asc or desc)
      */
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<String> getOrder() {
         return order;
     }
@@ -90,7 +90,7 @@ public final class ListResourcesRequest {
     /**
      * @return Whether to include total count
      */
-    @JsonIgnore
+    @JsonProperty("include_totals")
     public Optional<Boolean> getIncludeTotals() {
         return includeTotals;
     }
@@ -98,7 +98,7 @@ public final class ListResourcesRequest {
     /**
      * @return Comma-separated list of fields to include
      */
-    @JsonIgnore
+    @JsonProperty("fields")
     public Optional<String> getFields() {
         return fields;
     }
@@ -106,7 +106,7 @@ public final class ListResourcesRequest {
     /**
      * @return Search query
      */
-    @JsonIgnore
+    @JsonProperty("search")
     public Optional<String> getSearch() {
         return search;
     }

--- a/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/ListUsersRequest.java
+++ b/seed/java-sdk/client-side-params/default/src/main/java/com/seed/clientSideParams/resources/service/requests/ListUsersRequest.java
@@ -5,9 +5,9 @@ package com.seed.clientSideParams.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -62,7 +62,7 @@ public final class ListUsersRequest {
     /**
      * @return Page index of the results to return. First page is 0.
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -70,7 +70,7 @@ public final class ListUsersRequest {
     /**
      * @return Number of results per page.
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Integer> getPerPage() {
         return perPage;
     }
@@ -78,7 +78,7 @@ public final class ListUsersRequest {
     /**
      * @return Return results inside an object that contains the total result count (true) or as a direct array of results (false, default).
      */
-    @JsonIgnore
+    @JsonProperty("include_totals")
     public Optional<Boolean> getIncludeTotals() {
         return includeTotals;
     }
@@ -86,7 +86,7 @@ public final class ListUsersRequest {
     /**
      * @return Field to sort by. Use field:order where order is 1 for ascending and -1 for descending.
      */
-    @JsonIgnore
+    @JsonProperty("sort")
     public Optional<String> getSort() {
         return sort;
     }
@@ -94,7 +94,7 @@ public final class ListUsersRequest {
     /**
      * @return Connection filter
      */
-    @JsonIgnore
+    @JsonProperty("connection")
     public Optional<String> getConnection() {
         return connection;
     }
@@ -102,7 +102,7 @@ public final class ListUsersRequest {
     /**
      * @return Query string following Lucene query string syntax
      */
-    @JsonIgnore
+    @JsonProperty("q")
     public Optional<String> getQ() {
         return q;
     }
@@ -110,7 +110,7 @@ public final class ListUsersRequest {
     /**
      * @return Search engine version (v1, v2, or v3)
      */
-    @JsonIgnore
+    @JsonProperty("search_engine")
     public Optional<String> getSearchEngine() {
         return searchEngine;
     }
@@ -118,7 +118,7 @@ public final class ListUsersRequest {
     /**
      * @return Comma-separated list of fields to include or exclude
      */
-    @JsonIgnore
+    @JsonProperty("fields")
     public Optional<String> getFields() {
         return fields;
     }

--- a/seed/java-sdk/enum/forward-compatible-enums/src/main/java/com/seed/_enum/resources/queryparam/requests/SendEnumAsQueryParamRequest.java
+++ b/seed/java-sdk/enum/forward-compatible-enums/src/main/java/com/seed/_enum/resources/queryparam/requests/SendEnumAsQueryParamRequest.java
@@ -5,9 +5,9 @@ package com.seed._enum.resources.queryparam.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -46,22 +46,22 @@ public final class SendEnumAsQueryParamRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("operand")
     public Operand getOperand() {
         return operand;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeOperand")
     public Optional<Operand> getMaybeOperand() {
         return maybeOperand;
     }
 
-    @JsonIgnore
+    @JsonProperty("operandOrColor")
     public ColorOrOperand getOperandOrColor() {
         return operandOrColor;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeOperandOrColor")
     public Optional<ColorOrOperand> getMaybeOperandOrColor() {
         return maybeOperandOrColor;
     }

--- a/seed/java-sdk/enum/forward-compatible-enums/src/main/java/com/seed/_enum/resources/queryparam/requests/SendEnumListAsQueryParamRequest.java
+++ b/seed/java-sdk/enum/forward-compatible-enums/src/main/java/com/seed/_enum/resources/queryparam/requests/SendEnumListAsQueryParamRequest.java
@@ -5,9 +5,9 @@ package com.seed._enum.resources.queryparam.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -48,22 +48,22 @@ public final class SendEnumListAsQueryParamRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("operand")
     public List<Operand> getOperand() {
         return operand;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeOperand")
     public Optional<List<Operand>> getMaybeOperand() {
         return maybeOperand;
     }
 
-    @JsonIgnore
+    @JsonProperty("operandOrColor")
     public List<ColorOrOperand> getOperandOrColor() {
         return operandOrColor;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeOperandOrColor")
     public Optional<List<ColorOrOperand>> getMaybeOperandOrColor() {
         return maybeOperandOrColor;
     }

--- a/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/resources/queryparam/requests/SendEnumAsQueryParamRequest.java
+++ b/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/resources/queryparam/requests/SendEnumAsQueryParamRequest.java
@@ -5,9 +5,9 @@ package com.seed._enum.resources.queryparam.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -46,22 +46,22 @@ public final class SendEnumAsQueryParamRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("operand")
     public Operand getOperand() {
         return operand;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeOperand")
     public Optional<Operand> getMaybeOperand() {
         return maybeOperand;
     }
 
-    @JsonIgnore
+    @JsonProperty("operandOrColor")
     public ColorOrOperand getOperandOrColor() {
         return operandOrColor;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeOperandOrColor")
     public Optional<ColorOrOperand> getMaybeOperandOrColor() {
         return maybeOperandOrColor;
     }

--- a/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/resources/queryparam/requests/SendEnumListAsQueryParamRequest.java
+++ b/seed/java-sdk/enum/no-custom-config/src/main/java/com/seed/_enum/resources/queryparam/requests/SendEnumListAsQueryParamRequest.java
@@ -5,9 +5,9 @@ package com.seed._enum.resources.queryparam.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -48,22 +48,22 @@ public final class SendEnumListAsQueryParamRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("operand")
     public List<Operand> getOperand() {
         return operand;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeOperand")
     public Optional<List<Operand>> getMaybeOperand() {
         return maybeOperand;
     }
 
-    @JsonIgnore
+    @JsonProperty("operandOrColor")
     public List<ColorOrOperand> getOperandOrColor() {
         return operandOrColor;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeOperandOrColor")
     public Optional<List<ColorOrOperand>> getMaybeOperandOrColor() {
         return maybeOperandOrColor;
     }

--- a/seed/java-sdk/examples/default/src/main/java/com/seed/examples/resources/service/requests/GetMetadataRequest.java
+++ b/seed/java-sdk/examples/default/src/main/java/com/seed/examples/resources/service/requests/GetMetadataRequest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -42,7 +43,7 @@ public final class GetMetadataRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("tag")
     public Optional<List<String>> getTag() {
         return tag;
     }
@@ -52,7 +53,7 @@ public final class GetMetadataRequest {
         return xApiVersion;
     }
 
-    @JsonIgnore
+    @JsonProperty("shallow")
     public Optional<Boolean> getShallow() {
         return shallow;
     }

--- a/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/resources/service/requests/GetMetadataRequest.java
+++ b/seed/java-sdk/examples/inline-file-properties/src/main/java/com/seed/examples/resources/service/requests/GetMetadataRequest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -42,7 +43,7 @@ public final class GetMetadataRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("tag")
     public Optional<List<String>> getTag() {
         return tag;
     }
@@ -52,7 +53,7 @@ public final class GetMetadataRequest {
         return xApiVersion;
     }
 
-    @JsonIgnore
+    @JsonProperty("shallow")
     public Optional<Boolean> getShallow() {
         return shallow;
     }

--- a/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/resources/service/requests/GetMetadataRequest.java
+++ b/seed/java-sdk/examples/no-custom-config/src/main/java/com/seed/examples/resources/service/requests/GetMetadataRequest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -42,7 +43,7 @@ public final class GetMetadataRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("tag")
     public Optional<List<String>> getTag() {
         return tag;
     }
@@ -52,7 +53,7 @@ public final class GetMetadataRequest {
         return xApiVersion;
     }
 
-    @JsonIgnore
+    @JsonProperty("shallow")
     public Optional<Boolean> getShallow() {
         return shallow;
     }

--- a/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/resources/service/requests/GetMetadataRequest.java
+++ b/seed/java-sdk/examples/readme-config/src/main/java/com/seed/examples/resources/service/requests/GetMetadataRequest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -42,7 +43,7 @@ public final class GetMetadataRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("tag")
     public Optional<List<String>> getTag() {
         return tag;
     }
@@ -52,7 +53,7 @@ public final class GetMetadataRequest {
         return xApiVersion;
     }
 
-    @JsonIgnore
+    @JsonProperty("shallow")
     public Optional<Boolean> getShallow() {
         return shallow;
     }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.pagination.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class ListItemsRequest {
     /**
      * @return The cursor for pagination
      */
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }
@@ -44,7 +44,7 @@ public final class ListItemsRequest {
     /**
      * @return Maximum number of items to return
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -5,7 +5,6 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,7 +36,7 @@ public final class GetWithInlinePathAndQuery {
         return param;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,12 +34,12 @@ public final class GetWithMultipleQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public List<String> getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public List<Integer> getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithPathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -31,12 +31,12 @@ public final class GetWithQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public int getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.pagination.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class ListItemsRequest {
     /**
      * @return The cursor for pagination
      */
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }
@@ -44,7 +44,7 @@ public final class ListItemsRequest {
     /**
      * @return Maximum number of items to return
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -5,7 +5,6 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,7 +36,7 @@ public final class GetWithInlinePathAndQuery {
         return param;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,12 +34,12 @@ public final class GetWithMultipleQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public List<String> getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public List<Integer> getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithPathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -31,12 +31,12 @@ public final class GetWithQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public int getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.pagination.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class ListItemsRequest {
     /**
      * @return The cursor for pagination
      */
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }
@@ -44,7 +44,7 @@ public final class ListItemsRequest {
     /**
      * @return Maximum number of items to return
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -5,7 +5,6 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,7 +36,7 @@ public final class GetWithInlinePathAndQuery {
         return param;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,12 +34,12 @@ public final class GetWithMultipleQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public List<String> getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public List<Integer> getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithPathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -31,12 +31,12 @@ public final class GetWithQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public int getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.pagination.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class ListItemsRequest {
     /**
      * @return The cursor for pagination
      */
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }
@@ -44,7 +44,7 @@ public final class ListItemsRequest {
     /**
      * @return Maximum number of items to return
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithInlinePathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,12 +34,12 @@ public final class GetWithMultipleQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public List<String> getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public List<Integer> getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithPathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -31,12 +31,12 @@ public final class GetWithQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public int getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.pagination.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class ListItemsRequest {
     /**
      * @return The cursor for pagination
      */
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }
@@ -44,7 +44,7 @@ public final class ListItemsRequest {
     /**
      * @return Maximum number of items to return
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithInlinePathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,12 +34,12 @@ public final class GetWithMultipleQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public List<String> getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public List<Integer> getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithPathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -31,12 +31,12 @@ public final class GetWithQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public int getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.pagination.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class ListItemsRequest {
     /**
      * @return The cursor for pagination
      */
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }
@@ -44,7 +44,7 @@ public final class ListItemsRequest {
     /**
      * @return Maximum number of items to return
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -5,7 +5,6 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,7 +36,7 @@ public final class GetWithInlinePathAndQuery {
         return param;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,12 +34,12 @@ public final class GetWithMultipleQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public List<String> getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public List<Integer> getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithPathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -31,12 +31,12 @@ public final class GetWithQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public int getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.pagination.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class ListItemsRequest {
     /**
      * @return The cursor for pagination
      */
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }
@@ -44,7 +44,7 @@ public final class ListItemsRequest {
     /**
      * @return Maximum number of items to return
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -5,7 +5,6 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,7 +36,7 @@ public final class GetWithInlinePathAndQuery {
         return param;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,12 +34,12 @@ public final class GetWithMultipleQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public List<String> getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public List<Integer> getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithPathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -31,12 +31,12 @@ public final class GetWithQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public int getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithInlinePathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.endpoints.types;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithInlinePathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithMultipleQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.endpoints.types;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,12 +34,12 @@ public final class GetWithMultipleQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public List<String> getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public List<Integer> getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithPathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.endpoints.types;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithPathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/GetWithQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.endpoints.types;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -31,12 +31,12 @@ public final class GetWithQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public int getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/endpoints/types/ListItemsRequest.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.endpoints.types;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class ListItemsRequest {
     /**
      * @return The cursor for pagination
      */
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }
@@ -44,7 +44,7 @@ public final class ListItemsRequest {
     /**
      * @return Maximum number of items to return
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.pagination.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class ListItemsRequest {
     /**
      * @return The cursor for pagination
      */
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }
@@ -44,7 +44,7 @@ public final class ListItemsRequest {
     /**
      * @return Maximum number of items to return
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -5,7 +5,6 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,7 +36,7 @@ public final class GetWithInlinePathAndQuery {
         return param;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,12 +34,12 @@ public final class GetWithMultipleQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public List<String> getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public List<Integer> getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithPathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -31,12 +31,12 @@ public final class GetWithQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public int getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.pagination.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class ListItemsRequest {
     /**
      * @return The cursor for pagination
      */
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }
@@ -44,7 +44,7 @@ public final class ListItemsRequest {
     /**
      * @return Maximum number of items to return
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -5,7 +5,6 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,7 +36,7 @@ public final class GetWithInlinePathAndQuery {
         return param;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,12 +34,12 @@ public final class GetWithMultipleQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public List<String> getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public List<Integer> getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithPathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -31,12 +31,12 @@ public final class GetWithQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public int getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -6,9 +6,9 @@ package com.fern.sdk.resources.endpoints.pagination.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -42,7 +42,7 @@ public final class ListItemsRequest {
   /**
    * @return The cursor for pagination
    */
-  @JsonIgnore
+  @JsonProperty("cursor")
   public Optional<String> getCursor() {
     return cursor;
   }
@@ -50,7 +50,7 @@ public final class ListItemsRequest {
   /**
    * @return Maximum number of items to return
    */
-  @JsonIgnore
+  @JsonProperty("limit")
   public Optional<Integer> getLimit() {
     return limit;
   }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -6,9 +6,9 @@ package com.fern.sdk.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fern.sdk.core.ObjectMappers;
@@ -33,7 +33,7 @@ public final class GetWithInlinePathAndQuery {
     this.additionalProperties = additionalProperties;
   }
 
-  @JsonIgnore
+  @JsonProperty("query")
   public String getQuery() {
     return query;
   }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -6,9 +6,9 @@ package com.fern.sdk.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -41,12 +41,12 @@ public final class GetWithMultipleQuery {
     this.additionalProperties = additionalProperties;
   }
 
-  @JsonIgnore
+  @JsonProperty("query")
   public List<String> getQuery() {
     return query;
   }
 
-  @JsonIgnore
+  @JsonProperty("number")
   public List<Integer> getNumber() {
     return number;
   }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -6,9 +6,9 @@ package com.fern.sdk.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fern.sdk.core.ObjectMappers;
@@ -33,7 +33,7 @@ public final class GetWithPathAndQuery {
     this.additionalProperties = additionalProperties;
   }
 
-  @JsonIgnore
+  @JsonProperty("query")
   public String getQuery() {
     return query;
   }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/resources/endpoints/params/requests/GetWithQuery.java
@@ -6,9 +6,9 @@ package com.fern.sdk.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fern.sdk.core.ObjectMappers;
@@ -36,12 +36,12 @@ public final class GetWithQuery {
     this.additionalProperties = additionalProperties;
   }
 
-  @JsonIgnore
+  @JsonProperty("query")
   public String getQuery() {
     return query;
   }
 
-  @JsonIgnore
+  @JsonProperty("number")
   public int getNumber() {
     return number;
   }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.pagination.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class ListItemsRequest {
     /**
      * @return The cursor for pagination
      */
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }
@@ -44,7 +44,7 @@ public final class ListItemsRequest {
     /**
      * @return Maximum number of items to return
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithInlinePathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,12 +34,12 @@ public final class GetWithMultipleQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public List<String> getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public List<Integer> getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithPathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -31,12 +31,12 @@ public final class GetWithQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public int getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.pagination.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class ListItemsRequest {
     /**
      * @return The cursor for pagination
      */
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }
@@ -44,7 +44,7 @@ public final class ListItemsRequest {
     /**
      * @return Maximum number of items to return
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithInlinePathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,12 +34,12 @@ public final class GetWithMultipleQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public List<String> getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public List<Integer> getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithPathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -31,12 +31,12 @@ public final class GetWithQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public int getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/pagination/requests/ListItemsRequest.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.pagination.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class ListItemsRequest {
     /**
      * @return The cursor for pagination
      */
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }
@@ -44,7 +44,7 @@ public final class ListItemsRequest {
     /**
      * @return Maximum number of items to return
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithInlinePathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithInlinePathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithMultipleQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,12 +34,12 @@ public final class GetWithMultipleQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public List<String> getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public List<Integer> getNumber() {
         return number;
     }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithPathAndQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetWithPathAndQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/resources/endpoints/params/requests/GetWithQuery.java
@@ -5,9 +5,9 @@ package com.seed.exhaustive.resources.endpoints.params.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.exhaustive.core.ObjectMappers;
@@ -31,12 +31,12 @@ public final class GetWithQuery {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("number")
     public int getNumber() {
         return number;
     }

--- a/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithOptionalQueryParamsRequest.java
+++ b/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithOptionalQueryParamsRequest.java
@@ -5,7 +5,6 @@ package com.seed.fileUpload.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -47,12 +46,12 @@ public final class JustFileWithOptionalQueryParamsRequest {
         return file;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeString")
     public Optional<String> getMaybeString() {
         return maybeString;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeInteger")
     public Optional<Integer> getMaybeInteger() {
         return maybeInteger;
     }

--- a/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithQueryParamsRequest.java
+++ b/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithQueryParamsRequest.java
@@ -5,7 +5,6 @@ package com.seed.fileUpload.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -62,27 +61,27 @@ public final class JustFileWithQueryParamsRequest {
         return file;
     }
 
-    @JsonIgnore
+    @JsonProperty("listOfStrings")
     public List<String> getListOfStrings() {
         return listOfStrings;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalListOfStrings")
     public Optional<List<String>> getOptionalListOfStrings() {
         return optionalListOfStrings;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeString")
     public Optional<String> getMaybeString() {
         return maybeString;
     }
 
-    @JsonIgnore
+    @JsonProperty("integer")
     public int getInteger() {
         return integer;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeInteger")
     public Optional<Integer> getMaybeInteger() {
         return maybeInteger;
     }

--- a/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithOptionalQueryParamsRequest.java
+++ b/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithOptionalQueryParamsRequest.java
@@ -5,9 +5,9 @@ package com.seed.fileUpload.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -33,12 +33,12 @@ public final class JustFileWithOptionalQueryParamsRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeString")
     public Optional<String> getMaybeString() {
         return maybeString;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeInteger")
     public Optional<Integer> getMaybeInteger() {
         return maybeInteger;
     }

--- a/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithQueryParamsRequest.java
+++ b/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithQueryParamsRequest.java
@@ -5,9 +5,9 @@ package com.seed.fileUpload.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -50,27 +50,27 @@ public final class JustFileWithQueryParamsRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("listOfStrings")
     public List<String> getListOfStrings() {
         return listOfStrings;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalListOfStrings")
     public Optional<List<String>> getOptionalListOfStrings() {
         return optionalListOfStrings;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeString")
     public Optional<String> getMaybeString() {
         return maybeString;
     }
 
-    @JsonIgnore
+    @JsonProperty("integer")
     public int getInteger() {
         return integer;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeInteger")
     public Optional<Integer> getMaybeInteger() {
         return maybeInteger;
     }

--- a/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithOptionalQueryParamsRequest.java
+++ b/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithOptionalQueryParamsRequest.java
@@ -5,9 +5,9 @@ package com.seed.fileUpload.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -33,12 +33,12 @@ public final class JustFileWithOptionalQueryParamsRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeString")
     public Optional<String> getMaybeString() {
         return maybeString;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeInteger")
     public Optional<Integer> getMaybeInteger() {
         return maybeInteger;
     }

--- a/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithQueryParamsRequest.java
+++ b/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/requests/JustFileWithQueryParamsRequest.java
@@ -5,9 +5,9 @@ package com.seed.fileUpload.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -50,27 +50,27 @@ public final class JustFileWithQueryParamsRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("listOfStrings")
     public List<String> getListOfStrings() {
         return listOfStrings;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalListOfStrings")
     public Optional<List<String>> getOptionalListOfStrings() {
         return optionalListOfStrings;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeString")
     public Optional<String> getMaybeString() {
         return maybeString;
     }
 
-    @JsonIgnore
+    @JsonProperty("integer")
     public int getInteger() {
         return integer;
     }
 
-    @JsonIgnore
+    @JsonProperty("maybeInteger")
     public Optional<Integer> getMaybeInteger() {
         return maybeInteger;
     }

--- a/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/resources/user/requests/ListUsersRequest.java
+++ b/seed/java-sdk/http-head/src/main/java/com/seed/httpHead/resources/user/requests/ListUsersRequest.java
@@ -5,9 +5,9 @@ package com.seed.httpHead.resources.user.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.httpHead.core.ObjectMappers;
@@ -27,7 +27,7 @@ public final class ListUsersRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("limit")
     public int getLimit() {
         return limit;
     }

--- a/seed/java-sdk/java-optional-nullable-query-params/default/src/main/java/com/seed/javaOptionalNullableQueryParams/requests/SearchRequest.java
+++ b/seed/java-sdk/java-optional-nullable-query-params/default/src/main/java/com/seed/javaOptionalNullableQueryParams/requests/SearchRequest.java
@@ -5,13 +5,14 @@ package com.seed.javaOptionalNullableQueryParams.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.javaOptionalNullableQueryParams.core.Nullable;
+import com.seed.javaOptionalNullableQueryParams.core.NullableNonemptyFilter;
 import com.seed.javaOptionalNullableQueryParams.core.ObjectMappers;
 import com.seed.javaOptionalNullableQueryParams.core.OptionalNullable;
 import com.seed.javaOptionalNullableQueryParams.types.SortOrder;
@@ -61,7 +62,8 @@ public final class SearchRequest {
     /**
      * @return Search query - defaults to empty string when absent
      */
-    @JsonIgnore
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("query")
     public OptionalNullable<String> getQuery() {
         if (query == null) {
             return OptionalNullable.absent();
@@ -72,7 +74,8 @@ public final class SearchRequest {
     /**
      * @return Max results - defaults to 10 when absent
      */
-    @JsonIgnore
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("limit")
     public OptionalNullable<Integer> getLimit() {
         if (limit == null) {
             return OptionalNullable.absent();
@@ -83,7 +86,8 @@ public final class SearchRequest {
     /**
      * @return Include archived items - defaults to false when absent
      */
-    @JsonIgnore
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("includeArchived")
     public OptionalNullable<Boolean> getIncludeArchived() {
         if (includeArchived == null) {
             return OptionalNullable.absent();
@@ -94,7 +98,8 @@ public final class SearchRequest {
     /**
      * @return Sort order - defaults to ASC when absent
      */
-    @JsonIgnore
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("sortOrder")
     public OptionalNullable<SortOrder> getSortOrder() {
         if (sortOrder == null) {
             return OptionalNullable.absent();
@@ -105,7 +110,8 @@ public final class SearchRequest {
     /**
      * @return Optional nullable without default - should check wasSpecified
      */
-    @JsonIgnore
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("optionalWithoutDefault")
     public OptionalNullable<String> getOptionalWithoutDefault() {
         if (optionalWithoutDefault == null) {
             return OptionalNullable.absent();
@@ -116,7 +122,8 @@ public final class SearchRequest {
     /**
      * @return Another optional nullable with default for comparison
      */
-    @JsonIgnore
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("regularOptional")
     public OptionalNullable<String> getRegularOptional() {
         if (regularOptional == null) {
             return OptionalNullable.absent();
@@ -127,11 +134,54 @@ public final class SearchRequest {
     /**
      * @return Another optional nullable without default for comparison
      */
-    @JsonIgnore
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("regularOptionalNoDefault")
     public OptionalNullable<String> getRegularOptionalNoDefault() {
         if (regularOptionalNoDefault == null) {
             return OptionalNullable.absent();
         }
+        return regularOptionalNoDefault;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("query")
+    private OptionalNullable<String> _getQuery() {
+        return query;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("limit")
+    private OptionalNullable<Integer> _getLimit() {
+        return limit;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("includeArchived")
+    private OptionalNullable<Boolean> _getIncludeArchived() {
+        return includeArchived;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("sortOrder")
+    private OptionalNullable<SortOrder> _getSortOrder() {
+        return sortOrder;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("optionalWithoutDefault")
+    private OptionalNullable<String> _getOptionalWithoutDefault() {
+        return optionalWithoutDefault;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("regularOptional")
+    private OptionalNullable<String> _getRegularOptional() {
+        return regularOptional;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("regularOptionalNoDefault")
+    private OptionalNullable<String> _getRegularOptionalNoDefault() {
         return regularOptionalNoDefault;
     }
 

--- a/seed/java-sdk/java-optional-query-params-overloads/src/main/java/com/seed/javaOptionalQueryParamsOverloads/requests/SearchPoliciesRequest.java
+++ b/seed/java-sdk/java-optional-query-params-overloads/src/main/java/com/seed/javaOptionalQueryParamsOverloads/requests/SearchPoliciesRequest.java
@@ -5,9 +5,9 @@ package com.seed.javaOptionalQueryParamsOverloads.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class SearchPoliciesRequest {
     /**
      * @return Required search query
      */
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
@@ -44,7 +44,7 @@ public final class SearchPoliciesRequest {
     /**
      * @return Optional limit
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/java-optional-query-params-overloads/src/main/java/com/seed/javaOptionalQueryParamsOverloads/requests/UserGetLatestInsuranceRequest.java
+++ b/seed/java-sdk/java-optional-query-params-overloads/src/main/java/com/seed/javaOptionalQueryParamsOverloads/requests/UserGetLatestInsuranceRequest.java
@@ -5,9 +5,9 @@ package com.seed.javaOptionalQueryParamsOverloads.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -39,7 +39,7 @@ public final class UserGetLatestInsuranceRequest {
     /**
      * @return Include expired insurance policies
      */
-    @JsonIgnore
+    @JsonProperty("includeExpired")
     public Optional<Boolean> getIncludeExpired() {
         return includeExpired;
     }
@@ -47,7 +47,7 @@ public final class UserGetLatestInsuranceRequest {
     /**
      * @return Filter by policy type
      */
-    @JsonIgnore
+    @JsonProperty("policyType")
     public Optional<PolicyType> getPolicyType() {
         return policyType;
     }

--- a/seed/java-sdk/java-required-body-optional-headers/src/main/java/com/seed/javaRequiredBodyOptionalHeaders/requests/CreateUserWithOptionsRequest.java
+++ b/seed/java-sdk/java-required-body-optional-headers/src/main/java/com/seed/javaRequiredBodyOptionalHeaders/requests/CreateUserWithOptionsRequest.java
@@ -53,7 +53,7 @@ public final class CreateUserWithOptionsRequest {
     /**
      * @return Whether to validate the request
      */
-    @JsonIgnore
+    @JsonProperty("validate")
     public Optional<Boolean> getValidate() {
         return validate;
     }

--- a/seed/java-sdk/java-required-body-optional-headers/src/main/java/com/seed/javaRequiredBodyOptionalHeaders/requests/CreateUserWithRequiredQueryRequest.java
+++ b/seed/java-sdk/java-required-body-optional-headers/src/main/java/com/seed/javaRequiredBodyOptionalHeaders/requests/CreateUserWithRequiredQueryRequest.java
@@ -5,7 +5,6 @@ package com.seed.javaRequiredBodyOptionalHeaders.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,7 +36,7 @@ public final class CreateUserWithRequiredQueryRequest {
     /**
      * @return Required tenant ID
      */
-    @JsonIgnore
+    @JsonProperty("tenantId")
     public String getTenantId() {
         return tenantId;
     }

--- a/seed/java-sdk/java-required-body-optional-headers/src/main/java/com/seed/javaRequiredBodyOptionalHeaders/requests/GetUsersRequest.java
+++ b/seed/java-sdk/java-required-body-optional-headers/src/main/java/com/seed/javaRequiredBodyOptionalHeaders/requests/GetUsersRequest.java
@@ -5,9 +5,9 @@ package com.seed.javaRequiredBodyOptionalHeaders.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -32,7 +32,7 @@ public final class GetUsersRequest {
     /**
      * @return Maximum number of users to return
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/java-required-body-optional-headers/src/main/java/com/seed/javaRequiredBodyOptionalHeaders/requests/UpdateUserRequest.java
+++ b/seed/java-sdk/java-required-body-optional-headers/src/main/java/com/seed/javaRequiredBodyOptionalHeaders/requests/UpdateUserRequest.java
@@ -5,7 +5,6 @@ package com.seed.javaRequiredBodyOptionalHeaders.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,7 +37,7 @@ public final class UpdateUserRequest {
     /**
      * @return If true, validate the update without persisting
      */
-    @JsonIgnore
+    @JsonProperty("dryRun")
     public Optional<Boolean> getDryRun() {
         return dryRun;
     }

--- a/seed/java-sdk/java-single-property-endpoint/java-single-property-endpoint/src/main/java/com/seed/singleProperty/resources/singleproperty/requests/GetThingRequest.java
+++ b/seed/java-sdk/java-single-property-endpoint/java-single-property-endpoint/src/main/java/com/seed/singleProperty/resources/singleproperty/requests/GetThingRequest.java
@@ -5,9 +5,9 @@ package com.seed.singleProperty.resources.singleproperty.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -29,7 +29,7 @@ public final class GetThingRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("include-remote-data")
     public Optional<Boolean> getIncludeRemoteData() {
         return includeRemoteData;
     }

--- a/seed/java-sdk/literal/src/main/java/com/seed/literal/resources/query/requests/SendLiteralsInQueryRequest.java
+++ b/seed/java-sdk/literal/src/main/java/com/seed/literal/resources/query/requests/SendLiteralsInQueryRequest.java
@@ -5,9 +5,9 @@ package com.seed.literal.resources.query.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -56,47 +56,47 @@ public final class SendLiteralsInQueryRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("prompt")
     public String getPrompt() {
         return "You are a helpful assistant";
     }
 
-    @JsonIgnore
+    @JsonProperty("optional_prompt")
     public Optional<String> getOptionalPrompt() {
         return optionalPrompt;
     }
 
-    @JsonIgnore
+    @JsonProperty("alias_prompt")
     public String getAliasPrompt() {
         return aliasPrompt;
     }
 
-    @JsonIgnore
+    @JsonProperty("alias_optional_prompt")
     public Optional<String> getAliasOptionalPrompt() {
         return aliasOptionalPrompt;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonProperty("stream")
     public Boolean getStream() {
         return false;
     }
 
-    @JsonIgnore
+    @JsonProperty("optional_stream")
     public Optional<Boolean> getOptionalStream() {
         return optionalStream;
     }
 
-    @JsonIgnore
+    @JsonProperty("alias_stream")
     public Boolean getAliasStream() {
         return aliasStream;
     }
 
-    @JsonIgnore
+    @JsonProperty("alias_optional_stream")
     public Optional<Boolean> getAliasOptionalStream() {
         return aliasOptionalStream;
     }

--- a/seed/java-sdk/mixed-case/src/main/java/com/seed/mixedCase/resources/service/requests/ListResourcesRequest.java
+++ b/seed/java-sdk/mixed-case/src/main/java/com/seed/mixedCase/resources/service/requests/ListResourcesRequest.java
@@ -5,9 +5,9 @@ package com.seed.mixedCase.resources.service.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.mixedCase.core.ObjectMappers;
@@ -31,12 +31,12 @@ public final class ListResourcesRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("page_limit")
     public int getPageLimit() {
         return pageLimit;
     }
 
-    @JsonIgnore
+    @JsonProperty("beforeDate")
     public String getBeforeDate() {
         return beforeDate;
     }

--- a/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/resources/user/events/metadata/requests/GetEventMetadataRequest.java
+++ b/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/resources/user/events/metadata/requests/GetEventMetadataRequest.java
@@ -5,9 +5,9 @@ package com.seed.mixedFileDirectory.resources.user.events.metadata.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.mixedFileDirectory.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class GetEventMetadataRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("id")
     public String getId() {
         return id;
     }

--- a/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/resources/user/events/requests/ListUserEventsRequest.java
+++ b/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/resources/user/events/requests/ListUserEventsRequest.java
@@ -5,9 +5,9 @@ package com.seed.mixedFileDirectory.resources.user.events.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -32,7 +32,7 @@ public final class ListUserEventsRequest {
     /**
      * @return The maximum number of results to return.
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/resources/user/requests/ListUsersRequest.java
+++ b/seed/java-sdk/mixed-file-directory/src/main/java/com/seed/mixedFileDirectory/resources/user/requests/ListUsersRequest.java
@@ -5,9 +5,9 @@ package com.seed.mixedFileDirectory.resources.user.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -32,7 +32,7 @@ public final class ListUsersRequest {
     /**
      * @return The maximum number of results to return.
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/nullable-optional/collapse-optional-nullable/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/FilterByRoleRequest.java
+++ b/seed/java-sdk/nullable-optional/collapse-optional-nullable/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/FilterByRoleRequest.java
@@ -5,13 +5,14 @@ package com.seed.nullableOptional.resources.nullableoptional.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.nullableOptional.core.Nullable;
+import com.seed.nullableOptional.core.NullableNonemptyFilter;
 import com.seed.nullableOptional.core.ObjectMappers;
 import com.seed.nullableOptional.core.OptionalNullable;
 import com.seed.nullableOptional.resources.nullableoptional.types.UserRole;
@@ -43,7 +44,8 @@ public final class FilterByRoleRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("role")
     public OptionalNullable<UserRole> getRole() {
         if (role == null) {
             return OptionalNullable.absent();
@@ -51,16 +53,29 @@ public final class FilterByRoleRequest {
         return role;
     }
 
-    @JsonIgnore
+    @JsonProperty("status")
     public Optional<UserStatus> getStatus() {
         return status;
     }
 
-    @JsonIgnore
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("secondaryRole")
     public OptionalNullable<UserRole> getSecondaryRole() {
         if (secondaryRole == null) {
             return OptionalNullable.absent();
         }
+        return secondaryRole;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("role")
+    private OptionalNullable<UserRole> _getRole() {
+        return role;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("secondaryRole")
+    private OptionalNullable<UserRole> _getSecondaryRole() {
         return secondaryRole;
     }
 

--- a/seed/java-sdk/nullable-optional/collapse-optional-nullable/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/ListUsersRequest.java
+++ b/seed/java-sdk/nullable-optional/collapse-optional-nullable/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/ListUsersRequest.java
@@ -5,13 +5,14 @@ package com.seed.nullableOptional.resources.nullableoptional.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.nullableOptional.core.Nullable;
+import com.seed.nullableOptional.core.NullableNonemptyFilter;
 import com.seed.nullableOptional.core.ObjectMappers;
 import com.seed.nullableOptional.core.OptionalNullable;
 import java.util.HashMap;
@@ -45,26 +46,33 @@ public final class ListUsersRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }
 
-    @JsonIgnore
+    @JsonProperty("offset")
     public Optional<Integer> getOffset() {
         return offset;
     }
 
-    @JsonIgnore
+    @JsonProperty("includeDeleted")
     public Optional<Boolean> getIncludeDeleted() {
         return includeDeleted;
     }
 
-    @JsonIgnore
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("sortBy")
     public OptionalNullable<String> getSortBy() {
         if (sortBy == null) {
             return OptionalNullable.absent();
         }
+        return sortBy;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("sortBy")
+    private OptionalNullable<String> _getSortBy() {
         return sortBy;
     }
 

--- a/seed/java-sdk/nullable-optional/collapse-optional-nullable/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/SearchUsersRequest.java
+++ b/seed/java-sdk/nullable-optional/collapse-optional-nullable/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/SearchUsersRequest.java
@@ -5,13 +5,14 @@ package com.seed.nullableOptional.resources.nullableoptional.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.nullableOptional.core.Nullable;
+import com.seed.nullableOptional.core.NullableNonemptyFilter;
 import com.seed.nullableOptional.core.ObjectMappers;
 import com.seed.nullableOptional.core.OptionalNullable;
 import java.util.HashMap;
@@ -46,12 +47,13 @@ public final class SearchUsersRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
 
-    @JsonIgnore
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("department")
     public OptionalNullable<String> getDepartment() {
         if (department == null) {
             return OptionalNullable.absent();
@@ -59,16 +61,29 @@ public final class SearchUsersRequest {
         return department;
     }
 
-    @JsonIgnore
+    @JsonProperty("role")
     public Optional<String> getRole() {
         return role;
     }
 
-    @JsonIgnore
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("isActive")
     public OptionalNullable<Boolean> getIsActive() {
         if (isActive == null) {
             return OptionalNullable.absent();
         }
+        return isActive;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("department")
+    private OptionalNullable<String> _getDepartment() {
+        return department;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("isActive")
+    private OptionalNullable<Boolean> _getIsActive() {
         return isActive;
     }
 

--- a/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/FilterByRoleRequest.java
+++ b/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/FilterByRoleRequest.java
@@ -8,10 +8,12 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.nullableOptional.core.Nullable;
+import com.seed.nullableOptional.core.NullableNonemptyFilter;
 import com.seed.nullableOptional.core.ObjectMappers;
 import com.seed.nullableOptional.resources.nullableoptional.types.UserRole;
 import com.seed.nullableOptional.resources.nullableoptional.types.UserStatus;
@@ -50,7 +52,7 @@ public final class FilterByRoleRequest {
         return role;
     }
 
-    @JsonIgnore
+    @JsonProperty("status")
     public Optional<UserStatus> getStatus() {
         return status;
     }
@@ -60,6 +62,18 @@ public final class FilterByRoleRequest {
         if (secondaryRole == null) {
             return Optional.empty();
         }
+        return secondaryRole;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("role")
+    private Optional<UserRole> _getRole() {
+        return role;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("secondaryRole")
+    private Optional<UserRole> _getSecondaryRole() {
         return secondaryRole;
     }
 

--- a/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/ListUsersRequest.java
+++ b/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/ListUsersRequest.java
@@ -8,10 +8,12 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.nullableOptional.core.Nullable;
+import com.seed.nullableOptional.core.NullableNonemptyFilter;
 import com.seed.nullableOptional.core.ObjectMappers;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,17 +46,17 @@ public final class ListUsersRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }
 
-    @JsonIgnore
+    @JsonProperty("offset")
     public Optional<Integer> getOffset() {
         return offset;
     }
 
-    @JsonIgnore
+    @JsonProperty("includeDeleted")
     public Optional<Boolean> getIncludeDeleted() {
         return includeDeleted;
     }
@@ -64,6 +66,12 @@ public final class ListUsersRequest {
         if (sortBy == null) {
             return Optional.empty();
         }
+        return sortBy;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("sortBy")
+    private Optional<String> _getSortBy() {
         return sortBy;
     }
 

--- a/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/SearchUsersRequest.java
+++ b/seed/java-sdk/nullable-optional/legacy/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/SearchUsersRequest.java
@@ -8,10 +8,12 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.nullableOptional.core.Nullable;
+import com.seed.nullableOptional.core.NullableNonemptyFilter;
 import com.seed.nullableOptional.core.ObjectMappers;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,7 +47,7 @@ public final class SearchUsersRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
@@ -58,7 +60,7 @@ public final class SearchUsersRequest {
         return department;
     }
 
-    @JsonIgnore
+    @JsonProperty("role")
     public Optional<String> getRole() {
         return role;
     }
@@ -68,6 +70,18 @@ public final class SearchUsersRequest {
         if (isActive == null) {
             return Optional.empty();
         }
+        return isActive;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("department")
+    private Optional<String> _getDepartment() {
+        return department;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("isActive")
+    private Optional<Boolean> _getIsActive() {
         return isActive;
     }
 

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/FilterByRoleRequest.java
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/FilterByRoleRequest.java
@@ -8,9 +8,11 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.seed.nullableOptional.core.NullableNonemptyFilter;
 import com.seed.nullableOptional.core.ObjectMappers;
 import com.seed.nullableOptional.resources.nullableoptional.types.UserRole;
 import com.seed.nullableOptional.resources.nullableoptional.types.UserStatus;
@@ -49,7 +51,7 @@ public final class FilterByRoleRequest {
         return role;
     }
 
-    @JsonIgnore
+    @JsonProperty("status")
     public Optional<UserStatus> getStatus() {
         return status;
     }
@@ -59,6 +61,18 @@ public final class FilterByRoleRequest {
         if (secondaryRole == null) {
             return Optional.empty();
         }
+        return secondaryRole;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("role")
+    private UserRole _getRole() {
+        return role;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("secondaryRole")
+    private Optional<UserRole> _getSecondaryRole() {
         return secondaryRole;
     }
 

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/ListUsersRequest.java
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/ListUsersRequest.java
@@ -8,9 +8,11 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.seed.nullableOptional.core.NullableNonemptyFilter;
 import com.seed.nullableOptional.core.ObjectMappers;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,17 +46,17 @@ public final class ListUsersRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }
 
-    @JsonIgnore
+    @JsonProperty("offset")
     public Optional<Integer> getOffset() {
         return offset;
     }
 
-    @JsonIgnore
+    @JsonProperty("includeDeleted")
     public Optional<Boolean> getIncludeDeleted() {
         return includeDeleted;
     }
@@ -64,6 +66,12 @@ public final class ListUsersRequest {
         if (sortBy == null) {
             return Optional.empty();
         }
+        return sortBy;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("sortBy")
+    private Optional<String> _getSortBy() {
         return sortBy;
     }
 

--- a/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/SearchUsersRequest.java
+++ b/seed/java-sdk/nullable-optional/with-nullable-annotation/src/main/java/com/seed/nullableOptional/resources/nullableoptional/requests/SearchUsersRequest.java
@@ -8,9 +8,11 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.seed.nullableOptional.core.NullableNonemptyFilter;
 import com.seed.nullableOptional.core.ObjectMappers;
 import java.util.HashMap;
 import java.util.Map;
@@ -46,7 +48,7 @@ public final class SearchUsersRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("query")
     public String getQuery() {
         return query;
     }
@@ -57,7 +59,7 @@ public final class SearchUsersRequest {
         return department;
     }
 
-    @JsonIgnore
+    @JsonProperty("role")
     public Optional<String> getRole() {
         return role;
     }
@@ -67,6 +69,18 @@ public final class SearchUsersRequest {
         if (isActive == null) {
             return Optional.empty();
         }
+        return isActive;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("department")
+    private String _getDepartment() {
+        return department;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("isActive")
+    private Optional<Boolean> _getIsActive() {
         return isActive;
     }
 

--- a/seed/java-sdk/nullable-request-body/src/main/java/com/seed/api/resources/testgroup/requests/TestMethodNameTestGroupRequest.java
+++ b/seed/java-sdk/nullable-request-body/src/main/java/com/seed/api/resources/testgroup/requests/TestMethodNameTestGroupRequest.java
@@ -68,6 +68,18 @@ public final class TestMethodNameTestGroupRequest {
     }
 
     @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("query_param_object")
+    private Optional<PlainObject> _getQueryParamObject() {
+        return queryParamObject;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("query_param_integer")
+    private Optional<Integer> _getQueryParamInteger() {
+        return queryParamInteger;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
     @JsonProperty("body")
     private Optional<PlainObject> _getBody() {
         return body;

--- a/seed/java-sdk/nullable/no-custom-config/src/main/java/com/seed/nullable/resources/nullable/requests/GetUsersRequest.java
+++ b/seed/java-sdk/nullable/no-custom-config/src/main/java/com/seed/nullable/resources/nullable/requests/GetUsersRequest.java
@@ -8,10 +8,12 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.nullable.core.Nullable;
+import com.seed.nullable.core.NullableNonemptyFilter;
 import com.seed.nullable.core.ObjectMappers;
 import java.util.Collections;
 import java.util.HashMap;
@@ -50,12 +52,12 @@ public final class GetUsersRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("usernames")
     public Optional<List<String>> getUsernames() {
         return usernames;
     }
 
-    @JsonIgnore
+    @JsonProperty("activated")
     public Optional<List<Boolean>> getActivated() {
         return activated;
     }
@@ -68,7 +70,7 @@ public final class GetUsersRequest {
         return tags;
     }
 
-    @JsonIgnore
+    @JsonProperty("avatar")
     public Optional<String> getAvatar() {
         return avatar;
     }
@@ -78,6 +80,18 @@ public final class GetUsersRequest {
         if (extra == null) {
             return Optional.empty();
         }
+        return extra;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("tags")
+    private Optional<List<String>> _getTags() {
+        return tags;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("extra")
+    private Optional<Boolean> _getExtra() {
         return extra;
     }
 

--- a/seed/java-sdk/nullable/wrapped-aliases/src/main/java/com/seed/nullable/resources/nullable/requests/GetUsersRequest.java
+++ b/seed/java-sdk/nullable/wrapped-aliases/src/main/java/com/seed/nullable/resources/nullable/requests/GetUsersRequest.java
@@ -8,10 +8,12 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.nullable.core.Nullable;
+import com.seed.nullable.core.NullableNonemptyFilter;
 import com.seed.nullable.core.ObjectMappers;
 import java.util.Collections;
 import java.util.HashMap;
@@ -50,12 +52,12 @@ public final class GetUsersRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("usernames")
     public Optional<List<String>> getUsernames() {
         return usernames;
     }
 
-    @JsonIgnore
+    @JsonProperty("activated")
     public Optional<List<Boolean>> getActivated() {
         return activated;
     }
@@ -68,7 +70,7 @@ public final class GetUsersRequest {
         return tags;
     }
 
-    @JsonIgnore
+    @JsonProperty("avatar")
     public Optional<String> getAvatar() {
         return avatar;
     }
@@ -78,6 +80,18 @@ public final class GetUsersRequest {
         if (extra == null) {
             return Optional.empty();
         }
+        return extra;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("tags")
+    private Optional<List<String>> _getTags() {
+        return tags;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("extra")
+    private Optional<Boolean> _getExtra() {
         return extra;
     }
 

--- a/seed/java-sdk/pagination-custom/default/src/main/java/com/seed/pagination/resources/users/requests/ListWithCustomPagerRequest.java
+++ b/seed/java-sdk/pagination-custom/default/src/main/java/com/seed/pagination/resources/users/requests/ListWithCustomPagerRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,7 +36,7 @@ public final class ListWithCustomPagerRequest {
     /**
      * @return The maximum number of results to return.
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }
@@ -44,7 +44,7 @@ public final class ListWithCustomPagerRequest {
     /**
      * @return The cursor used for pagination.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsernamesRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsernamesRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -33,7 +33,7 @@ public final class ListUsernamesRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersCursorPaginationRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersCursorPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -47,7 +47,7 @@ public final class ListUsersCursorPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -55,12 +55,12 @@ public final class ListUsersCursorPaginationRequest {
     /**
      * @return Defaults to per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Integer> getPerPage() {
         return perPage;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }
@@ -69,7 +69,7 @@ public final class ListUsersCursorPaginationRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersDoubleOffsetPaginationRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersDoubleOffsetPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -47,7 +47,7 @@ public final class ListUsersDoubleOffsetPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Double> getPage() {
         return page;
     }
@@ -55,12 +55,12 @@ public final class ListUsersDoubleOffsetPaginationRequest {
     /**
      * @return Defaults to per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Double> getPerPage() {
         return perPage;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }
@@ -69,7 +69,7 @@ public final class ListUsersDoubleOffsetPaginationRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersExtendedRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersExtendedRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -30,7 +30,7 @@ public final class ListUsersExtendedRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<UUID> getCursor() {
         return cursor;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersExtendedRequestForOptionalData.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersExtendedRequestForOptionalData.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -30,7 +30,7 @@ public final class ListUsersExtendedRequestForOptionalData {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<UUID> getCursor() {
         return cursor;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersMixedTypeCursorPaginationRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersMixedTypeCursorPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -30,7 +30,7 @@ public final class ListUsersMixedTypeCursorPaginationRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersOffsetPaginationRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersOffsetPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -47,7 +47,7 @@ public final class ListUsersOffsetPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -55,12 +55,12 @@ public final class ListUsersOffsetPaginationRequest {
     /**
      * @return Defaults to per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Integer> getPerPage() {
         return perPage;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }
@@ -69,7 +69,7 @@ public final class ListUsersOffsetPaginationRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersOffsetStepPaginationRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersOffsetStepPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -43,7 +43,7 @@ public final class ListUsersOffsetStepPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -53,12 +53,12 @@ public final class ListUsersOffsetStepPaginationRequest {
      * This is also used as the step size in this
      * paginated endpoint.
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListWithGlobalConfigRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListWithGlobalConfigRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -29,7 +29,7 @@ public final class ListWithGlobalConfigRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("offset")
     public Optional<Integer> getOffset() {
         return offset;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListWithOffsetPaginationHasNextPageRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListWithOffsetPaginationHasNextPageRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -43,7 +43,7 @@ public final class ListWithOffsetPaginationHasNextPageRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -53,12 +53,12 @@ public final class ListWithOffsetPaginationHasNextPageRequest {
      * This is also used as the step size in this
      * paginated endpoint.
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsernamesRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsernamesRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -33,7 +33,7 @@ public final class ListUsernamesRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsernamesWithOptionalResponseRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsernamesWithOptionalResponseRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,7 +34,7 @@ public final class ListUsernamesWithOptionalResponseRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersAliasedDataRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersAliasedDataRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -42,7 +42,7 @@ public final class ListUsersAliasedDataRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -50,7 +50,7 @@ public final class ListUsersAliasedDataRequest {
     /**
      * @return Defaults to per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Integer> getPerPage() {
         return perPage;
     }
@@ -59,7 +59,7 @@ public final class ListUsersAliasedDataRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersCursorPaginationRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersCursorPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -47,7 +47,7 @@ public final class ListUsersCursorPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -55,12 +55,12 @@ public final class ListUsersCursorPaginationRequest {
     /**
      * @return Defaults to per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Integer> getPerPage() {
         return perPage;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }
@@ -69,7 +69,7 @@ public final class ListUsersCursorPaginationRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersDoubleOffsetPaginationRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersDoubleOffsetPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -47,7 +47,7 @@ public final class ListUsersDoubleOffsetPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Double> getPage() {
         return page;
     }
@@ -55,12 +55,12 @@ public final class ListUsersDoubleOffsetPaginationRequest {
     /**
      * @return Defaults to per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Double> getPerPage() {
         return perPage;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }
@@ -69,7 +69,7 @@ public final class ListUsersDoubleOffsetPaginationRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersExtendedRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersExtendedRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -30,7 +30,7 @@ public final class ListUsersExtendedRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<UUID> getCursor() {
         return cursor;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersExtendedRequestForOptionalData.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersExtendedRequestForOptionalData.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -30,7 +30,7 @@ public final class ListUsersExtendedRequestForOptionalData {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<UUID> getCursor() {
         return cursor;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersMixedTypeCursorPaginationRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersMixedTypeCursorPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -30,7 +30,7 @@ public final class ListUsersMixedTypeCursorPaginationRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersOffsetPaginationRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersOffsetPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -47,7 +47,7 @@ public final class ListUsersOffsetPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -55,12 +55,12 @@ public final class ListUsersOffsetPaginationRequest {
     /**
      * @return Defaults to per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Integer> getPerPage() {
         return perPage;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }
@@ -69,7 +69,7 @@ public final class ListUsersOffsetPaginationRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersOffsetStepPaginationRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersOffsetStepPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -43,7 +43,7 @@ public final class ListUsersOffsetStepPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -53,12 +53,12 @@ public final class ListUsersOffsetStepPaginationRequest {
      * This is also used as the step size in this
      * paginated endpoint.
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersOptionalDataRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListUsersOptionalDataRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -32,7 +32,7 @@ public final class ListUsersOptionalDataRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListWithGlobalConfigRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListWithGlobalConfigRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -29,7 +29,7 @@ public final class ListWithGlobalConfigRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("offset")
     public Optional<Integer> getOffset() {
         return offset;
     }

--- a/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListWithOffsetPaginationHasNextPageRequest.java
+++ b/seed/java-sdk/pagination/default/src/main/java/com/seed/pagination/resources/users/requests/ListWithOffsetPaginationHasNextPageRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -43,7 +43,7 @@ public final class ListWithOffsetPaginationHasNextPageRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -53,12 +53,12 @@ public final class ListWithOffsetPaginationHasNextPageRequest {
      * This is also used as the step size in this
      * paginated endpoint.
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsernamesRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsernamesRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -33,7 +33,7 @@ public final class ListUsernamesRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersCursorPaginationRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersCursorPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -47,7 +47,7 @@ public final class ListUsersCursorPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -55,12 +55,12 @@ public final class ListUsersCursorPaginationRequest {
     /**
      * @return Defaults to per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Integer> getPerPage() {
         return perPage;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }
@@ -69,7 +69,7 @@ public final class ListUsersCursorPaginationRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersDoubleOffsetPaginationRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersDoubleOffsetPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -47,7 +47,7 @@ public final class ListUsersDoubleOffsetPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Double> getPage() {
         return page;
     }
@@ -55,12 +55,12 @@ public final class ListUsersDoubleOffsetPaginationRequest {
     /**
      * @return Defaults to per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Double> getPerPage() {
         return perPage;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }
@@ -69,7 +69,7 @@ public final class ListUsersDoubleOffsetPaginationRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersExtendedRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersExtendedRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -30,7 +30,7 @@ public final class ListUsersExtendedRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<UUID> getCursor() {
         return cursor;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersExtendedRequestForOptionalData.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersExtendedRequestForOptionalData.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -30,7 +30,7 @@ public final class ListUsersExtendedRequestForOptionalData {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<UUID> getCursor() {
         return cursor;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersMixedTypeCursorPaginationRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersMixedTypeCursorPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -30,7 +30,7 @@ public final class ListUsersMixedTypeCursorPaginationRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersOffsetPaginationRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersOffsetPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -47,7 +47,7 @@ public final class ListUsersOffsetPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -55,12 +55,12 @@ public final class ListUsersOffsetPaginationRequest {
     /**
      * @return Defaults to per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Integer> getPerPage() {
         return perPage;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }
@@ -69,7 +69,7 @@ public final class ListUsersOffsetPaginationRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersOffsetStepPaginationRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListUsersOffsetStepPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -43,7 +43,7 @@ public final class ListUsersOffsetStepPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -53,12 +53,12 @@ public final class ListUsersOffsetStepPaginationRequest {
      * This is also used as the step size in this
      * paginated endpoint.
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListWithGlobalConfigRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListWithGlobalConfigRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -29,7 +29,7 @@ public final class ListWithGlobalConfigRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("offset")
     public Optional<Integer> getOffset() {
         return offset;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListWithOffsetPaginationHasNextPageRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/inlineusers/inlineusers/requests/ListWithOffsetPaginationHasNextPageRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.inlineusers.inlineusers.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -43,7 +43,7 @@ public final class ListWithOffsetPaginationHasNextPageRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -53,12 +53,12 @@ public final class ListWithOffsetPaginationHasNextPageRequest {
      * This is also used as the step size in this
      * paginated endpoint.
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsernamesRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsernamesRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -33,7 +33,7 @@ public final class ListUsernamesRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsernamesWithOptionalResponseRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsernamesWithOptionalResponseRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -34,7 +34,7 @@ public final class ListUsernamesWithOptionalResponseRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersAliasedDataRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersAliasedDataRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -42,7 +42,7 @@ public final class ListUsersAliasedDataRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -50,7 +50,7 @@ public final class ListUsersAliasedDataRequest {
     /**
      * @return Defaults to per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Integer> getPerPage() {
         return perPage;
     }
@@ -59,7 +59,7 @@ public final class ListUsersAliasedDataRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersCursorPaginationRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersCursorPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -47,7 +47,7 @@ public final class ListUsersCursorPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -55,12 +55,12 @@ public final class ListUsersCursorPaginationRequest {
     /**
      * @return Defaults to per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Integer> getPerPage() {
         return perPage;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }
@@ -69,7 +69,7 @@ public final class ListUsersCursorPaginationRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersDoubleOffsetPaginationRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersDoubleOffsetPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -47,7 +47,7 @@ public final class ListUsersDoubleOffsetPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Double> getPage() {
         return page;
     }
@@ -55,12 +55,12 @@ public final class ListUsersDoubleOffsetPaginationRequest {
     /**
      * @return Defaults to per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Double> getPerPage() {
         return perPage;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }
@@ -69,7 +69,7 @@ public final class ListUsersDoubleOffsetPaginationRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersExtendedRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersExtendedRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -30,7 +30,7 @@ public final class ListUsersExtendedRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<UUID> getCursor() {
         return cursor;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersExtendedRequestForOptionalData.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersExtendedRequestForOptionalData.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -30,7 +30,7 @@ public final class ListUsersExtendedRequestForOptionalData {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<UUID> getCursor() {
         return cursor;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersMixedTypeCursorPaginationRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersMixedTypeCursorPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -30,7 +30,7 @@ public final class ListUsersMixedTypeCursorPaginationRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("cursor")
     public Optional<String> getCursor() {
         return cursor;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersOffsetPaginationRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersOffsetPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -47,7 +47,7 @@ public final class ListUsersOffsetPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -55,12 +55,12 @@ public final class ListUsersOffsetPaginationRequest {
     /**
      * @return Defaults to per page
      */
-    @JsonIgnore
+    @JsonProperty("per_page")
     public Optional<Integer> getPerPage() {
         return perPage;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }
@@ -69,7 +69,7 @@ public final class ListUsersOffsetPaginationRequest {
      * @return The cursor used for pagination in order to fetch
      * the next page of results.
      */
-    @JsonIgnore
+    @JsonProperty("starting_after")
     public Optional<String> getStartingAfter() {
         return startingAfter;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersOffsetStepPaginationRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersOffsetStepPaginationRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -43,7 +43,7 @@ public final class ListUsersOffsetStepPaginationRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -53,12 +53,12 @@ public final class ListUsersOffsetStepPaginationRequest {
      * This is also used as the step size in this
      * paginated endpoint.
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersOptionalDataRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListUsersOptionalDataRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -32,7 +32,7 @@ public final class ListUsersOptionalDataRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListWithGlobalConfigRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListWithGlobalConfigRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -29,7 +29,7 @@ public final class ListWithGlobalConfigRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("offset")
     public Optional<Integer> getOffset() {
         return offset;
     }

--- a/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListWithOffsetPaginationHasNextPageRequest.java
+++ b/seed/java-sdk/pagination/item-index-semantics/src/main/java/com/seed/pagination/resources/users/requests/ListWithOffsetPaginationHasNextPageRequest.java
@@ -5,9 +5,9 @@ package com.seed.pagination.resources.users.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -43,7 +43,7 @@ public final class ListWithOffsetPaginationHasNextPageRequest {
     /**
      * @return Defaults to first page
      */
-    @JsonIgnore
+    @JsonProperty("page")
     public Optional<Integer> getPage() {
         return page;
     }
@@ -53,12 +53,12 @@ public final class ListWithOffsetPaginationHasNextPageRequest {
      * This is also used as the step size in this
      * paginated endpoint.
      */
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }
 
-    @JsonIgnore
+    @JsonProperty("order")
     public Optional<Order> getOrder() {
         return order;
     }

--- a/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/resources/organizations/requests/SearchOrganizationsRequest.java
+++ b/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/resources/organizations/requests/SearchOrganizationsRequest.java
@@ -5,9 +5,9 @@ package com.seed.pathParameters.resources.organizations.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -29,7 +29,7 @@ public final class SearchOrganizationsRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/resources/user/requests/SearchUsersRequest.java
+++ b/seed/java-sdk/path-parameters/src/main/java/com/seed/pathParameters/resources/user/requests/SearchUsersRequest.java
@@ -5,9 +5,9 @@ package com.seed.pathParameters.resources.user.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -29,7 +29,7 @@ public final class SearchUsersRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }

--- a/seed/java-sdk/query-parameters-openapi-as-objects/src/main/java/com/seed/api/requests/SearchRequest.java
+++ b/seed/java-sdk/query-parameters-openapi-as-objects/src/main/java/com/seed/api/requests/SearchRequest.java
@@ -5,9 +5,9 @@ package com.seed.api.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -107,17 +107,17 @@ public final class SearchRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("userList")
     public Optional<List<User>> getUserList() {
         return userList;
     }
 
-    @JsonIgnore
+    @JsonProperty("excludeUser")
     public Optional<List<User>> getExcludeUser() {
         return excludeUser;
     }
 
-    @JsonIgnore
+    @JsonProperty("filter")
     public Optional<List<String>> getFilter() {
         return filter;
     }
@@ -125,7 +125,7 @@ public final class SearchRequest {
     /**
      * @return List of tags. Serialized as a comma-separated list.
      */
-    @JsonIgnore
+    @JsonProperty("tags")
     public Optional<List<String>> getTags() {
         return tags;
     }
@@ -133,72 +133,72 @@ public final class SearchRequest {
     /**
      * @return Optional list of tags. Serialized as a comma-separated list.
      */
-    @JsonIgnore
+    @JsonProperty("optionalTags")
     public Optional<List<String>> getOptionalTags() {
         return optionalTags;
     }
 
-    @JsonIgnore
+    @JsonProperty("limit")
     public int getLimit() {
         return limit;
     }
 
-    @JsonIgnore
+    @JsonProperty("id")
     public String getId() {
         return id;
     }
 
-    @JsonIgnore
+    @JsonProperty("date")
     public String getDate() {
         return date;
     }
 
-    @JsonIgnore
+    @JsonProperty("deadline")
     public OffsetDateTime getDeadline() {
         return deadline;
     }
 
-    @JsonIgnore
+    @JsonProperty("bytes")
     public String getBytes() {
         return bytes;
     }
 
-    @JsonIgnore
+    @JsonProperty("user")
     public User getUser() {
         return user;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalDeadline")
     public Optional<OffsetDateTime> getOptionalDeadline() {
         return optionalDeadline;
     }
 
-    @JsonIgnore
+    @JsonProperty("keyValue")
     public Optional<Map<String, String>> getKeyValue() {
         return keyValue;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalString")
     public Optional<String> getOptionalString() {
         return optionalString;
     }
 
-    @JsonIgnore
+    @JsonProperty("nestedUser")
     public Optional<NestedUser> getNestedUser() {
         return nestedUser;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalUser")
     public Optional<User> getOptionalUser() {
         return optionalUser;
     }
 
-    @JsonIgnore
+    @JsonProperty("neighbor")
     public Optional<SearchRequestNeighbor> getNeighbor() {
         return neighbor;
     }
 
-    @JsonIgnore
+    @JsonProperty("neighborRequired")
     public SearchRequestNeighborRequired getNeighborRequired() {
         return neighborRequired;
     }

--- a/seed/java-sdk/query-parameters-openapi/src/main/java/com/seed/api/requests/SearchRequest.java
+++ b/seed/java-sdk/query-parameters-openapi/src/main/java/com/seed/api/requests/SearchRequest.java
@@ -5,9 +5,9 @@ package com.seed.api.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -107,17 +107,17 @@ public final class SearchRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("userList")
     public Optional<List<User>> getUserList() {
         return userList;
     }
 
-    @JsonIgnore
+    @JsonProperty("excludeUser")
     public Optional<List<User>> getExcludeUser() {
         return excludeUser;
     }
 
-    @JsonIgnore
+    @JsonProperty("filter")
     public Optional<List<String>> getFilter() {
         return filter;
     }
@@ -125,7 +125,7 @@ public final class SearchRequest {
     /**
      * @return List of tags. Serialized as a comma-separated list.
      */
-    @JsonIgnore
+    @JsonProperty("tags")
     public Optional<List<String>> getTags() {
         return tags;
     }
@@ -133,72 +133,72 @@ public final class SearchRequest {
     /**
      * @return Optional list of tags. Serialized as a comma-separated list.
      */
-    @JsonIgnore
+    @JsonProperty("optionalTags")
     public Optional<List<String>> getOptionalTags() {
         return optionalTags;
     }
 
-    @JsonIgnore
+    @JsonProperty("limit")
     public int getLimit() {
         return limit;
     }
 
-    @JsonIgnore
+    @JsonProperty("id")
     public String getId() {
         return id;
     }
 
-    @JsonIgnore
+    @JsonProperty("date")
     public String getDate() {
         return date;
     }
 
-    @JsonIgnore
+    @JsonProperty("deadline")
     public OffsetDateTime getDeadline() {
         return deadline;
     }
 
-    @JsonIgnore
+    @JsonProperty("bytes")
     public String getBytes() {
         return bytes;
     }
 
-    @JsonIgnore
+    @JsonProperty("user")
     public User getUser() {
         return user;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalDeadline")
     public Optional<OffsetDateTime> getOptionalDeadline() {
         return optionalDeadline;
     }
 
-    @JsonIgnore
+    @JsonProperty("keyValue")
     public Optional<Map<String, String>> getKeyValue() {
         return keyValue;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalString")
     public Optional<String> getOptionalString() {
         return optionalString;
     }
 
-    @JsonIgnore
+    @JsonProperty("nestedUser")
     public Optional<NestedUser> getNestedUser() {
         return nestedUser;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalUser")
     public Optional<User> getOptionalUser() {
         return optionalUser;
     }
 
-    @JsonIgnore
+    @JsonProperty("neighbor")
     public Optional<SearchRequestNeighbor> getNeighbor() {
         return neighbor;
     }
 
-    @JsonIgnore
+    @JsonProperty("neighborRequired")
     public SearchRequestNeighborRequired getNeighborRequired() {
         return neighborRequired;
     }

--- a/seed/java-sdk/query-parameters/src/main/java/com/seed/queryParameters/resources/user/requests/GetUsersRequest.java
+++ b/seed/java-sdk/query-parameters/src/main/java/com/seed/queryParameters/resources/user/requests/GetUsersRequest.java
@@ -5,9 +5,9 @@ package com.seed.queryParameters.resources.user.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -92,72 +92,72 @@ public final class GetUsersRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("excludeUser")
     public List<User> getExcludeUser() {
         return excludeUser;
     }
 
-    @JsonIgnore
+    @JsonProperty("filter")
     public List<String> getFilter() {
         return filter;
     }
 
-    @JsonIgnore
+    @JsonProperty("limit")
     public int getLimit() {
         return limit;
     }
 
-    @JsonIgnore
+    @JsonProperty("id")
     public UUID getId() {
         return id;
     }
 
-    @JsonIgnore
+    @JsonProperty("date")
     public String getDate() {
         return date;
     }
 
-    @JsonIgnore
+    @JsonProperty("deadline")
     public OffsetDateTime getDeadline() {
         return deadline;
     }
 
-    @JsonIgnore
+    @JsonProperty("bytes")
     public byte[] getBytes() {
         return bytes;
     }
 
-    @JsonIgnore
+    @JsonProperty("user")
     public User getUser() {
         return user;
     }
 
-    @JsonIgnore
+    @JsonProperty("userList")
     public List<User> getUserList() {
         return userList;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalDeadline")
     public Optional<OffsetDateTime> getOptionalDeadline() {
         return optionalDeadline;
     }
 
-    @JsonIgnore
+    @JsonProperty("keyValue")
     public Map<String, String> getKeyValue() {
         return keyValue;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalString")
     public Optional<String> getOptionalString() {
         return optionalString;
     }
 
-    @JsonIgnore
+    @JsonProperty("nestedUser")
     public NestedUser getNestedUser() {
         return nestedUser;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalUser")
     public Optional<User> getOptionalUser() {
         return optionalUser;
     }

--- a/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/resources/user/requests/CreateUsernameReferencedRequest.java
+++ b/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/resources/user/requests/CreateUsernameReferencedRequest.java
@@ -5,7 +5,6 @@ package com.seed.requestParameters.resources.user.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,7 +36,7 @@ public final class CreateUsernameReferencedRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("tags")
     public List<String> getTags() {
         return tags;
     }

--- a/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/resources/user/requests/GetUsersRequest.java
+++ b/seed/java-sdk/request-parameters/src/main/java/com/seed/requestParameters/resources/user/requests/GetUsersRequest.java
@@ -5,9 +5,9 @@ package com.seed.requestParameters.resources.user.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -101,82 +101,82 @@ public final class GetUsersRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("excludeUser")
     public List<User> getExcludeUser() {
         return excludeUser;
     }
 
-    @JsonIgnore
+    @JsonProperty("filter")
     public List<String> getFilter() {
         return filter;
     }
 
-    @JsonIgnore
+    @JsonProperty("limit")
     public int getLimit() {
         return limit;
     }
 
-    @JsonIgnore
+    @JsonProperty("id")
     public UUID getId() {
         return id;
     }
 
-    @JsonIgnore
+    @JsonProperty("date")
     public String getDate() {
         return date;
     }
 
-    @JsonIgnore
+    @JsonProperty("deadline")
     public OffsetDateTime getDeadline() {
         return deadline;
     }
 
-    @JsonIgnore
+    @JsonProperty("bytes")
     public byte[] getBytes() {
         return bytes;
     }
 
-    @JsonIgnore
+    @JsonProperty("user")
     public User getUser() {
         return user;
     }
 
-    @JsonIgnore
+    @JsonProperty("userList")
     public List<User> getUserList() {
         return userList;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalDeadline")
     public Optional<OffsetDateTime> getOptionalDeadline() {
         return optionalDeadline;
     }
 
-    @JsonIgnore
+    @JsonProperty("keyValue")
     public Map<String, String> getKeyValue() {
         return keyValue;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalString")
     public Optional<String> getOptionalString() {
         return optionalString;
     }
 
-    @JsonIgnore
+    @JsonProperty("nestedUser")
     public NestedUser getNestedUser() {
         return nestedUser;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalUser")
     public Optional<User> getOptionalUser() {
         return optionalUser;
     }
 
-    @JsonIgnore
+    @JsonProperty("longParam")
     public long getLongParam() {
         return longParam;
     }
 
-    @JsonIgnore
+    @JsonProperty("bigIntParam")
     public BigInteger getBigIntParam() {
         return bigIntParam;
     }

--- a/seed/java-sdk/required-nullable/src/main/java/com/seed/api/requests/GetFooRequest.java
+++ b/seed/java-sdk/required-nullable/src/main/java/com/seed/api/requests/GetFooRequest.java
@@ -8,10 +8,12 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.api.core.Nullable;
+import com.seed.api.core.NullableNonemptyFilter;
 import com.seed.api.core.ObjectMappers;
 import java.util.HashMap;
 import java.util.Map;
@@ -48,7 +50,7 @@ public final class GetFooRequest {
     /**
      * @return An optional baz
      */
-    @JsonIgnore
+    @JsonProperty("optional_baz")
     public Optional<String> getOptionalBaz() {
         return optionalBaz;
     }
@@ -67,7 +69,7 @@ public final class GetFooRequest {
     /**
      * @return A required baz
      */
-    @JsonIgnore
+    @JsonProperty("required_baz")
     public String getRequiredBaz() {
         return requiredBaz;
     }
@@ -80,6 +82,18 @@ public final class GetFooRequest {
         if (requiredNullableBaz == null) {
             return Optional.empty();
         }
+        return requiredNullableBaz;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("optional_nullable_baz")
+    private Optional<String> _getOptionalNullableBaz() {
+        return optionalNullableBaz;
+    }
+
+    @JsonInclude(value = JsonInclude.Include.CUSTOM, valueFilter = NullableNonemptyFilter.class)
+    @JsonProperty("required_nullable_baz")
+    private Optional<String> _getRequiredNullableBaz() {
         return requiredNullableBaz;
     }
 

--- a/seed/java-sdk/reserved-keywords/src/main/java/com/seed/nurseryApi/resources/package_/requests/TestRequest.java
+++ b/seed/java-sdk/reserved-keywords/src/main/java/com/seed/nurseryApi/resources/package_/requests/TestRequest.java
@@ -5,9 +5,9 @@ package com.seed.nurseryApi.resources.package_.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.nurseryApi.core.ObjectMappers;
@@ -28,7 +28,7 @@ public final class TestRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("for")
     public String getFor() {
         return for_;
     }

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/playlist/requests/CreatePlaylistRequest.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/playlist/requests/CreatePlaylistRequest.java
@@ -5,7 +5,6 @@ package com.seed.trace.resources.playlist.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -43,12 +42,12 @@ public final class CreatePlaylistRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("datetime")
     public OffsetDateTime getDatetime() {
         return datetime;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalDatetime")
     public Optional<OffsetDateTime> getOptionalDatetime() {
         return optionalDatetime;
     }

--- a/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/playlist/requests/GetPlaylistsRequest.java
+++ b/seed/java-sdk/trace/src/main/java/com/seed/trace/resources/playlist/requests/GetPlaylistsRequest.java
@@ -5,9 +5,9 @@ package com.seed.trace.resources.playlist.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -51,17 +51,17 @@ public final class GetPlaylistsRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("optionalMultipleField")
     public Optional<List<String>> getOptionalMultipleField() {
         return optionalMultipleField;
     }
 
-    @JsonIgnore
+    @JsonProperty("multipleField")
     public List<String> getMultipleField() {
         return multipleField;
     }
 
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<Integer> getLimit() {
         return limit;
     }
@@ -69,7 +69,7 @@ public final class GetPlaylistsRequest {
     /**
      * @return i'm another field
      */
-    @JsonIgnore
+    @JsonProperty("otherField")
     public String getOtherField() {
         return otherField;
     }
@@ -78,7 +78,7 @@ public final class GetPlaylistsRequest {
      * @return I'm a multiline
      * description
      */
-    @JsonIgnore
+    @JsonProperty("multiLineDocs")
     public String getMultiLineDocs() {
         return multiLineDocs;
     }

--- a/seed/java-sdk/union-query-parameters/src/main/java/com/seed/unionQueryParameters/resources/events/requests/SubscribeEventsRequest.java
+++ b/seed/java-sdk/union-query-parameters/src/main/java/com/seed/unionQueryParameters/resources/events/requests/SubscribeEventsRequest.java
@@ -5,9 +5,9 @@ package com.seed.unionQueryParameters.resources.events.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -37,12 +37,12 @@ public final class SubscribeEventsRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("event_type")
     public Optional<EventTypeParam> getEventType() {
         return eventType;
     }
 
-    @JsonIgnore
+    @JsonProperty("tags")
     public Optional<StringOrListParam> getTags() {
         return tags;
     }

--- a/seed/java-sdk/validation/src/main/java/com/seed/validation/requests/GetRequest.java
+++ b/seed/java-sdk/validation/src/main/java/com/seed/validation/requests/GetRequest.java
@@ -5,9 +5,9 @@ package com.seed.validation.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.seed.validation.core.ObjectMappers;
@@ -34,17 +34,17 @@ public final class GetRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("decimal")
     public double getDecimal() {
         return decimal;
     }
 
-    @JsonIgnore
+    @JsonProperty("even")
     public int getEven() {
         return even;
     }
 
-    @JsonIgnore
+    @JsonProperty("name")
     public String getName() {
         return name;
     }

--- a/seed/java-sdk/x-fern-default/src/main/java/com/seed/api/requests/TestGetRequest.java
+++ b/seed/java-sdk/x-fern-default/src/main/java/com/seed/api/requests/TestGetRequest.java
@@ -5,9 +5,9 @@ package com.seed.api.requests;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -29,7 +29,7 @@ public final class TestGetRequest {
         this.additionalProperties = additionalProperties;
     }
 
-    @JsonIgnore
+    @JsonProperty("limit")
     public Optional<String> getLimit() {
         return limit;
     }


### PR DESCRIPTION
## Summary

Java SDK 4.0.4 fixed query parameters leaking into the JSON body for endpoints that combine query params with an **inlined** body, by switching every query-parameter getter on every wrapped request to `@JsonIgnore`. That fix was over-scoped: it applied `@JsonIgnore` to query getters on requests that are *never* serialized as a body — pure-query GETs, referenced bodies (`writeValueAsBytes(request.getBody())`), file uploads (multipart), and bytes bodies. For those classes, blanket `@JsonIgnore` silently makes `toString()` and `ObjectMappers.stringify()` return `{}`, losing every parameter value in logs, debug views, and any user-side `mapper.writeValueAsString(request)` round-trips, while deserialization still works (the builder retains `@JsonSetter`) — an asymmetric round-trip regression.

This PR threads "is the body inlined?" through `WrappedRequestGenerator` and only marks query getters as `@JsonIgnore` in that case. Inlined-body wrappers (the original leak case) keep `@JsonIgnore`; everything else reverts to `@JsonProperty`.

## Motivation

A real-world Pipedream Java SDK regen on 4.8.1 produced an `AccountsListRequest` (GET /accounts, all-query) whose `toString()` returned `{ }` even when fully populated. End-to-end verified before/after with the same JUnit harness against a freshly regenerated SDK from the customer's `fern/` config:

**Before (4.8.1):**
```
toString output: { }
writeValueAsString output: {}
deserialization stillWorks: Optional[u_123], Optional[50], Optional[slack]
```

**After (this PR):**
```
toString output: {
  "external_user_id" : "u_123",
  "limit" : 50,
  "app" : "slack"
}
writeValueAsString output: {"external_user_id":"u_123","limit":50,"app":"slack"}
deserialization stillWorks: Optional[u_123], Optional[50], Optional[slack]
```

Mixed wrappers where the leak risk actually exists (e.g. `seed/java-sdk/query-param-name-conflict/.../BulkUpdateTasksRequest.java`, where `RawSeedApiClient` does `JSON_MAPPER.writeValueAsBytes(request)` on the whole wrapper) keep `@JsonIgnore` on their query getters — diff confirms zero behavioral change there.

## Implementation

`generators/java/sdk/src/main/java/com/fern/java/client/generators/WrappedRequestGenerator.java`: gate the `allQueryParameterProperties` set on a fresh `HttpRequestBody.Visitor<Boolean>` that returns `true` only for `visitInlinedRequestBody`. All other body shapes (referenced, file upload, bytes) and the no-body case skip marking query params, so `EnrichedObjectProperty.getter()` falls through to `@JsonProperty(wireKey)`.

## Test plan

- [x] `./gradlew :sdk:compileJava` in `generators/java` — clean
- [x] `pnpm seed test --generator java-sdk --skip-scripts --local` — 168/173 pass (all 5 failures are pre-existing, in `allowedFailures` in `seed/java-sdk/seed.yml`); 32 fixtures previously in `allowedFailures` now succeed (orthogonal noise, not addressed here)
- [x] Each regenerated fixture's `compileScript` (`./gradlew compileJava`) passes — verified by the seed runner
- [x] Snapshot diff sanity: 0 lines add `+@JsonIgnore`, 445 lines remove `@JsonIgnore`, 475 lines add `@JsonProperty(...)`. Mixed-body fixture `BulkUpdateTasksRequest` is unchanged
- [x] End-to-end against Pipedream's `fern/` config (`pnpm seed run --generator java-sdk --path … --local`) → `AccountsListRequest` getters revert to `@JsonProperty`, `CreateAccountOpts` query getters keep `@JsonIgnore`, and a focused JUnit `RegressionRepro` (`toString()`, `writeValueAsString`, deserialization) goes from 2/3 failing to 3/3 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)