### PR TITLE
fix(rust): only clear `config.environment` in wire tests when multiple base URLs exist, fix pagination error tests

### DIFF
--- a/generators/ruby-v2/ast/src/ast/Comment.ts
+++ b/generators/ruby-v2/ast/src/ast/Comment.ts
@@ -21,7 +21,7 @@ export class Comment extends AstNode {
     }
 
     public write(writer: Writer): void {
-        if (this.docs != null) {
+        if (this.docs?.trim()) {
             this.docs.split("\n").forEach((line) => {
                 const wrappedLines = this.wrapLine(line, writer);
                 wrappedLines.forEach((wrappedLine) => {

--- a/generators/ruby-v2/sdk/changes/unreleased/fix-empty-comment-rubocop.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/fix-empty-comment-rubocop.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix `Layout/EmptyComment` RuboCop offense emitted for types with no
+    description. The AST `Comment` node now skips writing when `docs` is
+    empty or whitespace-only, so undocumented model classes no longer
+    produce a bare `#` line above their class definition.
+  type: fix

--- a/generators/rust/base/src/asIs/pagination.rs
+++ b/generators/rust/base/src/asIs/pagination.rs
@@ -526,7 +526,7 @@ mod tests {
     fn test_sync_paginator_error_propagation() {
         let client = make_http_client();
         let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
+            Err(ApiError::Configuration("test error".to_string()))
         }, None).unwrap();
 
         let result = paginator.next_page();
@@ -537,7 +537,7 @@ mod tests {
     fn test_sync_paginator_iterator_error() {
         let client = make_http_client();
         let mut paginator = SyncPaginator::<String>::new(client, |_client, _cursor| {
-            Err(ApiError::Serialization("test error".to_string()))
+            Err(ApiError::Configuration("test error".to_string()))
         }, None).unwrap();
 
         let item = paginator.next();

--- a/generators/rust/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/rust/sdk/src/wire-tests/WireTestGenerator.ts
@@ -251,7 +251,9 @@ export class WireTestGenerator {
                     lines.push(`    };`);
                     // Override base_url and clear environment so requests go to WireMock
                     lines.push(`    config.base_url = wiremock_base_url.to_string();`);
-                    lines.push(`    config.environment = None;`);
+                    if (this.context.hasMultipleBaseUrls()) {
+                        lines.push(`    config.environment = None;`);
+                    }
                     inConfigStruct = false;
                 } else {
                     lines.push(`    ${trimmedLine}`);

--- a/seed/rust-sdk/multi-url-environment/.fern/metadata.json
+++ b/seed/rust-sdk/multi-url-environment/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/multi-url-environment/src/core/pagination.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/pagination.rs
@@ -559,7 +559,7 @@ mod tests {
         let client = make_http_client();
         let mut paginator = SyncPaginator::<String>::new(
             client,
-            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            |_client, _cursor| Err(ApiError::Configuration("test error".to_string())),
             None,
         )
         .unwrap();
@@ -573,7 +573,7 @@ mod tests {
         let client = make_http_client();
         let mut paginator = SyncPaginator::<String>::new(
             client,
-            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            |_client, _cursor| Err(ApiError::Configuration("test error".to_string())),
             None,
         )
         .unwrap();

--- a/seed/rust-sdk/pagination/.fern/metadata.json
+++ b/seed/rust-sdk/pagination/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/pagination/src/core/pagination.rs
+++ b/seed/rust-sdk/pagination/src/core/pagination.rs
@@ -559,7 +559,7 @@ mod tests {
         let client = make_http_client();
         let mut paginator = SyncPaginator::<String>::new(
             client,
-            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            |_client, _cursor| Err(ApiError::Configuration("test error".to_string())),
             None,
         )
         .unwrap();
@@ -573,7 +573,7 @@ mod tests {
         let client = make_http_client();
         let mut paginator = SyncPaginator::<String>::new(
             client,
-            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            |_client, _cursor| Err(ApiError::Configuration("test error".to_string())),
             None,
         )
         .unwrap();

--- a/seed/rust-sdk/single-url-environment-default/basic/.fern/metadata.json
+++ b/seed/rust-sdk/single-url-environment-default/basic/.fern/metadata.json
@@ -3,8 +3,7 @@
   "generatorName": "fernapi/fern-rust-sdk",
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/single-url-environment-default/basic/src/core/pagination.rs
+++ b/seed/rust-sdk/single-url-environment-default/basic/src/core/pagination.rs
@@ -559,7 +559,7 @@ mod tests {
         let client = make_http_client();
         let mut paginator = SyncPaginator::<String>::new(
             client,
-            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            |_client, _cursor| Err(ApiError::Configuration("test error".to_string())),
             None,
         )
         .unwrap();
@@ -573,7 +573,7 @@ mod tests {
         let client = make_http_client();
         let mut paginator = SyncPaginator::<String>::new(
             client,
-            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            |_client, _cursor| Err(ApiError::Configuration("test error".to_string())),
             None,
         )
         .unwrap();

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/.fern/metadata.json
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/.fern/metadata.json
@@ -8,8 +8,7 @@
     "crateVersion": "0.2.0"
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/pagination.rs
+++ b/seed/rust-sdk/single-url-environment-default/custom-environment/src/core/pagination.rs
@@ -559,7 +559,7 @@ mod tests {
         let client = make_http_client();
         let mut paginator = SyncPaginator::<String>::new(
             client,
-            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            |_client, _cursor| Err(ApiError::Configuration("test error".to_string())),
             None,
         )
         .unwrap();
@@ -573,7 +573,7 @@ mod tests {
         let client = make_http_client();
         let mut paginator = SyncPaginator::<String>::new(
             client,
-            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            |_client, _cursor| Err(ApiError::Configuration("test error".to_string())),
             None,
         )
         .unwrap();

--- a/seed/rust-sdk/single-url-environment-default/full-custom/.fern/metadata.json
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/.fern/metadata.json
@@ -19,8 +19,7 @@
     "enableWireTests": true
   },
   "originGitCommit": "DUMMY",
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/single-url-environment-default/full-custom/src/core/pagination.rs
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/src/core/pagination.rs
@@ -559,7 +559,7 @@ mod tests {
         let client = make_http_client();
         let mut paginator = SyncPaginator::<String>::new(
             client,
-            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            |_client, _cursor| Err(ApiError::Configuration("test error".to_string())),
             None,
         )
         .unwrap();
@@ -573,7 +573,7 @@ mod tests {
         let client = make_http_client();
         let mut paginator = SyncPaginator::<String>::new(
             client,
-            |_client, _cursor| Err(ApiError::Serialization("test error".to_string())),
+            |_client, _cursor| Err(ApiError::Configuration("test error".to_string())),
             None,
         )
         .unwrap();

--- a/seed/rust-sdk/single-url-environment-default/full-custom/tests/dummy_test.rs
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/tests/dummy_test.rs
@@ -13,7 +13,6 @@ async fn test_dummy_get_dummy_with_wiremock() {
         ..Default::default()
     };
     config.base_url = wiremock_base_url.to_string();
-    config.environment = None;
     let client = SingleUrlEnvironmentDefaultClient::new(config).expect("Failed to build client");
 
     let result = client.dummy.get_dummy(None).await;


### PR DESCRIPTION
## Description
Linear ticket: Closes
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->

Fixes two issues in the Rust SDK generator that broke generated wire tests and pagination unit tests:

1. **Wire test generator** unconditionally emitted `config.environment = None;` for the WireMock test setup. Single-URL SDKs do not expose an `environment` field on `ClientConfig`, so the generated test failed to compile. The line is now only emitted when the SDK was generated against multiple base URLs (i.e. `context.hasMultipleBaseUrls()` is true).
2. **Pagination error-propagation tests** in the Rust base template referenced `ApiError::Serialization`, which is not a valid variant in the current `ApiError` enum, so the test file failed to compile. Switched the test fixtures to `ApiError::Configuration`, which is the appropriate variant for synthesizing a configuration-style error from the paginator callback.

Seed snapshots for `rust-sdk` fixtures (`multi-url-environment`, `pagination`, `single-url-environment-default/{basic,custom-environment,full-custom}`) were regenerated to reflect the above. The single-URL `full-custom` wire test no longer carries the unused `config.environment = None;` line.

Note: this branch is stacked on top of #15854 (the ruby-v2 empty-comment RuboCop fix), so that commit appears in the diff. It will drop out once #15854 lands.

## Changes Made
- `generators/rust/sdk/src/wire-tests/WireTestGenerator.ts`: gate the `config.environment = None;` emission on `this.context.hasMultipleBaseUrls()`.
- `generators/rust/base/src/asIs/pagination.rs`: switch the synchronous-paginator error tests from `ApiError::Serialization` to `ApiError::Configuration`.
- Regenerate `seed/rust-sdk/**` snapshots for the affected fixtures (`pagination.rs`, `tests/dummy_test.rs`, `.fern/metadata.json`).
- [ ] Updated README.md generator (if applicable)

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed (seed snapshots regenerated; the previously failing rust-sdk wire test and pagination unit tests now compile and run).


Link to Devin session: https://app.devin.ai/sessions/2e4e587dd160400390839880a5434932
Requested by: @iamnamananand996