### PR TITLE
chore(ci): bump GitHub Actions built on Node 20 to Node 24 versions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -992,7 +992,7 @@ jobs:
       # Commit all applied patches back to branch (will be checked out in apply-patches step)
       - name: Add and Commit Changes
         id: commit-changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         if: ${{ steps.apply-patches.outputs.has-patches == 'true' }}
         with:
           add: "seed/*"


### PR DESCRIPTION
## Description
Linear ticket: Refs N/A

GitHub is deprecating actions built on the Node 20 runtime — they will start warning on June 2, 2026 and stop running on Sept 16, 2026. Audited every action used in `.github/workflows/` and `.github/actions/` against [its latest release notes](https://github.com/fern-api/fern-platform/pull/10859) — every action in this repo is already pinned to a major built on Node 24 *except* the two below:

| Action | Before | After | Node-24 release notes |
| --- | --- | --- | --- |
| `EndBug/add-and-commit` (used by `.github/workflows/update-seed.yml`) | `@v9` | `@v10` | https://github.com/EndBug/add-and-commit/releases/tag/v10.0.0 ("feat!: use node version 24") |
| `dependabot/fetch-metadata` (used by `.github/workflows/dependabot.yml`) | `@v2` | `@v3` | https://github.com/dependabot/fetch-metadata/releases/tag/v3.0.0 ("The breaking change is requiring Node.js version v24 as the Actions runtime") |

Both bumps are major-version bumps but neither changes the inputs/outputs we use:
- `EndBug/add-and-commit@v10` keeps the `add` / `push` / `fetch` / `message` inputs unchanged (only `engines.node` and `@types/node` were bumped — see #720 in that repo).
- `dependabot/fetch-metadata@v3` keeps the `github-token` input and the `update-type` / `dependency-names` outputs we read.

Following the same pattern as fern-api/fern-platform#10859.

## Changes Made
- `EndBug/add-and-commit@v9` → `@v10` in `update-seed.yml`
- `dependabot/fetch-metadata@v2` → `@v3` in `dependabot.yml`
- [ ] Updated README.md generator (if applicable) — N/A (CI-only change)

## Testing
- [ ] Unit tests added/updated — N/A
- [x] Lint-pr-title and other CI checks will exercise these two workflows on this PR; the `update-seed` job is only triggered via `workflow_dispatch` and on a schedule, so it will be exercised the next time seed is updated.

Link to Devin session: https://app.devin.ai/sessions/cef8d96eb5864047beaacde8bda48cbe
Requested by: @davidkonigsberg