### PR TITLE
chore(rust): remediate openssl 3.5.5 container vulns

### DIFF
--- a/generators/rust/sdk/Dockerfile
+++ b/generators/rust/sdk/Dockerfile
@@ -5,12 +5,19 @@
 FROM rust:1.82-alpine3.20 AS rust
 RUN rustup component add rustfmt
 
-FROM node:22.22-alpine3.22
+FROM node:22.22.2-alpine3.22
+
+# Pull the latest Alpine 3.22 package fixes on top of what ships in the base
+# image. This picks up the patched openssl/libssl3/libcrypto3 build from the
+# Alpine repository, addressing the seven openssl 3.5.5 CVEs (critical,
+# CVSS 9.8) flagged by the 2026-05-07 grype scan of the rust-sdk-generator
+# container.
+RUN apk --no-cache upgrade
 
 # Update bundled npm to refresh transitive dependencies (picomatch, brace-expansion,
 # ip-address, etc.) that ship inside /usr/local/lib/node_modules/npm and otherwise
 # carry known CVEs into the image. We install into a fresh prefix and swap directories
-# because in-place self-upgrade of the bundled npm in node:22.22-alpine3.22 fails with
+# because in-place self-upgrade of the bundled npm in node:22.22.2-alpine3.22 fails with
 # a stale module-resolution error.
 RUN mkdir -p /tmp/npm-upgrade \
     && npm install --prefix /tmp/npm-upgrade npm@11.13.0 \

--- a/generators/rust/sdk/Dockerfile
+++ b/generators/rust/sdk/Dockerfile
@@ -5,7 +5,7 @@
 FROM rust:1.82-alpine3.20 AS rust
 RUN rustup component add rustfmt
 
-FROM node:22.22.2-alpine3.22
+FROM node:22.22-alpine3.22
 
 # Pull the latest Alpine 3.22 package fixes on top of what ships in the base
 # image. This picks up the patched openssl/libssl3/libcrypto3 build from the
@@ -17,7 +17,7 @@ RUN apk --no-cache upgrade
 # Update bundled npm to refresh transitive dependencies (picomatch, brace-expansion,
 # ip-address, etc.) that ship inside /usr/local/lib/node_modules/npm and otherwise
 # carry known CVEs into the image. We install into a fresh prefix and swap directories
-# because in-place self-upgrade of the bundled npm in node:22.22.2-alpine3.22 fails with
+# because in-place self-upgrade of the bundled npm in node:22.22-alpine3.22 fails with
 # a stale module-resolution error.
 RUN mkdir -p /tmp/npm-upgrade \
     && npm install --prefix /tmp/npm-upgrade npm@11.13.0 \

--- a/generators/rust/sdk/changes/unreleased/remediate-openssl-3-5-5-cves.yml
+++ b/generators/rust/sdk/changes/unreleased/remediate-openssl-3-5-5-cves.yml
@@ -3,8 +3,7 @@
 - summary: |
     Remediate the seven critical (CVSS 9.8) `openssl/openssl:3.5.5` CVEs
     flagged by the 2026-05-07 grype scan of the `fern-rust-sdk` container.
-    Pin the Node base image to `node:22.22.2-alpine3.22` and run
-    `apk --no-cache upgrade` during the build to pick up the patched
-    `openssl`, `libssl3`, and `libcrypto3` packages from the Alpine 3.22
-    repository.
+    Run `apk --no-cache upgrade` during the Docker build to pick up the
+    patched `openssl`, `libssl3`, and `libcrypto3` packages from the
+    Alpine 3.22 repository.
   type: chore

--- a/generators/rust/sdk/changes/unreleased/remediate-openssl-3-5-5-cves.yml
+++ b/generators/rust/sdk/changes/unreleased/remediate-openssl-3-5-5-cves.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Remediate the seven critical (CVSS 9.8) `openssl/openssl:3.5.5` CVEs
+    flagged by the 2026-05-07 grype scan of the `fern-rust-sdk` container.
+    Pin the Node base image to `node:22.22.2-alpine3.22` and run
+    `apk --no-cache upgrade` during the build to pick up the patched
+    `openssl`, `libssl3`, and `libcrypto3` packages from the Alpine 3.22
+    repository.
+  type: chore


### PR DESCRIPTION
## Description

Linear ticket: Refs N/A

Addresses the seven critical (CVSS 9.8) `openssl/openssl:3.5.5` CVEs flagged by the 2026-05-07 grype scan of the `dev/rust-sdk-generator` ECR image.

The vulnerable openssl 3.5.5 build is shipped by the `node:22.22-alpine3.22` base image. Alpine 3.22's apk repository now publishes a patched openssl, so we pick it up via `apk --no-cache upgrade` during the Docker build (same pattern already used by the `csharp/sdk`, `ruby-v2/sdk`, and `openapi` generator Dockerfiles).

## Changes Made

- `generators/rust/sdk/Dockerfile`
  - Add `RUN apk --no-cache upgrade` immediately after the `FROM` line so the patched `openssl` / `libssl3` / `libcrypto3` packages from the Alpine 3.22 repo make it into the final image.
  - Node base image tag is left at the floating `node:22.22-alpine3.22` so future patch updates continue to flow in automatically (per review feedback in the thread on commit 2073269).
- `generators/rust/sdk/changes/unreleased/remediate-openssl-3-5-5-cves.yml`
  - New unreleased changelog entry (`type: chore`, patch bump per release-versioning rules).
- [ ] Updated README.md generator (N/A — Dockerfile-only change)

## Testing

- [x] `pnpm run check` (biome) passes locally.
- [ ] Unit tests added/updated (N/A — no logic change)
- [ ] Manual testing completed — image not built/scanned locally; the actual CVE remediation will be confirmed by the next grype scan after the image is published.

## Updates since last revision

- Reverted the Node tag pin (`node:22.22.2-alpine3.22` → `node:22.22-alpine3.22`) based on review feedback so we don't miss future patch updates. Diff is now Dockerfile-comment + single `RUN apk --no-cache upgrade` line.

## Reviewer checklist

- The unreleased changelog entry still mentions pinning to `node:22.22.2-alpine3.22`; that wording is now stale relative to the Dockerfile (the pin was reverted). Worth tightening the changelog wording before release if you want it to match exactly what shipped.
- Confirm `apk --no-cache upgrade` against `alpine3.22` actually pulls a patched openssl. If `alpine3.22` is still on 3.5.5 with no fix backported, the build will succeed but the CVEs will remain — in that case we should bump to `alpine3.23` as a follow-up (the approach taken by `ruby-v2/sdk`).

Link to Devin session: https://app.devin.ai/sessions/3ad3733e9503462daa8bc9b0daac13ad
Requested by: @davidkonigsberg