### PR TITLE
chore(swift): bump container node base to 24.15.0

### DIFF
--- a/generators/swift/sdk/Dockerfile
+++ b/generators/swift/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22-alpine3.23
+FROM node:24.15.0-alpine3.23
 
 RUN apk update && apk upgrade --no-cache
 RUN apk --no-cache add bash curl git zip

--- a/generators/swift/sdk/changes/unreleased/bump-node-24.yml
+++ b/generators/swift/sdk/changes/unreleased/bump-node-24.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump the Swift SDK generator container's Node base image from `node:22.22-alpine3.23`
+    to `node:24.15.0-alpine3.23`. Aligns the generator with the other Fern generator
+    containers on a single Node major version and picks up Node 24's CVE patches.
+  type: chore


### PR DESCRIPTION
## Description

Bumps the Swift SDK generator container's Node base image from `node:22.22-alpine3.23` to `node:24.15.0-alpine3.23`. Part of a wider effort to unify every Fern generator container on a single Node major version (Node 24). Sibling PRs migrate the other generators independently.

## Changes Made

- `generators/swift/sdk/Dockerfile`: `FROM node:22.22-alpine3.23` → `FROM node:24.15.0-alpine3.23`. Nothing else changes — the existing `apk update && apk upgrade --no-cache` security layer, the `bash curl git zip` install, and the git author config all stay as-is.
- `generators/swift/sdk/changes/unreleased/bump-node-24.yml`: `chore` changelog entry per the repo's `release-config.json` convention.

## Pre-flight check

- `docker manifest inspect node:24.15.0-alpine3.23` succeeds — the tag is published.
- The new base ships node v24.15.0 and npm 11.12.1. The Swift SDK image only invokes the bundled `cli.cjs` via `node --enable-source-maps`; it does not run `npm`/`pnpm`/`yarn` at runtime, so bundled-npm transitive CVEs don't reach this image.

## Testing

- [x] Local `docker build` of `generators/swift/sdk/Dockerfile` from the repo root succeeds end-to-end on the new base (with a stub `dist/cli.cjs` to validate the FROM line, `apk` layers, the `apk add` install, and the COPY steps — the dist isn't built locally and is produced by CI/release tooling).
- [x] `pnpm run check` passes at the repo root.
- [ ] CI on the PR.

## What to look at

- The container is mechanically `FROM` only — no apk packages added/removed, no patch steps. Risk is concentrated in whether the existing `dist/cli.cjs` bundle is compatible with Node 24 (no usage of deprecated APIs that were removed between Node 22 and Node 24). If you want belt-and-suspenders, run the published image of this PR against a representative `swift-sdk` generation locally.

Link to Devin session: https://app.devin.ai/sessions/fc68707890814797a8b50c18a4efd843
Requested by: @davidkonigsberg