### PR TITLE
chore(swift): bump model container node base to 24.15.0

### DIFF
--- a/generators/swift/model/Dockerfile
+++ b/generators/swift/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22-alpine3.23
+FROM node:24.15.0-alpine3.23
 
 RUN apk update && apk upgrade --no-cache
 

--- a/generators/swift/sdk/changes/unreleased/bump-node-24-model.yml
+++ b/generators/swift/sdk/changes/unreleased/bump-node-24-model.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump the Swift model generator container's Node base image from
+    `node:22.22-alpine3.23` to `node:24.15.0-alpine3.23`. Aligns the generator
+    with the other Fern generator containers on a single Node major version
+    and picks up Node 24's CVE patches.
+  type: chore


### PR DESCRIPTION
## Description

Bumps the Swift **model** generator container's Node base image from `node:22.22-alpine3.23` to `node:24.15.0-alpine3.23`. Part of a wider effort to unify every Fern generator container on a single Node major version (Node 24). Companion PRs migrate the other generators independently.

## Changes Made

- `generators/swift/model/Dockerfile`: `FROM node:22.22-alpine3.23` → `FROM node:24.15.0-alpine3.23`. Nothing else in the Dockerfile changes — the existing `apk update && apk upgrade --no-cache` security layer and the `COPY ... /dist` step are unchanged.
- `generators/swift/sdk/changes/unreleased/bump-node-24-model.yml`: `chore` changelog entry under the Swift generator's shared changelog folder (per `release-config.json`, `swift` → `generators/swift/sdk/changes`). The filename is suffixed `-model` to avoid colliding with the sibling Swift SDK node-bump PR's `bump-node-24.yml`.

## Pre-flight check

- `docker manifest inspect node:24.15.0-alpine3.23` succeeds — the tag is published on Docker Hub.
- The new base ships node v24.15.0 and npm 11.12.1. This image only invokes the bundled `cli.cjs` via `node --enable-source-maps`; it does not run `npm`/`pnpm`/`yarn` at runtime, so bundled-npm transitive CVEs don't reach this image.

## Testing

- [x] Local `docker build` of `generators/swift/model/Dockerfile` succeeds end-to-end on the new base (using a stub `dist/cli.cjs` to exercise the FROM line, the `apk` upgrade layer, and the `COPY dist /dist` step — the real dist is produced by CI/release tooling).
- [x] `pnpm run check` passes at the repo root.
- [ ] CI on the PR.

## What to look at

- The container is mechanically `FROM` only — no apk packages added/removed, no patch steps. The riskiest part is whether the existing `dist/cli.cjs` bundle is fully compatible with Node 24 (no usage of deprecated Node 22 APIs that were removed in 24). For belt-and-suspenders, run the published image of this PR against a representative `swift-model` generation locally.
- Confirm the `bump-node-24-model.yml` filename convention is OK given the sibling Swift SDK PR will land `bump-node-24.yml` in the same folder.

Link to Devin session: https://app.devin.ai/sessions/fc68707890814797a8b50c18a4efd843
Requested by: @davidkonigsberg