### PR TITLE
fix(seed): restore docker-compose in python + php seed containers

### DIFF
--- a/docker/seed/Dockerfile.php
+++ b/docker/seed/Dockerfile.php
@@ -41,9 +41,10 @@ RUN apk update && apk upgrade --no-cache --available
 # Overlay rebuilt containerd + runc binaries (see stage 2).
 COPY --from=overlay-binaries /overlay/ /
 
-# Drop unused docker CLI plugins (buildx, compose) that ship vulnerable
-# embedded Go modules; seed only uses `docker load` and `docker run`.
-RUN rm -rf /usr/local/libexec/docker/cli-plugins /usr/local/bin/docker-compose
+# Drop unused buildx CLI plugin that ships vulnerable embedded Go modules.
+# Keep docker-compose: wire-test bootstraps in generators/php/sdk run
+# `docker compose -f …` to start WireMock alongside generated SDK tests.
+RUN rm -f /usr/local/libexec/docker/cli-plugins/docker-buildx
 
 # Copy pre-pulled wiremock image
 COPY --from=wiremock-pull /wiremock.tar /wiremock.tar

--- a/docker/seed/Dockerfile.python
+++ b/docker/seed/Dockerfile.python
@@ -38,9 +38,10 @@ FROM docker:29.4.1-dind-alpine3.23
 # Overlay rebuilt containerd + runc binaries (see stage 2).
 COPY --from=overlay-binaries /overlay/ /
 
-# Drop unused docker CLI plugins (buildx, compose) that ship vulnerable
-# embedded Go modules; seed only uses `docker load` and `docker run`.
-RUN rm -rf /usr/local/libexec/docker/cli-plugins /usr/local/bin/docker-compose
+# Drop unused buildx CLI plugin that ships vulnerable embedded Go modules.
+# Keep docker-compose: wire-test bootstraps in generators/python-v2/sdk run
+# `docker compose -f …` to start WireMock alongside generated SDK tests.
+RUN rm -f /usr/local/libexec/docker/cli-plugins/docker-buildx
 
 # Copy pre-pulled wiremock image
 COPY --from=wiremock-pull /wiremock.tar /wiremock.tar


### PR DESCRIPTION
## Description

Linear ticket: Refs #15822
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->

PR #15822 ("fix(seed): clear grpc-go CVE, drop unused docker CLI plugins, …") dropped `docker-compose` from `docker/seed/Dockerfile.{python,php}` under the assumption that seed containers only invoke `docker load` and `docker run`. That assumption is wrong: the python-v2 and php SDK wire-test bootstraps shell out to `docker compose -f …` to start WireMock alongside the generated SDK tests — see <ref_snippet file="/home/ubuntu/repos/fern/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts" lines="265-299" />.

As a result every wire-test shard on `python-sdk` and `php-sdk` has been failing on `main` since #15822 landed. The user-visible failure inside the wire-test PHPUnit bootstrap is:

```
Failed to start WireMock: unknown shorthand flag: 'f' in -f
Usage:  docker [OPTIONS] COMMAND [ARG...]
```

…because `docker compose` parses as `compose` → unknown subcommand → `-f` falls back to a top-level docker flag → exit 125. Reproduced locally by pulling `fernapi/python-seed:latest` / `fernapi/php-seed:latest` from Docker Hub and running `docker compose -f /tmp/foo.yml up -d --wait` — same error, same exit code. Both published images ship without the compose plugin or its `/usr/local/bin/docker-compose` symlink.

## Changes Made
- `docker/seed/Dockerfile.python` + `docker/seed/Dockerfile.php`: stop removing the entire `cli-plugins` directory + the `docker-compose` symlink. Only `docker-buildx` is removed now; `docker-compose` (v5.1.3, bundled with the `docker:29.4.1-dind-alpine3.23` base) stays put.
- Comment block updated to reflect the new intent and to record why compose must stay.
- No changes to `Dockerfile.{ts,java,csharp,go}` — those seed containers don't drive wire-tests with `docker compose`, so the buildx/compose removal stayed valid there and is left untouched.
- [ ] Updated README.md generator (if applicable) — N/A, infra-only change.

## What to review carefully
- **CVE trade-off.** Restoring `docker-compose` v5.1.3 reintroduces whatever embedded-Go-module vulnerabilities motivated #15822 in the first place. The alternative (build compose from source like containerd/runc, or replace it in the wire-test bootstrap with `docker run`) is much bigger and was out of scope here; flagging in case you'd rather pursue that path instead.
- **CI on this PR cannot validate the fix.** `pnpm seed:local test` pulls `fernapi/{php,python}-seed:latest` from Docker Hub, and those images are only republished by `.github/workflows/seed-dockers.yml` on push to `main`. So this PR's `seed-test-results (php-sdk)` + `(python-sdk)` jobs will keep showing the same `unknown shorthand flag: 'f' in -f` failure until merge. Once merged, `seed-dockers.yml` rebuilds and republishes the seed images, then subsequent PRs (including #15827, the Node 24 migration) will pass.
- **Only python + php seed images touched.** Confirmed by grepping the wire-test generators — only those two shell out to `docker compose`.

## Testing
- [x] Manual testing completed
  - `docker build -f docker/seed/Dockerfile.python -t test-python-seed:local .` → clean build; `docker compose version` → `Docker Compose version v5.1.3`; `/usr/local/bin/docker-compose` symlinks back into `/usr/local/libexec/docker/cli-plugins/docker-compose`; `docker-buildx` is gone; only file under `cli-plugins/` is `docker-compose`.
  - Same checks for `docker/seed/Dockerfile.php`. PHP runtime still works (`php --version` → PHP 8.4.21).
  - Repro'd the pre-fix CI failure locally against the *published* `fernapi/php-seed:latest` (`unknown shorthand flag: 'f' in -f`, exit 125) to confirm root cause and that the fix targets it.
- [ ] Unit tests added/updated — N/A (Dockerfile-only change).
- End-to-end validation via `seed-test-results (php-sdk)` + `(python-sdk)` will only be possible on the **next** PR after this one merges, per the CI caveat above.

Link to Devin session: https://app.devin.ai/sessions/fc68707890814797a8b50c18a4efd843
Requested by: @davidkonigsberg