### PR TITLE
fix: include scripts in sparse checkout setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,9 @@ Instead of a regular `git clone`, use sparse checkout from the start:
 git clone --filter=blob:none --sparse https://github.com/fern-api/fern.git
 cd fern
 
+# Include the sparse checkout helper script
+git sparse-checkout add scripts
+
 # Configure sparse checkout to exclude large directories
 bash ./scripts/sparse-checkout.sh
 ```


### PR DESCRIPTION
## Summary
- add git sparse-checkout add scripts to the recommended clone flow in CONTRIBUTING.md
- ensure ash ./scripts/sparse-checkout.sh works for brand new sparse clones

## Testing
- not run (docs-only change)

Closes #14989