### PR TITLE
chore(ci): bump PostHog/posthog-github-action from v0.1 to v1

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -1791,7 +1791,7 @@ jobs:
 
       - name: Post to PostHog
         # https://github.com/PostHog/posthog-github-action
-        uses: PostHog/posthog-github-action@v0.1
+        uses: PostHog/posthog-github-action@v1
         with:
           posthog-token: ${{ secrets.POSTHOG_API_KEY }}
           event: "gh-actions-seed-test-metrics-event"


### PR DESCRIPTION
## Description
Linear ticket: Refs N/A

Follow-up to #15866. That PR cleared out every Node-20-built action except one I deliberately left behind: `PostHog/posthog-github-action@v0.1` in `seed.yml`. v0.1 is older still — it's pinned to the long-deprecated Node 16 runtime — so the auto-bump path is `v0.1 → v1` (skipping Node 20 entirely; v1.x is built on Node 24).

The input contract for the three fields we set is unchanged between v0.1 and v1.2.0:

```yaml
inputs:
  posthog-token: required
  event:         required
  properties:    optional (JSON string)
```

(Diff'd `action.yml` between [v0.1](https://github.com/PostHog/posthog-github-action/blob/v0.1/action.yml) and [v1.2.0](https://github.com/PostHog/posthog-github-action/blob/v1.2.0/action.yml).)

v1 adds five new optional inputs (`posthog-api-host`, `capture-run-duration`, `capture-job-durations`, `github-token`, `runner`, `status-job`) — none required, none of which we use.

### One behavior change worth flagging

The default value of the optional `posthog-api-host` input changed:

| Version | Default `posthog-api-host` |
| --- | --- |
| v0.1 | `https://app.posthog.com` |
| v1.x | `https://us.i.posthog.com` |

`seed.yml` does not set `posthog-api-host` explicitly, so after this lands the seed metrics event will POST to `us.i.posthog.com` instead of `app.posthog.com`. Both are valid endpoints on PostHog Cloud US — `app.posthog.com` is the dashboard host that historically also accepted ingestion, and `us.i.posthog.com` is the modern canonical ingestion host that PostHog now recommends. Assuming this org's PostHog project lives in PostHog Cloud US (which is what the existing key naming and `gh-actions-seed-test-metrics-event` flow suggest), the event will land in the same project; if the project lives in EU, we'd instead want `https://eu.i.posthog.com`. Easy to override later by adding `posthog-api-host:` to the `with:` block if needed.

## Changes Made
- `PostHog/posthog-github-action@v0.1` → `@v1` in `.github/workflows/seed.yml`
- [ ] Updated README.md generator (if applicable) — N/A (CI-only change)

## Testing
- [ ] Unit tests added/updated — N/A
- [x] After merge, the next seed run will exercise the v1 action. The event payload schema is unchanged, so the PostHog event named `gh-actions-seed-test-metrics-event` should continue to land with the same `event_type` / `branch` / `seed_generator_alias` / `duration_seconds` / `all_tests_passing` / `all_seed_files_deterministic` / `total_fixture_count` / `allowed_failures` / `allowed_failures_count` properties.

Link to Devin session: https://app.devin.ai/sessions/cef8d96eb5864047beaacde8bda48cbe
Requested by: @davidkonigsberg