### PR TITLE
fix(cli): allow esbuild build scripts in docs preview bundle folder for pnpm 11

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-esbuild-pnpm11.yml
+++ b/packages/cli/cli/changes/unreleased/fix-esbuild-pnpm11.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Fix `fern docs dev` failing with pnpm 11 due to esbuild build scripts being blocked by default.
+    Writes `onlyBuiltDependencies` config to the bundle folder before installing esbuild.
+  type: fix

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -527,6 +527,11 @@ export async function downloadBundle({
                 });
             }
 
+            const workspaceConfigPath = path.join(absolutePathToBundleFolder, "pnpm-workspace.yaml");
+            if (!existsSync(workspaceConfigPath)) {
+                await writeFile(workspaceConfigPath, "onlyBuiltDependencies:\n  - esbuild\n");
+            }
+
             try {
                 // install esbuild
                 logger.debug("Installing esbuild");


### PR DESCRIPTION
## Description

Fixes `fern docs dev` failing with pnpm 11 due to esbuild's postinstall build script being blocked by the new `onlyBuiltDependencies` security feature.

## Changes Made

- Writes a `pnpm-workspace.yaml` with `onlyBuiltDependencies: [esbuild]` to the bundle folder (`~/.fern/app-preview/`) before running `pnpm i esbuild`
- Only writes the config if it doesn't already exist (idempotent)
- Added changelog entry

## Context

pnpm 11 blocks build scripts by default for supply chain security. The fern repo's workspace already has `onlyBuiltDependencies: [esbuild]` in its root `pnpm-workspace.yaml`, but `fern docs dev` runs `pnpm i esbuild` in `~/.fern/app-preview/` which is outside the workspace, so the allowlist doesn't apply there.

This causes `[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.28.0` — esbuild's postinstall script needs to run to download the platform-specific binary.

This also fixes the `docs-bundle-smoke-test` CI failures in `fern-api/fern-platform` after upgrading to pnpm 11.

## Testing

- [x] `pnpm check` passes (biome lint)
- [x] Manual code review of the fix
- The fix writes `onlyBuiltDependencies` config to the same directory where `pnpm i esbuild` runs, ensuring pnpm picks it up

Link to Devin session: https://app.devin.ai/sessions/39eea5e73d364a1b919e3519594a2e17
Requested by: @ctondreau