### PR TITLE
fix(cli): fix `fern docs dev` Node 26 hang + smoke test resilience

### DIFF
--- a/.github/workflows/docs-bundle-smoke-test.yml
+++ b/.github/workflows/docs-bundle-smoke-test.yml
@@ -144,198 +144,109 @@ jobs:
 
       - name: Install Playwright
         if: steps.node-check.outputs.available == 'true'
+        timeout-minutes: 10
         shell: bash
         run: |
           cd docs-preview-smoke-test/playwright && npm install && npx playwright install chromium
 
-      # On Unix, background the server and wait for it to be ready, then run
-      # Playwright in a separate step.
-      - name: Start fern docs dev server (Unix)
-        if: steps.node-check.outputs.available == 'true' && runner.os != 'Windows'
-        shell: bash
-        run: |
-          cd docs-preview-smoke-test/fern
-          FERN_NO_VERSION_REDIRECTION=true fern docs dev \
-            > /tmp/fern-docs-dev.log 2>&1 &
-          FERN_PID=$!
-          echo "FERN_PID=$FERN_PID" >> $GITHUB_ENV
-
-          echo "Waiting for fern docs dev server to start (PID: $FERN_PID)..."
-          for i in $(seq 1 180); do
-            if grep -qi "ready on" /tmp/fern-docs-dev.log 2>/dev/null; then
-              echo "Server reported ready after ${i}s!"
-              break
-            fi
-
-            if ! kill -0 $FERN_PID 2>/dev/null; then
-              echo "fern docs dev process (PID: $FERN_PID) exited unexpectedly"
-              echo "--- Dev server logs (last 50 lines) ---"
-              tail -50 /tmp/fern-docs-dev.log
-              echo "--- End dev server logs ---"
-              exit 1
-            fi
-
-            if [ $i -eq 180 ]; then
-              echo "Timeout waiting for server to start after 180s"
-              echo "--- Dev server logs (last 50 lines) ---"
-              tail -50 /tmp/fern-docs-dev.log
-              echo "--- End dev server logs ---"
-              exit 1
-            fi
-
-            if [ $((i % 15)) -eq 0 ]; then
-              echo "Still waiting... (${i}s)"
-              tail -5 /tmp/fern-docs-dev.log 2>/dev/null || true
-            fi
-
-            sleep 1
-          done
-
-          # Wait for port 3000 to accept connections
-          echo "Waiting for server to return HTTP 200 on /sitemap.xml..."
-          for j in $(seq 1 30); do
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:3000/sitemap.xml 2>/dev/null || echo "000")
-            if [ "$HTTP_CODE" = "200" ]; then
-              echo "Server returning 200 on /sitemap.xml after ${j}s"
-              break
-            fi
-            if [ $j -eq 30 ]; then
-              echo "Server never returned 200 on /sitemap.xml after 30s (last HTTP $HTTP_CODE)"
-              echo "--- Dev server logs (last 100 lines) ---"
-              tail -100 /tmp/fern-docs-dev.log
-              echo "--- End dev server logs ---"
-              exit 1
-            fi
-            sleep 1
-          done
-
-          # Warm up SSR — first render may trigger compilation. Retry until 200.
-          echo "Warming up SSR on /welcome..."
-          for k in $(seq 1 60); do
-            HTTP_CODE=$(curl -s -o /tmp/warmup-response.html -w "%{http_code}" --max-time 10 http://localhost:3000/welcome 2>/dev/null || echo "000")
-            if [ "$HTTP_CODE" = "200" ]; then
-              echo "SSR warm-up succeeded after attempt ${k}"
-              break
-            fi
-            if [ $k -eq 60 ]; then
-              echo "SSR warm-up failed after 60 attempts (last HTTP $HTTP_CODE)"
-              echo "--- Response body (first 2000 chars) ---"
-              head -c 2000 /tmp/warmup-response.html 2>/dev/null || true
-              echo ""
-              echo "--- Dev server logs (last 100 lines) ---"
-              tail -100 /tmp/fern-docs-dev.log
-              echo "--- End dev server logs ---"
-              exit 1
-            fi
-            sleep 2
-          done
-
-      - name: Run Playwright smoke tests (Unix)
-        if: steps.node-check.outputs.available == 'true' && runner.os != 'Windows'
+      - name: Run smoke tests (with server restart on crash)
+        if: steps.node-check.outputs.available == 'true'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        env:
+          FERN_NO_VERSION_REDIRECTION: "true"
         with:
           timeout_minutes: 15
-          max_attempts: 2
+          max_attempts: 3
           retry_wait_seconds: 10
           shell: bash
-          command: cd docs-preview-smoke-test/playwright && npx playwright test smoke.spec.ts --config playwright.config.ts
-
-      # On Windows, background processes (&) are killed when the parent bash
-      # step exits. We must start the server and run Playwright in the SAME
-      # step so the server stays alive for the duration of the tests.
-      - name: Start server and run Playwright smoke tests (Windows)
-        if: steps.node-check.outputs.available == 'true' && runner.os == 'Windows'
-        shell: bash
-        run: |
-          cd docs-preview-smoke-test/fern
-          FERN_NO_VERSION_REDIRECTION=true fern docs dev \
-            > /tmp/fern-docs-dev.log 2>&1 &
-          FERN_PID=$!
-          echo "FERN_PID=$FERN_PID" >> $GITHUB_ENV
-
-          echo "Waiting for fern docs dev server to start (PID: $FERN_PID)..."
-          for i in $(seq 1 180); do
-            if grep -qi "ready on" /tmp/fern-docs-dev.log 2>/dev/null; then
-              echo "Server reported ready after ${i}s!"
-              break
+          command: |
+            # Kill any leftover server from a previous attempt
+            if [ -f /tmp/fern-server.pid ]; then
+              OLD_PID=$(cat /tmp/fern-server.pid)
+              if kill -0 "$OLD_PID" 2>/dev/null; then
+                echo "Killing leftover server (PID $OLD_PID) from previous attempt..."
+                kill "$OLD_PID" 2>/dev/null || true
+                sleep 2
+              fi
+              rm -f /tmp/fern-server.pid
             fi
 
+            LOG_FILE="/tmp/fern-docs-dev.log"
+            rm -f "$LOG_FILE"
+
+            # Start the fern docs dev server
+            cd docs-preview-smoke-test/fern
+            fern docs dev > "$LOG_FILE" 2>&1 &
+            FERN_PID=$!
+            cd "$GITHUB_WORKSPACE"
+
+            # Wait for the server to be ready
+            for i in $(seq 1 180); do
+              if grep -qi "ready on" "$LOG_FILE" 2>/dev/null; then
+                echo "Server ready after ${i}s"
+                break
+              fi
+
+              if ! kill -0 $FERN_PID 2>/dev/null; then
+                echo "Server crashed during startup (known Node.js v24 Windows issue)"
+                cat "$LOG_FILE"
+                exit 1
+              fi
+
+              if [ $i -eq 180 ]; then
+                echo "Server start timed out after 180s"
+                cat "$LOG_FILE"
+                kill $FERN_PID 2>/dev/null || true
+                exit 1
+              fi
+
+              sleep 1
+            done
+
+            # Verify server is still alive before running tests
             if ! kill -0 $FERN_PID 2>/dev/null; then
-              echo "fern docs dev process (PID: $FERN_PID) exited unexpectedly"
-              echo "--- Dev server logs (last 50 lines) ---"
-              tail -50 /tmp/fern-docs-dev.log
-              echo "--- End dev server logs ---"
+              echo "Server died after reporting ready (known Node.js v24 Windows crash)"
+              cat "$LOG_FILE"
               exit 1
             fi
 
-            if [ $i -eq 180 ]; then
-              echo "Timeout waiting for server to start after 180s"
-              echo "--- Dev server logs (last 50 lines) ---"
-              tail -50 /tmp/fern-docs-dev.log
-              echo "--- End dev server logs ---"
-              exit 1
-            fi
+            # Store PID for cleanup
+            echo "$FERN_PID" > /tmp/fern-server.pid
 
-            if [ $((i % 15)) -eq 0 ]; then
-              echo "Still waiting... (${i}s)"
-              tail -5 /tmp/fern-docs-dev.log 2>/dev/null || true
-            fi
+            # Wait for HTTP 200 on /sitemap.xml
+            echo "Waiting for server to return HTTP 200 on /sitemap.xml..."
+            for j in $(seq 1 30); do
+              HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:3000/sitemap.xml 2>/dev/null || echo "000")
+              if [ "$HTTP_CODE" = "200" ]; then
+                echo "Server returning 200 on /sitemap.xml after ${j}s"
+                break
+              fi
+              if [ $j -eq 30 ]; then
+                echo "Server never returned 200 on /sitemap.xml after 30s (last HTTP $HTTP_CODE)"
+                cat "$LOG_FILE"
+                exit 1
+              fi
+              sleep 1
+            done
 
-            sleep 1
-          done
+            # Warm up SSR — first render may trigger compilation
+            echo "Warming up SSR on /welcome..."
+            for k in $(seq 1 60); do
+              HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 http://localhost:3000/welcome 2>/dev/null || echo "000")
+              if [ "$HTTP_CODE" = "200" ]; then
+                echo "SSR warm-up succeeded after attempt ${k}"
+                break
+              fi
+              if [ $k -eq 60 ]; then
+                echo "SSR warm-up failed after 60 attempts (last HTTP $HTTP_CODE)"
+                cat "$LOG_FILE"
+                exit 1
+              fi
+              sleep 2
+            done
 
-          # Wait for port 3000 to accept connections
-          echo "Waiting for server to return HTTP 200 on /sitemap.xml..."
-          for j in $(seq 1 30); do
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:3000/sitemap.xml 2>/dev/null || echo "000")
-            if [ "$HTTP_CODE" = "200" ]; then
-              echo "Server returning 200 on /sitemap.xml after ${j}s"
-              break
-            fi
-            if [ $j -eq 30 ]; then
-              echo "Server never returned 200 on /sitemap.xml after 30s (last HTTP $HTTP_CODE)"
-              echo "--- Dev server logs (last 100 lines) ---"
-              tail -100 /tmp/fern-docs-dev.log
-              echo "--- End dev server logs ---"
-              exit 1
-            fi
-            sleep 1
-          done
-
-          echo "Warming up SSR on /welcome..."
-          for k in $(seq 1 60); do
-            HTTP_CODE=$(curl -s -o /tmp/warmup-response.html -w "%{http_code}" --max-time 10 http://localhost:3000/welcome 2>/dev/null || echo "000")
-            if [ "$HTTP_CODE" = "200" ]; then
-              echo "SSR warm-up succeeded after attempt ${k}"
-              break
-            fi
-            if [ $k -eq 60 ]; then
-              echo "SSR warm-up failed after 60 attempts (last HTTP $HTTP_CODE)"
-              echo "--- Response body (first 2000 chars) ---"
-              head -c 2000 /tmp/warmup-response.html 2>/dev/null || true
-              echo ""
-              echo "--- Dev server logs (last 100 lines) ---"
-              tail -100 /tmp/fern-docs-dev.log
-              echo "--- End dev server logs ---"
-              exit 1
-            fi
-            sleep 2
-          done
-
-          echo "Running Playwright smoke tests..."
-          cd "$GITHUB_WORKSPACE/docs-preview-smoke-test/playwright"
-          for attempt in 1 2; do
-            if npx playwright test smoke.spec.ts --config playwright.config.ts; then
-              echo "Playwright passed on attempt ${attempt}"
-              break
-            fi
-            if [ $attempt -eq 2 ]; then
-              echo "Playwright failed after 2 attempts"
-              exit 1
-            fi
-            echo "Playwright failed on attempt ${attempt}, retrying after 10s..."
-            sleep 10
-          done
+            # Run Playwright tests
+            cd docs-preview-smoke-test/playwright && npx playwright test smoke.spec.ts --config playwright.config.ts
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v6
@@ -368,6 +279,6 @@ jobs:
         if: always() && steps.node-check.outputs.available == 'true'
         shell: bash
         run: |
-          if [ -n "$FERN_PID" ]; then
-            kill $FERN_PID 2>/dev/null || true
+          if [ -f /tmp/fern-server.pid ]; then
+            kill "$(cat /tmp/fern-server.pid)" 2>/dev/null || true
           fi

--- a/.github/workflows/docs-bundle-smoke-test.yml
+++ b/.github/workflows/docs-bundle-smoke-test.yml
@@ -143,10 +143,32 @@ jobs:
           fern --version || echo "fern --version exited with $?"
 
       - name: Install Playwright
+        id: playwright-install
         if: steps.node-check.outputs.available == 'true'
         shell: bash
         run: |
-          cd docs-preview-smoke-test/playwright && npm install && npx playwright install chromium
+          cd docs-preview-smoke-test/playwright && npm install
+          # Playwright browser install hangs on Node 26 (all platforms).
+          # Run with a 120 s timeout; fall back to server-only smoke test.
+          npx playwright install chromium &
+          PW_PID=$!
+          for i in $(seq 1 120); do
+            if ! kill -0 $PW_PID 2>/dev/null; then
+              wait $PW_PID; PW_EXIT=$?
+              if [ $PW_EXIT -eq 0 ]; then
+                echo "installed=true" >> $GITHUB_OUTPUT
+              else
+                echo "::warning::Playwright browser install failed (exit $PW_EXIT) — skipping browser tests"
+                echo "installed=false" >> $GITHUB_OUTPUT
+              fi
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::warning::Playwright browser install timed out after 120s — skipping browser tests"
+          kill $PW_PID 2>/dev/null || true
+          wait $PW_PID 2>/dev/null || true
+          echo "installed=false" >> $GITHUB_OUTPUT
 
       # On Unix, background the server and wait for it to be ready, then run
       # Playwright in a separate step.
@@ -231,7 +253,7 @@ jobs:
           done
 
       - name: Run Playwright smoke tests (Unix)
-        if: steps.node-check.outputs.available == 'true' && runner.os != 'Windows'
+        if: steps.node-check.outputs.available == 'true' && runner.os != 'Windows' && steps.playwright-install.outputs.installed == 'true'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
@@ -244,7 +266,7 @@ jobs:
       # step exits. We must start the server and run Playwright in the SAME
       # step so the server stays alive for the duration of the tests.
       - name: Start server and run Playwright smoke tests (Windows)
-        if: steps.node-check.outputs.available == 'true' && runner.os == 'Windows'
+        if: steps.node-check.outputs.available == 'true' && runner.os == 'Windows' && steps.playwright-install.outputs.installed == 'true'
         shell: bash
         run: |
           cd docs-preview-smoke-test/fern
@@ -336,6 +358,57 @@ jobs:
             echo "Playwright failed on attempt ${attempt}, retrying after 10s..."
             sleep 10
           done
+
+      # When Playwright isn't available (e.g. Node 26), still verify the
+      # server starts on Windows. Same background-process approach.
+      - name: Start fern docs dev server (Windows, no Playwright)
+        if: steps.node-check.outputs.available == 'true' && runner.os == 'Windows' && steps.playwright-install.outputs.installed != 'true'
+        shell: bash
+        run: |
+          cd docs-preview-smoke-test/fern
+          FERN_NO_VERSION_REDIRECTION=true fern docs dev \
+            > /tmp/fern-docs-dev.log 2>&1 &
+          FERN_PID=$!
+          echo "FERN_PID=$FERN_PID" >> $GITHUB_ENV
+
+          echo "Waiting for fern docs dev server to start (PID: $FERN_PID)..."
+          for i in $(seq 1 180); do
+            if grep -qi "ready on" /tmp/fern-docs-dev.log 2>/dev/null; then
+              echo "Server reported ready after ${i}s!"
+              break
+            fi
+            if ! kill -0 $FERN_PID 2>/dev/null; then
+              echo "fern docs dev process (PID: $FERN_PID) exited unexpectedly"
+              tail -50 /tmp/fern-docs-dev.log
+              exit 1
+            fi
+            if [ $i -eq 180 ]; then
+              echo "Timeout waiting for server to start after 180s"
+              tail -50 /tmp/fern-docs-dev.log
+              exit 1
+            fi
+            if [ $((i % 15)) -eq 0 ]; then
+              echo "Still waiting... (${i}s)"
+              tail -5 /tmp/fern-docs-dev.log 2>/dev/null || true
+            fi
+            sleep 1
+          done
+
+          echo "Waiting for server to return HTTP 200 on /sitemap.xml..."
+          for j in $(seq 1 30); do
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:3000/sitemap.xml 2>/dev/null || echo "000")
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "Server returning 200 on /sitemap.xml after ${j}s"
+              break
+            fi
+            if [ $j -eq 30 ]; then
+              echo "Server never returned 200 on /sitemap.xml after 30s (last HTTP $HTTP_CODE)"
+              tail -100 /tmp/fern-docs-dev.log
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Server-only smoke test passed (Playwright unavailable)"
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v6

--- a/.github/workflows/docs-bundle-smoke-test.yml
+++ b/.github/workflows/docs-bundle-smoke-test.yml
@@ -143,32 +143,10 @@ jobs:
           fern --version || echo "fern --version exited with $?"
 
       - name: Install Playwright
-        id: playwright-install
         if: steps.node-check.outputs.available == 'true'
         shell: bash
         run: |
-          cd docs-preview-smoke-test/playwright && npm install
-          # Playwright browser install hangs on Node 26 (all platforms).
-          # Run with a 120 s timeout; fall back to server-only smoke test.
-          npx playwright install chromium &
-          PW_PID=$!
-          for i in $(seq 1 120); do
-            if ! kill -0 $PW_PID 2>/dev/null; then
-              wait $PW_PID; PW_EXIT=$?
-              if [ $PW_EXIT -eq 0 ]; then
-                echo "installed=true" >> $GITHUB_OUTPUT
-              else
-                echo "::warning::Playwright browser install failed (exit $PW_EXIT) — skipping browser tests"
-                echo "installed=false" >> $GITHUB_OUTPUT
-              fi
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "::warning::Playwright browser install timed out after 120s — skipping browser tests"
-          kill $PW_PID 2>/dev/null || true
-          wait $PW_PID 2>/dev/null || true
-          echo "installed=false" >> $GITHUB_OUTPUT
+          cd docs-preview-smoke-test/playwright && npm install && npx playwright install chromium
 
       # On Unix, background the server and wait for it to be ready, then run
       # Playwright in a separate step.
@@ -253,7 +231,7 @@ jobs:
           done
 
       - name: Run Playwright smoke tests (Unix)
-        if: steps.node-check.outputs.available == 'true' && runner.os != 'Windows' && steps.playwright-install.outputs.installed == 'true'
+        if: steps.node-check.outputs.available == 'true' && runner.os != 'Windows'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
@@ -266,7 +244,7 @@ jobs:
       # step exits. We must start the server and run Playwright in the SAME
       # step so the server stays alive for the duration of the tests.
       - name: Start server and run Playwright smoke tests (Windows)
-        if: steps.node-check.outputs.available == 'true' && runner.os == 'Windows' && steps.playwright-install.outputs.installed == 'true'
+        if: steps.node-check.outputs.available == 'true' && runner.os == 'Windows'
         shell: bash
         run: |
           cd docs-preview-smoke-test/fern
@@ -358,57 +336,6 @@ jobs:
             echo "Playwright failed on attempt ${attempt}, retrying after 10s..."
             sleep 10
           done
-
-      # When Playwright isn't available (e.g. Node 26), still verify the
-      # server starts on Windows. Same background-process approach.
-      - name: Start fern docs dev server (Windows, no Playwright)
-        if: steps.node-check.outputs.available == 'true' && runner.os == 'Windows' && steps.playwright-install.outputs.installed != 'true'
-        shell: bash
-        run: |
-          cd docs-preview-smoke-test/fern
-          FERN_NO_VERSION_REDIRECTION=true fern docs dev \
-            > /tmp/fern-docs-dev.log 2>&1 &
-          FERN_PID=$!
-          echo "FERN_PID=$FERN_PID" >> $GITHUB_ENV
-
-          echo "Waiting for fern docs dev server to start (PID: $FERN_PID)..."
-          for i in $(seq 1 180); do
-            if grep -qi "ready on" /tmp/fern-docs-dev.log 2>/dev/null; then
-              echo "Server reported ready after ${i}s!"
-              break
-            fi
-            if ! kill -0 $FERN_PID 2>/dev/null; then
-              echo "fern docs dev process (PID: $FERN_PID) exited unexpectedly"
-              tail -50 /tmp/fern-docs-dev.log
-              exit 1
-            fi
-            if [ $i -eq 180 ]; then
-              echo "Timeout waiting for server to start after 180s"
-              tail -50 /tmp/fern-docs-dev.log
-              exit 1
-            fi
-            if [ $((i % 15)) -eq 0 ]; then
-              echo "Still waiting... (${i}s)"
-              tail -5 /tmp/fern-docs-dev.log 2>/dev/null || true
-            fi
-            sleep 1
-          done
-
-          echo "Waiting for server to return HTTP 200 on /sitemap.xml..."
-          for j in $(seq 1 30); do
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 http://localhost:3000/sitemap.xml 2>/dev/null || echo "000")
-            if [ "$HTTP_CODE" = "200" ]; then
-              echo "Server returning 200 on /sitemap.xml after ${j}s"
-              break
-            fi
-            if [ $j -eq 30 ]; then
-              echo "Server never returned 200 on /sitemap.xml after 30s (last HTTP $HTTP_CODE)"
-              tail -100 /tmp/fern-docs-dev.log
-              exit 1
-            fi
-            sleep 1
-          done
-          echo "Server-only smoke test passed (Playwright unavailable)"
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v6

--- a/packages/cli/cli/changes/unreleased/fix-node26-io-uring-hang.yml
+++ b/packages/cli/cli/changes/unreleased/fix-node26-io-uring-hang.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix `fern docs dev` hanging indefinitely on Node.js v26+ on Linux by disabling
+    io_uring in the child server process. Node 26 enables io_uring by default in
+    libuv, which has a busy-loop bug where worker threads spin on an internal
+    eventfd, starving the main event loop.
+  type: fix

--- a/packages/cli/cli/changes/unreleased/fix-pnpm-ignored-builds-esbuild.yml
+++ b/packages/cli/cli/changes/unreleased/fix-pnpm-ignored-builds-esbuild.yml
@@ -1,6 +1,0 @@
-- summary: |
-    Fix `fern docs dev` failing on pnpm 10+ where `pnpm i esbuild` exits with
-    ERR_PNPM_IGNORED_BUILDS because build scripts are blocked by default. The
-    esbuild package is installed successfully; the error is now treated as
-    non-fatal since `install-esbuild.js` handles binary setup separately.
-  type: fix

--- a/packages/cli/cli/changes/unreleased/fix-pnpm-ignored-builds-esbuild.yml
+++ b/packages/cli/cli/changes/unreleased/fix-pnpm-ignored-builds-esbuild.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix `fern docs dev` failing on pnpm 10+ where `pnpm i esbuild` exits with
+    ERR_PNPM_IGNORED_BUILDS because build scripts are blocked by default. The
+    esbuild package is installed successfully; the error is now treated as
+    non-fatal since `install-esbuild.js` handles binary setup separately.
+  type: fix

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { spawnSync } from "node:child_process";
 import type { ReadStream, WriteStream } from "node:tty";
 import { fromBinary, toBinary } from "@bufbuild/protobuf";
 import { CodeGeneratorRequestSchema, CodeGeneratorResponseSchema } from "@bufbuild/protobuf/wkt";
@@ -92,6 +93,22 @@ import { FERN_CWD_ENV_VAR } from "./cwd.js";
 import { rerunFernCliAtVersion } from "./rerunFernCliAtVersion.js";
 import { resolveGroupGithubConfig } from "./resolveGroupGithubConfig.js";
 import { RUNTIME } from "./runtime.js";
+
+// Node 26+ on Linux enables io_uring in libuv, which has a busy-loop bug that
+// hangs the process. UV_USE_IO_URING must be set before Node starts (libuv
+// reads it at init), so re-exec with it set. spawnSync doesn't use the event
+// loop, so the broken io_uring backend cannot stall the re-exec.
+if (
+    process.platform === "linux" &&
+    parseInt(process.versions.node.split(".")[0] ?? "0", 10) >= 26 &&
+    process.env.UV_USE_IO_URING !== "0"
+) {
+    const result = spawnSync(process.execPath, process.argv.slice(1), {
+        env: { ...process.env, UV_USE_IO_URING: "0" },
+        stdio: "inherit"
+    });
+    process.exit(result.status ?? 1);
+}
 
 void runCli();
 

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -107,6 +107,9 @@ if (
         env: { ...process.env, UV_USE_IO_URING: "0" },
         stdio: "inherit"
     });
+    if (result.signal) {
+        process.kill(process.pid, result.signal);
+    }
     process.exit(result.status ?? 1);
 }
 

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -30,6 +30,7 @@ const LOCAL_STORAGE_FOLDER = process.env.LOCAL_STORAGE_FOLDER ?? ".fern";
 // Const for windows post-processing
 const INSTRUMENTATION_PATH = "packages/fern-docs/bundle/.next/server/instrumentation.js";
 const COREPACK_MISSING_KEYID_ERROR_MESSAGE = 'Cannot find matching keyid: {"signatures":';
+const PNPM_IGNORED_BUILDS_ERROR = "ERR_PNPM_IGNORED_BUILDS";
 
 interface SymlinkEntry {
     path: string;
@@ -541,11 +542,18 @@ export async function downloadBundle({
                 });
             } catch (error) {
                 if (error instanceof Error) {
-                    // If error message contains "Cannot find matching keyid:", try to upgrade corepack
-                    if (
+                    // pnpm 10+ blocks build scripts by default. esbuild is installed
+                    // but its postinstall is skipped — install-esbuild.js handles the
+                    // binary setup separately, so this error is non-fatal.
+                    if (typeof error?.message === "string" && error.message.includes(PNPM_IGNORED_BUILDS_ERROR)) {
+                        logger.debug(
+                            "pnpm blocked esbuild build scripts (ERR_PNPM_IGNORED_BUILDS) — continuing, install-esbuild.js will handle binary setup"
+                        );
+                    } else if (
                         typeof error?.message === "string" &&
                         error.message.includes(COREPACK_MISSING_KEYID_ERROR_MESSAGE)
                     ) {
+                        // If error message contains "Cannot find matching keyid:", try to upgrade corepack
                         logger.debug("Detected corepack missing keyid error. Attempting to upgrade corepack");
                         try {
                             await loggingExeca(logger, "npm", ["install", "-g", "corepack@latest"], {

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -1092,8 +1092,21 @@ export async function runAppPreviewServer({
 
     // Now start Next.js after backend is ready
 
+    // Node.js >= 26 on Linux enables io_uring by default in libuv, which has a
+    // busy-loop bug: worker threads spin on an internal eventfd, starving the
+    // main event loop and causing the server to hang during startup.
+    // Setting UV_USE_IO_URING=0 falls back to epoll and avoids the hang.
+    const nodeMajor = parseInt(process.versions.node.split(".")[0] ?? "0", 10);
+    const needsIoUringWorkaround = process.platform === "linux" && nodeMajor >= 26;
+    if (needsIoUringWorkaround) {
+        context.logger.debug(
+            `Node.js v${process.versions.node} on Linux detected — disabling io_uring to avoid libuv busy-loop`
+        );
+    }
+
     const env = {
         ...process.env,
+        ...(needsIoUringWorkaround ? { UV_USE_IO_URING: "0" } : {}),
         PORT: port.toString(),
         HOSTNAME: "0.0.0.0",
         NEXT_PUBLIC_FDR_ORIGIN_PORT: backendPort.toString(),


### PR DESCRIPTION
## Description

Fixes for `fern docs dev` startup failures on Node 26, plus CI smoke test improvements:

1. **Node 26 io_uring hang (parent process)**: Node 26 enables `io_uring` by default in libuv, which has a busy-loop bug — worker threads spin on an internal `eventfd`, starving the main event loop. Because `UV_USE_IO_URING` must be set *before* libuv initializes, the CLI entry point detects Node ≥ 26 on Linux and re-execs itself via `spawnSync` with `UV_USE_IO_URING=0`. `spawnSync` is safe here because it doesn't use the event loop.

2. **Node 26 io_uring hang (child process)**: The spawned Next.js standalone server also needs the workaround. `UV_USE_IO_URING=0` is injected into the child process environment so the child's libuv initializes with epoll instead of io_uring.

3. **pnpm 10+ esbuild install failure**: pnpm 10+ blocks build scripts by default (`ERR_PNPM_IGNORED_BUILDS`), causing `pnpm i esbuild` to exit code 1 even though the package is installed. The outer catch handler then **deletes the entire `app-preview/` folder**, so `writeNodePolyfillScript()` fails with `ENOENT: node-polyfills.cjs`. Now treated as non-fatal since `install-esbuild.js` handles binary setup separately.

4. **Smoke test retry-on-crash** (backported from fern-platform [#10791](https://github.com/fern-api/fern-platform/pull/10791)): Merged the separate Unix/Windows server start + Playwright steps into a single unified retry step. On crash (known Node.js v24 Windows issue), the server is automatically restarted and tests re-run (up to 3 attempts). Uses PID file for reliable cleanup across retries.

### Playwright + Node 26 CI hang (investigated & resolved)

The earlier CI timeout on Node 26 (`npx playwright install chromium` hanging indefinitely) was specific to Node 26.0.0 and is resolved in Node 26.1.0 (released May 7). Confirmed locally: Playwright browser install completes successfully on Node v26.1.0. CI now uses the standard `npx playwright install chromium` flow.

## Changes Made

**`cli.ts`** (CLI entry point):
- Detect Node.js ≥ 26 on Linux with `UV_USE_IO_URING` not already set
- Re-exec the CLI via `spawnSync` with `UV_USE_IO_URING=0` in the environment
- Exit with the child's exit code

**`runAppPreviewServer.ts`** (child process):
- Detect Node.js ≥ 26 on Linux
- Inject `UV_USE_IO_URING=0` into the child server process environment, falling back to `epoll`
- Log a debug message when the workaround is active

**`downloadLocalDocsBundle.ts`**:
- Detect `ERR_PNPM_IGNORED_BUILDS` in the esbuild install catch block and treat it as non-fatal
- The esbuild package IS installed; only its postinstall is skipped — `install-esbuild.js` handles binary setup separately

**`docs-bundle-smoke-test.yml`**:
- Merge separate Unix/Windows server start + Playwright steps into one unified retry step
- 3 max attempts with automatic server restart on crash (was 2 attempts, no restart)
- `timeout-minutes: 10` on Playwright install step
- PID file-based cleanup instead of `$GITHUB_ENV` variable

**Changelog**:
- Added unreleased changelog entry for io_uring fix

## Human Review Checklist

- [ ] **`spawnSync` re-exec safety**: The re-exec uses `spawnSync` which doesn't go through the event loop, so the broken io_uring backend shouldn't stall it. Worth verifying there are no edge cases with signal propagation or deeply nested CLI invocations.
- [ ] **install-esbuild.js coverage**: Verify that `install-esbuild.js` (in the downloaded bundle) actually handles downloading the platform-specific esbuild binary when the postinstall was skipped. If it doesn't, esbuild will be non-functional despite the package being installed.
- [ ] **Unified Unix/Windows step**: The previous workflow had separate Unix and Windows steps because background processes (`&`) are killed when a bash step exits on Windows. The new unified step avoids this by running server start + Playwright in a single retry `command:` block. Verify this works correctly on Windows CI.
- [ ] **Version threshold**: Confirm that `>= 26` is the correct cutoff (i.e., Node 25 and below don't enable io_uring by default in libuv).

## Testing

- [x] Lint/format checks pass (`pnpm check`)
- [x] Node 22/24/26 smoke tests pass on all platforms (ubuntu, macos, windows) — all 9 jobs green
- [x] Playwright install confirmed working on Node v26.1.0 (no hang)
- [ ] Manual testing on Node 26 Linux (requires Node 26 to reproduce the io_uring hang)

Link to Devin session: https://app.devin.ai/sessions/b574d69cd49e4949b04d87b25943557e