### PR TITLE
fix(typescript): update @types/node to ^20.0.0 for vitest 4.x compatibility

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/fix-types-node-vitest-compat.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-types-node-vitest-compat.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Update `@types/node` from `^18.19.70` to `^20.0.0` in generated SDKs to
+    satisfy vitest 4.x peer dependency requirements. Previously, `npm install`
+    failed with `ERESOLVE` because vitest 4.x requires
+    `@types/node@^20.0.0 || ^22.0.0 || >=24.0.0`.
+  type: fix

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -39,11 +39,11 @@ RUN pnpm add -g typescript@~5.9.3 \
   @biomejs/biome@2.4.10 \
   oxlint@1.63.0 \
   oxlint-tsgolint@0.22.1 \
-  @types/node@^18.19.70 \
+  @types/node@^20.0.0 \
   ts-loader@^9.5.4 \
   webpack@^5.105.4 \
   msw@2.12.14 \
-  vitest@^3.2.4
+  vitest@^4.1.1
 
 COPY generators/typescript/sdk/cli/dist/ /
 

--- a/generators/typescript/sdk/validator/warm-cache-package.json
+++ b/generators/typescript/sdk/validator/warm-cache-package.json
@@ -5,9 +5,9 @@
   "description": "Pre-installed during the validator image build so that common Fern-generated SDK devDependencies are present in the pnpm store. Must be kept in sync with the deps emitted by the TS SDK generator.",
   "devDependencies": {
     "@biomejs/biome": "2.4.10",
-    "@types/node": "^18.19.70",
+    "@types/node": "^20.0.0",
     "msw": "2.12.14",
     "typescript": "~5.9.3",
-    "vitest": "^3.2.4"
+    "vitest": "^4.1.1"
   }
 }

--- a/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
@@ -432,7 +432,7 @@ export abstract class TypescriptProject {
 
     protected getCommonDevDependencies(): Record<string, string> {
         const deps: Record<string, string> = {
-            "@types/node": "^18.19.70",
+            "@types/node": "^20.0.0",
             typescript: "~5.9.3"
         };
         if (this.linter === "biome" || this.formatter === "biome") {

--- a/seed/ts-sdk/accept-header/package.json
+++ b/seed/ts-sdk/accept-header/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/alias-extends/package.json
+++ b/seed/ts-sdk/alias-extends/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/alias/package.json
+++ b/seed/ts-sdk/alias/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/allof-inline/package.json
+++ b/seed/ts-sdk/allof-inline/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/allof/package.json
+++ b/seed/ts-sdk/allof/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/any-auth/always-send-auth/package.json
+++ b/seed/ts-sdk/any-auth/always-send-auth/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/package.json
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/any-auth/no-custom-config/package.json
+++ b/seed/ts-sdk/any-auth/no-custom-config/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/api-wide-base-path/package.json
+++ b/seed/ts-sdk/api-wide-base-path/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/audiences/no-custom-config/package.json
+++ b/seed/ts-sdk/audiences/no-custom-config/package.json
@@ -127,7 +127,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/audiences/with-partner-audience/package.json
+++ b/seed/ts-sdk/audiences/with-partner-audience/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/basic-auth-environment-variables/package.json
+++ b/seed/ts-sdk/basic-auth-environment-variables/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/basic-auth-pw-omitted/package.json
+++ b/seed/ts-sdk/basic-auth-pw-omitted/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/basic-auth/package.json
+++ b/seed/ts-sdk/basic-auth/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/bearer-token-environment-variable/package.json
+++ b/seed/ts-sdk/bearer-token-environment-variable/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/bytes-download/package.json
+++ b/seed/ts-sdk/bytes-download/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/bytes-upload/package.json
+++ b/seed/ts-sdk/bytes-upload/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/circular-references-advanced/package.json
+++ b/seed/ts-sdk/circular-references-advanced/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/circular-references-extends/package.json
+++ b/seed/ts-sdk/circular-references-extends/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/circular-references/package.json
+++ b/seed/ts-sdk/circular-references/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/client-side-params/package.json
+++ b/seed/ts-sdk/client-side-params/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/content-type/package.json
+++ b/seed/ts-sdk/content-type/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/package.json
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/package.json
@@ -127,7 +127,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/package.json
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/package.json
@@ -138,7 +138,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/dollar-string-examples/package.json
+++ b/seed/ts-sdk/dollar-string-examples/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/empty-clients/package.json
+++ b/seed/ts-sdk/empty-clients/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/endpoint-security-auth/package.json
+++ b/seed/ts-sdk/endpoint-security-auth/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/package.json
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/package.json
@@ -116,7 +116,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/enum/forward-compatible-enums/package.json
+++ b/seed/ts-sdk/enum/forward-compatible-enums/package.json
@@ -105,7 +105,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/enum/no-custom-config/package.json
+++ b/seed/ts-sdk/enum/no-custom-config/package.json
@@ -105,7 +105,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/enum/serde/package.json
+++ b/seed/ts-sdk/enum/serde/package.json
@@ -116,7 +116,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/error-property/no-custom-config/package.json
+++ b/seed/ts-sdk/error-property/no-custom-config/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/error-property/union-utils/package.json
+++ b/seed/ts-sdk/error-property/union-utils/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/errors/package.json
+++ b/seed/ts-sdk/errors/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/examples/examples-with-api-reference/package.json
+++ b/seed/ts-sdk/examples/examples-with-api-reference/package.json
@@ -138,7 +138,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/examples/retain-original-casing/package.json
+++ b/seed/ts-sdk/examples/retain-original-casing/package.json
@@ -138,7 +138,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/package.json
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/package.json
@@ -237,7 +237,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/package.json
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/package.json
@@ -252,7 +252,7 @@
         "ts-jest": "^29.3.4",
         "jest-environment-jsdom": "^29.7.0",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/bigint/package.json
+++ b/seed/ts-sdk/exhaustive/bigint/package.json
@@ -241,7 +241,7 @@
         "ts-jest": "^29.3.4",
         "jest-environment-jsdom": "^29.7.0",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/package.json
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/package.json
@@ -237,7 +237,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/package.json
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/package.json
@@ -237,7 +237,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/multiple-exports/package.json
+++ b/seed/ts-sdk/exhaustive/multiple-exports/package.json
@@ -237,7 +237,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/never-throw-errors/package.json
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/package.json
@@ -237,7 +237,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/no-custom-config/package.json
+++ b/seed/ts-sdk/exhaustive/no-custom-config/package.json
@@ -237,7 +237,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/node-fetch/package.json
+++ b/seed/ts-sdk/exhaustive/node-fetch/package.json
@@ -240,7 +240,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/package-path/package.json
+++ b/seed/ts-sdk/exhaustive/package-path/package.json
@@ -237,7 +237,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/package.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/package.json
@@ -237,7 +237,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/package.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/package.json
@@ -237,7 +237,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/package.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/package.json
@@ -237,7 +237,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/package.json
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/package.json
@@ -237,7 +237,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/retain-original-casing/package.json
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/package.json
@@ -237,7 +237,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/serde-layer/package.json
+++ b/seed/ts-sdk/exhaustive/serde-layer/package.json
@@ -248,7 +248,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/use-jest/package.json
+++ b/seed/ts-sdk/exhaustive/use-jest/package.json
@@ -241,7 +241,7 @@
         "ts-jest": "^29.3.4",
         "jest-environment-jsdom": "^29.7.0",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/package.json
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/package.json
@@ -237,7 +237,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/exhaustive/with-audiences/package.json
+++ b/seed/ts-sdk/exhaustive/with-audiences/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/extends/package.json
+++ b/seed/ts-sdk/extends/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/extra-properties/package.json
+++ b/seed/ts-sdk/extra-properties/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/file-download/file-download-response-headers/package.json
+++ b/seed/ts-sdk/file-download/file-download-response-headers/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/file-download/no-custom-config/package.json
+++ b/seed/ts-sdk/file-download/no-custom-config/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/file-download/stream-wrapper/package.json
+++ b/seed/ts-sdk/file-download/stream-wrapper/package.json
@@ -68,7 +68,7 @@
         "ts-jest": "^29.3.4",
         "jest-environment-jsdom": "^29.7.0",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/file-upload-openapi/package.json
+++ b/seed/ts-sdk/file-upload-openapi/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/file-upload/form-data-node16/package.json
+++ b/seed/ts-sdk/file-upload/form-data-node16/package.json
@@ -65,7 +65,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/file-upload/inline/package.json
+++ b/seed/ts-sdk/file-upload/inline/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/file-upload/no-custom-config/package.json
+++ b/seed/ts-sdk/file-upload/no-custom-config/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/file-upload/serde/package.json
+++ b/seed/ts-sdk/file-upload/serde/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/file-upload/use-jest/package.json
+++ b/seed/ts-sdk/file-upload/use-jest/package.json
@@ -65,7 +65,7 @@
         "ts-jest": "^29.3.4",
         "jest-environment-jsdom": "^29.7.0",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/file-upload/wrapper/package.json
+++ b/seed/ts-sdk/file-upload/wrapper/package.json
@@ -68,7 +68,7 @@
         "ts-jest": "^29.3.4",
         "jest-environment-jsdom": "^29.7.0",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/folders/package.json
+++ b/seed/ts-sdk/folders/package.json
@@ -116,7 +116,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/header-auth-environment-variable/package.json
+++ b/seed/ts-sdk/header-auth-environment-variable/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/header-auth/package.json
+++ b/seed/ts-sdk/header-auth/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/http-head/package.json
+++ b/seed/ts-sdk/http-head/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/idempotency-headers/package.json
+++ b/seed/ts-sdk/idempotency-headers/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/imdb/branded-string-aliases/package.json
+++ b/seed/ts-sdk/imdb/branded-string-aliases/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/imdb/no-custom-config/package.json
+++ b/seed/ts-sdk/imdb/no-custom-config/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/imdb/omit-undefined/package.json
+++ b/seed/ts-sdk/imdb/omit-undefined/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/inferred-auth-explicit/package.json
+++ b/seed/ts-sdk/inferred-auth-explicit/package.json
@@ -116,7 +116,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/package.json
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/package.json
@@ -116,7 +116,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/package.json
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/package.json
@@ -116,7 +116,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/inferred-auth-implicit-reference/package.json
+++ b/seed/ts-sdk/inferred-auth-implicit-reference/package.json
@@ -116,7 +116,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/inferred-auth-implicit/package.json
+++ b/seed/ts-sdk/inferred-auth-implicit/package.json
@@ -116,7 +116,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/license/package.json
+++ b/seed/ts-sdk/license/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/literal/package.json
+++ b/seed/ts-sdk/literal/package.json
@@ -105,7 +105,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/literals-unions/package.json
+++ b/seed/ts-sdk/literals-unions/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/mixed-case/no-custom-config/package.json
+++ b/seed/ts-sdk/mixed-case/no-custom-config/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/mixed-case/retain-original-casing/package.json
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/mixed-file-directory/package.json
+++ b/seed/ts-sdk/mixed-file-directory/package.json
@@ -94,7 +94,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/multi-line-docs/package.json
+++ b/seed/ts-sdk/multi-line-docs/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/multi-url-environment-no-default/package.json
+++ b/seed/ts-sdk/multi-url-environment-no-default/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/multi-url-environment-reference/package.json
+++ b/seed/ts-sdk/multi-url-environment-reference/package.json
@@ -83,7 +83,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/multi-url-environment/package.json
+++ b/seed/ts-sdk/multi-url-environment/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/multiple-request-bodies/package.json
+++ b/seed/ts-sdk/multiple-request-bodies/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/no-content-response/package.json
+++ b/seed/ts-sdk/no-content-response/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/no-environment/package.json
+++ b/seed/ts-sdk/no-environment/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/no-retries/package.json
+++ b/seed/ts-sdk/no-retries/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/null-type/package.json
+++ b/seed/ts-sdk/null-type/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/nullable-allof-extends/package.json
+++ b/seed/ts-sdk/nullable-allof-extends/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/nullable-optional/package.json
+++ b/seed/ts-sdk/nullable-optional/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/nullable-request-body/package.json
+++ b/seed/ts-sdk/nullable-request-body/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/nullable/package.json
+++ b/seed/ts-sdk/nullable/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/oauth-client-credentials-custom/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-custom/package.json
@@ -116,7 +116,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/oauth-client-credentials-default/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-default/package.json
@@ -116,7 +116,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/package.json
@@ -116,7 +116,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/package.json
@@ -94,7 +94,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/package.json
@@ -116,7 +116,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/package.json
@@ -116,7 +116,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/oauth-client-credentials-openapi/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/oauth-client-credentials-reference/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-reference/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/package.json
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/package.json
@@ -127,7 +127,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/package.json
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/package.json
@@ -116,7 +116,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/oauth-client-credentials/serde/package.json
+++ b/seed/ts-sdk/oauth-client-credentials/serde/package.json
@@ -127,7 +127,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/object/package.json
+++ b/seed/ts-sdk/object/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/objects-with-imports/package.json
+++ b/seed/ts-sdk/objects-with-imports/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/openapi-request-body-ref/no-custom-config/package.json
+++ b/seed/ts-sdk/openapi-request-body-ref/no-custom-config/package.json
@@ -83,7 +83,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/optional/package.json
+++ b/seed/ts-sdk/optional/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/package-yml/package.json
+++ b/seed/ts-sdk/package-yml/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/pagination-custom/package.json
+++ b/seed/ts-sdk/pagination-custom/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/pagination-uri-path/package.json
+++ b/seed/ts-sdk/pagination-uri-path/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/pagination/no-custom-config/package.json
+++ b/seed/ts-sdk/pagination/no-custom-config/package.json
@@ -83,7 +83,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/pagination/page-index-semantics/package.json
+++ b/seed/ts-sdk/pagination/page-index-semantics/package.json
@@ -83,7 +83,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/path-parameters/no-custom-config/package.json
+++ b/seed/ts-sdk/path-parameters/no-custom-config/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/package.json
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/package.json
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/package.json
@@ -83,7 +83,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/package.json
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/package.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/package.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/package.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/package.json
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/path-parameters/retain-original-casing/package.json
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/plain-text/package.json
+++ b/seed/ts-sdk/plain-text/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/package.json
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/property-access/no-custom-config/package.json
+++ b/seed/ts-sdk/property-access/no-custom-config/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/public-object/package.json
+++ b/seed/ts-sdk/public-object/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/query-param-name-conflict/package.json
+++ b/seed/ts-sdk/query-param-name-conflict/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/package.json
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/query-parameters-openapi/package.json
+++ b/seed/ts-sdk/query-parameters-openapi/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/query-parameters/no-custom-config/package.json
+++ b/seed/ts-sdk/query-parameters/no-custom-config/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/package.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/package.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/package.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/package.json
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/query-parameters/serde/package.json
+++ b/seed/ts-sdk/query-parameters/serde/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/package.json
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/request-parameters/no-custom-config/package.json
+++ b/seed/ts-sdk/request-parameters/no-custom-config/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/package.json
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/package.json
@@ -65,7 +65,7 @@
         "ts-jest": "^29.3.4",
         "jest-environment-jsdom": "^29.7.0",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/package.json
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/required-nullable/package.json
+++ b/seed/ts-sdk/required-nullable/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/reserved-keywords/package.json
+++ b/seed/ts-sdk/reserved-keywords/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/response-property/package.json
+++ b/seed/ts-sdk/response-property/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/schemaless-request-body-examples/package.json
+++ b/seed/ts-sdk/schemaless-request-body-examples/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/server-sent-event-examples/package.json
+++ b/seed/ts-sdk/server-sent-event-examples/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/package.json
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/server-sent-events/package.json
+++ b/seed/ts-sdk/server-sent-events/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/server-url-templating/package.json
+++ b/seed/ts-sdk/server-url-templating/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/package.json
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/simple-api/allow-extra-fields/package.json
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/simple-api/bundle/package.json
+++ b/seed/ts-sdk/simple-api/bundle/package.json
@@ -62,7 +62,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10",
         "esbuild": "~0.24.2"

--- a/seed/ts-sdk/simple-api/custom-package-json/package.json
+++ b/seed/ts-sdk/simple-api/custom-package-json/package.json
@@ -74,7 +74,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10",
         "jest": "^29.7.0"

--- a/seed/ts-sdk/simple-api/jsr/package.json
+++ b/seed/ts-sdk/simple-api/jsr/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/simple-api/legacy-exports/package.json
+++ b/seed/ts-sdk/simple-api/legacy-exports/package.json
@@ -27,7 +27,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/simple-api/naming-shorthand/package.json
+++ b/seed/ts-sdk/simple-api/naming-shorthand/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/simple-api/naming/package.json
+++ b/seed/ts-sdk/simple-api/naming/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/simple-api/no-custom-config/package.json
+++ b/seed/ts-sdk/simple-api/no-custom-config/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/package.json
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3"
     },
     "browser": {

--- a/seed/ts-sdk/simple-api/no-scripts/package.json
+++ b/seed/ts-sdk/simple-api/no-scripts/package.json
@@ -58,7 +58,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/simple-api/oidc-token/package.json
+++ b/seed/ts-sdk/simple-api/oidc-token/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/simple-api/omit-fern-headers/package.json
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/simple-api/use-oxc/package.json
+++ b/seed/ts-sdk/simple-api/use-oxc/package.json
@@ -65,7 +65,7 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "msw": "2.11.2",
         "oxfmt": "0.48.0",
         "oxlint": "1.63.0",

--- a/seed/ts-sdk/simple-api/use-oxfmt/package.json
+++ b/seed/ts-sdk/simple-api/use-oxfmt/package.json
@@ -66,7 +66,7 @@
     "dependencies": {},
     "devDependencies": {
         "@biomejs/biome": "2.4.10",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "msw": "2.11.2",
         "oxfmt": "0.48.0",
         "ts-loader": "^9.5.4",

--- a/seed/ts-sdk/simple-api/use-oxlint/package.json
+++ b/seed/ts-sdk/simple-api/use-oxlint/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10",
         "oxlint": "1.63.0",

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/package.json
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "prettier": "3.8.1"
     },

--- a/seed/ts-sdk/simple-api/use-prettier/package.json
+++ b/seed/ts-sdk/simple-api/use-prettier/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10",
         "prettier": "3.8.1"

--- a/seed/ts-sdk/simple-api/use-yarn/package.json
+++ b/seed/ts-sdk/simple-api/use-yarn/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/simple-fhir/package.json
+++ b/seed/ts-sdk/simple-fhir/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/single-url-environment-default/package.json
+++ b/seed/ts-sdk/single-url-environment-default/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/single-url-environment-no-default/package.json
+++ b/seed/ts-sdk/single-url-environment-no-default/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/streaming-parameter/package.json
+++ b/seed/ts-sdk/streaming-parameter/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/streaming/no-custom-config/package.json
+++ b/seed/ts-sdk/streaming/no-custom-config/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/streaming/serde-layer/package.json
+++ b/seed/ts-sdk/streaming/serde-layer/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/streaming/wrapper/package.json
+++ b/seed/ts-sdk/streaming/wrapper/package.json
@@ -68,7 +68,7 @@
         "ts-jest": "^29.3.4",
         "jest-environment-jsdom": "^29.7.0",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/trace/exhaustive/package.json
+++ b/seed/ts-sdk/trace/exhaustive/package.json
@@ -171,7 +171,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/trace/no-custom-config/package.json
+++ b/seed/ts-sdk/trace/no-custom-config/package.json
@@ -171,7 +171,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/trace/serde-no-throwing/package.json
+++ b/seed/ts-sdk/trace/serde-no-throwing/package.json
@@ -182,7 +182,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/trace/serde/package.json
+++ b/seed/ts-sdk/trace/serde/package.json
@@ -182,7 +182,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/ts-express-casing/package.json
+++ b/seed/ts-sdk/ts-express-casing/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/ts-extra-properties/package.json
+++ b/seed/ts-sdk/ts-extra-properties/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/ts-inline-types/inline/package.json
+++ b/seed/ts-sdk/ts-inline-types/inline/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/ts-inline-types/no-inline/package.json
+++ b/seed/ts-sdk/ts-inline-types/no-inline/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/package.json
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/package.json
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/package.json
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/union-query-parameters/no-custom-config/package.json
+++ b/seed/ts-sdk/union-query-parameters/no-custom-config/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/union-query-parameters/package.json
+++ b/seed/ts-sdk/union-query-parameters/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/unions-with-local-date/package.json
+++ b/seed/ts-sdk/unions-with-local-date/package.json
@@ -83,7 +83,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/unions/no-custom-config/package.json
+++ b/seed/ts-sdk/unions/no-custom-config/package.json
@@ -72,7 +72,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/unions/package.json
+++ b/seed/ts-sdk/unions/package.json
@@ -70,9 +70,9 @@
     "devDependencies": {
         "webpack": "^5.105.4",
         "ts-loader": "^9.5.4",
-        "vitest": "^3.2.4",
+        "vitest": "^4.1.1",
         "msw": "2.12.14",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.9"
     },

--- a/seed/ts-sdk/unions/serde-layer/package.json
+++ b/seed/ts-sdk/unions/serde-layer/package.json
@@ -83,7 +83,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/unknown/no-custom-config/package.json
+++ b/seed/ts-sdk/unknown/no-custom-config/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/unknown/unknown-as-any/package.json
+++ b/seed/ts-sdk/unknown/unknown-as-any/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/url-form-encoded/package.json
+++ b/seed/ts-sdk/url-form-encoded/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/validation/package.json
+++ b/seed/ts-sdk/validation/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/variables/package.json
+++ b/seed/ts-sdk/variables/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/version-no-default/package.json
+++ b/seed/ts-sdk/version-no-default/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/version/package.json
+++ b/seed/ts-sdk/version/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/webhook-audience/package.json
+++ b/seed/ts-sdk/webhook-audience/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/webhooks/no-custom-config/package.json
+++ b/seed/ts-sdk/webhooks/no-custom-config/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/package.json
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/package.json
@@ -75,7 +75,7 @@
         "@types/ws": "^8.18.1",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/package.json
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/package.json
@@ -75,7 +75,7 @@
         "@types/ws": "^8.18.1",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/websocket-multi-url/package.json
+++ b/seed/ts-sdk/websocket-multi-url/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/websocket/no-serde/package.json
+++ b/seed/ts-sdk/websocket/no-serde/package.json
@@ -86,7 +86,7 @@
         "@types/ws": "^8.18.1",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/websocket/no-websocket-clients/package.json
+++ b/seed/ts-sdk/websocket/no-websocket-clients/package.json
@@ -61,7 +61,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/websocket/serde/package.json
+++ b/seed/ts-sdk/websocket/serde/package.json
@@ -97,7 +97,7 @@
         "@types/ws": "^8.18.1",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },

--- a/seed/ts-sdk/x-fern-default/package.json
+++ b/seed/ts-sdk/x-fern-default/package.json
@@ -50,7 +50,7 @@
         "ts-loader": "^9.5.4",
         "vitest": "^4.1.1",
         "msw": "2.11.2",
-        "@types/node": "^18.19.70",
+        "@types/node": "^20.0.0",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.10"
     },


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-10431

[PR #14101](https://github.com/fern-api/fern/pull/14101) upgraded `vitest` from `^3.2.4` to `^4.1.1` in `TestGenerator.ts`, but left several gaps that cause `npm install` to fail with `ERESOLVE` in generated SDKs:

1. **`@types/node` was never bumped** — it stayed at `^18.19.70` in `TypescriptProject.ts`, the Dockerfile, and `warm-cache-package.json`. Vitest 4.x requires `@types/node@^20.0.0 || ^22.0.0 || >=24.0.0`, so the mismatch causes a peer dependency conflict.
2. **Dockerfile and warm-cache still had `vitest@^3.2.4`** — PR #14101 only updated the generator code but didn't sync the Docker image's pre-cached dependencies.
3. **One seed fixture (`unions/package.json`) still had `vitest: ^3.2.4`** — was missed in the snapshot regeneration.

This PR fixes all three gaps so generated SDKs install cleanly without `--legacy-peer-deps`.

## Changes Made
- Updated `@types/node` from `^18.19.70` to `^20.0.0` in `TypescriptProject.ts` (source of truth for generated SDK dev dependencies)
- Synced `@types/node` to `^20.0.0` in Dockerfile and `warm-cache-package.json`
- Synced `vitest` from `^3.2.4` to `^4.1.1` in Dockerfile and `warm-cache-package.json` to match `TestGenerator.ts`
- Updated all 212+ seed snapshot `package.json` files to reflect the new `@types/node` version
- Fixed stale seed fixture (`unions/package.json`) that still had `vitest: ^3.2.4`

## Testing
- [x] All seed snapshot files updated consistently
- [x] CI checks passing (compile, test, lint, seed tests)

Link to Devin session: https://app.devin.ai/sessions/3c649f8e12264bfbbd1ef05d3b646ec0
Requested by: @iamnamananand996