### PR TITLE
fix(cli): make docs-validator rule init failures honor configured severity

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-missing-redirects-init-failures-respect-severity.yml
+++ b/packages/cli/cli/changes/unreleased/fix-missing-redirects-init-failures-respect-severity.yml
@@ -1,0 +1,8 @@
+- summary: |
+    Fix `missing-redirects` causing `fern check` to exit with code 1 even when
+    the rule is configured at `warn`. Rule initialization failures now honor
+    the configured severity (`warn` emits a warning, `error` emits an error)
+    instead of always being reported as fatal. The `missing-redirects` rule
+    also degrades to a warning when the local docs navigation fails to
+    resolve, and non-`Error` throws no longer surface as `[object Object]`.
+  type: fix

--- a/packages/cli/cli/changes/unreleased/fix-missing-redirects-init-failures-respect-severity.yml
+++ b/packages/cli/cli/changes/unreleased/fix-missing-redirects-init-failures-respect-severity.yml
@@ -4,5 +4,7 @@
     the configured severity (`warn` emits a warning, `error` emits an error)
     instead of always being reported as fatal. The `missing-redirects` rule
     also degrades to a warning when the local docs navigation fails to
-    resolve, and non-`Error` throws no longer surface as `[object Object]`.
+    resolve, captures the underlying `failAndThrow` message so the warning
+    explains *why* (e.g. `Folder not found: ...`) instead of `[object Object]`,
+    and non-`Error` throws are formatted readably across the validator.
   type: fix

--- a/packages/cli/yaml/docs-validator/src/__test__/formatInitError.test.ts
+++ b/packages/cli/yaml/docs-validator/src/__test__/formatInitError.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { formatInitError } from "../formatInitError.js";
+
+describe("formatInitError", () => {
+    it("returns the message of an Error instance", () => {
+        expect(formatInitError(new Error("boom"))).toBe("boom");
+    });
+
+    it("returns string throws as-is", () => {
+        expect(formatInitError("kaboom")).toBe("kaboom");
+    });
+
+    it("serializes plain objects to JSON instead of returning [object Object]", () => {
+        expect(formatInitError({ code: "FDR_TIMEOUT", attempt: 3 })).toBe('{"code":"FDR_TIMEOUT","attempt":3}');
+    });
+
+    it("falls back to Object.prototype.toString for empty objects", () => {
+        // `{}` serializes to `"{}"` which is not informative; fall through to
+        // toString so users see at least the type tag.
+        expect(formatInitError({})).toBe("[object Object]");
+    });
+
+    it("falls back to Object.prototype.toString when JSON.stringify throws", () => {
+        const circular: Record<string, unknown> = {};
+        circular.self = circular;
+        expect(formatInitError(circular)).toBe("[object Object]");
+    });
+
+    it("does not crash on null or undefined", () => {
+        expect(formatInitError(null)).toBe("null");
+        expect(formatInitError(undefined)).toBe("[object Undefined]");
+    });
+});

--- a/packages/cli/yaml/docs-validator/src/formatInitError.ts
+++ b/packages/cli/yaml/docs-validator/src/formatInitError.ts
@@ -1,0 +1,22 @@
+/**
+ * Format an unknown thrown value (caught from a rule's `create()`) into a
+ * human-readable message. Avoids the unhelpful `[object Object]` that would
+ * otherwise come from `String({})`.
+ */
+export function formatInitError(error: unknown): string {
+    if (error instanceof Error) {
+        return error.message;
+    }
+    if (typeof error === "string") {
+        return error;
+    }
+    try {
+        const serialized = JSON.stringify(error);
+        if (serialized != null && serialized !== "{}") {
+            return serialized;
+        }
+    } catch {
+        // fall through to Object.prototype.toString
+    }
+    return Object.prototype.toString.call(error);
+}

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
@@ -1,10 +1,10 @@
 import { getToken } from "@fern-api/auth";
-import { noop } from "@fern-api/core-utils";
 import { DocsDefinitionResolver } from "@fern-api/docs-resolver";
 import { FernNavigation } from "@fern-api/fdr-sdk";
-import { createLogger } from "@fern-api/logger";
-import { createMockTaskContext } from "@fern-api/task-context";
+import { createLogger, type LogLevel } from "@fern-api/logger";
+import { createMockTaskContext, type TaskContext } from "@fern-api/task-context";
 
+import { formatInitError } from "../../formatInitError.js";
 import { Rule } from "../../Rule.js";
 import { getInstanceUrls, toBaseUrl } from "../valid-markdown-link/url-utils.js";
 import { buildPageIdToSlugMap } from "./buildPageIdToSlugMap.js";
@@ -15,7 +15,24 @@ import {
     type MarkdownEntry
 } from "./missing-redirects-logic.js";
 
-const NOOP_CONTEXT = createMockTaskContext({ logger: createLogger(noop) });
+/**
+ * Captures the last `error`-level message routed through the mock task context
+ * so we can surface it in the warning when `DocsDefinitionResolver.resolve()`
+ * aborts via `failAndThrow`. The mock's `failAndThrow` throws a
+ * `TaskAbortSignal` (a non-Error class) and logs the actual reason — without
+ * this capture the rule would only see `[object Object]`.
+ */
+function createResolverContext(): { context: TaskContext; getLastErrorMessage: () => string | undefined } {
+    let lastErrorMessage: string | undefined;
+    const context = createMockTaskContext({
+        logger: createLogger((level: LogLevel, ...args: string[]) => {
+            if (level === "error") {
+                lastErrorMessage = args.join(" ");
+            }
+        })
+    });
+    return { context, getLastErrorMessage: () => lastErrorMessage };
+}
 
 // The FDR SDK types config.root as {} via zod inference, but at runtime it is FernNavigation.V1.RootNode.
 // This type guard checks the "type" discriminant to safely narrow the type without a blind cast.
@@ -105,13 +122,14 @@ export const MissingRedirectsRule: Rule = {
         }
 
         let removedSlugs: ReturnType<typeof findRemovedSlugs>;
+        const { context: resolverContext, getLastErrorMessage } = createResolverContext();
         try {
             const docsDefinitionResolver = new DocsDefinitionResolver({
                 domain: url,
                 docsWorkspace: workspace,
                 ossWorkspaces,
                 apiWorkspaces,
-                taskContext: NOOP_CONTEXT,
+                taskContext: resolverContext,
                 editThisPage: undefined,
                 uploadFiles: undefined,
                 registerApi: undefined,
@@ -129,7 +147,11 @@ export const MissingRedirectsRule: Rule = {
             const latestEntries = keepLatestEntryPerPageId(result.entries);
             removedSlugs = findRemovedSlugs(latestEntries, localPageIdToSlug);
         } catch (error) {
-            const reason = error instanceof Error ? (error.message ?? String(error)) : String(error);
+            // `DocsDefinitionResolver` reports fatal errors via `taskContext.failAndThrow`,
+            // which throws a `TaskAbortSignal` (a non-Error sentinel class) after logging
+            // the real reason. Prefer the captured log message over `String(error)` so the
+            // warning includes something actionable instead of `[object Object]`.
+            const reason = getLastErrorMessage() ?? formatInitError(error);
             logger.debug(`[missing-redirects] Failed to resolve local docs navigation: ${reason}`);
             return makeSkipVisitor({ type: "resolve-failed", reason });
         }

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
@@ -28,6 +28,7 @@ type FetchResult =
     | { type: "no-token" }
     | { type: "no-instance-url" }
     | { type: "fetch-failed"; reason: string }
+    | { type: "resolve-failed"; reason: string }
     | { type: "first-publish" };
 
 /**
@@ -103,28 +104,35 @@ export const MissingRedirectsRule: Rule = {
             return makeSkipVisitor({ type: "first-publish" });
         }
 
-        const docsDefinitionResolver = new DocsDefinitionResolver({
-            domain: url,
-            docsWorkspace: workspace,
-            ossWorkspaces,
-            apiWorkspaces,
-            taskContext: NOOP_CONTEXT,
-            editThisPage: undefined,
-            uploadFiles: undefined,
-            registerApi: undefined,
-            targetAudiences: undefined
-        });
+        let removedSlugs: ReturnType<typeof findRemovedSlugs>;
+        try {
+            const docsDefinitionResolver = new DocsDefinitionResolver({
+                domain: url,
+                docsWorkspace: workspace,
+                ossWorkspaces,
+                apiWorkspaces,
+                taskContext: NOOP_CONTEXT,
+                editThisPage: undefined,
+                uploadFiles: undefined,
+                registerApi: undefined,
+                targetAudiences: undefined
+            });
 
-        const resolvedDocsDefinition = await docsDefinitionResolver.resolve();
-        const configRoot = resolvedDocsDefinition.config.root;
-        if (!configRoot || !isV1RootNode(configRoot)) {
-            return {};
+            const resolvedDocsDefinition = await docsDefinitionResolver.resolve();
+            const configRoot = resolvedDocsDefinition.config.root;
+            if (!configRoot || !isV1RootNode(configRoot)) {
+                return {};
+            }
+
+            const root = FernNavigation.migrate.FernNavigationV1ToLatest.create().root(configRoot);
+            const localPageIdToSlug = buildPageIdToSlugMap(root);
+            const latestEntries = keepLatestEntryPerPageId(result.entries);
+            removedSlugs = findRemovedSlugs(latestEntries, localPageIdToSlug);
+        } catch (error) {
+            const reason = error instanceof Error ? (error.message ?? String(error)) : String(error);
+            logger.debug(`[missing-redirects] Failed to resolve local docs navigation: ${reason}`);
+            return makeSkipVisitor({ type: "resolve-failed", reason });
         }
-
-        const root = FernNavigation.migrate.FernNavigationV1ToLatest.create().root(configRoot);
-        const localPageIdToSlug = buildPageIdToSlugMap(root);
-        const latestEntries = keepLatestEntryPerPageId(result.entries);
-        const removedSlugs = findRemovedSlugs(latestEntries, localPageIdToSlug);
 
         if (removedSlugs.length === 0) {
             return {};
@@ -175,6 +183,17 @@ function makeSkipVisitor(fetchResult: Exclude<FetchResult, { type: "success" }>)
                         message:
                             `Missing redirects check skipped: could not reach FDR (${fetchResult.reason}). ` +
                             "The check requires network access to compare against previously published docs."
+                    }
+                ]
+            };
+        case "resolve-failed":
+            return {
+                file: () => [
+                    {
+                        severity: "warning",
+                        message:
+                            `Missing redirects check skipped: failed to resolve local docs navigation (${fetchResult.reason}). ` +
+                            "Run `fern check --log-level=debug` for more detail."
                     }
                 ]
             };

--- a/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
+++ b/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
@@ -10,6 +10,7 @@ import {
     type SeverityOverride
 } from "./createDocsConfigFileAstVisitorForRules.js";
 import { visitDocsConfigFileYamlAst } from "./docsAst/visitDocsConfigFileYamlAst.js";
+import { formatInitError } from "./formatInitError.js";
 import { getAllRules } from "./getAllRules.js";
 import { Rule } from "./Rule.js";
 import { MissingRedirectsRule } from "./rules/missing-redirects/index.js";
@@ -20,7 +21,6 @@ import { ValidDocsEndpoints } from "./rules/valid-docs-endpoints/index.js";
 import { ValidLocalReferencesRule } from "./rules/valid-local-references/index.js";
 import { ValidMarkdownLinks } from "./rules/valid-markdown-link/index.js";
 import { ValidOpenApiExamples } from "./rules/valid-openapi-examples/index.js";
-import { formatInitError } from "./formatInitError.js";
 import { ValidationViolation } from "./ValidationViolation.js";
 
 function toSeverityOverride(severity: docsYml.RawSchemas.CheckRuleSeverity): SeverityOverride {

--- a/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
+++ b/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
@@ -20,6 +20,7 @@ import { ValidDocsEndpoints } from "./rules/valid-docs-endpoints/index.js";
 import { ValidLocalReferencesRule } from "./rules/valid-local-references/index.js";
 import { ValidMarkdownLinks } from "./rules/valid-markdown-link/index.js";
 import { ValidOpenApiExamples } from "./rules/valid-openapi-examples/index.js";
+import { formatInitError } from "./formatInitError.js";
 import { ValidationViolation } from "./ValidationViolation.js";
 
 function toSeverityOverride(severity: docsYml.RawSchemas.CheckRuleSeverity): SeverityOverride {
@@ -127,17 +128,24 @@ export async function runRulesOnDocsWorkspace({
     const allRulesWithVisitors: RuleWithVisitor[] = [];
     for (const result of ruleCreationResults) {
         if ("error" in result) {
-            const message = result.error instanceof Error ? result.error.message : String(result.error);
+            const message = formatInitError(result.error);
+            const severityOverride = severityOverrides.get(result.ruleName);
+            // Honor the user's configured severity for init failures. When a
+            // rule is configured at `warn` we should surface the failure as a
+            // warning rather than a fatal — otherwise the override is
+            // silently bypassed whenever the rule throws during setup.
+            const severity: ValidationViolation["severity"] =
+                severityOverride === "warning" ? "warning" : severityOverride === "error" ? "error" : "fatal";
             violations.push({
                 name: result.ruleName,
-                severity: "fatal",
+                severity,
                 relativeFilepath: RelativeFilePath.of(DOCS_CONFIGURATION_FILENAME),
                 nodePath: [],
                 message: `Rule "${result.ruleName}" failed to initialize: ${message}`
             });
             context.logger.debug(
                 `Rule "${result.ruleName}" failed to initialize: ${
-                    result.error instanceof Error ? (result.error.stack ?? result.error.message) : String(result.error)
+                    result.error instanceof Error ? (result.error.stack ?? result.error.message) : message
                 }`
             );
         } else {


### PR DESCRIPTION
## Description
Linear ticket: Refs

When a docs-validator rule throws an exception during its asynchronous `create()` step, the validator emits a `Rule "X" failed to initialize` violation. Previously this violation was hardcoded to `severity: "fatal"`, which meant configuring a rule at `warn` in `docs.yml` had no effect on init-time failures — `fern check` would still exit 1.

Reported by a customer (NVIDIA-NeMo/Gym) whose CI was failing on:

```
[docs] 1 error
    [error]
        path: docs.yml
        issue: Rule "missing-redirects" failed to initialize: [object Object]
```

…despite having `check.rules.missing-redirects: warn` configured in `docs.yml`. The rule itself already had defensive `makeSkipVisitor` paths that emit `warning` severity for things like FDR fetch failures, but an exception thrown from `DocsDefinitionResolver.resolve()` bypassed those and bubbled out of `create()`, hitting the hardcoded-fatal branch in `validateDocsWorkspace.ts`.

The `[object Object]` portion was a separate bug: `String(error)` was being called on a thrown non-`Error` value with no useful `toString`.

## Changes Made
- `validateDocsWorkspace.ts`: when `rule.create()` throws, look up the rule's configured severity (`severityOverrides`) and use it for the resulting violation. `warn` → `warning`, `error` → `error`, no override → `fatal` (preserves existing behavior for any rule without an explicit override).
- `formatInitError.ts` (new): format unknown thrown values into a readable message. Plain objects are serialized to JSON; circular / empty objects fall through to `Object.prototype.toString.call(...)`. Eliminates `[object Object]` in user-facing messages.
- `rules/missing-redirects/missing-redirects.ts`: wrap `DocsDefinitionResolver.resolve()` + the v1→latest navigation migration in a `try/catch` that returns a new `makeSkipVisitor({ type: "resolve-failed" })` (rendered as a `warning`). This is a defense-in-depth fix: even on a CLI version without the framework-level severity change above, the missing-redirects rule no longer crashes `check` when local navigation fails to resolve.
- `__test__/formatInitError.test.ts` (new): unit tests covering Error, string, plain object, empty object, circular object, `null`, and `undefined` inputs.
- Changelog entry under `packages/cli/cli/changes/unreleased/`.
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated (`pnpm test --filter @fern-api/docs-validator` → 151/151 passing, 6 new)
- [x] Manual testing completed — built the dev CLI and ran `fern check` against the customer's repo (NVIDIA-NeMo/Gym PR #1299, commit `bad8dead2`); rule degrades gracefully without modifying their docs.yml.
- [x] `pnpm lint:biome --fix` and `pnpm format:fix` clean.


Link to Devin session: https://app.devin.ai/sessions/bd3a58d7c2c44de0b1f23ea520709888
Requested by: @fern-support