### PR TITLE
fix(cli-v2): adjust file paths in `fern config migrate` to be root-relative

### DIFF
--- a/packages/cli/cli-v2/src/migrator/Migrator.ts
+++ b/packages/cli/cli-v2/src/migrator/Migrator.ts
@@ -115,7 +115,7 @@ export class Migrator {
         }
 
         // Point docs key at docs.yml via $ref if the file exists.
-        const docsResult = await migrateDocsYml(fernDir);
+        const docsResult = await migrateDocsYml(this.cwd, fernDir);
         if (docsResult.docsRef != null) {
             fernYml.docs = docsResult.docsRef as unknown as schemas.FernYmlSchema["docs"];
         }
@@ -169,6 +169,7 @@ export class Migrator {
         }
 
         const apiResult = await convertSingleApi({
+            projectRoot: this.cwd,
             fernDir,
             generatorsYmlApi: generatorsResult.rawApi
         });
@@ -237,6 +238,7 @@ export class Migrator {
 
         // Convert API configurations (handles Fern definition detection)
         const apisResult = await convertMultiApi({
+            projectRoot: this.cwd,
             fernDir,
             apisDir,
             generatorsYmlApis

--- a/packages/cli/cli-v2/src/migrator/__test__/Migrator.test.ts
+++ b/packages/cli/cli-v2/src/migrator/__test__/Migrator.test.ts
@@ -231,7 +231,7 @@ navigation:
         expect(result.success).toBe(true);
         const fernYmlContent = await readFile(join(projectDir, "fern.yml"), "utf-8");
         expect(fernYmlContent).toContain("docs:");
-        expect(fernYmlContent).toContain("$ref: ./docs.yml");
+        expect(fernYmlContent).toContain("$ref: ./fern/docs.yml");
         // docs.yml itself should not be deleted or modified
         const docsYmlContent = await readFile(join(fernDir, "docs.yml"), "utf-8");
         expect(docsYmlContent).toContain("instances:");
@@ -287,7 +287,7 @@ tabs:
         expect(fernYmlContent).not.toContain("navigation:");
         expect(fernYmlContent).not.toContain("tabs:");
         // Should only contain the $ref pointer
-        expect(fernYmlContent).toContain("$ref: ./docs.yml");
+        expect(fernYmlContent).toContain("$ref: ./fern/docs.yml");
     });
 
     // ── Multi-API migrations ─────────────────────────────────────────────────
@@ -446,8 +446,37 @@ navigation:
 
         expect(result.success).toBe(true);
         const fernYmlContent = await readFile(join(projectDir, "fern.yml"), "utf-8");
-        expect(fernYmlContent).toContain("$ref: ./docs.yml");
+        expect(fernYmlContent).toContain("$ref: ./fern/docs.yml");
         expect(fernYmlContent).toContain("apis:");
+    });
+
+    it("adjusts spec paths to be root-relative in single-API migration", async () => {
+        const projectDir = await createProjectDir(base);
+        const fernDir = join(projectDir, "fern");
+        await mkdir(fernDir, { recursive: true });
+        await writeFernConfig(fernDir, "payroc");
+        await writeFile(
+            join(fernDir, "generators.yml"),
+            `api:
+  specs:
+    - openapi: ../external/universal-api-v1.yaml
+      overrides: openapi-overrides.yml
+groups: {}
+`
+        );
+
+        const migrator = new Migrator({
+            cwd: AbsoluteFilePath.of(projectDir),
+            logger: makeLogger(),
+            deleteOriginals: false
+        });
+        await migrator.migrate();
+
+        const fernYmlContent = await readFile(join(projectDir, "fern.yml"), "utf-8");
+        expect(fernYmlContent).toContain("./external/universal-api-v1.yaml");
+        expect(fernYmlContent).toContain("./fern/openapi-overrides.yml");
+        expect(fernYmlContent).not.toContain("../external");
+        expect(fernYmlContent).not.toContain("overrides: openapi-overrides.yml");
     });
 
     it("adjusts spec paths to be root-relative in multi-API migration", async () => {

--- a/packages/cli/cli-v2/src/migrator/__test__/convertApiSpecs.test.ts
+++ b/packages/cli/cli-v2/src/migrator/__test__/convertApiSpecs.test.ts
@@ -211,7 +211,7 @@ describe("convertSingleApi", () => {
             fernDir: AbsoluteFilePath.of(testDir),
             generatorsYmlApi: { specs: [{ openapi: "./openapi.yml" }] }
         });
-        expect(result.api?.specs[0]).toMatchObject({ openapi: "./openapi.yml" });
+        expect(result.api?.specs[0]).toMatchObject({ openapi: "./fern/openapi.yml" });
     });
 
     it("uses Fern definition directory when it exists (takes precedence over generators.yml specs)", async () => {

--- a/packages/cli/cli-v2/src/migrator/__test__/convertApiSpecs.test.ts
+++ b/packages/cli/cli-v2/src/migrator/__test__/convertApiSpecs.test.ts
@@ -186,20 +186,23 @@ describe("convertApiSpecs", () => {
 // ---------------------------------------------------------------------------
 
 describe("convertSingleApi", () => {
-    let testDir: string;
+    let projectDir: string;
+    let fernDir: string;
 
     beforeEach(async () => {
-        testDir = join(tmpdir(), `convert-single-api-test-${randomUUID()}`);
-        await mkdir(testDir, { recursive: true });
+        projectDir = join(tmpdir(), `convert-single-api-test-${randomUUID()}`);
+        fernDir = join(projectDir, "fern");
+        await mkdir(fernDir, { recursive: true });
     });
 
     afterEach(async () => {
-        await rm(testDir, { recursive: true, force: true });
+        await rm(projectDir, { recursive: true, force: true });
     });
 
     it("returns undefined api when no generatorsYmlApi and no definition dir", async () => {
         const result = await convertSingleApi({
-            fernDir: AbsoluteFilePath.of(testDir),
+            projectRoot: AbsoluteFilePath.of(projectDir),
+            fernDir: AbsoluteFilePath.of(fernDir),
             generatorsYmlApi: undefined
         });
         expect(result.api).toBeUndefined();
@@ -208,16 +211,18 @@ describe("convertSingleApi", () => {
 
     it("uses generators.yml specs when no definition directory exists", async () => {
         const result = await convertSingleApi({
-            fernDir: AbsoluteFilePath.of(testDir),
+            projectRoot: AbsoluteFilePath.of(projectDir),
+            fernDir: AbsoluteFilePath.of(fernDir),
             generatorsYmlApi: { specs: [{ openapi: "./openapi.yml" }] }
         });
         expect(result.api?.specs[0]).toMatchObject({ openapi: "./fern/openapi.yml" });
     });
 
     it("uses Fern definition directory when it exists (takes precedence over generators.yml specs)", async () => {
-        await mkdir(join(testDir, "definition"), { recursive: true });
+        await mkdir(join(fernDir, "definition"), { recursive: true });
         const result = await convertSingleApi({
-            fernDir: AbsoluteFilePath.of(testDir),
+            projectRoot: AbsoluteFilePath.of(projectDir),
+            fernDir: AbsoluteFilePath.of(fernDir),
             generatorsYmlApi: { specs: [{ openapi: "./openapi.yml" }] }
         });
         // Definition takes precedence
@@ -228,9 +233,10 @@ describe("convertSingleApi", () => {
     });
 
     it("emits no warning when definition dir exists but generators.yml has no specs", async () => {
-        await mkdir(join(testDir, "definition"), { recursive: true });
+        await mkdir(join(fernDir, "definition"), { recursive: true });
         const result = await convertSingleApi({
-            fernDir: AbsoluteFilePath.of(testDir),
+            projectRoot: AbsoluteFilePath.of(projectDir),
+            fernDir: AbsoluteFilePath.of(fernDir),
             generatorsYmlApi: undefined
         });
         const spec = result.api?.specs[0] as { fern: string } | undefined;
@@ -262,6 +268,7 @@ describe("convertMultiApi", () => {
         await mkdir(join(apisDir, "grpc"), { recursive: true });
 
         const result = await convertMultiApi({
+            projectRoot: AbsoluteFilePath.of(testDir),
             fernDir: AbsoluteFilePath.of(join(testDir, "fern")),
             apisDir: AbsoluteFilePath.of(apisDir),
             generatorsYmlApis: {
@@ -278,6 +285,7 @@ describe("convertMultiApi", () => {
         await mkdir(join(apisDir, "rest"), { recursive: true });
 
         const result = await convertMultiApi({
+            projectRoot: AbsoluteFilePath.of(testDir),
             fernDir: AbsoluteFilePath.of(join(testDir, "fern")),
             apisDir: AbsoluteFilePath.of(apisDir),
             generatorsYmlApis: {
@@ -300,6 +308,7 @@ describe("convertMultiApi", () => {
         await mkdir(join(apisDir, "rest", "definition"), { recursive: true });
 
         const result = await convertMultiApi({
+            projectRoot: AbsoluteFilePath.of(testDir),
             fernDir: AbsoluteFilePath.of(join(testDir, "fern")),
             apisDir: AbsoluteFilePath.of(apisDir),
             generatorsYmlApis: {
@@ -317,6 +326,7 @@ describe("convertMultiApi", () => {
         await mkdir(join(apisDir, "empty-api"), { recursive: true });
 
         const result = await convertMultiApi({
+            projectRoot: AbsoluteFilePath.of(testDir),
             fernDir: AbsoluteFilePath.of(join(testDir, "fern")),
             apisDir: AbsoluteFilePath.of(apisDir),
             generatorsYmlApis: {}
@@ -330,6 +340,7 @@ describe("convertMultiApi", () => {
         await mkdir(join(apisDir, "rest"), { recursive: true });
 
         const result = await convertMultiApi({
+            projectRoot: AbsoluteFilePath.of(testDir),
             fernDir: AbsoluteFilePath.of(join(testDir, "fern")),
             apisDir: AbsoluteFilePath.of(apisDir),
             generatorsYmlApis: {

--- a/packages/cli/cli-v2/src/migrator/__test__/convertApiSpecs.test.ts
+++ b/packages/cli/cli-v2/src/migrator/__test__/convertApiSpecs.test.ts
@@ -232,6 +232,18 @@ describe("convertSingleApi", () => {
         expect(result.warnings.some((w) => w.message.includes("Fern definition"))).toBe(true);
     });
 
+    it("handles spec paths when fernDir equals projectRoot (empty sourcePrefix)", async () => {
+        // generators.yml is at projectRoot itself — sourcePrefix would be ""
+        const result = await convertSingleApi({
+            projectRoot: AbsoluteFilePath.of(projectDir),
+            fernDir: AbsoluteFilePath.of(projectDir),
+            generatorsYmlApi: { specs: [{ openapi: "./openapi.yml", overrides: "overrides.yml" }] }
+        });
+        const spec = result.api?.specs[0] as { openapi: string; overrides: string } | undefined;
+        expect(spec?.openapi).toBe("./openapi.yml");
+        expect(spec?.overrides).toBe("./overrides.yml");
+    });
+
     it("emits no warning when definition dir exists but generators.yml has no specs", async () => {
         await mkdir(join(fernDir, "definition"), { recursive: true });
         const result = await convertSingleApi({

--- a/packages/cli/cli-v2/src/migrator/__test__/customerConfigs.test.ts
+++ b/packages/cli/cli-v2/src/migrator/__test__/customerConfigs.test.ts
@@ -556,7 +556,7 @@ favicon: ./docs/assets/favicon.png
         expect(yml.org).toBe("intrinsic");
 
         const raw = await readMigratedYmlRaw(projectDir);
-        expect(raw).toContain("$ref: ./docs.yml");
+        expect(raw).toContain("$ref: ./fern/docs.yml");
         expect(raw).not.toContain("intrinsic.docs.buildwithfern.com");
         expect(raw).not.toContain("favicon");
 
@@ -682,7 +682,7 @@ navbar-links:
         expect(tsPublish.npm.packageName).toBe("plumery");
 
         const raw = await readMigratedYmlRaw(projectDir);
-        expect(raw).toContain("$ref: ./docs.yml");
+        expect(raw).toContain("$ref: ./fern/docs.yml");
         expect(raw).not.toContain("plumery.docs.buildwithfern.com");
     });
 
@@ -763,7 +763,7 @@ favicon: ./docs/assets/favicon.ico
         expect(ts.lang).toBe("typescript");
         expect(ts.output).toBe("../generated/sdk/node");
 
-        expect(raw).toContain("$ref: ./docs.yml");
+        expect(raw).toContain("$ref: ./fern/docs.yml");
     });
 
     // -- 10. Alpaca -- multi-API workspace (6 APIs), Postman generators
@@ -1067,7 +1067,7 @@ jobs:
         expect(sdks.targets).toHaveProperty("go");
 
         const raw = await readMigratedYmlRaw(projectDir);
-        expect(raw).toContain("$ref: ./docs.yml");
+        expect(raw).toContain("$ref: ./fern/docs.yml");
         expect(raw).not.toContain("default-group");
 
         const workflowContent = await readFile(join(projectDir, ".github", "workflows", "generate-sdks.yml"), "utf-8");

--- a/packages/cli/cli-v2/src/migrator/__test__/migrateDocsYml.test.ts
+++ b/packages/cli/cli-v2/src/migrator/__test__/migrateDocsYml.test.ts
@@ -28,14 +28,14 @@ describe("migrateDocsYml", () => {
         await writeFile(join(testDir, "docs.yml"), "title: My Docs\nnavigation:\n  - page: Home\n");
         const result = await migrateDocsYml(AbsoluteFilePath.of(testDir));
         expect(result.found).toBe(true);
-        expect(result.docsRef).toEqual({ $ref: "./docs.yml" });
+        expect(result.docsRef).toEqual({ $ref: "./fern/docs.yml" });
     });
 
     it("returns a $ref pointer even when docs.yml is empty", async () => {
         await writeFile(join(testDir, "docs.yml"), "");
         const result = await migrateDocsYml(AbsoluteFilePath.of(testDir));
         expect(result.found).toBe(true);
-        expect(result.docsRef).toEqual({ $ref: "./docs.yml" });
+        expect(result.docsRef).toEqual({ $ref: "./fern/docs.yml" });
     });
 
     it("returns a $ref pointer when docs.yml contains complex content with $ref references", async () => {
@@ -45,7 +45,7 @@ describe("migrateDocsYml", () => {
         );
         const result = await migrateDocsYml(AbsoluteFilePath.of(testDir));
         expect(result.found).toBe(true);
-        expect(result.docsRef).toEqual({ $ref: "./docs.yml" });
+        expect(result.docsRef).toEqual({ $ref: "./fern/docs.yml" });
     });
 
     it("does not resolve or inline any content from docs.yml", async () => {
@@ -53,7 +53,7 @@ describe("migrateDocsYml", () => {
         const result = await migrateDocsYml(AbsoluteFilePath.of(testDir));
         // The result should only contain a $ref pointer, never parsed content
         expect(result.docsRef).toBeDefined();
-        expect(result.docsRef).toEqual({ $ref: "./docs.yml" });
+        expect(result.docsRef).toEqual({ $ref: "./fern/docs.yml" });
         expect(result.docsRef).toBeDefined();
         expect(Object.keys(result.docsRef ?? {})).toEqual(["$ref"]);
     });

--- a/packages/cli/cli-v2/src/migrator/__test__/migrateDocsYml.test.ts
+++ b/packages/cli/cli-v2/src/migrator/__test__/migrateDocsYml.test.ts
@@ -7,50 +7,52 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { migrateDocsYml } from "../docs-yml/index.js";
 
 describe("migrateDocsYml", () => {
-    let testDir: string;
+    let projectDir: string;
+    let fernDir: string;
 
     beforeEach(async () => {
-        testDir = join(tmpdir(), `docs-yml-test-${randomUUID()}`);
-        await mkdir(testDir, { recursive: true });
+        projectDir = join(tmpdir(), `docs-yml-test-${randomUUID()}`);
+        fernDir = join(projectDir, "fern");
+        await mkdir(fernDir, { recursive: true });
     });
 
     afterEach(async () => {
-        await rm(testDir, { recursive: true, force: true });
+        await rm(projectDir, { recursive: true, force: true });
     });
 
     it("returns found=false when docs.yml does not exist", async () => {
-        const result = await migrateDocsYml(AbsoluteFilePath.of(testDir));
+        const result = await migrateDocsYml(AbsoluteFilePath.of(projectDir), AbsoluteFilePath.of(fernDir));
         expect(result.found).toBe(false);
         expect(result.docsRef).toBeUndefined();
     });
 
     it("returns a $ref pointer when docs.yml exists", async () => {
-        await writeFile(join(testDir, "docs.yml"), "title: My Docs\nnavigation:\n  - page: Home\n");
-        const result = await migrateDocsYml(AbsoluteFilePath.of(testDir));
+        await writeFile(join(fernDir, "docs.yml"), "title: My Docs\nnavigation:\n  - page: Home\n");
+        const result = await migrateDocsYml(AbsoluteFilePath.of(projectDir), AbsoluteFilePath.of(fernDir));
         expect(result.found).toBe(true);
         expect(result.docsRef).toEqual({ $ref: "./fern/docs.yml" });
     });
 
     it("returns a $ref pointer even when docs.yml is empty", async () => {
-        await writeFile(join(testDir, "docs.yml"), "");
-        const result = await migrateDocsYml(AbsoluteFilePath.of(testDir));
+        await writeFile(join(fernDir, "docs.yml"), "");
+        const result = await migrateDocsYml(AbsoluteFilePath.of(projectDir), AbsoluteFilePath.of(fernDir));
         expect(result.found).toBe(true);
         expect(result.docsRef).toEqual({ $ref: "./fern/docs.yml" });
     });
 
     it("returns a $ref pointer when docs.yml contains complex content with $ref references", async () => {
         await writeFile(
-            join(testDir, "docs.yml"),
+            join(fernDir, "docs.yml"),
             'title: My Docs\nnavigation:\n  - section: API\n    contents:\n      - $ref: "./api-ref.yml"\n'
         );
-        const result = await migrateDocsYml(AbsoluteFilePath.of(testDir));
+        const result = await migrateDocsYml(AbsoluteFilePath.of(projectDir), AbsoluteFilePath.of(fernDir));
         expect(result.found).toBe(true);
         expect(result.docsRef).toEqual({ $ref: "./fern/docs.yml" });
     });
 
     it("does not resolve or inline any content from docs.yml", async () => {
-        await writeFile(join(testDir, "docs.yml"), "title: My Docs\n");
-        const result = await migrateDocsYml(AbsoluteFilePath.of(testDir));
+        await writeFile(join(fernDir, "docs.yml"), "title: My Docs\n");
+        const result = await migrateDocsYml(AbsoluteFilePath.of(projectDir), AbsoluteFilePath.of(fernDir));
         // The result should only contain a $ref pointer, never parsed content
         expect(result.docsRef).toBeDefined();
         expect(result.docsRef).toEqual({ $ref: "./fern/docs.yml" });

--- a/packages/cli/cli-v2/src/migrator/converters/convertApiSpecs.ts
+++ b/packages/cli/cli-v2/src/migrator/converters/convertApiSpecs.ts
@@ -1,5 +1,5 @@
 import type { schemas } from "@fern-api/config";
-import { APIS_DIRECTORY, DEFINITION_DIRECTORY, FERN_DIRECTORY, generatorsYml } from "@fern-api/configuration";
+import { APIS_DIRECTORY, DEFINITION_DIRECTORY, generatorsYml } from "@fern-api/configuration";
 import path from "path";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { readdir } from "fs/promises";
@@ -12,6 +12,8 @@ export interface ConvertApiSpecsResult {
 }
 
 export interface ConvertSingleApiOptions {
+    /** The project root directory where fern.yml will be written */
+    projectRoot: AbsoluteFilePath;
     /** The fern directory (e.g., /path/to/project/fern) */
     fernDir: AbsoluteFilePath;
     /** API config from generators.yml */
@@ -28,16 +30,17 @@ export interface ConvertSingleApiResult {
  * Checks for Fern definition directory (takes precedence) or uses generators.yml specs.
  */
 export async function convertSingleApi(options: ConvertSingleApiOptions): Promise<ConvertSingleApiResult> {
-    const { fernDir, generatorsYmlApi } = options;
+    const { projectRoot, fernDir, generatorsYmlApi } = options;
     const warnings: MigratorWarning[] = [];
+    const fernRelPath = computeRelativePosixPath(projectRoot, fernDir);
 
     const definitionDir = join(fernDir, RelativeFilePath.of(DEFINITION_DIRECTORY));
     const hasFernDefinition = await doesPathExist(definitionDir, "directory");
 
     if (hasFernDefinition) {
-        // The Fern definition takes precedence.
+        const defRelPath = computeRelativePosixPath(projectRoot, definitionDir);
         const api: schemas.ApiDefinitionSchema = {
-            specs: [{ fern: `./${FERN_DIRECTORY}/${DEFINITION_DIRECTORY}` }]
+            specs: [{ fern: `./${defRelPath}` }]
         };
 
         if (generatorsYmlApi != null) {
@@ -62,7 +65,7 @@ export async function convertSingleApi(options: ConvertSingleApiOptions): Promis
         warnings.push(...result.warnings);
 
         if (result.specs.length > 0) {
-            const adjustedSpecs = adjustSpecPathsForSingleApi(result.specs);
+            const adjustedSpecs = rebaseSpecPaths(result.specs, fernRelPath);
             return { api: { specs: adjustedSpecs }, warnings };
         }
     }
@@ -71,6 +74,8 @@ export async function convertSingleApi(options: ConvertSingleApiOptions): Promis
 }
 
 export interface ConvertMultiApiOptions {
+    /** The project root directory where fern.yml will be written */
+    projectRoot: AbsoluteFilePath;
     /** The fern directory (e.g., /path/to/project/fern) */
     fernDir: AbsoluteFilePath;
     /** The apis directory (e.g., /path/to/project/fern/apis) */
@@ -85,7 +90,7 @@ export interface ConvertMultiApiResult {
 }
 
 export async function convertMultiApi(options: ConvertMultiApiOptions): Promise<ConvertMultiApiResult> {
-    const { apisDir, generatorsYmlApis } = options;
+    const { projectRoot, apisDir, generatorsYmlApis } = options;
     const warnings: MigratorWarning[] = [];
     const apis: schemas.ApisSchema = {};
 
@@ -96,13 +101,14 @@ export async function convertMultiApi(options: ConvertMultiApiOptions): Promise<
         const apiDir = join(apisDir, RelativeFilePath.of(apiName));
         const definitionDir = join(apiDir, RelativeFilePath.of(DEFINITION_DIRECTORY));
         const hasFernDefinition = await doesPathExist(definitionDir, "directory");
+        const apiRelPath = computeRelativePosixPath(projectRoot, apiDir);
 
         const generatorsYmlApi = generatorsYmlApis[apiName];
 
         if (hasFernDefinition) {
-            // The Fern definition takes precedence.
+            const defRelPath = computeRelativePosixPath(projectRoot, definitionDir);
             apis[apiName] = {
-                specs: [{ fern: `./${FERN_DIRECTORY}/${APIS_DIRECTORY}/${apiName}/${DEFINITION_DIRECTORY}` }]
+                specs: [{ fern: `./${defRelPath}` }]
             };
 
             if (generatorsYmlApi != null) {
@@ -121,7 +127,7 @@ export async function convertMultiApi(options: ConvertMultiApiOptions): Promise<
             const result = convertApiSpecs(generatorsYmlApi);
             warnings.push(...result.warnings);
             if (result.specs.length > 0) {
-                const adjustedSpecs = adjustSpecPaths(result.specs, apiName);
+                const adjustedSpecs = rebaseSpecPaths(result.specs, apiRelPath);
                 apis[apiName] = { specs: adjustedSpecs };
             } else {
                 apis[apiName] = { specs: [] };
@@ -145,49 +151,52 @@ export async function convertMultiApi(options: ConvertMultiApiOptions): Promise<
 }
 
 /**
- * Adjusts spec paths to be relative from the project root (where fern.yml is created).
+ * Rebases spec paths so they are relative to the project root (where fern.yml lives).
+ *
+ * `sourcePrefix` is the POSIX-style relative path from the project root to the directory
+ * that originally contained the generators.yml (e.g. "fern" or "fern/apis/rest").
  */
-function adjustSpecPaths(specs: schemas.ApiSpecSchema[], apiName: string): schemas.ApiSpecSchema[] {
+function rebaseSpecPaths(specs: schemas.ApiSpecSchema[], sourcePrefix: string): schemas.ApiSpecSchema[] {
     return specs.map((spec) => {
         if ("openapi" in spec) {
             return {
                 ...spec,
-                openapi: adjustPath(spec.openapi, apiName),
-                overrides: spec.overrides != null ? adjustPathOrPaths(spec.overrides, apiName) : undefined,
-                overlays: spec.overlays != null ? adjustPath(spec.overlays, apiName) : undefined
+                openapi: rebasePath(spec.openapi, sourcePrefix),
+                overrides: spec.overrides != null ? rebasePathOrPaths(spec.overrides, sourcePrefix) : undefined,
+                overlays: spec.overlays != null ? rebasePath(spec.overlays, sourcePrefix) : undefined
             };
         }
         if ("asyncapi" in spec) {
             return {
                 ...spec,
-                asyncapi: adjustPath(spec.asyncapi, apiName),
-                overrides: spec.overrides != null ? adjustPathOrPaths(spec.overrides, apiName) : undefined
+                asyncapi: rebasePath(spec.asyncapi, sourcePrefix),
+                overrides: spec.overrides != null ? rebasePathOrPaths(spec.overrides, sourcePrefix) : undefined
             };
         }
         if ("fern" in spec) {
             return {
                 ...spec,
-                fern: adjustPath(spec.fern, apiName)
+                fern: rebasePath(spec.fern, sourcePrefix)
             };
         }
         if ("conjure" in spec) {
             return {
                 ...spec,
-                conjure: adjustPath(spec.conjure, apiName)
+                conjure: rebasePath(spec.conjure, sourcePrefix)
             };
         }
         if ("openrpc" in spec) {
             return {
                 ...spec,
-                openrpc: adjustPath(spec.openrpc, apiName),
-                overrides: spec.overrides != null ? adjustPathOrPaths(spec.overrides, apiName) : undefined
+                openrpc: rebasePath(spec.openrpc, sourcePrefix),
+                overrides: spec.overrides != null ? rebasePathOrPaths(spec.overrides, sourcePrefix) : undefined
             };
         }
         if ("graphql" in spec) {
             return {
                 ...spec,
-                graphql: adjustPath(spec.graphql, apiName),
-                overrides: spec.overrides != null ? adjustPathOrPaths(spec.overrides, apiName) : undefined
+                graphql: rebasePath(spec.graphql, sourcePrefix),
+                overrides: spec.overrides != null ? rebasePathOrPaths(spec.overrides, sourcePrefix) : undefined
             };
         }
         if ("proto" in spec) {
@@ -195,9 +204,9 @@ function adjustSpecPaths(specs: schemas.ApiSpecSchema[], apiName: string): schem
                 ...spec,
                 proto: {
                     ...spec.proto,
-                    root: adjustPath(spec.proto.root, apiName),
+                    root: rebasePath(spec.proto.root, sourcePrefix),
                     overrides:
-                        spec.proto.overrides != null ? adjustPathOrPaths(spec.proto.overrides, apiName) : undefined
+                        spec.proto.overrides != null ? rebasePathOrPaths(spec.proto.overrides, sourcePrefix) : undefined
                 }
             };
         }
@@ -205,104 +214,31 @@ function adjustSpecPaths(specs: schemas.ApiSpecSchema[], apiName: string): schem
     });
 }
 
-function adjustPath(filePath: string, apiName: string): string {
+/**
+ * Rebases a single file path from being relative to `sourcePrefix` to being
+ * relative to the project root. Absolute paths are left untouched.
+ */
+function rebasePath(filePath: string, sourcePrefix: string): string {
     if (filePath.startsWith("/")) {
         return filePath;
     }
     const rawPath = filePath.startsWith("./") ? filePath.slice(2) : filePath;
-    return `./${normalizePosixPath(`${FERN_DIRECTORY}/${APIS_DIRECTORY}/${apiName}/${rawPath}`)}`;
+    return `./${path.posix.normalize(`${sourcePrefix}/${rawPath}`)}`;
 }
 
-function adjustPathOrPaths(paths: string | string[], apiName: string): string | string[] {
+function rebasePathOrPaths(paths: string | string[], sourcePrefix: string): string | string[] {
     if (Array.isArray(paths)) {
-        return paths.map((p) => adjustPath(p, apiName));
+        return paths.map((p) => rebasePath(p, sourcePrefix));
     }
-    return adjustPath(paths, apiName);
+    return rebasePath(paths, sourcePrefix);
 }
 
 /**
- * Adjusts spec paths for single-API projects to be relative from the project root.
- * Paths in generators.yml are relative to the fern/ directory, but fern.yml is
- * created at the project root, so paths need to be re-rooted.
+ * Computes a POSIX-style relative path from `from` to `to`.
  */
-function adjustSpecPathsForSingleApi(specs: schemas.ApiSpecSchema[]): schemas.ApiSpecSchema[] {
-    return specs.map((spec) => {
-        if ("openapi" in spec) {
-            return {
-                ...spec,
-                openapi: adjustPathForSingleApi(spec.openapi),
-                overrides: spec.overrides != null ? adjustPathOrPathsForSingleApi(spec.overrides) : undefined,
-                overlays: spec.overlays != null ? adjustPathForSingleApi(spec.overlays) : undefined
-            };
-        }
-        if ("asyncapi" in spec) {
-            return {
-                ...spec,
-                asyncapi: adjustPathForSingleApi(spec.asyncapi),
-                overrides: spec.overrides != null ? adjustPathOrPathsForSingleApi(spec.overrides) : undefined
-            };
-        }
-        if ("fern" in spec) {
-            return {
-                ...spec,
-                fern: adjustPathForSingleApi(spec.fern)
-            };
-        }
-        if ("conjure" in spec) {
-            return {
-                ...spec,
-                conjure: adjustPathForSingleApi(spec.conjure)
-            };
-        }
-        if ("openrpc" in spec) {
-            return {
-                ...spec,
-                openrpc: adjustPathForSingleApi(spec.openrpc),
-                overrides: spec.overrides != null ? adjustPathOrPathsForSingleApi(spec.overrides) : undefined
-            };
-        }
-        if ("graphql" in spec) {
-            return {
-                ...spec,
-                graphql: adjustPathForSingleApi(spec.graphql),
-                overrides: spec.overrides != null ? adjustPathOrPathsForSingleApi(spec.overrides) : undefined
-            };
-        }
-        if ("proto" in spec) {
-            return {
-                ...spec,
-                proto: {
-                    ...spec.proto,
-                    root: adjustPathForSingleApi(spec.proto.root),
-                    overrides:
-                        spec.proto.overrides != null ? adjustPathOrPathsForSingleApi(spec.proto.overrides) : undefined
-                }
-            };
-        }
-        return spec;
-    });
-}
-
-function adjustPathForSingleApi(filePath: string): string {
-    if (filePath.startsWith("/")) {
-        return filePath;
-    }
-    const rawPath = filePath.startsWith("./") ? filePath.slice(2) : filePath;
-    return `./${normalizePosixPath(`${FERN_DIRECTORY}/${rawPath}`)}`;
-}
-
-function adjustPathOrPathsForSingleApi(paths: string | string[]): string | string[] {
-    if (Array.isArray(paths)) {
-        return paths.map((p) => adjustPathForSingleApi(p));
-    }
-    return adjustPathForSingleApi(paths);
-}
-
-/**
- * Normalizes a POSIX path by resolving `.` and `..` segments.
- */
-function normalizePosixPath(p: string): string {
-    return path.posix.normalize(p);
+function computeRelativePosixPath(from: AbsoluteFilePath, to: AbsoluteFilePath): string {
+    const rel = path.relative(from, to);
+    return rel.split(path.sep).join(path.posix.sep);
 }
 
 /**

--- a/packages/cli/cli-v2/src/migrator/converters/convertApiSpecs.ts
+++ b/packages/cli/cli-v2/src/migrator/converters/convertApiSpecs.ts
@@ -223,6 +223,9 @@ function rebasePath(filePath: string, sourcePrefix: string): string {
         return filePath;
     }
     const rawPath = filePath.startsWith("./") ? filePath.slice(2) : filePath;
+    if (sourcePrefix === "") {
+        return `./${rawPath}`;
+    }
     return `./${path.posix.normalize(`${sourcePrefix}/${rawPath}`)}`;
 }
 

--- a/packages/cli/cli-v2/src/migrator/converters/convertApiSpecs.ts
+++ b/packages/cli/cli-v2/src/migrator/converters/convertApiSpecs.ts
@@ -1,8 +1,8 @@
 import type { schemas } from "@fern-api/config";
-import { APIS_DIRECTORY, DEFINITION_DIRECTORY, generatorsYml } from "@fern-api/configuration";
-import path from "path";
+import { DEFINITION_DIRECTORY, generatorsYml } from "@fern-api/configuration";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { readdir } from "fs/promises";
+import path from "path";
 import type { MigratorWarning } from "../types/index.js";
 import { convertOpenApiSpecSettings } from "./convertSettings.js";
 

--- a/packages/cli/cli-v2/src/migrator/converters/convertApiSpecs.ts
+++ b/packages/cli/cli-v2/src/migrator/converters/convertApiSpecs.ts
@@ -1,5 +1,6 @@
 import type { schemas } from "@fern-api/config";
 import { APIS_DIRECTORY, DEFINITION_DIRECTORY, FERN_DIRECTORY, generatorsYml } from "@fern-api/configuration";
+import path from "path";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { readdir } from "fs/promises";
 import type { MigratorWarning } from "../types/index.js";
@@ -61,7 +62,8 @@ export async function convertSingleApi(options: ConvertSingleApiOptions): Promis
         warnings.push(...result.warnings);
 
         if (result.specs.length > 0) {
-            return { api: { specs: result.specs }, warnings };
+            const adjustedSpecs = adjustSpecPathsForSingleApi(result.specs);
+            return { api: { specs: adjustedSpecs }, warnings };
         }
     }
 
@@ -203,14 +205,12 @@ function adjustSpecPaths(specs: schemas.ApiSpecSchema[], apiName: string): schem
     });
 }
 
-function adjustPath(path: string, apiName: string): string {
-    if (path.startsWith("/")) {
-        return path;
+function adjustPath(filePath: string, apiName: string): string {
+    if (filePath.startsWith("/")) {
+        return filePath;
     }
-    if (path.startsWith("./")) {
-        return `./${FERN_DIRECTORY}/${APIS_DIRECTORY}/${apiName}/${path.slice(2)}`;
-    }
-    return `./${FERN_DIRECTORY}/${APIS_DIRECTORY}/${apiName}/${path}`;
+    const rawPath = filePath.startsWith("./") ? filePath.slice(2) : filePath;
+    return `./${normalizePosixPath(`${FERN_DIRECTORY}/${APIS_DIRECTORY}/${apiName}/${rawPath}`)}`;
 }
 
 function adjustPathOrPaths(paths: string | string[], apiName: string): string | string[] {
@@ -218,6 +218,91 @@ function adjustPathOrPaths(paths: string | string[], apiName: string): string | 
         return paths.map((p) => adjustPath(p, apiName));
     }
     return adjustPath(paths, apiName);
+}
+
+/**
+ * Adjusts spec paths for single-API projects to be relative from the project root.
+ * Paths in generators.yml are relative to the fern/ directory, but fern.yml is
+ * created at the project root, so paths need to be re-rooted.
+ */
+function adjustSpecPathsForSingleApi(specs: schemas.ApiSpecSchema[]): schemas.ApiSpecSchema[] {
+    return specs.map((spec) => {
+        if ("openapi" in spec) {
+            return {
+                ...spec,
+                openapi: adjustPathForSingleApi(spec.openapi),
+                overrides: spec.overrides != null ? adjustPathOrPathsForSingleApi(spec.overrides) : undefined,
+                overlays: spec.overlays != null ? adjustPathForSingleApi(spec.overlays) : undefined
+            };
+        }
+        if ("asyncapi" in spec) {
+            return {
+                ...spec,
+                asyncapi: adjustPathForSingleApi(spec.asyncapi),
+                overrides: spec.overrides != null ? adjustPathOrPathsForSingleApi(spec.overrides) : undefined
+            };
+        }
+        if ("fern" in spec) {
+            return {
+                ...spec,
+                fern: adjustPathForSingleApi(spec.fern)
+            };
+        }
+        if ("conjure" in spec) {
+            return {
+                ...spec,
+                conjure: adjustPathForSingleApi(spec.conjure)
+            };
+        }
+        if ("openrpc" in spec) {
+            return {
+                ...spec,
+                openrpc: adjustPathForSingleApi(spec.openrpc),
+                overrides: spec.overrides != null ? adjustPathOrPathsForSingleApi(spec.overrides) : undefined
+            };
+        }
+        if ("graphql" in spec) {
+            return {
+                ...spec,
+                graphql: adjustPathForSingleApi(spec.graphql),
+                overrides: spec.overrides != null ? adjustPathOrPathsForSingleApi(spec.overrides) : undefined
+            };
+        }
+        if ("proto" in spec) {
+            return {
+                ...spec,
+                proto: {
+                    ...spec.proto,
+                    root: adjustPathForSingleApi(spec.proto.root),
+                    overrides:
+                        spec.proto.overrides != null ? adjustPathOrPathsForSingleApi(spec.proto.overrides) : undefined
+                }
+            };
+        }
+        return spec;
+    });
+}
+
+function adjustPathForSingleApi(filePath: string): string {
+    if (filePath.startsWith("/")) {
+        return filePath;
+    }
+    const rawPath = filePath.startsWith("./") ? filePath.slice(2) : filePath;
+    return `./${normalizePosixPath(`${FERN_DIRECTORY}/${rawPath}`)}`;
+}
+
+function adjustPathOrPathsForSingleApi(paths: string | string[]): string | string[] {
+    if (Array.isArray(paths)) {
+        return paths.map((p) => adjustPathForSingleApi(p));
+    }
+    return adjustPathForSingleApi(paths);
+}
+
+/**
+ * Normalizes a POSIX path by resolving `.` and `..` segments.
+ */
+function normalizePosixPath(p: string): string {
+    return path.posix.normalize(p);
 }
 
 /**

--- a/packages/cli/cli-v2/src/migrator/docs-yml/DocsYmlMigrator.ts
+++ b/packages/cli/cli-v2/src/migrator/docs-yml/DocsYmlMigrator.ts
@@ -1,4 +1,5 @@
-import { DOCS_CONFIGURATION_FILENAME, FERN_DIRECTORY } from "@fern-api/configuration";
+import { DOCS_CONFIGURATION_FILENAME } from "@fern-api/configuration";
+import path from "path";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 
 export interface DocsYmlMigratorResult {
@@ -12,10 +13,14 @@ export interface DocsYmlMigratorResult {
  * pointer so the migrated fern.yml can reference docs.yml directly.
  * The path is relative to the project root (where fern.yml is created).
  */
-export async function migrateDocsYml(fernDir: AbsoluteFilePath): Promise<DocsYmlMigratorResult> {
+export async function migrateDocsYml(
+    projectRoot: AbsoluteFilePath,
+    fernDir: AbsoluteFilePath
+): Promise<DocsYmlMigratorResult> {
     const filePath = join(fernDir, RelativeFilePath.of(DOCS_CONFIGURATION_FILENAME));
     if (!(await doesPathExist(filePath, "file"))) {
         return { found: false };
     }
-    return { docsRef: { $ref: `./${FERN_DIRECTORY}/${DOCS_CONFIGURATION_FILENAME}` }, found: true };
+    const relPath = path.relative(projectRoot, filePath).split(path.sep).join(path.posix.sep);
+    return { docsRef: { $ref: `./${relPath}` }, found: true };
 }

--- a/packages/cli/cli-v2/src/migrator/docs-yml/DocsYmlMigrator.ts
+++ b/packages/cli/cli-v2/src/migrator/docs-yml/DocsYmlMigrator.ts
@@ -1,4 +1,4 @@
-import { DOCS_CONFIGURATION_FILENAME } from "@fern-api/configuration";
+import { DOCS_CONFIGURATION_FILENAME, FERN_DIRECTORY } from "@fern-api/configuration";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 
 export interface DocsYmlMigratorResult {
@@ -10,11 +10,12 @@ export interface DocsYmlMigratorResult {
 /**
  * Checks if docs.yml exists in the fern directory. If so, returns a `$ref`
  * pointer so the migrated fern.yml can reference docs.yml directly.
+ * The path is relative to the project root (where fern.yml is created).
  */
 export async function migrateDocsYml(fernDir: AbsoluteFilePath): Promise<DocsYmlMigratorResult> {
     const filePath = join(fernDir, RelativeFilePath.of(DOCS_CONFIGURATION_FILENAME));
     if (!(await doesPathExist(filePath, "file"))) {
         return { found: false };
     }
-    return { docsRef: { $ref: `./${DOCS_CONFIGURATION_FILENAME}` }, found: true };
+    return { docsRef: { $ref: `./${FERN_DIRECTORY}/${DOCS_CONFIGURATION_FILENAME}` }, found: true };
 }

--- a/packages/cli/cli-v2/src/migrator/docs-yml/DocsYmlMigrator.ts
+++ b/packages/cli/cli-v2/src/migrator/docs-yml/DocsYmlMigrator.ts
@@ -1,6 +1,6 @@
 import { DOCS_CONFIGURATION_FILENAME } from "@fern-api/configuration";
-import path from "path";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
+import path from "path";
 
 export interface DocsYmlMigratorResult {
     /** If docs.yml exists, a `$ref` pointer to include in fern.yml. */

--- a/packages/cli/cli/changes/unreleased/fix-migrate-file-paths.yml
+++ b/packages/cli/cli/changes/unreleased/fix-migrate-file-paths.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix `fern config migrate` producing wrong file path references in the generated `fern.yml`. Paths from `generators.yml` (relative to the `fern/` directory) are now correctly re-rooted to be relative to the project root where `fern.yml` is created. This also fixes the `docs` `$ref` pointer to use `./fern/docs.yml` instead of `./docs.yml`.
+  type: fix


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-10462](https://linear.app/buildwithfern/issue/FER-10462/bug-fern-config-migrate-cause-wrong-file-path-reference-errors)

`fern config migrate` produced wrong file path references in the generated `fern.yml` for single-API projects. Paths from `generators.yml` (relative to the `fern/` directory) were not re-rooted to be relative to the project root where `fern.yml` is written. The `docs` `$ref` pointer also used `./docs.yml` instead of `./fern/docs.yml`.

## Changes Made
- Added `projectRoot` parameter to `convertSingleApi`, `convertMultiApi`, and `migrateDocsYml` so paths are computed dynamically via `path.relative(projectRoot, fernDir)` — no hardcoded directory names
- Unified path adjustment into `rebaseSpecPaths(specs, sourcePrefix)` / `rebasePath(filePath, sourcePrefix)` / `computeRelativePosixPath(from, to)`, replacing the duplicated `adjustSpecPaths`/`adjustSpecPathsForSingleApi` functions
- Both single-API and multi-API code paths now use the same dynamic path rebasing logic
- Updated `Migrator.ts` to pass `this.cwd` as `projectRoot` to all path-adjusting functions
- [ ] Updated README.md generator (if applicable) — N/A

### Example
Given `generators.yml` in `fern/` with `openapi: ../external/universal-api-v1.yaml` and `overrides: ./openapi-overrides.yml`:
- **Before**: paths copied verbatim → `../external/...` and `./openapi-overrides.yml` (wrong from project root)
- **After**: paths rebased → `./external/universal-api-v1.yaml` and `./fern/openapi-overrides.yml` (correct)

## Testing
- [x] Unit tests added/updated — all 690 tests pass
- [x] New test for single-API path adjustment with `../` paths
- [x] Updated existing test assertions for correct path expectations
- [x] `pnpm format` clean

Link to Devin session: https://app.devin.ai/sessions/294b273b9cb84d6a82171f9c2e67a4a8
Requested by: @iamnamananand996