### PR TITLE
chore(openapi): bump container node base to 24.15.0

### DIFF
--- a/generators/openapi/Dockerfile
+++ b/generators/openapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22-alpine3.23
+FROM node:24.15.0-alpine3.23
 RUN apk update && apk upgrade --no-cache \
     && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 COPY dist /dist


### PR DESCRIPTION
## Description

Bumps the openapi generator container base image from `node:22.22-alpine3.23` to `node:24.15.0-alpine3.23` as part of unifying every Fern generator container on the same Node major version. Companion PRs migrate the other generators independently.

## Changes Made

- `generators/openapi/Dockerfile`: `FROM node:22.22-alpine3.23` → `FROM node:24.15.0-alpine3.23`

The rest of the Dockerfile is unchanged. npm/npx are still removed in the same `apk upgrade` layer, so bundled-npm transitive CVEs are not a concern for this image — only the node binary itself ships in the final image.

No changelog file is added: `release-config.json` has no entry for `openapi`, and there is no `generators/openapi/changes/unreleased/` folder on disk. Versioning for this generator is driven by direct edits to `generators/openapi/versions.yml` when releasing, which is out of scope here.

## Pre-flight check

`node:24.15.0-alpine3.23` exists on Docker Hub (`docker manifest inspect` succeeds). Bundled in the image: node v24.15.0, npm 11.12.1, yarn 1.22.22, corepack 0.34.6 — npm/npx are stripped by the existing `rm -rf` line, so the bundled versions don't reach the runtime image.

## Testing

- [x] Local `docker build` of `generators/openapi/Dockerfile` succeeds end-to-end with a stub `dist/cli.cjs` (the apk update/upgrade layer and the npm/npx removal step both run clean on the new base image).
- [x] `pnpm run check` passes at the repo root.
- [ ] CI on the PR.

Link to Devin session: https://app.devin.ai/sessions/fc68707890814797a8b50c18a4efd843
Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->