### PR TITLE
chore(internal): Remove replay.yml from REPLAY_FERNIGNORE_ENTRIES

### DIFF
--- a/packages/generator-cli/src/__test__/replay-core.test.ts
+++ b/packages/generator-cli/src/__test__/replay-core.test.ts
@@ -126,7 +126,6 @@ describe("first generation - no lockfile (auto-bootstrap)", { tags: ["slow", "fl
 
         const fernignore = readFileSync(join(repoPath, ".fernignore"), "utf-8");
         expect(fernignore).toContain(".fern/replay.lock");
-        expect(fernignore).toContain(".fern/replay.yml");
         expect(fernignore).toContain(".gitattributes");
 
         const gitattributes = readFileSync(join(repoPath, ".gitattributes"), "utf-8");

--- a/packages/generator-cli/src/__test__/replay-pure.test.ts
+++ b/packages/generator-cli/src/__test__/replay-pure.test.ts
@@ -439,9 +439,8 @@ describe("parseCommitMessageForPR", () => {
 describe("fernignore", () => {
     it("REPLAY_FERNIGNORE_ENTRIES contains expected values", () => {
         expect(REPLAY_FERNIGNORE_ENTRIES).toContain(".fern/replay.lock");
-        expect(REPLAY_FERNIGNORE_ENTRIES).toContain(".fern/replay.yml");
         expect(REPLAY_FERNIGNORE_ENTRIES).toContain(".gitattributes");
-        expect(REPLAY_FERNIGNORE_ENTRIES.length).toBeGreaterThanOrEqual(3);
+        expect(REPLAY_FERNIGNORE_ENTRIES.length).toBeGreaterThanOrEqual(2);
     });
 
     it("GITATTRIBUTES_ENTRIES marks the replay lockfile as linguist-generated", () => {

--- a/packages/generator-cli/src/replay/fernignore.ts
+++ b/packages/generator-cli/src/replay/fernignore.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import { readFile, writeFile } from "fs/promises";
 import { join } from "path";
 
-export const REPLAY_FERNIGNORE_ENTRIES = [".fern/replay.lock", ".fern/replay.yml", ".gitattributes"];
+export const REPLAY_FERNIGNORE_ENTRIES = [".fern/replay.lock", ".gitattributes"];
 
 export const GITATTRIBUTES_ENTRIES = [".fern/replay.lock linguist-generated=true"];
 


### PR DESCRIPTION
## Description

Removes `.fern/replay.yml` from `REPLAY_FERNIGNORE_ENTRIES` since this file no longer exists in the replay system. A companion PR with the same change exists in `fern-api/fern-replay`.

## Changes Made

- Removed `.fern/replay.yml` from the `REPLAY_FERNIGNORE_ENTRIES` array in `packages/generator-cli/src/replay/fernignore.ts`
- Updated test assertions in `replay-core.test.ts` and `replay-pure.test.ts` to no longer expect `.fern/replay.yml` in fernignore entries

## Testing

- [x] Unit tests updated (`replay-core.test.ts`, `replay-pure.test.ts`)
- [x] All 393 tests in `@fern-api/generator-cli` pass locally

## Review Checklist

- [ ] Confirm `.fern/replay.yml` is no longer created by any code path (if it is still written somewhere, removing it from `.fernignore` would cause `fern generate` to delete it)

Link to Devin session: https://app.devin.ai/sessions/718d34517d2845a99c208365b3a7df4d
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->