### PR TITLE
fix: ignore empty OpenAPI operation tags

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/parseEmptyOperationTags.test.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/__test__/parseEmptyOperationTags.test.ts
@@ -1,0 +1,54 @@
+import { Source } from "@fern-api/openapi-ir";
+import { TaskContext } from "@fern-api/task-context";
+import { OpenAPIV3 } from "openapi-types";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_PARSE_OPENAPI_SETTINGS } from "../options.js";
+import { parse } from "../parse.js";
+
+describe("parse with empty operation tags", () => {
+    const mockTaskContext = {
+        logger: {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            trace: vi.fn(),
+            log: vi.fn()
+        }
+    } as unknown as TaskContext;
+
+    it("treats empty-string tags as untagged operations", () => {
+        const doc: OpenAPIV3.Document = {
+            openapi: "3.0.0",
+            info: { title: "Test API", version: "1.0.0" },
+            paths: {
+                "/bad": {
+                    get: {
+                        operationId: ".GetBad",
+                        tags: [""],
+                        responses: {
+                            "200": {
+                                description: "OK"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        const ir = parse({
+            context: mockTaskContext,
+            documents: [
+                {
+                    type: "openapi",
+                    value: doc,
+                    source: Source.openapi({ file: "test.yml" }),
+                    settings: DEFAULT_PARSE_OPENAPI_SETTINGS
+                }
+            ]
+        });
+
+        expect(ir.endpoints).toHaveLength(1);
+        expect(ir.endpoints[0]?.tags).toEqual([]);
+    });
+});

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/AbstractOpenAPIV3ParserContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/AbstractOpenAPIV3ParserContext.ts
@@ -78,7 +78,7 @@ export abstract class AbstractOpenAPIV3ParserContext implements SchemaParserCont
         if (this.namespace != null) {
             tags.push(this.namespace);
         }
-        return tags.concat(operationTags ?? []);
+        return tags.concat((operationTags ?? []).filter((tag) => tag.trim().length > 0));
     }
 
     public resolveTags(operationTags: string[] | undefined): SdkGroup[] {
@@ -91,7 +91,7 @@ export abstract class AbstractOpenAPIV3ParserContext implements SchemaParserCont
 
             tags.push(namespaceSegment);
         }
-        return tags.concat(operationTags ?? []);
+        return tags.concat((operationTags ?? []).filter((tag) => tag.trim().length > 0));
     }
 
     public resolveGroupName(groupName: SdkGroupName): SdkGroupName {


### PR DESCRIPTION
## Summary
- filter blank OpenAPI operation tags before they are converted into Fern endpoint groups
- treat 	ags: [''] the same as an untagged operation so generators keep the method on the root client
- add a parser regression test covering the empty-tag case from the issue repro

## Testing
- pnpm --dir packages/cli/api-importers/openapi/openapi-ir-parser test

Closes #15142