### PR TITLE
feat(csharp): add default-timeout-in-seconds generator config

### DIFF
--- a/generators/csharp/codegen/src/context/generation-info.ts
+++ b/generators/csharp/codegen/src/context/generation-info.ts
@@ -247,6 +247,8 @@ export class Generation {
         maxRetries: () => this.customConfig.maxRetries,
         /** Controls which HTTP status codes trigger automatic retries. Default: "legacy". */
         retryStatusCodes: () => this.customConfig.retryStatusCodes ?? "legacy",
+        /** Override the default request timeout (in seconds) for the generated SDK client. `"infinity"` disables the default timeout. Default: 30. */
+        defaultTimeoutInSeconds: () => this.customConfig["default-timeout-in-seconds"],
         /**
          * Output path configuration for generated files.
          * Returns normalized paths for library, test, solution, and other files.

--- a/generators/csharp/codegen/src/custom-config/CsharpConfigSchema.ts
+++ b/generators/csharp/codegen/src/custom-config/CsharpConfigSchema.ts
@@ -117,7 +117,13 @@ export const CsharpConfigSchema = z.object({
     // "slnx" (default) generates only the modern .slnx format.
     "sln-format": z.enum(["sln", "slnx"]).optional(),
     maxRetries: z.number().int().min(0).optional(),
-    retryStatusCodes: z.optional(z.enum(["legacy", "recommended"]))
+    retryStatusCodes: z.optional(z.enum(["legacy", "recommended"])),
+    "default-timeout-in-seconds": z
+        .union([z.number().positive(), z.literal("infinity")])
+        .optional()
+        .describe(
+            "The default timeout for network requests, in seconds. Set to `infinity` to disable the default timeout. SDK users can still override this per-request via request options."
+        )
 });
 
 export type CsharpConfigSchema = z.infer<typeof CsharpConfigSchema>;

--- a/generators/csharp/codegen/src/custom-config/__test__/defaultTimeoutInSeconds.test.ts
+++ b/generators/csharp/codegen/src/custom-config/__test__/defaultTimeoutInSeconds.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { CsharpConfigSchema } from "../CsharpConfigSchema.js";
+
+describe("C# default-timeout-in-seconds config", () => {
+    it("should accept a positive number", () => {
+        const result = CsharpConfigSchema.safeParse({ "default-timeout-in-seconds": 60 });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data["default-timeout-in-seconds"]).toBe(60);
+        }
+    });
+
+    it("should accept fractional seconds", () => {
+        const result = CsharpConfigSchema.safeParse({ "default-timeout-in-seconds": 1.5 });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data["default-timeout-in-seconds"]).toBe(1.5);
+        }
+    });
+
+    it("should accept the literal 'infinity'", () => {
+        const result = CsharpConfigSchema.safeParse({ "default-timeout-in-seconds": "infinity" });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data["default-timeout-in-seconds"]).toBe("infinity");
+        }
+    });
+
+    it("should accept config without the option (optional)", () => {
+        const result = CsharpConfigSchema.safeParse({});
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data["default-timeout-in-seconds"]).toBeUndefined();
+        }
+    });
+
+    it("should reject zero", () => {
+        const result = CsharpConfigSchema.safeParse({ "default-timeout-in-seconds": 0 });
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject negative numbers", () => {
+        const result = CsharpConfigSchema.safeParse({ "default-timeout-in-seconds": -1 });
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject other strings", () => {
+        const result = CsharpConfigSchema.safeParse({ "default-timeout-in-seconds": "60" });
+        expect(result.success).toBe(false);
+    });
+});

--- a/generators/csharp/sdk/changes/unreleased/feat-default-timeout-in-seconds.yml
+++ b/generators/csharp/sdk/changes/unreleased/feat-default-timeout-in-seconds.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Add a `default-timeout-in-seconds` config option to the C# SDK generator.
+    When set, the generated `ClientOptions.Timeout` defaults to the configured
+    value (or `Timeout.InfiniteTimeSpan` when set to `"infinity"`) instead of
+    the previously hardcoded 30 seconds. SDK users can still override the
+    timeout per-request via `RequestOptions.Timeout`.
+  type: feat

--- a/generators/csharp/sdk/src/options/BaseOptionsGenerator.ts
+++ b/generators/csharp/sdk/src/options/BaseOptionsGenerator.ts
@@ -94,13 +94,18 @@ export class BaseOptionsGenerator extends WithGeneration {
 
     public getTimeoutField(classOrInterface: ast.Interface | ast.Class, { optional, includeInitializer }: OptionArgs) {
         const type = this.System.TimeSpan;
+        const configured = this.settings.defaultTimeoutInSeconds;
+        const initializer =
+            configured === "infinity"
+                ? this.csharp.codeblock("System.Threading.Timeout.InfiniteTimeSpan")
+                : this.csharp.codeblock(`TimeSpan.FromSeconds(${configured ?? 30})`);
         classOrInterface.addField({
             origin: classOrInterface.explicit("Timeout"),
             access: ast.Access.Public,
             get: true,
             init: true,
             type: optional ? type.asOptional() : type,
-            initializer: includeInitializer ? this.csharp.codeblock("TimeSpan.FromSeconds(30)") : undefined,
+            initializer: includeInitializer ? initializer : undefined,
             summary: "The timeout for the request."
         });
     }


### PR DESCRIPTION
## Description

Adds a new `default-timeout-in-seconds` option to the C# SDK generator's custom config, mirroring the existing option in the Java/TypeScript/Python generators. When set, the generated `ClientOptions.Timeout` defaults to the configured value (or `Timeout.InfiniteTimeSpan` when set to `"infinity"`) instead of the previously hardcoded 30 seconds.

SDK end users can still override the timeout per-request via `RequestOptions.Timeout` — this option only changes the *default* baked into the generated SDK at generation time.

Example `generators.yml`:

```yaml
- name: fernapi/fern-csharp-sdk
  config:
    default-timeout-in-seconds: 60   # or "infinity"
```

## Changes Made

- `CsharpConfigSchema.ts`: added `"default-timeout-in-seconds": number | "infinity"` (positive numbers only; fractional seconds allowed since `TimeSpan.FromSeconds` accepts a double).
- `generation-info.ts`: exposed the value as `settings.defaultTimeoutInSeconds`.
- `BaseOptionsGenerator.getTimeoutField`: emits `TimeSpan.FromSeconds(<configured>)` when set, `System.Threading.Timeout.InfiniteTimeSpan` when `"infinity"`, and falls back to `TimeSpan.FromSeconds(30)` (unchanged default) when unset.
- Added unit tests for the new schema field.
- Added an unreleased changelog entry (`feat`).

Docs page update is in a separate PR against `fern-api/docs`.

## Testing

- [x] Unit tests added for the schema (positive numbers, fractional seconds, `"infinity"`, missing-field, zero/negative/non-`"infinity"` strings rejected).
- [x] Full `csharp-codegen` vitest suite passes locally (609 tests).
- [x] `biome check` and `biome format` clean.
- [ ] Did **not** run seed / wire-test snapshots locally — relying on CI. Default behavior is preserved (`?? 30`), so existing snapshots should be unaffected, but worth a careful look at any C# seed diffs in CI.

## Reviewer notes / things to double-check

- The `"infinity"` branch emits a fully-qualified `System.Threading.Timeout.InfiniteTimeSpan` reference rather than going through the codegen import system. Worth confirming this is the right pattern for this generator (vs. e.g. `this.csharp.classReference({ name: "Timeout", namespace: "System.Threading" })`).
- Naming: I used kebab-case (`default-timeout-in-seconds`) to match Java's option exactly, even though the recently-added `maxRetries` in this same schema uses camelCase. Happy to switch to `defaultTimeoutInSeconds` if camelCase is preferred for new C# config keys.
- Schema uses `z.number().positive()` (not `.int()`) so fractional seconds are allowed; `TimeSpan.FromSeconds` accepts a `double` so this is intentional.

Link to Devin session: https://app.devin.ai/sessions/1ad0d89c7aed4cf499de2fb8e324eac1
Requested by: @fern-support
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15801" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->