### PR TITLE
fix(seed): tolerate no *-seed images in refresh step

### DIFF
--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -93,8 +93,11 @@ runs:
         # fallback above, that can pin CI to a stale seed image for days after
         # a fix has shipped via .github/workflows/seed-dockers.yml. Force a
         # re-pull so the manifest digest matches what's currently on Docker Hub.
+        # awk (not grep) so an empty match returns 0 under `set -o pipefail` —
+        # shards like openapi never load a *-seed:* image and would otherwise
+        # fail the step before anything actually ran.
         docker images --format '{{.Repository}}:{{.Tag}}' \
-          | grep -E '^[^/]+/[^:]+-seed:' \
+          | awk '/^[^/]+\/[^:]+-seed:/' \
           | sort -u \
           | while read -r img; do
               echo "Refreshing $img"


### PR DESCRIPTION
## Description

Linear ticket: Refs #15829

Follow-up to #15829, which added a "Refresh cached seed images from Docker Hub" step in `.github/actions/cached-seed/action.yaml`. That step pipes `docker images | grep -E '...-seed:' | sort -u | while read -r img`. Under `set -o pipefail`, an empty match from `grep` exits 1 and fails the whole step — which is exactly what happens on shards that never load a `*-seed:*` image (openapi is the obvious case, since there is no `fernapi/openapi-seed` published). All 13 openapi shards on #15827 turned red on this step right after #15829 landed.

## Changes Made
- Swap `grep -E '^[^/]+/[^:]+-seed:'` for `awk '/^[^/]+\/[^:]+-seed:/'`. `awk` exits 0 when no record matches, so the pipeline is a no-op when there's nothing to refresh.
- Comment added inline explaining why `awk` was chosen.

## What to review carefully
- **Regex equivalence.** grep's ERE `^[^/]+/[^:]+-seed:` should be the same as awk's `/^[^/]+\/[^:]+-seed:/`. Worth a quick eyeball — the `/` is the only delimiter that needs escaping inside the awk literal; the bracket classes and `+` carry over.
- **Doesn't regress the seed-loading shards.** For shards that do load a `fernapi/<lang>-seed:<tag>` image (python-sdk, php-sdk, ts-sdk, etc.), `awk` still emits the match line and the `while read -r img; do docker pull "$img" || true; done` re-pull behavior is unchanged.

## Testing
- [ ] Unit tests added/updated — N/A (CI action change).
- [x] Manual testing — verified locally:
  ```
  $ printf 'fernapi/python-seed:latest\nbusybox:latest\n' | awk '/^[^/]+\/[^:]+-seed:/'
  fernapi/python-seed:latest
  $ printf 'busybox:latest\n' | awk '/^[^/]+\/[^:]+-seed:/'; echo "exit=$?"
  exit=0
  ```
  End-to-end validation will happen on the next CI run on #15827 after this lands and main is re-merged in.

Link to Devin session: https://app.devin.ai/sessions/fc68707890814797a8b50c18a4efd843
Requested by: @davidkonigsberg