### PR TITLE
fix(java): emit guarded undiscriminated-union members before all-optional ones in deserializer

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/generators/UndiscriminatedUnionGenerator.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/generators/UndiscriminatedUnionGenerator.java
@@ -601,12 +601,24 @@ public final class UndiscriminatedUnionGenerator extends AbstractTypeGenerator {
                         .endControlFlow();
             }
         }
-        for (int i = 0; i < membersWithoutLiterals.size(); ++i) {
-            UndiscriminatedUnionMember member = membersWithoutLiterals.get(i);
+        // Sort: members with required key guards first, then unguarded (all-optional) members last.
+        // This prevents all-optional object types from greedily matching payloads intended for
+        // more specific members — e.g. PayMethodCloud (0 required keys) consuming {"achHolder":"x"}
+        // before Check (1 required key) gets a chance.
+        List<UndiscriminatedUnionMember> nonPrimitiveMembers = membersWithoutLiterals.stream()
+                .filter(m -> {
+                    TypeName tn = memberTypeNames.get(m);
+                    return !tn.isPrimitive() && !tn.isBoxedPrimitive();
+                })
+                .collect(Collectors.toList());
+        nonPrimitiveMembers.sort((a, b) -> {
+            boolean aHasGuard = !getRequiredWireKeys(a).isEmpty();
+            boolean bHasGuard = !getRequiredWireKeys(b).isEmpty();
+            if (aHasGuard == bHasGuard) return 0;
+            return aHasGuard ? -1 : 1;
+        });
+        for (UndiscriminatedUnionMember member : nonPrimitiveMembers) {
             TypeName typeName = memberTypeNames.get(member);
-            if (typeName.isPrimitive() || typeName.isBoxedPrimitive()) {
-                continue;
-            }
             List<String> requiredKeys = getRequiredWireKeys(member);
             boolean hasRequiredKeyGuard = !requiredKeys.isEmpty();
             if (hasRequiredKeyGuard) {

--- a/generators/java/sdk/changes/unreleased/fix-undiscriminated-union-all-optional-ordering.yml
+++ b/generators/java/sdk/changes/unreleased/fix-undiscriminated-union-all-optional-ordering.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix undiscriminated union deserialization when one member has all-optional fields.
+    Previously, an all-optional object variant (e.g. `PayMethodCloud`) could greedily
+    consume a payload intended for a more specific variant with required fields (e.g.
+    `Check` requiring `achHolder`), because Jackson's `@JsonIgnoreProperties(ignoreUnknown=true)`
+    silently accepts any JSON object when all fields are optional. The deserializer now
+    emits guarded members (those with at least one required field) before unguarded
+    (all-optional) members, ensuring the more specific match wins.
+  type: fix


### PR DESCRIPTION
## Description
Linear ticket: Closes
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->

Fix incorrect deserialization of Java undiscriminated unions where one variant has all-optional fields. Because Jackson's `@JsonIgnoreProperties(ignoreUnknown = true)` silently accepts any JSON object when every field is optional, an all-optional variant could greedily match a payload intended for a more specific sibling that requires certain keys.

The generated deserializer in `UndiscriminatedUnionGenerator` now stably partitions non-primitive members so that variants with at least one required wire key (a "key guard") are attempted first, and unguarded (all-optional) variants are tried last. This preserves prior ordering within each partition while ensuring the more specific match wins.

Concrete failure mode this fixes: a union containing `Check` (requires `achHolder`) and `PayMethodCloud` (all optional) previously deserialized `{"achHolder": "..."}` as `PayMethodCloud` instead of `Check`.

## Changes Made
- `generators/java/generator-utils/src/main/java/com/fern/java/generators/UndiscriminatedUnionGenerator.java`: filter out primitives/boxed primitives, then `List#sort` non-primitive members so those with required wire keys (`getRequiredWireKeys(...)` non-empty) come before those without, before emitting their `try { ... } catch` blocks.
- `generators/java/sdk/changes/unreleased/fix-undiscriminated-union-all-optional-ordering.yml`: add a `fix` changelog entry describing the deserialization fix.
- [ ] Updated README.md generator (if applicable)

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed


Link to Devin session: https://app.devin.ai/sessions/2e4e587dd160400390839880a5434932
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->