### PR TITLE
chore(deps): bump generator/seed container base images and apply security updates

### DIFF
--- a/docker/seed/Dockerfile.go
+++ b/docker/seed/Dockerfile.go
@@ -1,15 +1,18 @@
 # Stage 1: Pull wiremock image as tar (no daemon needed)
-FROM alpine:3.22 AS wiremock-pull
+FROM alpine:3.23 AS wiremock-pull
 RUN apk add --no-cache curl && \
     ARCH=$(uname -m) && if [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; fi && \
     curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
     crane pull wiremock/wiremock:3.9.1 /wiremock.tar
 
 # Stage 2: Build the seed image
-FROM docker:28.4.0-dind-alpine3.22
+FROM docker:29.4.1-dind-alpine3.23
 
 # Copy pre-pulled wiremock image
 COPY --from=wiremock-pull /wiremock.tar /wiremock.tar
+
+# Apply the latest APK security patches available for the base image
+RUN apk update && apk upgrade --no-cache
 
 # Install Go (multi-arch: supports both amd64 and arm64)
 ENV GO_VERSION=1.23.8

--- a/generators/csharp/model/Dockerfile
+++ b/generators/csharp/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine3.20 AS node
+FROM node:22.22-alpine3.23 AS node
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine
 
 ENV YARN_CACHE_FOLDER=/.yarn
@@ -13,7 +13,8 @@ ENV SENTRY_DSN=$SENTRY_DSN
 ENV SENTRY_ENVIRONMENT=$SENTRY_ENVIRONMENT
 ENV SENTRY_RELEASE=$SENTRY_RELEASE
 
-RUN apk --no-cache add bash curl git zip && \
+RUN apk update && apk upgrade --no-cache && \
+    apk --no-cache add bash curl git zip && \
     git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"
 

--- a/generators/csharp/sdk/Dockerfile
+++ b/generators/csharp/sdk/Dockerfile
@@ -1,12 +1,12 @@
 # Stage 1: Node.js
-# Pinned to 22.22.2-alpine3.22 to fix Node.js binary CVEs picked up by the
+# Pinned to 22.22-alpine3.23 to fix Node.js binary CVEs picked up by the
 # 2026-05-06 grype scan (CVE-2025-23166, CVE-2025-23083, CVE-2025-59465,
 # CVE-2026-21637, CVE-2025-55131, CVE-2026-21710, CVE-2025-59466,
 # CVE-2025-23085, CVE-2026-21717, CVE-2026-21713, CVE-2026-21714,
 # CVE-2025-55132, CVE-2025-23165, CVE-2026-21715, CVE-2026-21716,
 # CVE-2025-55130) and to upgrade npm-bundled deps cross-spawn (>=7.0.5),
 # minimatch (>=9.0.7), glob (>=10.5.0), tar (>=7.5.11), and diff (>=5.2.2).
-FROM node:22.22.2-alpine3.22 AS node
+FROM node:22.22-alpine3.23 AS node
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine
 

--- a/generators/csharp/sdk/changes/unreleased/chore-bump-node-base-image.yml
+++ b/generators/csharp/sdk/changes/unreleased/chore-bump-node-base-image.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump generator container Node.js base image to `node:22.22-alpine3.23` and
+    apply latest Alpine package security updates at build time.
+  type: chore

--- a/generators/go/model/Dockerfile
+++ b/generators/go/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine3.20 AS node
+FROM node:22.22-alpine3.23 AS node
 
 FROM golang:1.26.2-alpine3.23
 
@@ -10,6 +10,7 @@ ENV SENTRY_DSN=$SENTRY_DSN
 ENV SENTRY_ENVIRONMENT=$SENTRY_ENVIRONMENT
 ENV SENTRY_RELEASE=$SENTRY_RELEASE
 
+RUN apk update && apk upgrade --no-cache
 RUN apk --no-cache add bash curl git zip libstdc++
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"

--- a/generators/go/sdk/Dockerfile
+++ b/generators/go/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build Node CLI
-FROM node:22.22-alpine3.22 AS node
+FROM node:22.22-alpine3.23 AS node
 
 RUN apk --no-cache add git zip
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
@@ -28,6 +28,7 @@ FROM golang:1.26.2-alpine3.23
 
 WORKDIR /workspace
 
+RUN apk update && apk upgrade --no-cache
 RUN apk add --no-cache ca-certificates git libstdc++
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"

--- a/generators/go/sdk/changes/unreleased/chore-bump-node-base-image.yml
+++ b/generators/go/sdk/changes/unreleased/chore-bump-node-base-image.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump generator container Node.js base image to `node:22.22-alpine3.23` and
+    apply latest Alpine package security updates at build time.
+  type: chore

--- a/generators/java/model/Dockerfile
+++ b/generators/java/model/Dockerfile
@@ -1,6 +1,14 @@
 # Apple Silicon: FROM gradle:latest
 FROM gradle:8.5.0-jdk17-jammy
 
+# Apply latest Ubuntu security updates so OS package CVEs (libc, openssl,
+# zlib, etc.) tracked by grype against the jammy base image are picked up
+# at build time.
+RUN apt-get update \
+    && apt-get -y --no-install-recommends dist-upgrade \
+    && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
+
 # Replace vulnerable jackson-core in Gradle distribution to fix GHSA-72hv-8253-57qq
 # (async parser bypasses maxNumberLength constraint, leading to potential DoS)
 RUN rm -f /opt/gradle/lib/jackson-core-*.jar && \

--- a/generators/java/sdk/changes/unreleased/chore-apply-latest-ubuntu-security-updates-to-model.yml
+++ b/generators/java/sdk/changes/unreleased/chore-apply-latest-ubuntu-security-updates-to-model.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Apply latest Ubuntu security updates to the Java model generator container
+    (`gradle:8.5.0-jdk17-jammy`) at build time so OS-level package CVEs are
+    picked up.
+  type: chore

--- a/generators/openapi/Dockerfile
+++ b/generators/openapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.2-alpine3.22
+FROM node:22.22-alpine3.23
 RUN apk update && apk upgrade --no-cache \
     && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 COPY dist /dist

--- a/generators/php/model/Dockerfile
+++ b/generators/php/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine3.20 AS node
+FROM node:22.22-alpine3.23 AS node
 FROM composer:2.7.9
 
 ENV YARN_CACHE_FOLDER=/.yarn
@@ -9,6 +9,7 @@ ENV SENTRY_DSN=$SENTRY_DSN
 ENV SENTRY_ENVIRONMENT=$SENTRY_ENVIRONMENT
 ENV SENTRY_RELEASE=$SENTRY_RELEASE
 
+RUN apk update && apk upgrade --no-cache
 RUN apk --no-cache add bash curl git zip
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"

--- a/generators/php/sdk/Dockerfile
+++ b/generators/php/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine3.20 AS node
+FROM node:22.22-alpine3.23 AS node
 FROM composer:2.7.9
 
 ENV YARN_CACHE_FOLDER=/.yarn
@@ -9,6 +9,7 @@ ENV SENTRY_DSN=$SENTRY_DSN
 ENV SENTRY_ENVIRONMENT=$SENTRY_ENVIRONMENT
 ENV SENTRY_RELEASE=$SENTRY_RELEASE
 
+RUN apk update && apk upgrade --no-cache
 RUN apk --no-cache add bash curl git zip
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"

--- a/generators/php/sdk/changes/unreleased/chore-bump-node-base-image.yml
+++ b/generators/php/sdk/changes/unreleased/chore-bump-node-base-image.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump generator container Node.js base image to `node:22.22-alpine3.23` and
+    apply latest Alpine package security updates at build time.
+  type: chore

--- a/generators/python-v2/pydantic-model/Dockerfile
+++ b/generators/python-v2/pydantic-model/Dockerfile
@@ -1,4 +1,4 @@
-# Updated Node.js base from 22.12-slim to 22.22.2-bookworm-slim to address container CVEs:
+# Updated Node.js base from 22.12-slim to 22.22-bookworm-slim to address container CVEs:
 # - Node binary CVEs (CVE-2025-23083, CVE-2025-23166, CVE-2025-23085, CVE-2025-23165, CVE-2025-55131,
 #   CVE-2025-55132, CVE-2025-59465, CVE-2025-59466, CVE-2026-21637, CVE-2026-21710, CVE-2026-21712,
 #   CVE-2026-21713, CVE-2026-21714, CVE-2026-21715, CVE-2026-21716, CVE-2026-21717)
@@ -7,7 +7,7 @@
 # Bundled npm globals are removed below so the npm-bundled JS dependencies (cross-spawn, glob,
 # minimatch, tar, brace-expansion, ip-address, diff) cannot be flagged or invoked at runtime — this
 # image only runs the bundled CLI directly via node.
-FROM node:22.22.2-bookworm-slim
+FROM node:22.22-bookworm-slim
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl \

--- a/generators/python-v2/sdk/Dockerfile
+++ b/generators/python-v2/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.2-bookworm-slim
+FROM node:22.22-bookworm-slim
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl \

--- a/generators/python-v2/sdk/Dockerfile
+++ b/generators/python-v2/sdk/Dockerfile
@@ -1,5 +1,8 @@
-FROM node:22.12-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+FROM node:22.22.2-bookworm-slim
+RUN apt-get update \
+    && apt-get -y --no-install-recommends dist-upgrade \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
 RUN curl -LsSf https://astral.sh/ruff/0.15.7/install.sh | sh
 ENV PATH="/root/.local/bin:${PATH}"
 RUN ruff --version

--- a/generators/python/pydantic/Dockerfile
+++ b/generators/python/pydantic/Dockerfile
@@ -1,6 +1,11 @@
 # Build base image with dependencies
 FROM python:3.11.13 AS base
 
+RUN apt-get update \
+    && apt-get -y --no-install-recommends dist-upgrade \
+    && apt-get -y autoremove \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV PYTHONPATH=${PYTHONPATH}:${PWD}
 ENV _TYPER_STANDARD_TRACEBACK=1
 

--- a/generators/python/sdk/changes/unreleased/chore-bump-pydantic-base-image-security-patches.yml
+++ b/generators/python/sdk/changes/unreleased/chore-bump-pydantic-base-image-security-patches.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Apply latest Debian security updates to the python pydantic generator container
+    (`python:3.11.13`) at build time so OS-level package CVEs are picked up.
+  type: chore

--- a/generators/ruby-v2/model/Dockerfile
+++ b/generators/ruby-v2/model/Dockerfile
@@ -1,6 +1,7 @@
-FROM ruby:3.3-alpine3.20
+FROM ruby:3.3-alpine3.23
 
-RUN apk --no-cache add \
+RUN apk --no-cache upgrade && \
+    apk --no-cache add \
     bash \
     build-base \
     curl \

--- a/generators/ruby-v2/sdk/changes/unreleased/chore-bump-ruby-model-base-image.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/chore-bump-ruby-model-base-image.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump ruby-v2 model container Ruby base image to `ruby:3.3-alpine3.23` (matching
+    the ruby-v2 SDK container) and apply latest Alpine package security updates at
+    build time.
+  type: chore

--- a/generators/rust/model/Dockerfile
+++ b/generators/rust/model/Dockerfile
@@ -8,7 +8,9 @@ RUN rustup component add rustfmt \
     && cp "$RUSTFMT" /rustfmt/rustfmt \
     && cp "$(dirname "$RUSTFMT")/../lib"/librustc_driver-*.so /rustfmt/lib/
 
-FROM node:22.12-alpine3.20
+FROM node:22.22-alpine3.23
+
+RUN apk update && apk upgrade --no-cache
 
 ARG SENTRY_DSN
 ARG SENTRY_ENVIRONMENT=production

--- a/generators/rust/sdk/Dockerfile
+++ b/generators/rust/sdk/Dockerfile
@@ -5,12 +5,14 @@
 FROM rust:1.82-alpine3.20 AS rust
 RUN rustup component add rustfmt
 
-FROM node:22.22-alpine3.22
+FROM node:22.22-alpine3.23
+
+RUN apk update && apk upgrade --no-cache
 
 # Update bundled npm to refresh transitive dependencies (picomatch, brace-expansion,
 # ip-address, etc.) that ship inside /usr/local/lib/node_modules/npm and otherwise
 # carry known CVEs into the image. We install into a fresh prefix and swap directories
-# because in-place self-upgrade of the bundled npm in node:22.22-alpine3.22 fails with
+# because in-place self-upgrade of the bundled npm in node:22.22-alpine3.23 fails with
 # a stale module-resolution error.
 RUN mkdir -p /tmp/npm-upgrade \
     && npm install --prefix /tmp/npm-upgrade npm@11.13.0 \

--- a/generators/rust/sdk/changes/unreleased/chore-bump-node-base-image.yml
+++ b/generators/rust/sdk/changes/unreleased/chore-bump-node-base-image.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump generator container Node.js base image to `node:22.22-alpine3.23` and
+    apply latest Alpine package security updates at build time.
+  type: chore

--- a/generators/swift/model/Dockerfile
+++ b/generators/swift/model/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:22.12-alpine3.20
+FROM node:22.22-alpine3.23
+
+RUN apk update && apk upgrade --no-cache
 
 ARG SENTRY_DSN
 ARG SENTRY_ENVIRONMENT=production

--- a/generators/swift/sdk/Dockerfile
+++ b/generators/swift/sdk/Dockerfile
@@ -1,5 +1,6 @@
-FROM node:22.22-alpine3.22
+FROM node:22.22-alpine3.23
 
+RUN apk update && apk upgrade --no-cache
 RUN apk --no-cache add bash curl git zip
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"

--- a/generators/swift/sdk/changes/unreleased/chore-bump-node-base-image.yml
+++ b/generators/swift/sdk/changes/unreleased/chore-bump-node-base-image.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump generator container Node.js base image to `node:22.22-alpine3.23` and
+    apply latest Alpine package security updates at build time.
+  type: chore

--- a/generators/typescript/sdk/changes/unreleased/chore-apply-latest-debian-security-updates.yml
+++ b/generators/typescript/sdk/changes/unreleased/chore-apply-latest-debian-security-updates.yml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Apply latest Debian security updates to the TypeScript SDK CLI container
+    (`node:24.14-slim`) at build time so OS-level package CVEs are picked up.
+  type: chore

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:24.14-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git zip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get -y --no-install-recommends dist-upgrade \
+    && apt-get install -y --no-install-recommends ca-certificates git zip \
+    && rm -rf /var/lib/apt/lists/*
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"
 


### PR DESCRIPTION
## Description

Linear ticket: Refs

Addresses CVEs in seed/generator containers from the recurring "outdated base image" theme. Bumps generator Dockerfiles already on `node:22.x-alpine` to `node:22.22-alpine3.23`, brings additional Alpine/Debian/Ruby/Docker bases up to current versions, and adds explicit security-update steps (`apk update && apk upgrade --no-cache` or `apt-get dist-upgrade`) to stages that didn't already run one so builds pull the latest OS package security fixes.

## Changes Made

### Node `22.22-alpine3.23` bumps
- `generators/openapi/Dockerfile`
- `generators/swift/{sdk,model}/Dockerfile`
- `generators/go/{sdk,model}/Dockerfile` (intermediate `node` stage; final stage stays on `golang:1.26.2-alpine3.23`)
- `generators/php/{sdk,model}/Dockerfile` (intermediate `node` stage; final stage stays on `composer:2.7.9`)
- `generators/csharp/{sdk,model}/Dockerfile` (intermediate `node` stage; final stage stays on `mcr.microsoft.com/dotnet/sdk:10.0-alpine`)
- `generators/rust/{sdk,model}/Dockerfile` (final `node` stage)

Added `RUN apk update && apk upgrade --no-cache` to alpine stages that did not already run an apk upgrade. `openapi/Dockerfile` and `csharp/sdk/Dockerfile` already had equivalent calls.

### Additional base-image bumps
- `docker/seed/Dockerfile.go` — `alpine:3.22` → `alpine:3.23` (wiremock-pull stage) and `docker:28.4.0-dind-alpine3.22` → `docker:29.4.1-dind-alpine3.23` (final stage); adds `apk update && apk upgrade --no-cache` (matches the pattern already in `Dockerfile.php` / `Dockerfile.python`).
- `generators/ruby-v2/model/Dockerfile` — `ruby:3.3-alpine3.20` → `ruby:3.3-alpine3.23` (matches `ruby-v2/sdk` which is already on 3.23); adds `apk --no-cache upgrade`.
- `generators/python-v2/sdk/Dockerfile` — `node:22.12-slim` → `node:22.22-bookworm-slim` (floating tag); folds `apt-get -y dist-upgrade` into the existing apt-get RUN.
- `generators/python-v2/pydantic-model/Dockerfile` — repinned from `node:22.22.2-bookworm-slim` to the floating `node:22.22-bookworm-slim` tag to match the convention used elsewhere (per review feedback). The CVE-rationale comment block is updated to reference the new tag.

### Pure security-update hygiene (no base-image change)
- `generators/python/pydantic/Dockerfile` — adds `apt-get -y dist-upgrade` against `python:3.11.13` (debian-bookworm).
- `generators/typescript/sdk/cli/Dockerfile` — adds `apt-get -y dist-upgrade` against `node:24.14-slim`.
- `generators/java/model/Dockerfile` — adds `apt-get -y dist-upgrade` against `gradle:8.5.0-jdk17-jammy`.

### Changelogs
Added unreleased `chore` changelog entries under each affected generator's SDK changes folder: `csharp`, `go`, `php`, `rust`, `swift`, `ruby-v2` (model bump tracked in the sdk changelog folder, which is the location defined in `release-config.json`), `python` (pydantic), `typescript` (cli), `java` (model).

### Intentionally NOT changed (would not be safe / would not help)
- `generators/java/sdk/Dockerfile` — uses `node:24.14.1-bookworm` (glibc) copied into `gradle:jdk11-corretto` (Amazon Linux, glibc). Switching the node stage to alpine would break the dynamically linked node binary in the glibc final image, and recent CVE-fix work intentionally moved this to node 24.
- `generators/python/sdk/Dockerfile` — `node:20.19.4-slim` copied into `python:3.13.7-slim` (glibc). Same musl/glibc ABI mismatch. Bumping to node 22 here is plausible but worth its own PR/investigation since this image runs the python-v2 CLI.
- `docker/seed/Dockerfile.ts`, `generators/typescript/sdk/cli/Dockerfile` — intentionally on node 24; not downgrading.
- `docker/seed/Dockerfile.csharp` — already has surgical CVE-targeted `apt-get install -y --only-upgrade` calls; broadening to `dist-upgrade` could paper over deliberate decisions.
- `docker/seed/Dockerfile.java` — already runs `yum update -y` at the top of the build; bumping minor (`9.7` → `9.8`) would need verification that tag exists.
- `generators/rust/{sdk,model}` `rust:1.82-alpine3.20` intermediate stage — only `rustfmt` is copied out, so apk upgrade in that intermediate stage would not affect the final image. Rust's image policy may not republish `rust:1.82` onto a newer Alpine base.

## What reviewers should pay attention to

- **Tag existence:** All bumped tags (`node:22.22-alpine3.23`, `alpine:3.23`, `docker:29.4.1-dind-alpine3.23`, `ruby:3.3-alpine3.23`, `node:22.22-bookworm-slim`) are already in use elsewhere in this repo or were verified by the CI build of the Node-bump portion of this PR, so they should all be valid Docker Hub tags.
- **Build reproducibility tradeoff:** `apk upgrade --no-cache` and `apt-get dist-upgrade` deliberately pull floating "latest" package versions. This is what was requested for security freshness, but it does mean two builds of the same Dockerfile on different days can ship different package versions. Worth confirming this is the intended trade-off.
- **Floating node patch tag (`22.22` not `22.22.2`):** per review feedback, both python-v2 images use the floating `22.22-bookworm-slim` tag rather than pinning a specific patch. Same minor-line LTS, slight loss of reproducibility, gain of automatic patch fixes on rebuild.
- **Benchmark side effect from `apk upgrade`** (per the bot comment on the PR): generator times moved csharp +8.6%, go +14.0%, php +20.9%, rust +3.6%, swift +12.2% — expected for the security-freshness tradeoff; can be removed from the hottest images if regression is unacceptable.
- **`csharp/sdk` CVE comment block** at the top of the Dockerfile referenced the original `22.22.2-alpine3.22` pin — the version mentioned in the comment is updated but the CVE list is preserved. Worth a sanity check that those CVEs remain fixed in `22.22-alpine3.23`.
- **`rust/sdk` npm self-upgrade comment** updated to reference 3.23. The workaround (install npm into `/tmp` and swap) is conservative and should still work, but the underlying "stale module-resolution error" was not re-verified under 3.23.
- **22.12 → 22.22 minor bump:** several Dockerfiles jump node minor (22.12 → 22.22) on top of the alpine bump. Same LTS line so no expected breakage.

## Testing

- [ ] Unit tests added/updated — _N/A; mechanical Dockerfile changes_
- [ ] Manual testing completed — _not run locally; relying on CI to build all affected images_
- [x] CI green on the Node-bump portion of this PR (initial commit)
- [ ] CI green on the additional base-image bumps + apt/apk hygiene additions + floating-tag fixup

The diff is mechanical (FROM line + apk/apt upgrade RUN), so the most useful verification is the CI image build for each generator/seed image.

Link to Devin session: https://app.devin.ai/sessions/e94572bad80c4a3eb42d722d331c65b6
Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->