### PR TITLE
fix(seed): clear grpc-go CVE, drop unused docker CLI plugins, rebuild containerd/runc/golangci-lint with go1.26.3

### DIFF
--- a/docker/seed/Dockerfile.go
+++ b/docker/seed/Dockerfile.go
@@ -5,26 +5,37 @@ RUN apk add --no-cache curl && \
     curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
     crane pull wiremock/wiremock:3.9.1 /wiremock.tar
 
-# Stage 2: Pull statically-linked containerd v2.3.0 to overlay on the DinD base
-# (ships v2.2.3) and clear grpc / otel / go-jose CVEs in containerd binaries.
-FROM alpine:3.23 AS overlay-binaries
+# Stage 2: Build containerd v2.3.0 + runc v1.3.5 from source with go1.26.3 and
+# golang.org/x/net v0.53.0 to clear stdlib + x/net CVEs the upstream prebuilts
+# (still go1.26.2 / x/net <0.53) carry, and pick up the grpc / otel / go-jose
+# bumps in containerd v2.3.0.
+FROM golang:1.26.3-alpine3.23 AS overlay-binaries
 ARG CONTAINERD_VERSION=2.3.0
-RUN apk add --no-cache curl tar && \
-    ARCH=$(uname -m) && \
-    case "$ARCH" in \
-      x86_64) GOARCH=amd64 ;; \
-      aarch64) GOARCH=arm64 ;; \
-      *) echo "Unsupported arch: $ARCH"; exit 1 ;; \
-    esac && \
-    mkdir -p /overlay/usr/local/bin && \
-    curl -fsSL "https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-static-${CONTAINERD_VERSION}-linux-${GOARCH}.tar.gz" \
-      | tar -xz -C /overlay/usr/local --no-same-owner \
-        bin/containerd bin/containerd-shim-runc-v2 bin/ctr
+ARG RUNC_VERSION=1.3.5
+ARG XNET_VERSION=0.53.0
+RUN apk add --no-cache git make gcc musl-dev linux-headers libseccomp-dev libseccomp-static bash ca-certificates && \
+    mkdir -p /overlay/usr/local/bin
+RUN git clone --depth 1 --branch v${CONTAINERD_VERSION} https://github.com/containerd/containerd.git /src/containerd && \
+    cd /src/containerd && \
+    go get golang.org/x/net@v${XNET_VERSION} && \
+    go mod tidy && \
+    go mod vendor && \
+    for cmd in containerd ctr containerd-shim-runc-v2; do \
+      CGO_ENABLED=0 go build -tags "osusergo netgo static_build" -trimpath -ldflags "-s -w" \
+        -o /overlay/usr/local/bin/$cmd ./cmd/$cmd ; \
+    done
+RUN git clone --depth 1 --branch v${RUNC_VERSION} https://github.com/opencontainers/runc.git /src/runc && \
+    cd /src/runc && \
+    go get golang.org/x/net@v${XNET_VERSION} && \
+    go mod tidy && \
+    go mod vendor && \
+    make static EXTRA_LDFLAGS="-s -w" && \
+    cp runc /overlay/usr/local/bin/runc
 
 # Stage 3: Build the seed image
 FROM docker:29.4.1-dind-alpine3.23
 
-# Overlay containerd v2.3.0 binaries (see stage 2).
+# Overlay rebuilt containerd + runc binaries (see stage 2).
 COPY --from=overlay-binaries /overlay/ /
 
 # Drop unused docker CLI plugins (buildx, compose) that ship vulnerable
@@ -56,9 +67,13 @@ ENV PATH="/usr/local/go/bin:${PATH}" \
 
 RUN mkdir -p "${GOPATH}/src" "${GOPATH}/bin"
 
-# Install golangci-lint
+# Install golangci-lint via `go install` so the binary embeds the just-installed
+# go1.26.3 stdlib instead of the older toolchain used by the upstream prebuilt.
 ENV GOLANGCI_LINT_VERSION=v2.12.2
-RUN wget -O- -nv https://golangci-lint.run/install.sh | sh -s -- -b /usr/local/bin ${GOLANGCI_LINT_VERSION}
+RUN GOBIN=/usr/local/bin CGO_ENABLED=0 go install -ldflags "-s -w" \
+      github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION} && \
+    go clean -modcache && \
+    rm -rf /root/.cache/go-build
 
 # Create entrypoint script to start dockerd and wait until it is ready
 RUN echo '#!/bin/sh' > /entrypoint.sh && \

--- a/docker/seed/Dockerfile.go
+++ b/docker/seed/Dockerfile.go
@@ -5,8 +5,44 @@ RUN apk add --no-cache curl && \
     curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
     crane pull wiremock/wiremock:3.9.1 /wiremock.tar
 
-# Stage 2: Build the seed image
+# Stage 2: Download a newer containerd build to address CVEs in the Go-module
+# deps baked into docker:29.4.1-dind-alpine3.23 (which ships containerd v2.2.3).
+#
+# containerd v2.3.0 bumps grpc v1.78.0 -> v1.80.0, otel v1.38.0 -> v1.43.0,
+# otel/sdk v1.38.0 -> v1.43.0, go-jose v4.1.3 -> v4.1.4 in the /usr/local/bin
+# containerd / ctr / containerd-shim-runc-v2 binaries. The dockerd binary in
+# 29.4.1 talks to containerd over the stable gRPC plugin protocol so newer
+# minor versions of containerd are wire-compatible.
+#
+# We use the `containerd-static-*` archive (statically linked) because the
+# default release tarball is dynamically linked against glibc and won't run
+# on Alpine's musl libc.
+#
+# We deliberately do NOT overlay runc here: the upstream runc v1.4.2 release
+# was built with go1.25.8, which has unfixed stdlib CVEs (CVE-2026-27143 et
+# al.), while the runc v1.3.5 already shipped in the base image was built
+# with the patched go1.26.2 toolchain. Bumping runc would trade two
+# golang.org/x/net findings for several Critical/High stdlib findings, which
+# is a regression.
+FROM alpine:3.23 AS overlay-binaries
+ARG CONTAINERD_VERSION=2.3.0
+RUN apk add --no-cache curl tar && \
+    ARCH=$(uname -m) && \
+    case "$ARCH" in \
+      x86_64) GOARCH=amd64 ;; \
+      aarch64) GOARCH=arm64 ;; \
+      *) echo "Unsupported arch: $ARCH"; exit 1 ;; \
+    esac && \
+    mkdir -p /overlay/usr/local/bin && \
+    curl -fsSL "https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-static-${CONTAINERD_VERSION}-linux-${GOARCH}.tar.gz" \
+      | tar -xz -C /overlay/usr/local --no-same-owner \
+        bin/containerd bin/containerd-shim-runc-v2 bin/ctr
+
+# Stage 3: Build the seed image
 FROM docker:29.4.1-dind-alpine3.23
+
+# Overlay newer containerd binaries (see overlay-binaries stage above).
+COPY --from=overlay-binaries /overlay/ /
 
 # Copy pre-pulled wiremock image
 COPY --from=wiremock-pull /wiremock.tar /wiremock.tar

--- a/docker/seed/Dockerfile.go
+++ b/docker/seed/Dockerfile.go
@@ -5,25 +5,8 @@ RUN apk add --no-cache curl && \
     curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
     crane pull wiremock/wiremock:3.9.1 /wiremock.tar
 
-# Stage 2: Download a newer containerd build to address CVEs in the Go-module
-# deps baked into docker:29.4.1-dind-alpine3.23 (which ships containerd v2.2.3).
-#
-# containerd v2.3.0 bumps grpc v1.78.0 -> v1.80.0, otel v1.38.0 -> v1.43.0,
-# otel/sdk v1.38.0 -> v1.43.0, go-jose v4.1.3 -> v4.1.4 in the /usr/local/bin
-# containerd / ctr / containerd-shim-runc-v2 binaries. The dockerd binary in
-# 29.4.1 talks to containerd over the stable gRPC plugin protocol so newer
-# minor versions of containerd are wire-compatible.
-#
-# We use the `containerd-static-*` archive (statically linked) because the
-# default release tarball is dynamically linked against glibc and won't run
-# on Alpine's musl libc.
-#
-# We deliberately do NOT overlay runc here: the upstream runc v1.4.2 release
-# was built with go1.25.8, which has unfixed stdlib CVEs (CVE-2026-27143 et
-# al.), while the runc v1.3.5 already shipped in the base image was built
-# with the patched go1.26.2 toolchain. Bumping runc would trade two
-# golang.org/x/net findings for several Critical/High stdlib findings, which
-# is a regression.
+# Stage 2: Pull statically-linked containerd v2.3.0 to overlay on the DinD base
+# (ships v2.2.3) and clear grpc / otel / go-jose CVEs in containerd binaries.
 FROM alpine:3.23 AS overlay-binaries
 ARG CONTAINERD_VERSION=2.3.0
 RUN apk add --no-cache curl tar && \
@@ -41,13 +24,17 @@ RUN apk add --no-cache curl tar && \
 # Stage 3: Build the seed image
 FROM docker:29.4.1-dind-alpine3.23
 
-# Overlay newer containerd binaries (see overlay-binaries stage above).
+# Overlay containerd v2.3.0 binaries (see stage 2).
 COPY --from=overlay-binaries /overlay/ /
+
+# Drop unused docker CLI plugins (buildx, compose) that ship vulnerable
+# embedded Go modules; seed only uses `docker load` and `docker run`.
+RUN rm -rf /usr/local/libexec/docker/cli-plugins /usr/local/bin/docker-compose
 
 # Copy pre-pulled wiremock image
 COPY --from=wiremock-pull /wiremock.tar /wiremock.tar
 
-# Apply the latest APK security patches available for the base image
+# Apply latest APK security patches
 RUN apk update && apk upgrade --no-cache --available
 
 # Install Go (multi-arch: supports both amd64 and arm64)

--- a/docker/seed/Dockerfile.php
+++ b/docker/seed/Dockerfile.php
@@ -5,21 +5,32 @@ RUN apk add --no-cache curl && \
     curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
     crane pull wiremock/wiremock:3.9.1 /wiremock.tar
 
-# Stage 2: Pull statically-linked containerd v2.3.0 to overlay on the DinD base
-# (ships v2.2.3) and clear grpc / otel / go-jose CVEs in containerd binaries.
-FROM alpine:3.23 AS overlay-binaries
+# Stage 2: Build containerd v2.3.0 + runc v1.3.5 from source with go1.26.3 and
+# golang.org/x/net v0.53.0 to clear stdlib + x/net CVEs the upstream prebuilts
+# (still go1.26.2 / x/net <0.53) carry, and pick up the grpc / otel / go-jose
+# bumps in containerd v2.3.0.
+FROM golang:1.26.3-alpine3.23 AS overlay-binaries
 ARG CONTAINERD_VERSION=2.3.0
-RUN apk add --no-cache curl tar && \
-    ARCH=$(uname -m) && \
-    case "$ARCH" in \
-      x86_64) GOARCH=amd64 ;; \
-      aarch64) GOARCH=arm64 ;; \
-      *) echo "Unsupported arch: $ARCH"; exit 1 ;; \
-    esac && \
-    mkdir -p /overlay/usr/local/bin && \
-    curl -fsSL "https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-static-${CONTAINERD_VERSION}-linux-${GOARCH}.tar.gz" \
-      | tar -xz -C /overlay/usr/local --no-same-owner \
-        bin/containerd bin/containerd-shim-runc-v2 bin/ctr
+ARG RUNC_VERSION=1.3.5
+ARG XNET_VERSION=0.53.0
+RUN apk add --no-cache git make gcc musl-dev linux-headers libseccomp-dev libseccomp-static bash ca-certificates && \
+    mkdir -p /overlay/usr/local/bin
+RUN git clone --depth 1 --branch v${CONTAINERD_VERSION} https://github.com/containerd/containerd.git /src/containerd && \
+    cd /src/containerd && \
+    go get golang.org/x/net@v${XNET_VERSION} && \
+    go mod tidy && \
+    go mod vendor && \
+    for cmd in containerd ctr containerd-shim-runc-v2; do \
+      CGO_ENABLED=0 go build -tags "osusergo netgo static_build" -trimpath -ldflags "-s -w" \
+        -o /overlay/usr/local/bin/$cmd ./cmd/$cmd ; \
+    done
+RUN git clone --depth 1 --branch v${RUNC_VERSION} https://github.com/opencontainers/runc.git /src/runc && \
+    cd /src/runc && \
+    go get golang.org/x/net@v${XNET_VERSION} && \
+    go mod tidy && \
+    go mod vendor && \
+    make static EXTRA_LDFLAGS="-s -w" && \
+    cp runc /overlay/usr/local/bin/runc
 
 # Stage 3: Build the seed image
 FROM docker:29.4.1-dind-alpine3.23
@@ -27,7 +38,7 @@ FROM docker:29.4.1-dind-alpine3.23
 # Apply latest APK security patches
 RUN apk update && apk upgrade --no-cache --available
 
-# Overlay containerd v2.3.0 binaries (see stage 2).
+# Overlay rebuilt containerd + runc binaries (see stage 2).
 COPY --from=overlay-binaries /overlay/ /
 
 # Drop unused docker CLI plugins (buildx, compose) that ship vulnerable

--- a/docker/seed/Dockerfile.php
+++ b/docker/seed/Dockerfile.php
@@ -5,25 +5,8 @@ RUN apk add --no-cache curl && \
     curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
     crane pull wiremock/wiremock:3.9.1 /wiremock.tar
 
-# Stage 2: Download a newer containerd build to address CVEs in the Go-module
-# deps baked into docker:29.4.1-dind-alpine3.23 (which ships containerd v2.2.3).
-#
-# containerd v2.3.0 bumps grpc v1.78.0 -> v1.80.0, otel v1.38.0 -> v1.43.0,
-# otel/sdk v1.38.0 -> v1.43.0, go-jose v4.1.3 -> v4.1.4 in the /usr/local/bin
-# containerd / ctr / containerd-shim-runc-v2 binaries. The dockerd binary in
-# 29.4.1 talks to containerd over the stable gRPC plugin protocol so newer
-# minor versions of containerd are wire-compatible.
-#
-# We use the `containerd-static-*` archive (statically linked) because the
-# default release tarball is dynamically linked against glibc and won't run
-# on Alpine's musl libc.
-#
-# We deliberately do NOT overlay runc here: the upstream runc v1.4.2 release
-# was built with go1.25.8, which has unfixed stdlib CVEs (CVE-2026-27143 et
-# al.), while the runc v1.3.5 already shipped in the base image was built
-# with the patched go1.26.2 toolchain. Bumping runc would trade two
-# golang.org/x/net findings for several Critical/High stdlib findings, which
-# is a regression.
+# Stage 2: Pull statically-linked containerd v2.3.0 to overlay on the DinD base
+# (ships v2.2.3) and clear grpc / otel / go-jose CVEs in containerd binaries.
 FROM alpine:3.23 AS overlay-binaries
 ARG CONTAINERD_VERSION=2.3.0
 RUN apk add --no-cache curl tar && \
@@ -41,18 +24,21 @@ RUN apk add --no-cache curl tar && \
 # Stage 3: Build the seed image
 FROM docker:29.4.1-dind-alpine3.23
 
-# Apply latest security patches to base image packages (libssl3, libcrypto3, libcurl, etc.)
-RUN apk upgrade --no-cache
+# Apply latest APK security patches
+RUN apk update && apk upgrade --no-cache --available
 
-# Overlay newer containerd binaries (see overlay-binaries stage above).
+# Overlay containerd v2.3.0 binaries (see stage 2).
 COPY --from=overlay-binaries /overlay/ /
+
+# Drop unused docker CLI plugins (buildx, compose) that ship vulnerable
+# embedded Go modules; seed only uses `docker load` and `docker run`.
+RUN rm -rf /usr/local/libexec/docker/cli-plugins /usr/local/bin/docker-compose
 
 # Copy pre-pulled wiremock image
 COPY --from=wiremock-pull /wiremock.tar /wiremock.tar
 
-# Install PHP, Composer, and required extensions
-# alpine 3.23's composer package depends on php84, so php84 is the runtime here.
-# This is forward-compatible with the generated SDK templates (which require php: ^8.1).
+# Install PHP, Composer, and required extensions. alpine 3.23's composer pulls
+# in php84 (forward-compatible with generated SDK templates requiring php: ^8.1).
 RUN apk add --no-cache \
     php84 \
     php84-phar \

--- a/docker/seed/Dockerfile.python
+++ b/docker/seed/Dockerfile.python
@@ -5,26 +5,37 @@ RUN apk add --no-cache curl && \
     curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
     crane pull wiremock/wiremock:3.9.1 /wiremock.tar
 
-# Stage 2: Pull statically-linked containerd v2.3.0 to overlay on the DinD base
-# (ships v2.2.3) and clear grpc / otel / go-jose CVEs in containerd binaries.
-FROM alpine:3.23 AS overlay-binaries
+# Stage 2: Build containerd v2.3.0 + runc v1.3.5 from source with go1.26.3 and
+# golang.org/x/net v0.53.0 to clear stdlib + x/net CVEs the upstream prebuilts
+# (still go1.26.2 / x/net <0.53) carry, and pick up the grpc / otel / go-jose
+# bumps in containerd v2.3.0.
+FROM golang:1.26.3-alpine3.23 AS overlay-binaries
 ARG CONTAINERD_VERSION=2.3.0
-RUN apk add --no-cache curl tar && \
-    ARCH=$(uname -m) && \
-    case "$ARCH" in \
-      x86_64) GOARCH=amd64 ;; \
-      aarch64) GOARCH=arm64 ;; \
-      *) echo "Unsupported arch: $ARCH"; exit 1 ;; \
-    esac && \
-    mkdir -p /overlay/usr/local/bin && \
-    curl -fsSL "https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-static-${CONTAINERD_VERSION}-linux-${GOARCH}.tar.gz" \
-      | tar -xz -C /overlay/usr/local --no-same-owner \
-        bin/containerd bin/containerd-shim-runc-v2 bin/ctr
+ARG RUNC_VERSION=1.3.5
+ARG XNET_VERSION=0.53.0
+RUN apk add --no-cache git make gcc musl-dev linux-headers libseccomp-dev libseccomp-static bash ca-certificates && \
+    mkdir -p /overlay/usr/local/bin
+RUN git clone --depth 1 --branch v${CONTAINERD_VERSION} https://github.com/containerd/containerd.git /src/containerd && \
+    cd /src/containerd && \
+    go get golang.org/x/net@v${XNET_VERSION} && \
+    go mod tidy && \
+    go mod vendor && \
+    for cmd in containerd ctr containerd-shim-runc-v2; do \
+      CGO_ENABLED=0 go build -tags "osusergo netgo static_build" -trimpath -ldflags "-s -w" \
+        -o /overlay/usr/local/bin/$cmd ./cmd/$cmd ; \
+    done
+RUN git clone --depth 1 --branch v${RUNC_VERSION} https://github.com/opencontainers/runc.git /src/runc && \
+    cd /src/runc && \
+    go get golang.org/x/net@v${XNET_VERSION} && \
+    go mod tidy && \
+    go mod vendor && \
+    make static EXTRA_LDFLAGS="-s -w" && \
+    cp runc /overlay/usr/local/bin/runc
 
 # Stage 3: Build the seed image
 FROM docker:29.4.1-dind-alpine3.23
 
-# Overlay containerd v2.3.0 binaries (see stage 2).
+# Overlay rebuilt containerd + runc binaries (see stage 2).
 COPY --from=overlay-binaries /overlay/ /
 
 # Drop unused docker CLI plugins (buildx, compose) that ship vulnerable

--- a/docker/seed/Dockerfile.python
+++ b/docker/seed/Dockerfile.python
@@ -5,8 +5,44 @@ RUN apk add --no-cache curl && \
     curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
     crane pull wiremock/wiremock:3.9.1 /wiremock.tar
 
-# Stage 2: Build the seed image
+# Stage 2: Download a newer containerd build to address CVEs in the Go-module
+# deps baked into docker:29.4.1-dind-alpine3.23 (which ships containerd v2.2.3).
+#
+# containerd v2.3.0 bumps grpc v1.78.0 -> v1.80.0, otel v1.38.0 -> v1.43.0,
+# otel/sdk v1.38.0 -> v1.43.0, go-jose v4.1.3 -> v4.1.4 in the /usr/local/bin
+# containerd / ctr / containerd-shim-runc-v2 binaries. The dockerd binary in
+# 29.4.1 talks to containerd over the stable gRPC plugin protocol so newer
+# minor versions of containerd are wire-compatible.
+#
+# We use the `containerd-static-*` archive (statically linked) because the
+# default release tarball is dynamically linked against glibc and won't run
+# on Alpine's musl libc.
+#
+# We deliberately do NOT overlay runc here: the upstream runc v1.4.2 release
+# was built with go1.25.8, which has unfixed stdlib CVEs (CVE-2026-27143 et
+# al.), while the runc v1.3.5 already shipped in the base image was built
+# with the patched go1.26.2 toolchain. Bumping runc would trade two
+# golang.org/x/net findings for several Critical/High stdlib findings, which
+# is a regression.
+FROM alpine:3.23 AS overlay-binaries
+ARG CONTAINERD_VERSION=2.3.0
+RUN apk add --no-cache curl tar && \
+    ARCH=$(uname -m) && \
+    case "$ARCH" in \
+      x86_64) GOARCH=amd64 ;; \
+      aarch64) GOARCH=arm64 ;; \
+      *) echo "Unsupported arch: $ARCH"; exit 1 ;; \
+    esac && \
+    mkdir -p /overlay/usr/local/bin && \
+    curl -fsSL "https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-static-${CONTAINERD_VERSION}-linux-${GOARCH}.tar.gz" \
+      | tar -xz -C /overlay/usr/local --no-same-owner \
+        bin/containerd bin/containerd-shim-runc-v2 bin/ctr
+
+# Stage 3: Build the seed image
 FROM docker:29.4.1-dind-alpine3.23
+
+# Overlay newer containerd binaries (see overlay-binaries stage above).
+COPY --from=overlay-binaries /overlay/ /
 
 # Copy pre-pulled wiremock image
 COPY --from=wiremock-pull /wiremock.tar /wiremock.tar

--- a/docker/seed/Dockerfile.python
+++ b/docker/seed/Dockerfile.python
@@ -5,25 +5,8 @@ RUN apk add --no-cache curl && \
     curl -sL "https://github.com/google/go-containerregistry/releases/download/v0.21.2/go-containerregistry_Linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin crane && \
     crane pull wiremock/wiremock:3.9.1 /wiremock.tar
 
-# Stage 2: Download a newer containerd build to address CVEs in the Go-module
-# deps baked into docker:29.4.1-dind-alpine3.23 (which ships containerd v2.2.3).
-#
-# containerd v2.3.0 bumps grpc v1.78.0 -> v1.80.0, otel v1.38.0 -> v1.43.0,
-# otel/sdk v1.38.0 -> v1.43.0, go-jose v4.1.3 -> v4.1.4 in the /usr/local/bin
-# containerd / ctr / containerd-shim-runc-v2 binaries. The dockerd binary in
-# 29.4.1 talks to containerd over the stable gRPC plugin protocol so newer
-# minor versions of containerd are wire-compatible.
-#
-# We use the `containerd-static-*` archive (statically linked) because the
-# default release tarball is dynamically linked against glibc and won't run
-# on Alpine's musl libc.
-#
-# We deliberately do NOT overlay runc here: the upstream runc v1.4.2 release
-# was built with go1.25.8, which has unfixed stdlib CVEs (CVE-2026-27143 et
-# al.), while the runc v1.3.5 already shipped in the base image was built
-# with the patched go1.26.2 toolchain. Bumping runc would trade two
-# golang.org/x/net findings for several Critical/High stdlib findings, which
-# is a regression.
+# Stage 2: Pull statically-linked containerd v2.3.0 to overlay on the DinD base
+# (ships v2.2.3) and clear grpc / otel / go-jose CVEs in containerd binaries.
 FROM alpine:3.23 AS overlay-binaries
 ARG CONTAINERD_VERSION=2.3.0
 RUN apk add --no-cache curl tar && \
@@ -41,14 +24,18 @@ RUN apk add --no-cache curl tar && \
 # Stage 3: Build the seed image
 FROM docker:29.4.1-dind-alpine3.23
 
-# Overlay newer containerd binaries (see overlay-binaries stage above).
+# Overlay containerd v2.3.0 binaries (see stage 2).
 COPY --from=overlay-binaries /overlay/ /
+
+# Drop unused docker CLI plugins (buildx, compose) that ship vulnerable
+# embedded Go modules; seed only uses `docker load` and `docker run`.
+RUN rm -rf /usr/local/libexec/docker/cli-plugins /usr/local/bin/docker-compose
 
 # Copy pre-pulled wiremock image
 COPY --from=wiremock-pull /wiremock.tar /wiremock.tar
 
-# Apply the latest APK security patches available for the base image
-RUN apk update && apk upgrade --no-cache
+# Apply latest APK security patches
+RUN apk update && apk upgrade --no-cache --available
 
 # Install Python and Poetry
 RUN apk add --no-cache python3 py3-pip \


### PR DESCRIPTION
## Description

Linear ticket: N/A

Addresses the non-openssl AWS ECR findings flagged in the `dev/python-seed`, `dev/go-seed`, and `dev/php-seed` images:

1. Critical `google.golang.org/grpc:v1.78.0` / [CVE-2026-33186](https://nvd.nist.gov/vuln/detail/cve-2026-33186) (gRPC-Go authorization bypass via malformed `:path` headers; fixed in grpc-go v1.79.3) — visible in python-seed and go-seed.
2. ~55 additional High/Medium grype findings per image embedded in the unused `docker-buildx` and `docker-compose` CLI plugins shipped by the `docker:29.4.1-dind-alpine3.23` base image (in-toto, sigstore, spdystream, otel, moby, plus go-stdlib 1.25.8).
3. The remaining `go-stdlib@go1.26.2` / `golang.org/x/net@v0.35.0-v0.52.0` findings embedded in `/usr/local/bin/containerd`, `/usr/local/bin/ctr`, `/usr/local/bin/containerd-shim-runc-v2`, `/usr/local/bin/runc`, and (go-seed only) `/usr/local/bin/golangci-lint`. The upstream prebuilts ship with go1.26.2 even though Go 1.26.3 was released with stdlib CVE fixes, so we rebuild from source.

### Fix

**1. Drop unused docker CLI plugins.** Seed containers only invoke `docker load` (pre-pulled wiremock tar) and `docker run` (driven by SDK tests). They never use `docker buildx` or `docker compose`, so the plugins are dead weight. Removing them clears all in-toto / sigstore / spdystream / otel / docker / go1.25.8-stdlib findings against `/usr/local/libexec/docker/cli-plugins/`.

**2. Rebuild containerd v2.3.0, runc v1.3.5, and golangci-lint v2.12.2 from source with go1.26.3 + golang.org/x/net v0.53.0.** Build stage uses `golang:1.26.3-alpine3.23`, clones each project, bumps `golang.org/x/net` to v0.53.0 (re-vendors), and emits static binaries that get overlaid onto the DinD base. golangci-lint switches from the install.sh script to `go install` so it uses the same toolchain.

**3. Tighten Dockerfile comments** to 1–2 lines per section and standardize on `apk upgrade --no-cache --available` across the three Alpine-based seed Dockerfiles.

`gnutls28:3.8.9` / [CVE-2026-33845](https://security-tracker.debian.org/tracker/CVE-2026-33845) in `dev/python-sdk-generator` is intentionally left unaddressed: GnuTLS 3.8.13 is currently only in Debian `sid`, with no backport to `bookworm-security`, `trixie-security`, or `forky`. Per maintainer direction we keep the alert visible.

### Remaining findings (out of scope)

After this PR, grype on the rebuilt images reports:
- **python-seed**: 58 total / 36 unique — Critical 1, High 21, Medium 31
- **go-seed**: 38 total / 16 unique — High 19, Medium 19
- **php-seed**: 38 total / 16 unique — High 19, Medium 19

The remaining findings are all concentrated in `dockerd`, `docker`, and `docker-proxy` (still built upstream with go1.26.2) plus python3/py3-pip apk-DB entries in python-seed. These will auto-resolve when moby/docker ships a build against go1.26.3+.

## Changes Made
- `docker/seed/Dockerfile.python`, `Dockerfile.go`, `Dockerfile.php`: replace the static-tarball `overlay-binaries` stage with a `golang:1.26.3-alpine3.23` stage that builds `containerd v2.3.0` (containerd + ctr + containerd-shim-runc-v2) and `runc v1.3.5` from source against `golang.org/x/net@v0.53.0`. Overlay the rebuilt binaries onto the DinD base.
- `docker/seed/Dockerfile.python`, `Dockerfile.go`, `Dockerfile.php`: remove `/usr/local/libexec/docker/cli-plugins` and `/usr/local/bin/docker-compose`; switch apk upgrade to `--available`; compress comment blocks.
- `docker/seed/Dockerfile.go`: switch `golangci-lint v2.12.2` from `install.sh` to `go install` so it embeds the just-installed go1.26.3 stdlib; `go clean -modcache` after install to keep the image small.
- [ ] Updated README.md generator (if applicable) — N/A (infra-only)

## Testing
- [ ] Unit tests added/updated — N/A (infra-only)
- [x] Manual testing completed:
  - Built all three images locally with the updated Dockerfiles.
  - Functional smoke test on go-seed: `dockerd` starts, `docker info` succeeds, `wiremock.tar` loads via the entrypoint, all overlaid binaries report the expected versions:
    - `runc --version` → `runc version 1.3.5 … go: go1.26.3, libseccomp: 2.6.0`
    - `containerd --version` → `containerd github.com/containerd/containerd/v2 2.3.0+unknown`
    - `golangci-lint version` → `golangci-lint has version 2.12.2 built with go1.26.3`
  - `grype docker:<image> -o json` reductions on python-seed: `159 → 58` total findings (Critical `3 → 1`, High `73 → 21`, Medium `78 → 31`); zero CVE-2026-33186 matches, zero `google.golang.org/grpc` artifact entries, zero `containerd / ctr / containerd-shim-runc-v2 / runc / golangci-lint` findings in any of the three rebuilt images.

Link to Devin session: https://app.devin.ai/sessions/8fc78adb558c4ca79a74afbff0b58151
Requested by: @davidkonigsberg