### PR TITLE
fix(cli): docs dev hot reload not working for .mdx file changes

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-docs-dev-hot-reload.yml
+++ b/packages/cli/cli/changes/unreleased/fix-docs-dev-hot-reload.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Fix `fern docs dev` hot reload not working for .mdx file changes. The backend
+    now updates the docs definition before notifying the browser to refresh, and
+    the reload handler properly recovers from errors instead of silently blocking
+    all future reloads.
+  type: fix

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -1243,8 +1243,7 @@ export async function runAppPreviewServer({
                 try {
                     // Expand the list of files to include pages that depend on changed snippets
                     const filesToReload = snippetTracker.getFilesToReload(editedAbsoluteFilepaths);
-                    const hasSnippetDependencies =
-                        snippetTracker.hasSnippetDependencies(editedAbsoluteFilepaths);
+                    const hasSnippetDependencies = snippetTracker.hasSnippetDependencies(editedAbsoluteFilepaths);
 
                     if (hasSnippetDependencies) {
                         context.logger.info(
@@ -1263,18 +1262,14 @@ export async function runAppPreviewServer({
                     // so the backend serves fresh data when the browser refreshes.
                     if (reloadedPreviewResult != null) {
                         // Detect slug changes before updating the docs definition
-                        const slugChanges = slugTracker.updateAndDetectChanges(
-                            reloadedPreviewResult.docsDefinition
-                        );
+                        const slugChanges = slugTracker.updateAndDetectChanges(reloadedPreviewResult.docsDefinition);
 
                         previewResult = reloadedPreviewResult;
 
                         // Recompute translated definitions
                         translatedDefinitions = await computeTranslatedDefinitions(reloadedPreviewResult);
                         if (translatedDefinitions.size > 0) {
-                            context.logger.debug(
-                                `Recomputed translations for ${translatedDefinitions.size} locale(s)`
-                            );
+                            context.logger.debug(`Recomputed translations for ${translatedDefinitions.size} locale(s)`);
                         }
 
                         sendData({

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -1240,57 +1240,76 @@ export async function runAppPreviewServer({
             void (async () => {
                 isReloading = true;
 
-                // Expand the list of files to include pages that depend on changed snippets
-                const filesToReload = snippetTracker.getFilesToReload(editedAbsoluteFilepaths);
-                const hasSnippetDependencies = snippetTracker.hasSnippetDependencies(editedAbsoluteFilepaths);
+                try {
+                    // Expand the list of files to include pages that depend on changed snippets
+                    const filesToReload = snippetTracker.getFilesToReload(editedAbsoluteFilepaths);
+                    const hasSnippetDependencies =
+                        snippetTracker.hasSnippetDependencies(editedAbsoluteFilepaths);
 
-                if (hasSnippetDependencies) {
-                    context.logger.info(
-                        `Snippet dependencies detected. Reloading ${filesToReload.length} files (${editedAbsoluteFilepaths.length} changed, ${filesToReload.length - editedAbsoluteFilepaths.length} dependent pages)`
-                    );
-                }
-
-                sendData({
-                    version: 1,
-                    type: "startReload"
-                });
-
-                const reloadedPreviewResult = await reloadDocsDefinition(filesToReload);
-
-                editedAbsoluteFilepaths.length = 0;
-
-                isReloading = false;
-
-                sendData({
-                    version: 1,
-                    type: "finishReload"
-                });
-
-                if (reloadedPreviewResult != null) {
-                    // Detect slug changes before updating the docs definition
-                    const slugChanges = slugTracker.updateAndDetectChanges(reloadedPreviewResult.docsDefinition);
-
-                    previewResult = reloadedPreviewResult;
-
-                    // Recompute translated definitions
-                    translatedDefinitions = await computeTranslatedDefinitions(reloadedPreviewResult);
-                    if (translatedDefinitions.size > 0) {
-                        context.logger.debug(`Recomputed translations for ${translatedDefinitions.size} locale(s)`);
+                    if (hasSnippetDependencies) {
+                        context.logger.info(
+                            `Snippet dependencies detected. Reloading ${filesToReload.length} files (${editedAbsoluteFilepaths.length} changed, ${filesToReload.length - editedAbsoluteFilepaths.length} dependent pages)`
+                        );
                     }
 
-                    // Send navigateToSlug events for any slug changes
-                    if (slugChanges.length > 0) {
-                        slugChanges.forEach((change) => {
-                            const eventData = {
-                                version: 1,
-                                type: "navigateToSlug",
-                                oldSlug: change.oldSlug,
-                                newSlug: change.newSlug
-                            };
+                    sendData({
+                        version: 1,
+                        type: "startReload"
+                    });
 
-                            sendData(eventData);
+                    const reloadedPreviewResult = await reloadDocsDefinition(filesToReload);
+
+                    // Update the docs definition BEFORE notifying the browser,
+                    // so the backend serves fresh data when the browser refreshes.
+                    if (reloadedPreviewResult != null) {
+                        // Detect slug changes before updating the docs definition
+                        const slugChanges = slugTracker.updateAndDetectChanges(
+                            reloadedPreviewResult.docsDefinition
+                        );
+
+                        previewResult = reloadedPreviewResult;
+
+                        // Recompute translated definitions
+                        translatedDefinitions = await computeTranslatedDefinitions(reloadedPreviewResult);
+                        if (translatedDefinitions.size > 0) {
+                            context.logger.debug(
+                                `Recomputed translations for ${translatedDefinitions.size} locale(s)`
+                            );
+                        }
+
+                        sendData({
+                            version: 1,
+                            type: "finishReload"
+                        });
+
+                        // Send navigateToSlug events for any slug changes
+                        if (slugChanges.length > 0) {
+                            slugChanges.forEach((change) => {
+                                const eventData = {
+                                    version: 1,
+                                    type: "navigateToSlug",
+                                    oldSlug: change.oldSlug,
+                                    newSlug: change.newSlug
+                                };
+
+                                sendData(eventData);
+                            });
+                        }
+                    } else {
+                        sendData({
+                            version: 1,
+                            type: "finishReload"
                         });
                     }
+                } catch (err) {
+                    context.logger.error(`Reload failed: ${extractErrorMessage(err)}`);
+                    sendData({
+                        version: 1,
+                        type: "finishReload"
+                    });
+                } finally {
+                    editedAbsoluteFilepaths.length = 0;
+                    isReloading = false;
                 }
             })();
         }, RELOAD_DEBOUNCE_MS);

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -1240,6 +1240,11 @@ export async function runAppPreviewServer({
             void (async () => {
                 isReloading = true;
 
+                sendData({
+                    version: 1,
+                    type: "startReload"
+                });
+
                 try {
                     // Expand the list of files to include pages that depend on changed snippets
                     const filesToReload = snippetTracker.getFilesToReload(editedAbsoluteFilepaths);
@@ -1250,11 +1255,6 @@ export async function runAppPreviewServer({
                             `Snippet dependencies detected. Reloading ${filesToReload.length} files (${editedAbsoluteFilepaths.length} changed, ${filesToReload.length - editedAbsoluteFilepaths.length} dependent pages)`
                         );
                     }
-
-                    sendData({
-                        version: 1,
-                        type: "startReload"
-                    });
 
                     const reloadedPreviewResult = await reloadDocsDefinition(filesToReload);
 


### PR DESCRIPTION
## Description

Fixes `fern docs dev` hot reload not triggering visible updates when `.mdx` files are changed. Changes to `docs.yml` triggered reloads successfully, but `.mdx` file changes appeared to do nothing.

## Changes Made

- **Move `previewResult` update before `finishReload`**: Previously, the backend sent `finishReload` to the browser *before* updating `previewResult`. This created a race condition where the browser could refresh and fetch stale data from the backend because the new docs definition hadn't been stored yet. Now the definition is updated first, ensuring the backend serves fresh data when the browser refreshes.

- **Wrap reload handler in try/finally**: If the reload handler threw an uncaught error (e.g., from snippet tracking or translated definition computation), the `isReloading` flag was never reset to `false`. This permanently blocked all future file change events from triggering reloads — silently breaking hot reload for the rest of the session. The try/finally ensures `isReloading` and `editedAbsoluteFilepaths` are always cleaned up.

- **Send `startReload` before try block**: Ensures every reload cycle has a paired `startReload`/`finishReload`, even if errors occur during snippet tracking or file expansion.

- **Add error logging for reload failures**: Errors during reload are now logged instead of silently swallowed.

## Testing

- [x] Lint passes (`pnpm lint:biome`)
- [ ] Manual testing with `fern docs dev` — edit `.mdx` file and verify reload triggers

Link to Devin session: https://app.devin.ai/sessions/5c239378d6c54711bb2ca5ece16c5aec
Requested by: @thesandlord