### PR TITLE
fix(seed): force-refresh cached *-seed images before tests

### DIFF
--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -85,6 +85,22 @@ runs:
           [ -f "$f" ] && docker load -i "$f" || true
         done
 
+    - name: Refresh cached seed images from Docker Hub
+      shell: bash
+      run: |
+        # `docker load` rebinds tags like fernapi/<lang>-seed:latest to whatever
+        # was captured in the cached tarball. Combined with the restore-keys
+        # fallback above, that can pin CI to a stale seed image for days after
+        # a fix has shipped via .github/workflows/seed-dockers.yml. Force a
+        # re-pull so the manifest digest matches what's currently on Docker Hub.
+        docker images --format '{{.Repository}}:{{.Tag}}' \
+          | grep -E '^[^/]+/[^:]+-seed:' \
+          | sort -u \
+          | while read -r img; do
+              echo "Refreshing $img"
+              docker pull "$img" || true
+            done
+
     - name: Record pre-existing Docker images
       shell: bash
       run: docker images -q | sort -u > /tmp/docker-images-before.txt


### PR DESCRIPTION
## Description

Linear ticket: Refs #15828

The `cached-seed` action caches docker tarballs under a key derived from `hashFiles('**/Dockerfile*')` plus a `restore-keys` prefix fallback. When the exact key misses, GHA restores the most-recent prefix match and `docker load` rebinds tags like `fernapi/python-seed:latest` to whatever was captured in that tarball. Result: CI keeps using a stale seed image for days after a fix has shipped via `.github/workflows/seed-dockers.yml` — even though Docker Hub already has the correct manifest. This is exactly what blocked the python-sdk + php-sdk wire-test shards on #15827 after #15828 merged.

## Changes Made
- Added a new "Refresh cached seed images from Docker Hub" step in `.github/actions/cached-seed/action.yaml`, immediately after `docker load`. It enumerates locally-loaded `*-seed:*` images via `docker images --format '{{.Repository}}:{{.Tag}}'`, then `docker pull`s each one so the tag points at the current Docker Hub manifest.
- Failures are tolerated (`|| true`) — if Docker Hub is unreachable or rate-limits us, the cached image is still usable.
- [ ] Updated README.md generator — N/A.

## What to review carefully
- **Grep pattern `^[^/]+/[^:]+-seed:`** — intended to match `fernapi/python-seed:latest`, `fernapi/php-seed:latest`, etc., and nothing else. Worth confirming there are no other org-namespaced `*-seed` images that should be excluded, and no seed images that don't match this shape.
- **Step ordering.** The refresh runs *before* "Record pre-existing Docker images", so any digest change introduced by the pull is captured in the "before" snapshot and won't be re-saved by the existing `comm -13` save step. The practical effect is that `*-seed:*` images become effectively un-cacheable going forward (they'll always be pulled fresh) — that's the desired behavior here.
- **Failure tolerance.** Suppressing pull errors means a Docker-Hub-down day silently falls back to the stale cached image. That matches the existing "best-effort" pattern in this action (`Save Docker images for cache` and the login retries) but worth flagging.

## Testing
- [ ] Unit tests added/updated — N/A (CI action, not application code).
- [x] Manual testing completed — reproduced the underlying staleness locally by pulling the pre-#15828 `fernapi/python-seed:latest` tarball, running `docker compose -f /tmp/foo.yml up -d --wait` inside, and observing the `unknown shorthand flag: 'f' in -f` error from the failing CI shards. Re-pulling the post-#15828 image clears the error.
- End-to-end validation will happen on the next PR that touches a `**/Dockerfile*` — once this lands and the relevant PR re-merges main, the wire-test shards should go green.

Link to Devin session: https://app.devin.ai/sessions/fc68707890814797a8b50c18a4efd843
Requested by: @davidkonigsberg