### PR TITLE
chore(cli): pass GHE host to Fiddle for remote generation

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-ghe-remote-generation.yml
+++ b/packages/cli/cli/changes/unreleased/fix-ghe-remote-generation.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Pass GitHub Enterprise host to Fiddle for remote generation so that
+    self-hosted GHE instances are correctly targeted by the remote pipeline.
+  type: fix

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -815,7 +815,12 @@ async function convertOutputMode({
     const downloadSnippets = generator.snippets != null && generator.snippets.path !== "";
     if (generator.github) {
         const repoString = isGithubSelfhosted(generator.github) ? generator.github.uri : generator.github.repository;
-        const { owner, repo } = parseRepository(repoString);
+        const { owner, repo, remote } = parseRepository(repoString);
+        // For GHE instances, pass the host so Fiddle targets the correct API endpoint.
+        // The field isn't on the current fiddle-sdk types yet; intermediate variables
+        // bypass TypeScript's excess-property check (same pattern as `replay` in
+        // createAndStartJob.ts). Once the SDK is regenerated the field will type-check.
+        const host = remote !== "github.com" ? remote : undefined;
         const publishInfo =
             generator.output != null
                 ? getGithubPublishInfo(generator.output, maybeGroupLevelMetadata, maybeTopLevelMetadata)
@@ -833,15 +838,17 @@ async function convertOutputMode({
             case "commit":
             case "release": {
                 const releaseConfig = generator.github as generatorsYml.GithubCommitAndReleaseSchema;
+                const commitAndReleaseValue = {
+                    owner,
+                    repo,
+                    host,
+                    branch: releaseConfig.branch,
+                    license,
+                    publishInfo,
+                    downloadSnippets
+                };
                 return FernFiddle.OutputMode.githubV2(
-                    FernFiddle.GithubOutputModeV2.commitAndRelease({
-                        owner,
-                        repo,
-                        branch: releaseConfig.branch,
-                        license,
-                        publishInfo,
-                        downloadSnippets
-                    })
+                    FernFiddle.GithubOutputModeV2.commitAndRelease(commitAndReleaseValue)
                 );
             }
             case "pull-request": {
@@ -851,29 +858,30 @@ async function convertOutputMode({
                     groupLevelReviewers: maybeGroupLevelReviewers,
                     outputModeReviewers: pullRequestConfig.reviewers
                 });
-                return FernFiddle.OutputMode.githubV2(
-                    FernFiddle.GithubOutputModeV2.pullRequest({
-                        owner,
-                        repo,
-                        license,
-                        publishInfo,
-                        downloadSnippets,
-                        reviewers,
-                        branch: pullRequestConfig.branch
-                    })
-                );
+                const pullRequestValue = {
+                    owner,
+                    repo,
+                    host,
+                    license,
+                    publishInfo,
+                    downloadSnippets,
+                    reviewers,
+                    branch: pullRequestConfig.branch
+                };
+                return FernFiddle.OutputMode.githubV2(FernFiddle.GithubOutputModeV2.pullRequest(pullRequestValue));
             }
-            case "push":
-                return FernFiddle.OutputMode.githubV2(
-                    FernFiddle.GithubOutputModeV2.push({
-                        owner,
-                        repo,
-                        branch: generator.github.mode === "push" ? generator.github.branch : undefined,
-                        license,
-                        publishInfo,
-                        downloadSnippets
-                    })
-                );
+            case "push": {
+                const pushValue = {
+                    owner,
+                    repo,
+                    host,
+                    branch: generator.github.mode === "push" ? generator.github.branch : undefined,
+                    license,
+                    publishInfo,
+                    downloadSnippets
+                };
+                return FernFiddle.OutputMode.githubV2(FernFiddle.GithubOutputModeV2.push(pushValue));
+            }
             default:
                 assertNever(mode);
         }

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -816,10 +816,6 @@ async function convertOutputMode({
     if (generator.github) {
         const repoString = isGithubSelfhosted(generator.github) ? generator.github.uri : generator.github.repository;
         const { owner, repo, remote } = parseRepository(repoString);
-        // For GHE instances, pass the host so Fiddle targets the correct API endpoint.
-        // The field isn't on the current fiddle-sdk types yet; intermediate variables
-        // bypass TypeScript's excess-property check (same pattern as `replay` in
-        // createAndStartJob.ts). Once the SDK is regenerated the field will type-check.
         const host = remote !== "github.com" ? remote : undefined;
         const publishInfo =
             generator.output != null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ catalogs:
       specifier: ^0.0.5297
       version: 0.0.5297
     '@fern-fern/fiddle-sdk':
-      specifier: 1.0.2
-      version: 1.0.2
+      specifier: 1.0.3
+      version: 1.0.3
     '@fern-fern/generator-exec-sdk':
       specifier: ^0.0.1167
       version: 0.0.1167
@@ -4438,7 +4438,7 @@ importers:
         version: link:../workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.2
+        version: 1.0.3
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -4848,7 +4848,7 @@ importers:
         version: link:../yaml/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.2
+        version: 1.0.3
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -4981,7 +4981,7 @@ importers:
         version: link:../../commons/path-utils
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.2
+        version: 1.0.3
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -5024,7 +5024,7 @@ importers:
         version: link:../task-context
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.2
+        version: 1.0.3
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -6116,7 +6116,7 @@ importers:
         version: link:../../../workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.2
+        version: 1.0.3
       '@fern-fern/generator-exec-sdk':
         specifier: 'catalog:'
         version: 0.0.1167
@@ -6276,7 +6276,7 @@ importers:
         version: link:../../../workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.2
+        version: 1.0.3
       axios:
         specifier: 'catalog:'
         version: 1.16.0
@@ -7013,7 +7013,7 @@ importers:
         version: link:../../api-importers/v3-importer-commons
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.2
+        version: 1.0.3
       '@open-rpc/meta-schema':
         specifier: 'catalog:'
         version: 1.14.9
@@ -7454,7 +7454,7 @@ importers:
         version: link:../../cli/task-context
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.2
+        version: 1.0.3
       '@redocly/openapi-core':
         specifier: 'catalog:'
         version: 1.34.11
@@ -7856,7 +7856,7 @@ importers:
         version: 0.0.5297
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.2
+        version: 1.0.3
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -8100,7 +8100,7 @@ importers:
         version: link:../cli/workspace/loader
       '@fern-fern/fiddle-sdk':
         specifier: 'catalog:'
-        version: 1.0.2
+        version: 1.0.3
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
@@ -9437,8 +9437,8 @@ packages:
   '@fern-fern/fdr-test-sdk@0.0.5297':
     resolution: {integrity: sha512-jrZUZ6oIA64LHtrv77xEq0X7qJhT9xRMGWhKcLjIUArMsD7h6KMWUHVdoB/1MP0Mz/uL/E2xmM31SOgJicpIcA==}
 
-  '@fern-fern/fiddle-sdk@1.0.2':
-    resolution: {integrity: sha512-xh0ZMAVBvXNRtSJsr+gxANEgZMZgRzchvwO1BDgpYTacou6Th8SWY0JuakAwWpm0hEoNSd+/XSlWeyiKNpjL9g==}
+  '@fern-fern/fiddle-sdk@1.0.3':
+    resolution: {integrity: sha512-JXR2YRzitbGdd1cioDkUhEQNuq1SckJJpCahJKHTPROQirRnjVHJrzC6PG2MZpuCbgSw6cg4TmqRVm66VISBkg==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/generator-cli-sdk@0.1.8':
@@ -16501,7 +16501,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@fern-fern/fiddle-sdk@1.0.2': {}
+  '@fern-fern/fiddle-sdk@1.0.3': {}
 
   '@fern-fern/generator-cli-sdk@0.1.8':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,7 +65,7 @@ catalog:
   "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80
   "@fern-fern/fdr-test-sdk": ^0.0.5297
-  "@fern-fern/fiddle-sdk": 1.0.2
+  "@fern-fern/fiddle-sdk": 1.0.3
   "@fern-fern/generator-exec-sdk": ^0.0.1167
   "@fern-fern/generators-sdk": 0.114.0-5745f9e74
   "@fern-fern/ir-v53-sdk": 1.0.1


### PR DESCRIPTION
## Description

Refs: Companion to https://github.com/fern-api/fiddle/pull/736

Passes the GitHub Enterprise host extracted from the repository URI to Fiddle's remote generation API, so that self-hosted GHE instances are correctly targeted during remote SDK generation.

## Changes Made

- Extract `remote` from `parseRepository()` result in `convertGeneratorsConfiguration.ts`
- Compute `host` (non-github.com remotes only) and pass it to all GitHub output mode constructors (`commitAndRelease`, `pullRequest`, `push`)
- Bump `@fern-fern/fiddle-sdk` to `1.0.3` which includes the properly typed `host` field on `BaseGithubInfo`
- Add unreleased changelog entry

## Testing

- [x] `pnpm turbo run compile --filter @fern-api/configuration-loader` passes with proper types
- [x] `pnpm format` applied (Biome)
- [ ] Full end-to-end testing requires a GHE instance

Link to Devin session: https://app.devin.ai/sessions/d6f0693ed3d54dc59a04619b58f2a599
Requested by: @iamnamananand996