### PR TITLE
feat(csharp): add opt-in User-Agent fallback flag

### DIFF
--- a/generators/csharp/codegen/src/context/generation-info.ts
+++ b/generators/csharp/codegen/src/context/generation-info.ts
@@ -236,7 +236,7 @@ export class Generation {
         /** When true, omits Fern platform headers (X-Fern-Language, SDK name/version, User-Agent) from generated SDK requests. Default: false. */
         omitFernHeaders: () => this.customConfig["omit-fern-headers"] ?? false,
         /** When true, falls back to `<NuGetPackageId>/<version>` for the `User-Agent` header when the IR doesn't supply one. Default: false. */
-        userAgentFromPackage: () => this.customConfig["user-agent-from-package"] ?? false,
+        userAgentNameFromPackage: () => this.customConfig["user-agent-name-from-package"] ?? false,
         /** When true, moves auth params and IR headers into ClientOptions so the constructor takes only named arguments. Default: false. */
         unifiedClientOptions: () => this.customConfig["unified-client-options"] ?? false,
         /** When true, uses PascalCase for environment names (e.g., "Production" instead of "production"). Default: true. */

--- a/generators/csharp/codegen/src/context/generation-info.ts
+++ b/generators/csharp/codegen/src/context/generation-info.ts
@@ -235,6 +235,8 @@ export class Generation {
         extraDependencies: () => this.customConfig["extra-dependencies"] ?? {},
         /** When true, omits Fern platform headers (X-Fern-Language, SDK name/version, User-Agent) from generated SDK requests. Default: false. */
         omitFernHeaders: () => this.customConfig["omit-fern-headers"] ?? false,
+        /** When true, falls back to `<NuGetPackageId>/<version>` for the `User-Agent` header when the IR doesn't supply one. Default: false. */
+        userAgentFromPackage: () => this.customConfig["user-agent-from-package"] ?? false,
         /** When true, moves auth params and IR headers into ClientOptions so the constructor takes only named arguments. Default: false. */
         unifiedClientOptions: () => this.customConfig["unified-client-options"] ?? false,
         /** When true, uses PascalCase for environment names (e.g., "Production" instead of "production"). Default: true. */

--- a/generators/csharp/codegen/src/custom-config/CsharpConfigSchema.ts
+++ b/generators/csharp/codegen/src/custom-config/CsharpConfigSchema.ts
@@ -99,6 +99,11 @@ export const CsharpConfigSchema = z.object({
     "custom-readme-sections": z.array(CustomReadmeSectionSchema).optional(),
     "omit-fern-headers": z.boolean().optional(),
     "unified-client-options": z.boolean().optional(),
+    // When true, fall back to `$"<NuGetPackageId>/{Version.Current}"` for the
+    // `User-Agent` platform header when the IR's `platformHeaders.userAgent` is
+    // unset (e.g. SDKs imported from OpenAPI). Off by default to preserve the
+    // pre-existing behavior of emitting no `User-Agent` header in that case.
+    "user-agent-from-package": z.boolean().optional(),
 
     // Deprecated.
     "extra-dependencies": z

--- a/generators/csharp/codegen/src/custom-config/CsharpConfigSchema.ts
+++ b/generators/csharp/codegen/src/custom-config/CsharpConfigSchema.ts
@@ -103,7 +103,7 @@ export const CsharpConfigSchema = z.object({
     // `User-Agent` platform header when the IR's `platformHeaders.userAgent` is
     // unset (e.g. SDKs imported from OpenAPI). Off by default to preserve the
     // pre-existing behavior of emitting no `User-Agent` header in that case.
-    "user-agent-from-package": z.boolean().optional(),
+    "user-agent-name-from-package": z.boolean().optional(),
 
     // Deprecated.
     "extra-dependencies": z

--- a/generators/csharp/sdk/changes/unreleased/user-agent-fallback.yml
+++ b/generators/csharp/sdk/changes/unreleased/user-agent-fallback.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fall back to a `<NuGetPackageId>/<version>` User-Agent header when no
+    `platformHeaders.userAgent` is set in the IR (e.g. for OpenAPI imports),
+    matching the TypeScript generator's npm-package-name fallback.
+  type: fix

--- a/generators/csharp/sdk/changes/unreleased/user-agent-fallback.yml
+++ b/generators/csharp/sdk/changes/unreleased/user-agent-fallback.yml
@@ -1,7 +1,11 @@
 # yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
 
 - summary: |
-    Fall back to a `<NuGetPackageId>/<version>` User-Agent header when no
-    `platformHeaders.userAgent` is set in the IR (e.g. for OpenAPI imports),
-    matching the TypeScript generator's npm-package-name fallback.
-  type: fix
+    Add an opt-in `user-agent-from-package` custom config option. When set to
+    `true`, the generated client falls back to a
+    `<NuGetPackageId>/<version>` `User-Agent` header when no
+    `platformHeaders.userAgent` is set in the IR (e.g. for SDKs imported from
+    OpenAPI), matching the TypeScript generator's npm-package-name fallback.
+    Defaults to `false`, preserving the existing behavior of emitting no
+    `User-Agent` header in that case.
+  type: feat

--- a/generators/csharp/sdk/changes/unreleased/user-agent-fallback.yml
+++ b/generators/csharp/sdk/changes/unreleased/user-agent-fallback.yml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
 
 - summary: |
-    Add an opt-in `user-agent-from-package` custom config option. When set to
-    `true`, the generated client falls back to a
+    Add an opt-in `user-agent-name-from-package` custom config option. When set
+    to `true`, the generated client falls back to a
     `<NuGetPackageId>/<version>` `User-Agent` header when no
     `platformHeaders.userAgent` is set in the IR (e.g. for SDKs imported from
     OpenAPI), matching the TypeScript generator's npm-package-name fallback.

--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -335,6 +335,19 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                     key: this.csharp.codeblock(`"${platformHeaders.userAgent.header}"`),
                     value: this.csharp.codeblock(`"${platformHeaders.userAgent.value}"`)
                 });
+            } else {
+                // Fallback: emit `<NuGetPackageId>/<version>` so SDKs imported from OpenAPI
+                // (where `platformHeaders.userAgent` is unset) still send a User-Agent,
+                // mirroring the TypeScript generator's npm-package-name fallback.
+                const packageName = this.generation.names.project.packageId;
+                platformHeaderEntries.push({
+                    key: this.csharp.codeblock('"User-Agent"'),
+                    value: this.csharp.codeblock((writer) => {
+                        writer.write(`$"${packageName}/{`);
+                        writer.writeNode(this.context.getCurrentVersionValueAccess());
+                        writer.write('}"');
+                    })
+                });
             }
         }
 

--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -331,7 +331,7 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                 key: this.csharp.codeblock(`"${platformHeaders.sdkVersion}"`),
                 value: this.context.getCurrentVersionValueAccess()
             });
-            // When `user-agent-from-package` is enabled, falls back to
+            // When `user-agent-name-from-package` is enabled, falls back to
             // `$"<NuGetPackageId>/{Version.Current}"` when the IR has no
             // `platformHeaders.userAgent` (e.g. OpenAPI imports), mirroring the
             // TypeScript generator's npm-package-name fallback. Defaults off so
@@ -341,7 +341,7 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                 packageName: this.generation.names.project.packageId,
                 csharp: this.csharp,
                 versionValueAccess: this.context.getCurrentVersionValueAccess(),
-                userAgentFromPackage: this.settings.userAgentFromPackage
+                userAgentNameFromPackage: this.settings.userAgentNameFromPackage
             });
             if (userAgentEntry != null) {
                 platformHeaderEntries.push(userAgentEntry);

--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -23,6 +23,7 @@ import { RawClient } from "../endpoint/http/RawClient.js";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 import { collectInferredAuthCredentials } from "../utils/inferredAuthUtils.js";
 import { WebSocketClientGenerator } from "../websocket/WebsocketClientGenerator.js";
+import { buildUserAgentHeaderEntry } from "./buildUserAgentHeaderEntry.js";
 import { dedupAuthHeaderEntries } from "./dedupAuthHeaderEntries.js";
 
 const GetFromEnvironmentOrThrow = "GetFromEnvironmentOrThrow";
@@ -330,25 +331,17 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                 key: this.csharp.codeblock(`"${platformHeaders.sdkVersion}"`),
                 value: this.context.getCurrentVersionValueAccess()
             });
-            if (platformHeaders.userAgent != null) {
-                platformHeaderEntries.push({
-                    key: this.csharp.codeblock(`"${platformHeaders.userAgent.header}"`),
-                    value: this.csharp.codeblock(`"${platformHeaders.userAgent.value}"`)
-                });
-            } else {
-                // Fallback: emit `<NuGetPackageId>/<version>` so SDKs imported from OpenAPI
-                // (where `platformHeaders.userAgent` is unset) still send a User-Agent,
-                // mirroring the TypeScript generator's npm-package-name fallback.
-                const packageName = this.generation.names.project.packageId;
-                platformHeaderEntries.push({
-                    key: this.csharp.codeblock('"User-Agent"'),
-                    value: this.csharp.codeblock((writer) => {
-                        writer.write(`$"${packageName}/{`);
-                        writer.writeNode(this.context.getCurrentVersionValueAccess());
-                        writer.write('}"');
-                    })
-                });
-            }
+            // Falls back to `$"<NuGetPackageId>/{Version.Current}"` when the IR has no
+            // `platformHeaders.userAgent` (e.g. OpenAPI imports), mirroring the TypeScript
+            // generator's npm-package-name fallback.
+            platformHeaderEntries.push(
+                buildUserAgentHeaderEntry({
+                    userAgent: platformHeaders.userAgent,
+                    packageName: this.generation.names.project.packageId,
+                    csharp: this.csharp,
+                    versionValueAccess: this.context.getCurrentVersionValueAccess()
+                })
+            );
         }
 
         const platformHeaderDictionary = this.csharp.dictionary({

--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -331,17 +331,21 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                 key: this.csharp.codeblock(`"${platformHeaders.sdkVersion}"`),
                 value: this.context.getCurrentVersionValueAccess()
             });
-            // Falls back to `$"<NuGetPackageId>/{Version.Current}"` when the IR has no
-            // `platformHeaders.userAgent` (e.g. OpenAPI imports), mirroring the TypeScript
-            // generator's npm-package-name fallback.
-            platformHeaderEntries.push(
-                buildUserAgentHeaderEntry({
-                    userAgent: platformHeaders.userAgent,
-                    packageName: this.generation.names.project.packageId,
-                    csharp: this.csharp,
-                    versionValueAccess: this.context.getCurrentVersionValueAccess()
-                })
-            );
+            // When `user-agent-from-package` is enabled, falls back to
+            // `$"<NuGetPackageId>/{Version.Current}"` when the IR has no
+            // `platformHeaders.userAgent` (e.g. OpenAPI imports), mirroring the
+            // TypeScript generator's npm-package-name fallback. Defaults off so
+            // existing C# SDKs imported from OpenAPI keep emitting no User-Agent.
+            const userAgentEntry = buildUserAgentHeaderEntry({
+                userAgent: platformHeaders.userAgent,
+                packageName: this.generation.names.project.packageId,
+                csharp: this.csharp,
+                versionValueAccess: this.context.getCurrentVersionValueAccess(),
+                userAgentFromPackage: this.settings.userAgentFromPackage
+            });
+            if (userAgentEntry != null) {
+                platformHeaderEntries.push(userAgentEntry);
+            }
         }
 
         const platformHeaderDictionary = this.csharp.dictionary({

--- a/generators/csharp/sdk/src/root-client/__test__/buildUserAgentHeaderEntry.test.ts
+++ b/generators/csharp/sdk/src/root-client/__test__/buildUserAgentHeaderEntry.test.ts
@@ -29,7 +29,7 @@ function fakeVersionAccess(): ast.CodeBlock {
 }
 
 describe("buildUserAgentHeaderEntry", () => {
-    it("emits the IR-supplied header and value when `userAgent` is set, regardless of `userAgentFromPackage`", () => {
+    it("emits the IR-supplied header and value when `userAgent` is set, regardless of `userAgentNameFromPackage`", () => {
         // Mirrors the Fern Definition path where `sdkConfig.platformHeaders.userAgent`
         // is always populated, so the generator should pass it through verbatim
         // even when the new opt-in flag is off.
@@ -38,7 +38,7 @@ describe("buildUserAgentHeaderEntry", () => {
             packageName: "Plantstore",
             csharp: generation.csharp,
             versionValueAccess: fakeVersionAccess(),
-            userAgentFromPackage: false
+            userAgentNameFromPackage: false
         });
 
         if (entry == null) {
@@ -48,7 +48,7 @@ describe("buildUserAgentHeaderEntry", () => {
         expect(render(entry.value)).toBe('"MyClient/1.2.3"');
     });
 
-    it("returns `undefined` when `userAgent` is unset and `userAgentFromPackage` is false", () => {
+    it("returns `undefined` when `userAgent` is unset and `userAgentNameFromPackage` is false", () => {
         // Default behavior for OpenAPI imports: the generator must emit no
         // User-Agent entry at all so the generated SDK matches the pre-flag
         // baseline. Returning `undefined` lets the caller skip the push.
@@ -57,7 +57,7 @@ describe("buildUserAgentHeaderEntry", () => {
             packageName: "Plantstore",
             csharp: generation.csharp,
             versionValueAccess: fakeVersionAccess(),
-            userAgentFromPackage: false
+            userAgentNameFromPackage: false
         });
 
         expect(entry).toBeUndefined();
@@ -66,17 +66,17 @@ describe("buildUserAgentHeaderEntry", () => {
     it("falls back to `<packageName>/{Version.Current}` when `userAgent` is undefined and the flag is on", () => {
         // Opt-in parity with the TypeScript generator's
         // `<npm-package-name>/<version>` fallback: only emitted when the user
-        // has explicitly enabled `user-agent-from-package`.
+        // has explicitly enabled `user-agent-name-from-package`.
         const entry = buildUserAgentHeaderEntry({
             userAgent: undefined,
             packageName: "Plantstore",
             csharp: generation.csharp,
             versionValueAccess: fakeVersionAccess(),
-            userAgentFromPackage: true
+            userAgentNameFromPackage: true
         });
 
         if (entry == null) {
-            throw new Error("Expected entry to be defined when `userAgentFromPackage` is true.");
+            throw new Error("Expected entry to be defined when `userAgentNameFromPackage` is true.");
         }
         expect(render(entry.key)).toBe('"User-Agent"');
         expect(render(entry.value)).toBe('$"Plantstore/{Version.Current}"');
@@ -90,11 +90,11 @@ describe("buildUserAgentHeaderEntry", () => {
             packageName: "DocuSign.eSign",
             csharp: generation.csharp,
             versionValueAccess: fakeVersionAccess(),
-            userAgentFromPackage: true
+            userAgentNameFromPackage: true
         });
 
         if (entry == null) {
-            throw new Error("Expected entry to be defined when `userAgentFromPackage` is true.");
+            throw new Error("Expected entry to be defined when `userAgentNameFromPackage` is true.");
         }
         expect(render(entry.value)).toBe('$"DocuSign.eSign/{Version.Current}"');
     });
@@ -111,11 +111,11 @@ describe("buildUserAgentHeaderEntry", () => {
             versionValueAccess: generation.csharp.codeblock((writer) => {
                 writer.write("MyVersionType.Current");
             }),
-            userAgentFromPackage: true
+            userAgentNameFromPackage: true
         });
 
         if (entry == null) {
-            throw new Error("Expected entry to be defined when `userAgentFromPackage` is true.");
+            throw new Error("Expected entry to be defined when `userAgentNameFromPackage` is true.");
         }
         expect(render(entry.value)).toBe('$"pkg/{MyVersionType.Current}"');
     });

--- a/generators/csharp/sdk/src/root-client/__test__/buildUserAgentHeaderEntry.test.ts
+++ b/generators/csharp/sdk/src/root-client/__test__/buildUserAgentHeaderEntry.test.ts
@@ -99,6 +99,49 @@ describe("buildUserAgentHeaderEntry", () => {
         expect(render(entry.value)).toBe('$"DocuSign.eSign/{Version.Current}"');
     });
 
+    it("uses the namespace cascade as the User-Agent prefix when no `package-id` is configured", () => {
+        // Regression guard for the `names.project.packageId` cascade in
+        // generation-info.ts: when neither `package-id` nor `namespace` is set
+        // in custom config, the project's package id falls back to
+        // `PascalCase(<organization>_<apiName>)` — the same string the SDK
+        // ships under as a NuGet project. The fallback must therefore be
+        // non-empty, so the User-Agent prefix always matches whatever package
+        // the customer is publishing.
+        const cascadingGeneration = new Generation(
+            {} as unknown as IntermediateRepresentation,
+            "plantstore",
+            {} as CsharpConfigSchema,
+            {
+                dryRun: false,
+                irFilepath: "",
+                organization: "fern",
+                workspaceName: "plantstore"
+            }
+        );
+        const cascadedPackageId = cascadingGeneration.names.project.packageId;
+        expect(cascadedPackageId).toBe("FernPlantstore");
+
+        const entry = buildUserAgentHeaderEntry({
+            userAgent: undefined,
+            packageName: cascadedPackageId,
+            csharp: cascadingGeneration.csharp,
+            versionValueAccess: cascadingGeneration.csharp.codeblock("Version.Current"),
+            userAgentNameFromPackage: true
+        });
+
+        if (entry == null) {
+            throw new Error("Expected entry to be defined when `userAgentNameFromPackage` is true.");
+        }
+        expect(
+            entry.value.toString({
+                namespace: "",
+                allNamespaceSegments: new Set<string>(),
+                allTypeClassReferences: new Map<string, Set<string>>(),
+                generation: cascadingGeneration
+            })
+        ).toBe('$"FernPlantstore/{Version.Current}"');
+    });
+
     it("interpolates the version value access without re-quoting the prefix", () => {
         // Regression guard: the helper builds the value via a writer callback so
         // the version sub-expression is emitted as code, not as a string literal.

--- a/generators/csharp/sdk/src/root-client/__test__/buildUserAgentHeaderEntry.test.ts
+++ b/generators/csharp/sdk/src/root-client/__test__/buildUserAgentHeaderEntry.test.ts
@@ -29,32 +29,55 @@ function fakeVersionAccess(): ast.CodeBlock {
 }
 
 describe("buildUserAgentHeaderEntry", () => {
-    it("emits the IR-supplied header and value when `userAgent` is set", () => {
+    it("emits the IR-supplied header and value when `userAgent` is set, regardless of `userAgentFromPackage`", () => {
         // Mirrors the Fern Definition path where `sdkConfig.platformHeaders.userAgent`
-        // is always populated, so the generator should pass it through verbatim.
+        // is always populated, so the generator should pass it through verbatim
+        // even when the new opt-in flag is off.
         const entry = buildUserAgentHeaderEntry({
             userAgent: { header: "User-Agent", value: "MyClient/1.2.3" },
             packageName: "Plantstore",
             csharp: generation.csharp,
-            versionValueAccess: fakeVersionAccess()
+            versionValueAccess: fakeVersionAccess(),
+            userAgentFromPackage: false
         });
 
+        if (entry == null) {
+            throw new Error("Expected entry to be defined when `userAgent` is set.");
+        }
         expect(render(entry.key)).toBe('"User-Agent"');
         expect(render(entry.value)).toBe('"MyClient/1.2.3"');
     });
 
-    it("falls back to `<packageName>/{Version.Current}` when `userAgent` is undefined", () => {
-        // OpenAPI imports never set `platformHeaders.userAgent`, so the generator
-        // must synthesize a User-Agent from the NuGet package id and the static
-        // `Version.Current` expression — matching the TS generator's
-        // `<npm-package-name>/<version>` fallback.
+    it("returns `undefined` when `userAgent` is unset and `userAgentFromPackage` is false", () => {
+        // Default behavior for OpenAPI imports: the generator must emit no
+        // User-Agent entry at all so the generated SDK matches the pre-flag
+        // baseline. Returning `undefined` lets the caller skip the push.
         const entry = buildUserAgentHeaderEntry({
             userAgent: undefined,
             packageName: "Plantstore",
             csharp: generation.csharp,
-            versionValueAccess: fakeVersionAccess()
+            versionValueAccess: fakeVersionAccess(),
+            userAgentFromPackage: false
         });
 
+        expect(entry).toBeUndefined();
+    });
+
+    it("falls back to `<packageName>/{Version.Current}` when `userAgent` is undefined and the flag is on", () => {
+        // Opt-in parity with the TypeScript generator's
+        // `<npm-package-name>/<version>` fallback: only emitted when the user
+        // has explicitly enabled `user-agent-from-package`.
+        const entry = buildUserAgentHeaderEntry({
+            userAgent: undefined,
+            packageName: "Plantstore",
+            csharp: generation.csharp,
+            versionValueAccess: fakeVersionAccess(),
+            userAgentFromPackage: true
+        });
+
+        if (entry == null) {
+            throw new Error("Expected entry to be defined when `userAgentFromPackage` is true.");
+        }
         expect(render(entry.key)).toBe('"User-Agent"');
         expect(render(entry.value)).toBe('$"Plantstore/{Version.Current}"');
     });
@@ -66,9 +89,13 @@ describe("buildUserAgentHeaderEntry", () => {
             userAgent: undefined,
             packageName: "DocuSign.eSign",
             csharp: generation.csharp,
-            versionValueAccess: fakeVersionAccess()
+            versionValueAccess: fakeVersionAccess(),
+            userAgentFromPackage: true
         });
 
+        if (entry == null) {
+            throw new Error("Expected entry to be defined when `userAgentFromPackage` is true.");
+        }
         expect(render(entry.value)).toBe('$"DocuSign.eSign/{Version.Current}"');
     });
 
@@ -83,9 +110,13 @@ describe("buildUserAgentHeaderEntry", () => {
             csharp: generation.csharp,
             versionValueAccess: generation.csharp.codeblock((writer) => {
                 writer.write("MyVersionType.Current");
-            })
+            }),
+            userAgentFromPackage: true
         });
 
+        if (entry == null) {
+            throw new Error("Expected entry to be defined when `userAgentFromPackage` is true.");
+        }
         expect(render(entry.value)).toBe('$"pkg/{MyVersionType.Current}"');
     });
 });

--- a/generators/csharp/sdk/src/root-client/__test__/buildUserAgentHeaderEntry.test.ts
+++ b/generators/csharp/sdk/src/root-client/__test__/buildUserAgentHeaderEntry.test.ts
@@ -1,0 +1,91 @@
+import { ast, CsharpConfigSchema, Generation } from "@fern-api/csharp-codegen";
+import { FernIr } from "@fern-fern/ir-sdk";
+
+import { buildUserAgentHeaderEntry } from "../buildUserAgentHeaderEntry.js";
+
+type IntermediateRepresentation = FernIr.IntermediateRepresentation;
+
+const generation = new Generation({} as unknown as IntermediateRepresentation, "", {} as CsharpConfigSchema, {
+    dryRun: false,
+    irFilepath: "",
+    organization: "",
+    workspaceName: ""
+});
+
+function render(node: ast.AstNode): string {
+    return node.toString({
+        namespace: "",
+        allNamespaceSegments: new Set<string>(),
+        allTypeClassReferences: new Map<string, Set<string>>(),
+        generation
+    });
+}
+
+// Stand-in for `context.getCurrentVersionValueAccess()`. The real codeblock writes
+// `Version.Current` (and emits a using directive); for unit-testing the helper's
+// composition with the version expression, a literal codeblock is sufficient.
+function fakeVersionAccess(): ast.CodeBlock {
+    return generation.csharp.codeblock("Version.Current");
+}
+
+describe("buildUserAgentHeaderEntry", () => {
+    it("emits the IR-supplied header and value when `userAgent` is set", () => {
+        // Mirrors the Fern Definition path where `sdkConfig.platformHeaders.userAgent`
+        // is always populated, so the generator should pass it through verbatim.
+        const entry = buildUserAgentHeaderEntry({
+            userAgent: { header: "User-Agent", value: "MyClient/1.2.3" },
+            packageName: "Plantstore",
+            csharp: generation.csharp,
+            versionValueAccess: fakeVersionAccess()
+        });
+
+        expect(render(entry.key)).toBe('"User-Agent"');
+        expect(render(entry.value)).toBe('"MyClient/1.2.3"');
+    });
+
+    it("falls back to `<packageName>/{Version.Current}` when `userAgent` is undefined", () => {
+        // OpenAPI imports never set `platformHeaders.userAgent`, so the generator
+        // must synthesize a User-Agent from the NuGet package id and the static
+        // `Version.Current` expression — matching the TS generator's
+        // `<npm-package-name>/<version>` fallback.
+        const entry = buildUserAgentHeaderEntry({
+            userAgent: undefined,
+            packageName: "Plantstore",
+            csharp: generation.csharp,
+            versionValueAccess: fakeVersionAccess()
+        });
+
+        expect(render(entry.key)).toBe('"User-Agent"');
+        expect(render(entry.value)).toBe('$"Plantstore/{Version.Current}"');
+    });
+
+    it("preserves dotted NuGet package ids verbatim in the fallback", () => {
+        // NuGet package ids canonically use `.` segments (e.g. `DocuSign.eSign`),
+        // so the helper must not normalize or escape them.
+        const entry = buildUserAgentHeaderEntry({
+            userAgent: undefined,
+            packageName: "DocuSign.eSign",
+            csharp: generation.csharp,
+            versionValueAccess: fakeVersionAccess()
+        });
+
+        expect(render(entry.value)).toBe('$"DocuSign.eSign/{Version.Current}"');
+    });
+
+    it("interpolates the version value access without re-quoting the prefix", () => {
+        // Regression guard: the helper builds the value via a writer callback so
+        // the version sub-expression is emitted as code, not as a string literal.
+        // The output must be a single `$"..."`-style interpolated string with the
+        // version inside `{...}` braces.
+        const entry = buildUserAgentHeaderEntry({
+            userAgent: undefined,
+            packageName: "pkg",
+            csharp: generation.csharp,
+            versionValueAccess: generation.csharp.codeblock((writer) => {
+                writer.write("MyVersionType.Current");
+            })
+        });
+
+        expect(render(entry.value)).toBe('$"pkg/{MyVersionType.Current}"');
+    });
+});

--- a/generators/csharp/sdk/src/root-client/buildUserAgentHeaderEntry.ts
+++ b/generators/csharp/sdk/src/root-client/buildUserAgentHeaderEntry.ts
@@ -1,0 +1,39 @@
+import { ast } from "@fern-api/csharp-codegen";
+import { FernIr } from "@fern-fern/ir-sdk";
+
+/**
+ * Builds the platform-headers `Dictionary` entry for the `User-Agent` header.
+ *
+ * - When the IR's `sdkConfig.platformHeaders.userAgent` is set (Fern Definition),
+ *   emit the explicit `header`/`value` pair as a plain string literal.
+ * - Otherwise (e.g. OpenAPI imports, where the IR generator only sets
+ *   `userAgent` when both `version` and `packageName` are non-null), fall back
+ *   to `$"<NuGetPackageId>/{Version.Current}"` — mirroring the TypeScript
+ *   generator's `<npm-package-name>/<version>` fallback.
+ */
+export function buildUserAgentHeaderEntry({
+    userAgent,
+    packageName,
+    csharp,
+    versionValueAccess
+}: {
+    userAgent: FernIr.UserAgent | undefined;
+    packageName: string;
+    csharp: { codeblock: (arg: ast.CodeBlock.Arg) => ast.CodeBlock };
+    versionValueAccess: ast.CodeBlock;
+}): ast.Dictionary.MapEntry {
+    if (userAgent != null) {
+        return {
+            key: csharp.codeblock(`"${userAgent.header}"`),
+            value: csharp.codeblock(`"${userAgent.value}"`)
+        };
+    }
+    return {
+        key: csharp.codeblock('"User-Agent"'),
+        value: csharp.codeblock((writer) => {
+            writer.write(`$"${packageName}/{`);
+            writer.writeNode(versionValueAccess);
+            writer.write('}"');
+        })
+    };
+}

--- a/generators/csharp/sdk/src/root-client/buildUserAgentHeaderEntry.ts
+++ b/generators/csharp/sdk/src/root-client/buildUserAgentHeaderEntry.ts
@@ -2,31 +2,41 @@ import { ast } from "@fern-api/csharp-codegen";
 import { FernIr } from "@fern-fern/ir-sdk";
 
 /**
- * Builds the platform-headers `Dictionary` entry for the `User-Agent` header.
+ * Builds the platform-headers `Dictionary` entry for the `User-Agent` header,
+ * or `undefined` when no entry should be emitted.
  *
  * - When the IR's `sdkConfig.platformHeaders.userAgent` is set (Fern Definition),
  *   emit the explicit `header`/`value` pair as a plain string literal.
- * - Otherwise (e.g. OpenAPI imports, where the IR generator only sets
- *   `userAgent` when both `version` and `packageName` are non-null), fall back
- *   to `$"<NuGetPackageId>/{Version.Current}"` — mirroring the TypeScript
- *   generator's `<npm-package-name>/<version>` fallback.
+ *   `userAgentFromPackage` is irrelevant in this branch.
+ * - When `userAgent` is unset and `userAgentFromPackage` is `true`, fall back to
+ *   `$"<NuGetPackageId>/{Version.Current}"` — mirroring the TypeScript
+ *   generator's `<npm-package-name>/<version>` fallback. This is the opt-in
+ *   parity behavior for SDKs imported from OpenAPI.
+ * - When `userAgent` is unset and `userAgentFromPackage` is `false` (default),
+ *   return `undefined` so the caller emits no `User-Agent` entry — preserving
+ *   the historical C# generator behavior for OpenAPI imports.
  */
 export function buildUserAgentHeaderEntry({
     userAgent,
     packageName,
     csharp,
-    versionValueAccess
+    versionValueAccess,
+    userAgentFromPackage
 }: {
     userAgent: FernIr.UserAgent | undefined;
     packageName: string;
     csharp: { codeblock: (arg: ast.CodeBlock.Arg) => ast.CodeBlock };
     versionValueAccess: ast.CodeBlock;
-}): ast.Dictionary.MapEntry {
+    userAgentFromPackage: boolean;
+}): ast.Dictionary.MapEntry | undefined {
     if (userAgent != null) {
         return {
             key: csharp.codeblock(`"${userAgent.header}"`),
             value: csharp.codeblock(`"${userAgent.value}"`)
         };
+    }
+    if (!userAgentFromPackage) {
+        return undefined;
     }
     return {
         key: csharp.codeblock('"User-Agent"'),

--- a/generators/csharp/sdk/src/root-client/buildUserAgentHeaderEntry.ts
+++ b/generators/csharp/sdk/src/root-client/buildUserAgentHeaderEntry.ts
@@ -7,27 +7,27 @@ import { FernIr } from "@fern-fern/ir-sdk";
  *
  * - When the IR's `sdkConfig.platformHeaders.userAgent` is set (Fern Definition),
  *   emit the explicit `header`/`value` pair as a plain string literal.
- *   `userAgentFromPackage` is irrelevant in this branch.
- * - When `userAgent` is unset and `userAgentFromPackage` is `true`, fall back to
- *   `$"<NuGetPackageId>/{Version.Current}"` — mirroring the TypeScript
- *   generator's `<npm-package-name>/<version>` fallback. This is the opt-in
- *   parity behavior for SDKs imported from OpenAPI.
- * - When `userAgent` is unset and `userAgentFromPackage` is `false` (default),
- *   return `undefined` so the caller emits no `User-Agent` entry — preserving
- *   the historical C# generator behavior for OpenAPI imports.
+ *   `userAgentNameFromPackage` is irrelevant in this branch.
+ * - When `userAgent` is unset and `userAgentNameFromPackage` is `true`, fall
+ *   back to `$"<NuGetPackageId>/{Version.Current}"` — mirroring the
+ *   TypeScript generator's `<npm-package-name>/<version>` fallback. This is
+ *   the opt-in parity behavior for SDKs imported from OpenAPI.
+ * - When `userAgent` is unset and `userAgentNameFromPackage` is `false`
+ *   (default), return `undefined` so the caller emits no `User-Agent` entry —
+ *   preserving the historical C# generator behavior for OpenAPI imports.
  */
 export function buildUserAgentHeaderEntry({
     userAgent,
     packageName,
     csharp,
     versionValueAccess,
-    userAgentFromPackage
+    userAgentNameFromPackage
 }: {
     userAgent: FernIr.UserAgent | undefined;
     packageName: string;
     csharp: { codeblock: (arg: ast.CodeBlock.Arg) => ast.CodeBlock };
     versionValueAccess: ast.CodeBlock;
-    userAgentFromPackage: boolean;
+    userAgentNameFromPackage: boolean;
 }): ast.Dictionary.MapEntry | undefined {
     if (userAgent != null) {
         return {
@@ -35,7 +35,7 @@ export function buildUserAgentHeaderEntry({
             value: csharp.codeblock(`"${userAgent.value}"`)
         };
     }
-    if (!userAgentFromPackage) {
+    if (!userAgentNameFromPackage) {
         return undefined;
     }
     return {


### PR DESCRIPTION
## Description

Linear ticket: Refs

Bring the C# SDK generator to optional parity with the TypeScript generator's User-Agent fallback. When `sdkConfig.platformHeaders.userAgent` is unset in the IR (which happens for SDKs imported from OpenAPI when `version`/`packageName` aren't both passed to `generateIntermediateRepresentation`), the C# generator emits no `User-Agent` header at all. The TS generator already falls back to `<npm-package-name>/<version>` in the analogous branch — see <ref_snippet file="/home/ubuntu/repos/fern/generators/typescript/sdk/client-class-generator/src/BaseClientTypeGenerator.ts" lines="171-181" />.

This PR adds an opt-in `user-agent-name-from-package` boolean custom config (default `false`) that makes C# emit `$"<NuGetPackageId>/{Version.Current}"` in that fallback branch, where:
- `<NuGetPackageId>` resolves via `this.generation.names.project.packageId`. The cascade is `package-id` → `namespace` → `PascalCase(<organization>_<api-name>)`, so the prefix always matches the name the SDK ships under on NuGet (e.g. `DocuSign.eSign`, or `FernPlantstore` if neither `package-id` nor `namespace` is set).
- `Version.Current` is the same compile-time constant already used for the `X-Fern-SDK-Version` header.

Defaulting to `false` preserves the historical "no `User-Agent` header for OpenAPI-imported SDKs" behavior; turning it on is now a one-line generator config change.

The companion docs PR is [fern-api/docs#5439](https://github.com/fern-api/docs/pull/5439), which adds the new flag to the C# configuration reference.

## Changes Made

- `generators/csharp/codegen/src/custom-config/CsharpConfigSchema.ts`: new optional boolean `user-agent-name-from-package`.
- `generators/csharp/codegen/src/context/generation-info.ts`: new `userAgentNameFromPackage` setting wired to the new schema key, defaulting to `false`.
- `generators/csharp/sdk/src/root-client/buildUserAgentHeaderEntry.ts`: new pure helper that returns the platform-headers `Dictionary.MapEntry` for `User-Agent`, branching on whether `userAgent` is set on the IR and whether the flag is on.
- `generators/csharp/sdk/src/root-client/RootClientGenerator.ts`: the existing `if (userAgent != null)` block is replaced with a call to the new helper, gated on `this.settings.userAgentNameFromPackage`.
- `generators/csharp/sdk/src/root-client/__test__/buildUserAgentHeaderEntry.test.ts`: 5 unit tests covering both branches (explicit IR header, fallback) plus regression guards for dotted NuGet ids, the version-expression interpolation, and — crucially — the `names.project.packageId` cascade when no `package-id`/`namespace` is configured.
- `generators/csharp/sdk/changes/unreleased/user-agent-fallback.yml`: `feat` changelog entry.
- [ ] Updated README.md generator (if applicable) — N/A

## Testing

- [x] Unit tests added/updated — 5 cases in `buildUserAgentHeaderEntry.test.ts`; all pass via `pnpm --filter=@fern-api/fern-csharp-sdk run test` (41 passed, 41 total).
- [x] `pnpm run check` (biome) clean.
- [x] `pnpm turbo run compile --filter=@fern-api/fern-csharp-sdk` clean.
- [x] All required CI checks green (49 pass, 0 fail), including every `csharp-sdk` seed-fixture matrix job and `seed-test-results (csharp-sdk)`.
- [x] **Manual end-to-end** against an IR with `platformHeaders.userAgent` unset (`fern-unions` test fixture, run through the locally-built `cli.cjs`).

  **Flag off (default), `package-id: "Plantstore.eSign"`** — generated `FernPlantstoreClient.cs` has no `User-Agent` entry (matches pre-PR behavior):
  ```csharp
  new Dictionary<string, string>()
  {
      { "X-Fern-Language", "C#" },
      { "X-Fern-SDK-Name", "FernUnions" },
      { "X-Fern-SDK-Version", Version.Current },
  }
  ```

  **Flag on, `package-id: "Plantstore.eSign"`** — fallback entry is emitted:
  ```csharp
  { "User-Agent", $"Plantstore.eSign/{Version.Current}" },
  ```

  **Flag on, no `package-id`, no `namespace`** — fallback degrades to the cascade, producing `$"FernUnions/{Version.Current}"` (the same string the SDK ships under as the NuGet project), confirming the User-Agent prefix is never empty.

  The Fern-Definition path is byte-identical: `seed/csharp-sdk/simple-api/no-custom-config/.../SeedSimpleApiClient.cs` continues to emit `{ "User-Agent", "Fernsimple-api/0.0.1" }` regardless of the flag.

## Things worth a careful look

- The fallback emits a single interpolated string by combining a literal prefix with `writer.writeNode(this.context.getCurrentVersionValueAccess())`. Confirmed via the unit tests and manual e2e that the rendered output is exactly `$"<PackageId>/{Version.Current}"` and that the `Version` using directive is wired up the same way as the existing `X-Fern-SDK-Version` entry.
- `packageName`, `userAgent.header`, and `userAgent.value` are interpolated unescaped into `$"..."` / `"..."`. NuGet package ids in practice only use letters/digits/`.`/`-`/`_`, so this matches the existing convention used by the `X-Fern-SDK-Name` entry; the IR-supplied header/value path is identical to the pre-PR behavior. Worth a sanity check that we're comfortable with that assumption.
- The cascade test uses real `Generation` rather than the `{} as` mock used elsewhere in this file, so it actually exercises `names.project.packageId` end-to-end. If anyone changes that cascade in `generation-info.ts`, this test should fail.
- Renaming the flag from my initial `user-agent-from-package` to `user-agent-name-from-package` happened mid-review per @fern-support's request — sanity-check that no stragglers from the old name remain (e.g. in changelog filenames). The changelog file is still named `user-agent-fallback.yml` to avoid bake-in of either flag spelling.

Link to Devin session: https://app.devin.ai/sessions/02d3233caaac4616b6f38488ff08ef1a