### PR TITLE
fix(deps): bump urllib3 to 2.7.0 in basic-auth-pw-omitted seed lockfile

### DIFF
--- a/seed/python-sdk/basic-auth-pw-omitted/poetry.lock
+++ b/seed/python-sdk/basic-auth-pw-omitted/poetry.lock
@@ -1275,13 +1275,13 @@ typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]


### PR DESCRIPTION
## Description

Addresses Dependabot urllib3 alerts in the fern repo (#2065, #2066). Bumps urllib3 from 2.6.3 → 2.7.0 in `seed/python-sdk/basic-auth-pw-omitted/poetry.lock`, the only remaining seed lockfile still on a vulnerable version. All other seed python-sdk lockfiles are already on 2.7.0.

Advisories patched:
- GHSA-38jv-5279-wg99 — Decompression-bomb safeguards bypassed when following HTTP redirects in the streaming API (High)
- GHSA-fp4f-r3rg-x6xv — Sensitive headers forwarded across origins in proxied low-level redirects (Moderate)

Both advisories are first patched in urllib3 2.7.0.

## Changes Made

- Ran `poetry update urllib3 --lock` in `seed/python-sdk/basic-auth-pw-omitted/` to bump urllib3 from 2.6.3 to 2.7.0.
- [ ] Updated README.md generator (if applicable)

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed — verified `seed/python-sdk/basic-auth-pw-omitted/poetry.lock` is the only seed python-sdk lockfile still pinning urllib3 < 2.7.0; the diff is minimal (urllib3 version, python-versions, and file hashes only) and matches the entry already present in other seed python-sdk lockfiles.

Link to Devin session: https://app.devin.ai/sessions/23026b94d4f4450887c8b888495f821e
Requested by: @davidkonigsberg