### PR TITLE
fix(ruby): skip empty Comment nodes to avoid `Layout/EmptyComment` RuboCop offense in ruby-v2

### DIFF
--- a/generators/ruby-v2/ast/src/ast/Comment.ts
+++ b/generators/ruby-v2/ast/src/ast/Comment.ts
@@ -21,7 +21,7 @@ export class Comment extends AstNode {
     }
 
     public write(writer: Writer): void {
-        if (this.docs != null) {
+        if (this.docs?.trim()) {
             this.docs.split("\n").forEach((line) => {
                 const wrappedLines = this.wrapLine(line, writer);
                 wrappedLines.forEach((wrappedLine) => {

--- a/generators/ruby-v2/sdk/changes/unreleased/fix-empty-comment-rubocop.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/fix-empty-comment-rubocop.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix `Layout/EmptyComment` RuboCop offense emitted for types with no
+    description. The AST `Comment` node now skips writing when `docs` is
+    empty or whitespace-only, so undocumented model classes no longer
+    produce a bare `#` line above their class definition.
+  type: fix


### PR DESCRIPTION
## Description
Linear ticket: Closes
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->

Types with no description were emitting a bare `#` line above their class definition in `ruby-v2` generator output, triggering the `Layout/EmptyComment` RuboCop offense on generated SDKs. The Ruby AST `Comment.write` path is now guarded so that whitespace-only or empty docs produce no output at all, instead of writing a bare comment marker.

## Changes Made
- `generators/ruby-v2/ast/src/ast/Comment.ts`: tighten the write guard from `this.docs != null` to `this.docs?.trim()` so undocumented model classes no longer emit a leading `#` line.
- `generators/ruby-v2/sdk/changes/unreleased/fix-empty-comment-rubocop.yml`: add a `fix` changelog entry describing the RuboCop fix.
- [ ] Updated README.md generator (if applicable)

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed


Link to Devin session: https://app.devin.ai/sessions/2e4e587dd160400390839880a5434932
Requested by: @iamnamananand996