### PR TITLE
chore(rust): add changelog entry for wire-test environment and pagination error fixes

### DIFF
--- a/generators/rust/sdk/changes/unreleased/fix-wire-test-environment-and-pagination-error.yml
+++ b/generators/rust/sdk/changes/unreleased/fix-wire-test-environment-and-pagination-error.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix generated Rust wire tests for single-URL SDKs and pagination error
+    tests. The wire test generator no longer emits `config.environment = None;`
+    when the SDK was generated against a single base URL (since the
+    `environment` field does not exist on `ClientConfig` in that case).
+    The synchronous-paginator error-propagation tests now use
+    `ApiError::Configuration` instead of the non-existent
+    `ApiError::Serialization` variant, so the generated `pagination.rs` test
+    module compiles.
+  type: fix


### PR DESCRIPTION
## Description
Linear ticket: Refs #15856
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->

Follow-up to #15856, which shipped two Rust SDK generator fixes without a corresponding `generators/rust/sdk/changes/unreleased/` entry. This PR adds that changelog file so the next Rust SDK release picks up a patch bump and a release-notes entry describing the fixes.

The entry documents both fixes from #15856:
- Wire test generator: only emits `config.environment = None;` when the SDK was generated against multiple base URLs (single-URL `ClientConfig` has no `environment` field, so the previously-generated test failed to compile).
- Synchronous-paginator error-propagation tests: switched from the non-existent `ApiError::Serialization` variant to `ApiError::Configuration` so the generated `pagination.rs` test module compiles.

## Changes Made
- `generators/rust/sdk/changes/unreleased/fix-wire-test-environment-and-pagination-error.yml`: new `fix` changelog entry covering both rust-sdk fixes from #15856.
- [ ] Updated README.md generator (if applicable)

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed (changelog file is data-only; the underlying generator fixes already landed in #15856 and were validated there).


Link to Devin session: https://app.devin.ai/sessions/2e4e587dd160400390839880a5434932
Requested by: @iamnamananand996