### PR TITLE
chore(deps): bump all generator containers to node 24.15.0

### DIFF
--- a/generators/csharp/model/Dockerfile
+++ b/generators/csharp/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15.0-alpine3.23 AS node
+FROM node:24.15-alpine3.23 AS node
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine
 
 ENV YARN_CACHE_FOLDER=/.yarn

--- a/generators/csharp/model/Dockerfile
+++ b/generators/csharp/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22-alpine3.23 AS node
+FROM node:24.15.0-alpine3.23 AS node
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine
 
 ENV YARN_CACHE_FOLDER=/.yarn

--- a/generators/csharp/sdk/Dockerfile
+++ b/generators/csharp/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Node.js
-FROM node:24.15.0-alpine3.23 AS node
+FROM node:24.15-alpine3.23 AS node
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine
 

--- a/generators/csharp/sdk/Dockerfile
+++ b/generators/csharp/sdk/Dockerfile
@@ -1,8 +1,4 @@
 # Stage 1: Node.js
-# Pinned to 24.15.0-alpine3.23 alongside the other Fern generator containers.
-# node:24.15.0 already bundles patched glob (13.0.6), minimatch (10.2.4),
-# tar (7.5.11), brace-expansion (5.0.4), and diff (8.0.3); the only npm-
-# bundled deps that still need patching below are ip-address and picomatch.
 FROM node:24.15.0-alpine3.23 AS node
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine

--- a/generators/csharp/sdk/Dockerfile
+++ b/generators/csharp/sdk/Dockerfile
@@ -1,12 +1,9 @@
 # Stage 1: Node.js
-# Pinned to 22.22-alpine3.23 to fix Node.js binary CVEs picked up by the
-# 2026-05-06 grype scan (CVE-2025-23166, CVE-2025-23083, CVE-2025-59465,
-# CVE-2026-21637, CVE-2025-55131, CVE-2026-21710, CVE-2025-59466,
-# CVE-2025-23085, CVE-2026-21717, CVE-2026-21713, CVE-2026-21714,
-# CVE-2025-55132, CVE-2025-23165, CVE-2026-21715, CVE-2026-21716,
-# CVE-2025-55130) and to upgrade npm-bundled deps cross-spawn (>=7.0.5),
-# minimatch (>=9.0.7), glob (>=10.5.0), tar (>=7.5.11), and diff (>=5.2.2).
-FROM node:22.22-alpine3.23 AS node
+# Pinned to 24.15.0-alpine3.23 alongside the other Fern generator containers.
+# node:24.15.0 already bundles patched glob (13.0.6), minimatch (10.2.4),
+# tar (7.5.11), brace-expansion (5.0.4), and diff (8.0.3); the only npm-
+# bundled deps that still need patching below are ip-address and picomatch.
+FROM node:24.15.0-alpine3.23 AS node
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine
 
@@ -73,21 +70,6 @@ RUN for dir in \
         tar -xzf picomatch-4.0.4.tgz && \
         mv package picomatch && \
         rm picomatch-4.0.4.tgz; \
-      fi; \
-    done
-
-# Patch brace-expansion to 2.0.3 to fix GHSA-f886-m6hf-6m8v
-# (zero-step sequence causes process hang and memory exhaustion).
-# Location: npm bundles its own copy of brace-expansion.
-RUN for dir in \
-      /usr/local/lib/node_modules/npm/node_modules/brace-expansion; do \
-      if [ -d "$dir" ]; then \
-        rm -rf "$dir" && \
-        cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz -o brace-expansion-2.0.3.tgz && \
-        tar -xzf brace-expansion-2.0.3.tgz && \
-        mv package brace-expansion && \
-        rm brace-expansion-2.0.3.tgz; \
       fi; \
     done
 

--- a/generators/csharp/sdk/changes/unreleased/bump-node-24.yml
+++ b/generators/csharp/sdk/changes/unreleased/bump-node-24.yml
@@ -2,12 +2,12 @@
 
 - summary: |
     Bump the C# SDK and C# model generator containers' Node base image from
-    `node:22.22-alpine3.23` to `node:24.15.0-alpine3.23`. Aligns the generators
+    `node:22.22-alpine3.23` to `node:24.15-alpine3.23`. Aligns the generators
     with the rest of the Fern generator containers on a single Node major
     version (Node 24) and picks up Node 24's CVE patches. The bundled npm
-    11.12.1 in `node:24.15.0` already ships patched `brace-expansion@5.0.4`, so
+    11.12.1 in `node:24.15` already ships patched `brace-expansion@5.0.4`, so
     the C# SDK's `brace-expansion 2.0.3` replacement step is removed. The
     `ip-address` and `picomatch` patches are retained because the bundled
-    versions in `node:24.15.0` (10.1.0 and 4.0.3 respectively) are still
+    versions in `node:24.15` (10.1.0 and 4.0.3 respectively) are still
     vulnerable.
   type: chore

--- a/generators/csharp/sdk/changes/unreleased/bump-node-24.yml
+++ b/generators/csharp/sdk/changes/unreleased/bump-node-24.yml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump the C# SDK and C# model generator containers' Node base image from
+    `node:22.22-alpine3.23` to `node:24.15.0-alpine3.23`. Aligns the generators
+    with the rest of the Fern generator containers on a single Node major
+    version (Node 24) and picks up Node 24's CVE patches. The bundled npm
+    11.12.1 in `node:24.15.0` already ships patched `brace-expansion@5.0.4`, so
+    the C# SDK's `brace-expansion 2.0.3` replacement step is removed. The
+    `ip-address` and `picomatch` patches are retained because the bundled
+    versions in `node:24.15.0` (10.1.0 and 4.0.3 respectively) are still
+    vulnerable.
+  type: chore

--- a/generators/go/model/Dockerfile
+++ b/generators/go/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22-alpine3.23 AS node
+FROM node:24.15.0-alpine3.23 AS node
 
 FROM golang:1.26.2-alpine3.23
 

--- a/generators/go/model/Dockerfile
+++ b/generators/go/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15.0-alpine3.23 AS node
+FROM node:24.15-alpine3.23 AS node
 
 FROM golang:1.26.2-alpine3.23
 

--- a/generators/go/sdk/Dockerfile
+++ b/generators/go/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build Node CLI
-FROM node:22.22-alpine3.23 AS node
+FROM node:24.15.0-alpine3.23 AS node
 
 RUN apk --no-cache add git zip
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \

--- a/generators/go/sdk/Dockerfile
+++ b/generators/go/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build Node CLI
-FROM node:24.15.0-alpine3.23 AS node
+FROM node:24.15-alpine3.23 AS node
 
 RUN apk --no-cache add git zip
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \

--- a/generators/go/sdk/changes/unreleased/bump-node-24.yml
+++ b/generators/go/sdk/changes/unreleased/bump-node-24.yml
@@ -2,7 +2,7 @@
 
 - summary: |
     Bump the Go SDK and Go model generator containers' Node base image from
-    `node:22.22-alpine3.23` to `node:24.15.0-alpine3.23`. Aligns the generators
+    `node:22.22-alpine3.23` to `node:24.15-alpine3.23`. Aligns the generators
     with the rest of the Fern generator containers on a single Node major
     version (Node 24) and picks up Node 24's CVE patches. The existing
     `npm pack <pkg>@latest` loop that swaps in patched `ip-address`,

--- a/generators/go/sdk/changes/unreleased/bump-node-24.yml
+++ b/generators/go/sdk/changes/unreleased/bump-node-24.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump the Go SDK and Go model generator containers' Node base image from
+    `node:22.22-alpine3.23` to `node:24.15.0-alpine3.23`. Aligns the generators
+    with the rest of the Fern generator containers on a single Node major
+    version (Node 24) and picks up Node 24's CVE patches. The existing
+    `npm pack <pkg>@latest` loop that swaps in patched `ip-address`,
+    `brace-expansion`, and `picomatch` is retained because `npm pack @latest`
+    continues to resolve the same fixed releases on Node 24.
+  type: chore

--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -1,16 +1,5 @@
 # Stage 1: Java V2
-# Updated: WebSocket feature support added
-# Pinned to node:24.15.0-trixie alongside the other Fern generator containers.
-# Trixie ships patched versions of glibc, dpkg, nghttp2, libcap2, systemd,
-# libgcrypt20, krb5, curl, and expat that are not available on bookworm,
-# so the base-image choice clears AWS Inspector findings that dist-upgrade
-# alone could not. The non-slim variant is intentional — the patch RUN
-# steps below shell out to `curl` and `tar`, which are not preinstalled on
-# the *-slim image.
-# node:24.15.0 already bundles patched glob (13.0.6), minimatch (10.2.4), tar
-# (7.5.11), and brace-expansion (5.0.4), so those patch steps below are dropped.
-# ip-address (10.1.0) and picomatch (4.0.3) bundled with this npm release are
-# still vulnerable and continue to be patched below.
+# Non-slim trixie because the patch RUN steps below shell out to curl and tar.
 FROM node:24.15.0-trixie AS node
 COPY generators/java-v2/sdk/dist/cli.cjs /dist/cli.cjs
 COPY generators/java-v2/sdk/features.yml /assets/features.yml

--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Java V2
 # Non-slim trixie because the patch RUN steps below shell out to curl and tar.
-FROM node:24.15.0-trixie AS node
+FROM node:24.15-trixie AS node
 COPY generators/java-v2/sdk/dist/cli.cjs /dist/cli.cjs
 COPY generators/java-v2/sdk/features.yml /assets/features.yml
 

--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -1,8 +1,11 @@
 # Stage 1: Java V2
 # Updated: WebSocket feature support added
-# Updated Node.js to 24.14.1 to fix CVE-2026-21710, CVE-2026-21717, CVE-2026-21713,
-# CVE-2026-21714, CVE-2026-21712, CVE-2026-21715, CVE-2026-21716
-FROM node:24.14.1-bookworm AS node
+# Pinned to node:24.15.0-bookworm alongside the other Fern generator containers.
+# node:24.15.0 already bundles patched glob (13.0.6), minimatch (10.2.4), tar
+# (7.5.11), and brace-expansion (5.0.4), so those patch steps below are dropped.
+# ip-address (10.1.0) and picomatch (4.0.3) bundled with this npm release are
+# still vulnerable and continue to be patched below.
+FROM node:24.15.0-bookworm AS node
 COPY generators/java-v2/sdk/dist/cli.cjs /dist/cli.cjs
 COPY generators/java-v2/sdk/features.yml /assets/features.yml
 
@@ -116,43 +119,6 @@ COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
-# Update npm and glob to fix CVE-2025-64756 (glob vulnerability requires 11.1.0+)
-RUN npm install -g npm@11.12.0 && npm install -g glob@11.1.0
-
-# Patch npm's bundled glob to 11.1.0 (npm bundles its own copy at node_modules/npm/node_modules/glob)
-RUN cd /usr/local/lib/node_modules/npm/node_modules && \
-    rm -rf glob && \
-    npm pack glob@11.1.0 && \
-    tar -xzf glob-11.1.0.tgz && \
-    mv package glob && \
-    rm glob-11.1.0.tgz
-
-# Patch npm's bundled tar to 7.5.11 to fix GHSA-34x7-hfp2-rc4v, GHSA-r6q2-hw4h-h46w, GHSA-83g3-92jg-28cx,
-# GHSA-qffp-2rhf-9h96 (Hardlink Path Traversal via Drive-Relative Linkpath)
-# Note: We use curl instead of npm pack because npm pack depends on tar itself
-RUN cd /usr/local/lib/node_modules/npm/node_modules && \
-    rm -rf tar && \
-    curl -sL https://registry.npmjs.org/tar/-/tar-7.5.11.tgz -o tar-7.5.11.tgz && \
-    tar -xzf tar-7.5.11.tgz && \
-    mv package tar && \
-    rm tar-7.5.11.tgz
-
-# Patch minimatch to 10.2.3 to fix GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74
-# (ReDoS via combinatorial backtracking in matchOne() and nested *() extglobs)
-RUN for dir in \
-      /usr/local/lib/node_modules/glob/node_modules/minimatch \
-      /usr/local/lib/node_modules/npm/node_modules/minimatch \
-      /usr/local/lib/node_modules/npm/node_modules/glob/node_modules/minimatch; do \
-      if [ -d "$dir" ]; then \
-        rm -rf "$dir" && \
-        cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz -o minimatch-10.2.3.tgz && \
-        tar -xzf minimatch-10.2.3.tgz && \
-        mv package minimatch && \
-        rm minimatch-10.2.3.tgz; \
-      fi; \
-    done
-
 # Patch picomatch to 4.0.4 to fix GHSA-c2c7-rcm5-vvqj (ReDoS via extglob quantifiers),
 # GHSA-3v7f-55p6-f55p (Method Injection in POSIX Character Classes)
 # Location: npm's bundled tinyglobby depends on picomatch
@@ -165,21 +131,6 @@ RUN for dir in \
         tar -xzf picomatch-4.0.4.tgz && \
         mv package picomatch && \
         rm picomatch-4.0.4.tgz; \
-      fi; \
-    done
-
-# Patch brace-expansion to 5.0.5 to fix GHSA-f886-m6hf-6m8v
-# (Zero-step sequence causes process hang and memory exhaustion)
-# Location: npm bundles its own copy of brace-expansion
-RUN for dir in \
-      /usr/local/lib/node_modules/npm/node_modules/brace-expansion; do \
-      if [ -d "$dir" ]; then \
-        rm -rf "$dir" && \
-        cd "$(dirname "$dir")" && \
-        curl -sL https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz -o brace-expansion-5.0.5.tgz && \
-        tar -xzf brace-expansion-5.0.5.tgz && \
-        mv package brace-expansion && \
-        rm brace-expansion-5.0.5.tgz; \
       fi; \
     done
 

--- a/generators/java/sdk/changes/unreleased/bump-node-24.yml
+++ b/generators/java/sdk/changes/unreleased/bump-node-24.yml
@@ -2,14 +2,14 @@
 
 - summary: |
     Bump the Java SDK generator container's Node base image from
-    `node:24.14.1-bookworm` to `node:24.15.0-trixie`. Aligns the generator
+    `node:24.14.1-bookworm` to `node:24.15-trixie`. Aligns the generator
     with the rest of the Fern generator containers on a single Node patch
-    version (24.15.0) and a single Debian release (trixie). Trixie ships
+    minor (floating `24.15`) and a single Debian release (trixie). Trixie ships
     patched versions of glibc, dpkg, nghttp2, libcap2, systemd, libgcrypt20,
     krb5, curl, and expat that are not available on bookworm, clearing the
     AWS Inspector findings that dist-upgrade alone could not. The non-slim
     variant is intentional because the Node-stage patch steps shell out to
-    `curl` and `tar`. The bundled npm 11.12.1 in `node:24.15.0` already ships
+    `curl` and `tar`. The bundled npm 11.12.1 in `node:24.15` already ships
     patched `glob@13.0.6`, `minimatch@10.2.4`, `tar@7.5.11`, and
     `brace-expansion@5.0.4`, so those tarball-replacement patch steps are
     removed. The `ip-address` and `picomatch` patches are retained because the

--- a/generators/java/sdk/changes/unreleased/bump-node-24.yml
+++ b/generators/java/sdk/changes/unreleased/bump-node-24.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump the Java SDK generator container's Node base image from
+    `node:24.14.1-bookworm` to `node:24.15.0-bookworm`. Aligns the generator
+    with the rest of the Fern generator containers on a single Node patch
+    version (24.15.0). The bundled npm 11.12.1 in `node:24.15.0` already ships
+    patched `glob@13.0.6`, `minimatch@10.2.4`, `tar@7.5.11`, and
+    `brace-expansion@5.0.4`, so those tarball-replacement patch steps are
+    removed. The `ip-address` and `picomatch` patches are retained because the
+    bundled versions (10.1.0 and 4.0.3 respectively) are still vulnerable.
+  type: chore

--- a/generators/openapi/Dockerfile
+++ b/generators/openapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22-alpine3.23
+FROM node:24.15.0-alpine3.23
 RUN apk update && apk upgrade --no-cache \
     && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 COPY dist /dist

--- a/generators/openapi/Dockerfile
+++ b/generators/openapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15.0-alpine3.23
+FROM node:24.15-alpine3.23
 RUN apk update && apk upgrade --no-cache \
     && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 COPY dist /dist

--- a/generators/openapi/versions.yml
+++ b/generators/openapi/versions.yml
@@ -3,7 +3,7 @@
   changelogEntry:
     - summary: |
         Bump the OpenAPI generator container's Node base image from `node:22.22-alpine3.23`
-        to `node:24.15.0-alpine3.23`. Aligns the generator with the rest of the Fern
+        to `node:24.15-alpine3.23`. Aligns the generator with the rest of the Fern
         generator containers on a single Node major version (Node 24) and picks up Node
         24's CVE patches.
       type: chore

--- a/generators/openapi/versions.yml
+++ b/generators/openapi/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../fern-versions-yml.schema.json
+- version: 0.5.2
+  changelogEntry:
+    - summary: |
+        Bump the OpenAPI generator container's Node base image from `node:22.22-alpine3.23`
+        to `node:24.15.0-alpine3.23`. Aligns the generator with the rest of the Fern
+        generator containers on a single Node major version (Node 24) and picks up Node
+        24's CVE patches.
+      type: chore
+  createdAt: "2026-05-11"
+  irVersion: 66
+
 - version: 0.5.1
   changelogEntry:
     - summary: |

--- a/generators/php/model/Dockerfile
+++ b/generators/php/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15.0-alpine3.23 AS node
+FROM node:24.15-alpine3.23 AS node
 FROM composer:2.9.7
 
 ENV YARN_CACHE_FOLDER=/.yarn

--- a/generators/php/model/Dockerfile
+++ b/generators/php/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22-alpine3.23 AS node
+FROM node:24.15.0-alpine3.23 AS node
 FROM composer:2.9.7
 
 ENV YARN_CACHE_FOLDER=/.yarn

--- a/generators/php/sdk/Dockerfile
+++ b/generators/php/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15.0-alpine3.23 AS node
+FROM node:24.15-alpine3.23 AS node
 FROM composer:2.9.7
 
 ENV YARN_CACHE_FOLDER=/.yarn

--- a/generators/php/sdk/Dockerfile
+++ b/generators/php/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22-alpine3.23 AS node
+FROM node:24.15.0-alpine3.23 AS node
 FROM composer:2.9.7
 
 ENV YARN_CACHE_FOLDER=/.yarn

--- a/generators/php/sdk/changes/unreleased/bump-node-24.yml
+++ b/generators/php/sdk/changes/unreleased/bump-node-24.yml
@@ -2,7 +2,7 @@
 
 - summary: |
     Bump the PHP SDK and PHP model generator containers' Node base image from
-    `node:22.22-alpine3.23` to `node:24.15.0-alpine3.23`. Aligns the generators
+    `node:22.22-alpine3.23` to `node:24.15-alpine3.23`. Aligns the generators
     with the rest of the Fern generator containers on a single Node major
     version (Node 24) and picks up Node 24's CVE patches.
   type: chore

--- a/generators/php/sdk/changes/unreleased/bump-node-24.yml
+++ b/generators/php/sdk/changes/unreleased/bump-node-24.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump the PHP SDK and PHP model generator containers' Node base image from
+    `node:22.22-alpine3.23` to `node:24.15.0-alpine3.23`. Aligns the generators
+    with the rest of the Fern generator containers on a single Node major
+    version (Node 24) and picks up Node 24's CVE patches.
+  type: chore

--- a/generators/python-v2/pydantic-model/Dockerfile
+++ b/generators/python-v2/pydantic-model/Dockerfile
@@ -1,6 +1,6 @@
 # Bundled npm globals are removed below so npm's JS dependencies cannot be
 # flagged or invoked at runtime — this image only runs the bundled CLI via node.
-FROM node:24.15.0-trixie-slim
+FROM node:24.15-trixie-slim
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl \

--- a/generators/python-v2/pydantic-model/Dockerfile
+++ b/generators/python-v2/pydantic-model/Dockerfile
@@ -1,12 +1,5 @@
-# Updated Node.js base from 22.12-slim to 22.22-bookworm-slim to address container CVEs:
-# - Node binary CVEs (CVE-2025-23083, CVE-2025-23166, CVE-2025-23085, CVE-2025-23165, CVE-2025-55131,
-#   CVE-2025-55132, CVE-2025-59465, CVE-2025-59466, CVE-2026-21637, CVE-2026-21710, CVE-2026-21712,
-#   CVE-2026-21713, CVE-2026-21714, CVE-2026-21715, CVE-2026-21716, CVE-2026-21717)
-# - Debian package CVEs in perl-base, liblzma5, libgnutls30, libpam*, libc-bin, libc6, libtasn1-6,
-#   libsystemd0, libudev1, libcap2, login, passwd, gpgv (all carried by the newer bookworm-slim base)
-# Bundled npm globals are removed below so the npm-bundled JS dependencies (cross-spawn, glob,
-# minimatch, tar, brace-expansion, ip-address, diff) cannot be flagged or invoked at runtime — this
-# image only runs the bundled CLI directly via node.
+# Bundled npm globals are removed below so npm's JS dependencies cannot be
+# flagged or invoked at runtime — this image only runs the bundled CLI via node.
 FROM node:24.15.0-trixie-slim
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \

--- a/generators/python-v2/pydantic-model/Dockerfile
+++ b/generators/python-v2/pydantic-model/Dockerfile
@@ -7,7 +7,7 @@
 # Bundled npm globals are removed below so the npm-bundled JS dependencies (cross-spawn, glob,
 # minimatch, tar, brace-expansion, ip-address, diff) cannot be flagged or invoked at runtime — this
 # image only runs the bundled CLI directly via node.
-FROM node:22.22-bookworm-slim
+FROM node:24.15.0-bookworm-slim
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl \

--- a/generators/python-v2/sdk/Dockerfile
+++ b/generators/python-v2/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15.0-trixie-slim
+FROM node:24.15-trixie-slim
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl \

--- a/generators/python-v2/sdk/Dockerfile
+++ b/generators/python-v2/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22-bookworm-slim
+FROM node:24.15.0-bookworm-slim
 RUN apt-get update \
     && apt-get -y --no-install-recommends dist-upgrade \
     && apt-get install -y --no-install-recommends ca-certificates curl \

--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Copy Node.js from official image
-FROM node:24.15.0-trixie-slim AS node
+FROM node:24.15-trixie-slim AS node
 
 # Stage 2: Base Python image with dependencies
 FROM python:3.13.7-slim AS python-base

--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Copy Node.js from official image
-FROM node:22.22-bookworm-slim AS node
+FROM node:24.15.0-bookworm-slim AS node
 
 # Stage 2: Base Python image with dependencies
 FROM python:3.13.7-slim AS python-base

--- a/generators/python/sdk/changes/unreleased/bump-node-24.yml
+++ b/generators/python/sdk/changes/unreleased/bump-node-24.yml
@@ -2,7 +2,7 @@
 
 - summary: |
     Bump the Python SDK generator container's Node base image from
-    `node:22.22-bookworm-slim` to `node:24.15.0-trixie-slim`. Aligns the
+    `node:22.22-bookworm-slim` to `node:24.15-trixie-slim`. Aligns the
     generator with the rest of the Fern generator containers on a single
     Node major version (Node 24) and Debian release (trixie). Trixie ships
     patched versions of glibc, dpkg, nghttp2, libcap2, systemd, libgcrypt20,

--- a/generators/python/sdk/changes/unreleased/bump-node-24.yml
+++ b/generators/python/sdk/changes/unreleased/bump-node-24.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump the Python SDK generator container's Node base image from
+    `node:22.22-bookworm-slim` to `node:24.15.0-bookworm-slim`. Aligns the
+    generator with the rest of the Fern generator containers on a single Node
+    major version (Node 24) and picks up Node 24's CVE patches.
+  type: chore

--- a/generators/rust/model/Dockerfile
+++ b/generators/rust/model/Dockerfile
@@ -8,7 +8,7 @@ RUN rustup component add rustfmt \
     && cp "$RUSTFMT" /rustfmt/rustfmt \
     && cp "$(dirname "$RUSTFMT")/../lib"/librustc_driver-*.so /rustfmt/lib/
 
-FROM node:24.15.0-alpine3.23
+FROM node:24.15-alpine3.23
 
 RUN apk update && apk upgrade --no-cache
 

--- a/generators/rust/model/Dockerfile
+++ b/generators/rust/model/Dockerfile
@@ -8,7 +8,7 @@ RUN rustup component add rustfmt \
     && cp "$RUSTFMT" /rustfmt/rustfmt \
     && cp "$(dirname "$RUSTFMT")/../lib"/librustc_driver-*.so /rustfmt/lib/
 
-FROM node:22.22-alpine3.23
+FROM node:24.15.0-alpine3.23
 
 RUN apk update && apk upgrade --no-cache
 

--- a/generators/rust/sdk/Dockerfile
+++ b/generators/rust/sdk/Dockerfile
@@ -5,7 +5,7 @@
 FROM rust:1.82-alpine3.20 AS rust
 RUN rustup component add rustfmt
 
-FROM node:22.22-alpine3.23
+FROM node:24.15.0-alpine3.23
 
 RUN apk update && apk upgrade --no-cache
 

--- a/generators/rust/sdk/Dockerfile
+++ b/generators/rust/sdk/Dockerfile
@@ -5,7 +5,7 @@
 FROM rust:1.91-alpine3.23 AS rust
 RUN rustup component add rustfmt
 
-FROM node:24.15.0-alpine3.23
+FROM node:24.15-alpine3.23
 
 RUN apk update && apk upgrade --no-cache
 

--- a/generators/rust/sdk/changes/unreleased/bump-node-24.yml
+++ b/generators/rust/sdk/changes/unreleased/bump-node-24.yml
@@ -2,7 +2,7 @@
 
 - summary: |
     Bump the Rust SDK and Rust model generator containers' Node base image from
-    `node:22.22-alpine3.23` to `node:24.15.0-alpine3.23`. Aligns the generators
+    `node:22.22-alpine3.23` to `node:24.15-alpine3.23`. Aligns the generators
     with the rest of the Fern generator containers on a single Node major
     version (Node 24) and picks up Node 24's CVE patches. The Rust SDK's
     in-place `npm@11.13.0` self-upgrade and the bundled `ip-address` patch are

--- a/generators/rust/sdk/changes/unreleased/bump-node-24.yml
+++ b/generators/rust/sdk/changes/unreleased/bump-node-24.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump the Rust SDK and Rust model generator containers' Node base image from
+    `node:22.22-alpine3.23` to `node:24.15.0-alpine3.23`. Aligns the generators
+    with the rest of the Fern generator containers on a single Node major
+    version (Node 24) and picks up Node 24's CVE patches. The Rust SDK's
+    in-place `npm@11.13.0` self-upgrade and the bundled `ip-address` patch are
+    retained because the Node 24 `npm` ship (`11.12.1`) still vendors
+    `ip-address@10.1.0`, which is vulnerable to GHSA-v2v4-37r5-5v8g.
+  type: chore

--- a/generators/swift/model/Dockerfile
+++ b/generators/swift/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15.0-alpine3.23
+FROM node:24.15-alpine3.23
 
 RUN apk update && apk upgrade --no-cache
 

--- a/generators/swift/model/Dockerfile
+++ b/generators/swift/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22-alpine3.23
+FROM node:24.15.0-alpine3.23
 
 RUN apk update && apk upgrade --no-cache
 

--- a/generators/swift/sdk/Dockerfile
+++ b/generators/swift/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22-alpine3.23
+FROM node:24.15.0-alpine3.23
 
 RUN apk update && apk upgrade --no-cache
 RUN apk --no-cache add bash curl git zip

--- a/generators/swift/sdk/Dockerfile
+++ b/generators/swift/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15.0-alpine3.23
+FROM node:24.15-alpine3.23
 
 RUN apk update && apk upgrade --no-cache
 RUN apk --no-cache add bash curl git zip

--- a/generators/swift/sdk/changes/unreleased/bump-node-24.yml
+++ b/generators/swift/sdk/changes/unreleased/bump-node-24.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump the Swift SDK and Swift model generator containers' Node base image
+    from `node:22.22-alpine3.23` to `node:24.15.0-alpine3.23`. Aligns the
+    generators with the rest of the Fern generator containers on a single Node
+    major version (Node 24) and picks up Node 24's CVE patches.
+  type: chore

--- a/generators/swift/sdk/changes/unreleased/bump-node-24.yml
+++ b/generators/swift/sdk/changes/unreleased/bump-node-24.yml
@@ -2,7 +2,7 @@
 
 - summary: |
     Bump the Swift SDK and Swift model generator containers' Node base image
-    from `node:22.22-alpine3.23` to `node:24.15.0-alpine3.23`. Aligns the
+    from `node:22.22-alpine3.23` to `node:24.15-alpine3.23`. Aligns the
     generators with the rest of the Fern generator containers on a single Node
     major version (Node 24) and picks up Node 24's CVE patches.
   type: chore

--- a/generators/typescript/sdk/changes/unreleased/bump-node-24-validator.yml
+++ b/generators/typescript/sdk/changes/unreleased/bump-node-24-validator.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump the TypeScript SDK validator container's Node base image from
+    `node:22.22-bookworm-slim` to `node:24.15.0-bookworm-slim`. Aligns the
+    validator with the rest of the Fern generator containers on a single Node
+    major version (Node 24) and picks up Node 24's CVE patches. The
+    `typescript-sdk-cli` container is untouched and is migrated separately by
+    PR #15779.
+  type: chore

--- a/generators/typescript/sdk/changes/unreleased/bump-node-24-validator.yml
+++ b/generators/typescript/sdk/changes/unreleased/bump-node-24-validator.yml
@@ -2,7 +2,7 @@
 
 - summary: |
     Bump the TypeScript SDK validator container's Node base image to
-    `node:24.15.0-trixie-slim`. Aligns the validator with the rest of the
+    `node:24.15-trixie-slim`. Aligns the validator with the rest of the
     Fern generator containers on a single Node major version (Node 24) on
     top of the trixie-slim base introduced for `typescript-sdk-cli` and
     `typescript-sdk-validator` by PR #15779.

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15.0-trixie-slim
+FROM node:24.15-trixie-slim
 
 # Apply latest Debian security updates so that grype-tracked OS package
 # vulnerabilities (glibc, dpkg, nghttp2, libcap2, systemd, libgcrypt20,

--- a/generators/typescript/sdk/validator/Dockerfile
+++ b/generators/typescript/sdk/validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22-bookworm-slim
+FROM node:24.15.0-bookworm-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates git \

--- a/generators/typescript/sdk/validator/Dockerfile
+++ b/generators/typescript/sdk/validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.15.0-trixie-slim
+FROM node:24.15-trixie-slim
 
 # Apply latest Debian security updates so that grype-tracked OS package
 # vulnerabilities (glibc, dpkg, nghttp2, libcap2, systemd, libgcrypt20,


### PR DESCRIPTION
## Description

Aligns every Fern generator container on a single Node major version (Node 24, floating `24.15`) for both Debian and Alpine bases. Today the tree is split across Node 22.22 and Node 24.x, which inflates the surface of grype-tracked Node-bundled CVEs we have to chase across multiple base images.

Pinning to the floating `24.15` minor — not the exact `24.15.0` patch — means new 24.15.x releases automatically pick up Node-binary CVE patches without a manual Dockerfile bump on each Node release. Staying inside the `24.15` minor keeps the bundled-npm dep paths that the patch RUN steps depend on stable.

All Debian-based Fern generator containers also land on the same `trixie` release that <a href="https://github.com/fern-api/fern/pull/15779">#15779</a> introduced for `typescript-sdk-{cli,validator}`. Trixie ships patched glibc, dpkg, nghttp2, libcap2, systemd, libgcrypt20, krb5, curl, and expat that are not available on bookworm, so the base-image choice — not just `dist-upgrade` — is what clears the AWS Inspector findings for those packages.

## Changes Made

**Dockerfile `FROM` line bumps (16 containers):**

| Generator | From | To |
| --- | --- | --- |
| openapi | `node:22.22-alpine3.23` | `node:24.15-alpine3.23` |
| swift/{sdk,model} | `node:22.22-alpine3.23` | `node:24.15-alpine3.23` |
| typescript/sdk/cli | `node:24.15.0-trixie-slim` (from #15779) | `node:24.15-trixie-slim` |
| typescript/sdk/validator | `node:22.22-bookworm-slim` (now `22.22-trixie-slim` on main via #15779) | `node:24.15-trixie-slim` |
| python/sdk (node stage) | `node:22.22-bookworm-slim` | `node:24.15-trixie-slim` |
| python-v2/{sdk,pydantic-model} | `node:22.22-bookworm-slim` | `node:24.15-trixie-slim` |
| php/{sdk,model} (node stage) | `node:22.22-alpine3.23` | `node:24.15-alpine3.23` |
| go/{sdk,model} (node stage) | `node:22.22-alpine3.23` | `node:24.15-alpine3.23` |
| csharp/{sdk,model} (node stage) | `node:22.22-alpine3.23` | `node:24.15-alpine3.23` |
| rust/{sdk,model} (final node stage) | `node:22.22-alpine3.23` | `node:24.15-alpine3.23` |
| java/sdk (node stage) | `node:24.14.1-bookworm` | `node:24.15-trixie` |

The `java/sdk` node stage stays on the **non-slim** Debian variant (`24.15-trixie`, not `-trixie-slim`) because the patch RUN steps shell out to `curl` and `tar`, which are not preinstalled on the `*-slim` image.

**Bundled-npm patch cleanup** — `node:24.15` ships `npm 11.12.1`, which already vendors patched `glob@13.0.6`, `minimatch@10.2.4`, `tar@7.5.11`, `brace-expansion@5.0.4`, and `diff@8.0.3`. Stale tarball replacements are removed:

- `generators/java/sdk/Dockerfile`: drops the `npm install -g npm@11.12.0 && npm install -g glob@11.1.0` block, the `glob 11.1.0`, `tar 7.5.11`, `minimatch 10.2.3`, and `brace-expansion 5.0.5` patch blocks. Keeps `picomatch 4.0.4` and `ip-address 10.2.0` (bundled `picomatch@4.0.3` and `ip-address@10.1.0` are still vulnerable).
- `generators/csharp/sdk/Dockerfile`: drops the `brace-expansion 2.0.3` patch block. Keeps `ip-address 10.1.1` and `picomatch 4.0.4`.
- `generators/go/sdk/Dockerfile`: keeps the existing `npm pack <pkg>@latest` loop for `ip-address`/`brace-expansion`/`picomatch` (resolves to current fixed releases on Node 24).
- `generators/rust/sdk/Dockerfile`: keeps the in-place `npm@11.13.0` upgrade and `ip-address 10.1.1` patch.

**Verbose Dockerfile comment cleanup** — trimmed multi-paragraph rationale blocks on `csharp/sdk`, `java/sdk`, and `python-v2/pydantic-model` to 1-2 lines each per reviewer feedback.

**Changelogs / versions:**
- New `chore` entry under `generators/{csharp,go,java,php,python,rust,swift}/sdk/changes/unreleased/bump-node-24.yml` (one per `release-config.json` scope; each entry covers both that scope's SDK and model where applicable). The `java/sdk`, `python/sdk`, and `typescript/sdk/validator` entries also describe the bookworm → trixie move.
- New `chore` entry under `generators/typescript/sdk/changes/unreleased/bump-node-24-validator.yml`.
- New entry `version: 0.5.2` in `generators/openapi/versions.yml`. `openapi` has no `release-config.json` mapping and no `changes/unreleased/` folder, so per the documented exception this is a direct `versions.yml` edit instead of a changelog file. **Please double-check `irVersion: 66` and the `0.5.2` slot are correct before merging** — I copied `irVersion` from the previous entry.

**Out of scope:**
- `generators/java/model/Dockerfile`, `generators/python/pydantic/Dockerfile`, `generators/ruby-v2/{sdk,model}/Dockerfile` — no Node base image.
- `python-v2/*` does not appear in `release-config.json`, so no separate changelog entry is added for it. Flagging in case that is wrong.

## Tag verification

`docker manifest inspect` and the `library/node` tag listing on Docker Hub confirm that `node:24.15-alpine3.23`, `node:24.15-trixie-slim`, and `node:24.15-trixie` all exist and currently resolve to `node:24.15.0-*`.

## Testing

- [x] `pnpm run check` clean from repo root.
- [x] Full `docker build` of `generators/csharp/sdk/Dockerfile` against the new base + retained patches → builds clean, image entrypoint resolves.
- [x] Smoke build of `generators/python-v2/sdk/Dockerfile` on `node:24.15-trixie-slim` confirms the trixie-slim base + `apt-get update && dist-upgrade && install ca-certificates curl` + `curl | sh` ruff install all succeed.
- [x] Patch-only smoke-test images for `go/sdk`, `rust/sdk`, and `java/sdk` patch blocks, verifying the final `package.json` versions of every patched dep on the Node 24 base:
  - go/sdk path: `ip-address 10.2.0`, `brace-expansion 5.0.6`, `picomatch 4.0.4`
  - rust/sdk path: `npm 11.13.0`, `ip-address 10.1.1`
  - java/sdk path: `npm 11.12.1`, `ip-address 10.2.0`, `picomatch 4.0.4` (tinyglobby), with bundled `glob 13.0.6` / `minimatch 10.2.4` / `tar 7.5.11` / `brace-expansion 5.0.4` already on the fixed line.
- [ ] Full end-to-end `docker build` for the other 10 generator Dockerfiles relies on CI rather than local builds. CI image builds are the real verification gate here.

## Reviewer focus / risks

1. **Floating-pin risk.** The npm-bundled-dep patches (`picomatch`, `ip-address`) use guarded `for dir in …; if [ -d "$dir" ]; then …` loops. If a future bundled npm changes the path layout, the guard turns the patch into a **silent** no-op. Mitigated for now by staying inside `24.15` (npm minor is frozen), but worth knowing before any future bump to `24.16` or `25`.
2. **java/sdk `bookworm` → `trixie` (non-slim retained).** The node stage still needs `curl` and `tar`, so we stay on the non-slim variant.
3. **java/sdk patch deletions.** Confirm bundled `glob 13.0.6` / `minimatch 10.2.4` / `tar 7.5.11` / `brace-expansion 5.0.4` are acceptable for the CVEs the old patches targeted. Technically a *downgrade* of `brace-expansion` from the old patched 5.0.5 to bundled 5.0.4; GHSA-f886-m6hf-6m8v lists 5.0.1+ as fixed, so 5.0.4 should be safe.
4. **csharp/sdk `brace-expansion 2.0.3` deletion** — same rationale; bundled 5.0.4 is well past the GHSA-f886-m6hf-6m8v fix line.
5. **openapi `versions.yml` hand edit** — confirm `0.5.2` and `irVersion: 66` are the right values; flag if release automation expects to manage this slot.
6. **No changelog for python-v2** — confirm this is correct; if python-v2 publishes via a different changelog path, I'll add one.
7. **typescript/sdk/cli inclusion.** Originally out of scope (owned by <a href="https://github.com/fern-api/fern/pull/15779">#15779</a>, which has merged); pulled in only for the `24.15.0` → `24.15` float so the entire generators tree shares the same Node pin.

## Updates since last revision

- Switched every generator Dockerfile from the exact `24.15.0-…` pin to floating `24.15-…` so new 24.15.x releases pick up Node CVE patches automatically without a manual Dockerfile bump.
- Pulled `typescript/sdk/cli/Dockerfile` into the float for consistency across the tree.
- Trimmed verbose multi-paragraph Dockerfile comments to 1-2 lines per reviewer feedback.
- Earlier in the revision history: merged `main` (including <a href="https://github.com/fern-api/fern/pull/15779">#15779</a>, <a href="https://github.com/fern-api/fern/pull/15828">#15828</a>, <a href="https://github.com/fern-api/fern/pull/15829">#15829</a>, <a href="https://github.com/fern-api/fern/pull/15830">#15830</a>) and migrated every Debian-based node stage from `bookworm[-slim]` to `trixie[-slim]` to clear AWS Inspector findings that `dist-upgrade` alone could not.

Link to Devin session: https://app.devin.ai/sessions/fc68707890814797a8b50c18a4efd843
Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->