### PR TITLE
fix(typescript): honor HeaderAuthScheme prefix in HeaderAuthProvider

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/fix-header-auth-prefix.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-header-auth-prefix.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Honor the auth scheme `prefix` for `HeaderAuthScheme` when generating `HeaderAuthProvider`.
+    Previously, the generator emitted the raw header value into the configured header (e.g.
+    `Authorization`) and dropped any prefix declared in the API definition (e.g. `Bearer`).
+    The provider now emits a `HEADER_PREFIX` constant and prepends it to the header value,
+    matching the behavior of the Java, Python, Go, C#, PHP, Rust, and Ruby v2 generators.
+  type: fix

--- a/generators/typescript/sdk/client-class-generator/src/__test__/AuthProviders.test.ts
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/AuthProviders.test.ts
@@ -721,7 +721,7 @@ describe("HeaderAuthProviderGenerator", () => {
                 createHeaderAuthScheme({
                     name: "authorization",
                     wireValue: "Authorization",
-                    prefix: "Bearer "
+                    prefix: "Bearer"
                 })
             );
             const ir = createMinimalIR({ authSchemes: [authScheme] });

--- a/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/AuthProviders.test.ts.snap
+++ b/generators/typescript/sdk/client-class-generator/src/__test__/__snapshots__/AuthProviders.test.ts.snap
@@ -640,6 +640,7 @@ exports[`HeaderAuthProviderGenerator > getAuthOptionsProperties() > returns requ
 exports[`HeaderAuthProviderGenerator > writeToFile() > generates header auth provider with custom header name and prefix 1`] = `
 "const PARAM_KEY = "authorization" as const;
 const HEADER_NAME = "Authorization" as const;
+const HEADER_PREFIX = "Bearer " as const;
 
 export class HeaderAuthProvider implements core.AuthProvider {
     private readonly options: HeaderAuthProvider.Options;
@@ -664,7 +665,7 @@ export class HeaderAuthProvider implements core.AuthProvider {
                 }
 
                 return {
-                    headers: { [HEADER_NAME]: headerValue },
+                    headers: { [HEADER_NAME]: \`\${HEADER_PREFIX}\${headerValue}\` },
                 };
                 
     }

--- a/generators/typescript/sdk/client-class-generator/src/auth-provider/HeaderAuthProviderGenerator.ts
+++ b/generators/typescript/sdk/client-class-generator/src/auth-provider/HeaderAuthProviderGenerator.ts
@@ -137,6 +137,7 @@ export class HeaderAuthProviderGenerator implements AuthProviderGenerator {
         const headerEnvVar = this.authScheme.headerEnvVar;
         const headerName = getWireValue(this.authScheme.name);
         const wrapperPropertyName = this.getWrapperPropertyName();
+        const prefix = this.authScheme.prefix;
 
         const constants: string[] = [];
 
@@ -147,6 +148,9 @@ export class HeaderAuthProviderGenerator implements AuthProviderGenerator {
             constants.push(`const ENV_HEADER_KEY = "${headerEnvVar}" as const;`);
         }
         constants.push(`const HEADER_NAME = "${headerName}" as const;`);
+        if (prefix != null) {
+            constants.push(`const HEADER_PREFIX = "${prefix} " as const;`);
+        }
 
         for (const constant of constants.filter((c) => c !== "")) {
             context.sourceFile.addStatements(constant);
@@ -272,6 +276,8 @@ export class HeaderAuthProviderGenerator implements AuthProviderGenerator {
                 ? `\n            (${supplierGetCode}) ??\n            process.env?.[ENV_HEADER_KEY]`
                 : supplierGetCode;
 
+        const headerValueExpr = this.authScheme.prefix != null ? `\`\${HEADER_PREFIX}\${${headerVar}}\`` : headerVar;
+
         if (this.neverThrowErrors) {
             // When neverThrowErrors is true, return empty headers if header value is missing
             return `
@@ -281,7 +287,7 @@ export class HeaderAuthProviderGenerator implements AuthProviderGenerator {
         }
 
         return {
-            headers: { [HEADER_NAME]: ${headerVar} },
+            headers: { [HEADER_NAME]: ${headerValueExpr} },
         };
         `;
         } else {
@@ -299,7 +305,7 @@ export class HeaderAuthProviderGenerator implements AuthProviderGenerator {
         }
 
         return {
-            headers: { [HEADER_NAME]: ${headerVar} },
+            headers: { [HEADER_NAME]: ${headerValueExpr} },
         };
         `;
         }

--- a/seed/ts-sdk/header-auth-environment-variable/src/auth/HeaderAuthProvider.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/auth/HeaderAuthProvider.ts
@@ -6,6 +6,7 @@ import * as errors from "../errors/index.js";
 const PARAM_KEY = "headerTokenAuth" as const;
 const ENV_HEADER_KEY = "HEADER_TOKEN_ENV_VAR" as const;
 const HEADER_NAME = "x-api-key" as const;
+const HEADER_PREFIX = "test_prefix " as const;
 
 export class HeaderAuthProvider implements core.AuthProvider {
     private readonly options: HeaderAuthProvider.Options;
@@ -31,7 +32,7 @@ export class HeaderAuthProvider implements core.AuthProvider {
         }
 
         return {
-            headers: { [HEADER_NAME]: headerValue },
+            headers: { [HEADER_NAME]: `${HEADER_PREFIX}${headerValue}` },
         };
     }
 }

--- a/seed/ts-sdk/header-auth/src/auth/HeaderAuthProvider.ts
+++ b/seed/ts-sdk/header-auth/src/auth/HeaderAuthProvider.ts
@@ -5,6 +5,7 @@ import * as errors from "../errors/index.js";
 
 const PARAM_KEY = "headerTokenAuth" as const;
 const HEADER_NAME = "x-api-key" as const;
+const HEADER_PREFIX = "test_prefix " as const;
 
 export class HeaderAuthProvider implements core.AuthProvider {
     private readonly options: HeaderAuthProvider.Options;
@@ -30,7 +31,7 @@ export class HeaderAuthProvider implements core.AuthProvider {
         }
 
         return {
-            headers: { [HEADER_NAME]: headerValue },
+            headers: { [HEADER_NAME]: `${HEADER_PREFIX}${headerValue}` },
         };
     }
 }


### PR DESCRIPTION
## Description

The TypeScript SDK generator's `HeaderAuthProviderGenerator` was ignoring the `prefix` field on `HeaderAuthScheme` in the IR. As a result, SDKs whose IR landed on the apiKey-shaped `HeaderAuthScheme` path (e.g. Swagger 2.0 specs that use `type: apiKey, in: header, name: Authorization` + `x-bearer-format: JWT` / `x-fern-header.prefix: Bearer`) generated an `Authorization` header containing the raw token instead of `Bearer <token>`. Customers had to wrap their token supplier and prepend `Bearer ` themselves.

Java, Python, Go, C#, PHP, Rust, and Ruby v2 already honor `HeaderAuthScheme.prefix`. This PR brings TypeScript in line.

Note: Swift also drops the prefix (its `ClientConfig.HeaderAuth` template has no `prefix` field) — that's a separate fix.

## Changes Made

- `HeaderAuthProviderGenerator.ts`:
  - Emit `const HEADER_PREFIX = "<prefix> " as const;` (trailing space, matching Java/Python/Go/C#/PHP/Rust convention) when `authScheme.prefix != null`.
  - When prefix is set, write the header value as `` `${HEADER_PREFIX}${headerValue}` `` instead of the raw `headerValue`. Both `neverThrowErrors=true` and `false` code paths are updated.
  - No-op when prefix is unset (backwards compatible for header auth without a prefix).
- Added `generators/typescript/sdk/changes/unreleased/fix-header-auth-prefix.yml` (`type: fix`).
- Updated the `AuthProviders.test.ts` snapshot for `generates header auth provider with custom header name and prefix` to assert the new `HEADER_PREFIX` constant + templated header value. Adjusted the test fixture to use `prefix: "Bearer"` (no trailing space) to match real-world IR convention from `convertSecurityScheme.ts`.
- Regenerated seed snapshots for the two ts-sdk fixtures that already declare a `prefix` in their fern definition (`header-auth`, `header-auth-environment-variable`). Diff is the expected `HEADER_PREFIX` constant and the templated header value.

## Testing

- [x] Unit tests added/updated — `AuthProviders.test.ts` snapshot regenerated; `pnpm vitest run src/__test__/AuthProviders.test.ts` passes (44/44).
- [x] `pnpm run check` (biome) passes.
- [x] Seed regeneration succeeded for both relevant ts-sdk fixtures; the diff to existing snapshots is exactly the prefix-related change.
- [x] CI green on PR (49 checks pass), including required `seed-test-results (ts-sdk)`, `test`, `test-ete`, `lint`, `compile`, and the full ts-sdk seed matrix.
- [x] Verified other ts-sdk auth fixtures (basic-auth, bearer-token-environment-variable, inferred-auth-explicit) don't carry a `prefix` on `HeaderAuthScheme`, so they're untouched by this change.

## Reviewer notes / risks

- **Migration impact**: any customer who was manually wrapping `getAccessToken` to prepend `Bearer ` (e.g. as a workaround) will need to drop that wrapping after upgrading, otherwise the prefix will be applied twice. Worth calling out in release notes.
- The prefix constant always appends a single trailing space (`"${prefix} "`), matching the Java implementation (`prefix + " "`). If an IR ever produced a prefix that already ended in whitespace, this would double-space; the IR convention from `convertSecurityScheme.ts` is no trailing whitespace, so this is consistent in practice.
- Only the two fixtures with a configured prefix are touched in `seed/`; please confirm no other seed snapshots are expected to change.

Link to Devin session: https://app.devin.ai/sessions/ba02218e3d8b462eb39d200c4ce894ba
Requested by: @fern-support
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->