### PR TITLE
feat(cli): route `fern login` through dashboard `/cli-login` for email-based SSO

### DIFF
--- a/packages/cli/cli/changes/unreleased/add-dashboard-email-login.yml
+++ b/packages/cli/cli/changes/unreleased/add-dashboard-email-login.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    `fern login` now opens the Fern dashboard's `/cli-login` page, which adds
+    email-based enterprise SSO alongside the existing GitHub / Google / Postman
+    options. The dashboard resolves the email to an Auth0 connection and
+    redirects back to Auth0 with the CLI's localhost callback, so the token
+    exchange is unchanged.
+
+    `fern login --email <email>` and `fern login --device-code` continue to go
+    straight to Auth0.
+  type: feat

--- a/packages/cli/login/src/auth0-login/constructDashboardLoginUrl.test.ts
+++ b/packages/cli/login/src/auth0-login/constructDashboardLoginUrl.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { constructDashboardLoginUrl } from "./constructDashboardLoginUrl.js";
+
+describe("constructDashboardLoginUrl", () => {
+    const base = {
+        dashboardBaseUrl: "https://dashboard.buildwithfern.com",
+        auth0ClientId: "syaWnk6SjNoo5xBf1omfvziU3q7085lh",
+        redirectUri: "http://localhost:3129",
+        audience: "venus-prod"
+    };
+
+    it("builds a minimal /cli-login URL", () => {
+        const url = new URL(constructDashboardLoginUrl(base));
+        expect(url.origin).toBe("https://dashboard.buildwithfern.com");
+        expect(url.pathname).toBe("/cli-login");
+        expect(url.searchParams.get("client_id")).toBe(base.auth0ClientId);
+        expect(url.searchParams.get("redirect_uri")).toBe(base.redirectUri);
+        expect(url.searchParams.get("audience")).toBe("venus-prod");
+        expect(url.searchParams.get("state")).toBeNull();
+        expect(url.searchParams.get("prompt")).toBeNull();
+    });
+
+    it("forwards state and prompt when provided", () => {
+        const url = new URL(constructDashboardLoginUrl({ ...base, state: "csrf-state", prompt: "login" }));
+        expect(url.searchParams.get("state")).toBe("csrf-state");
+        expect(url.searchParams.get("prompt")).toBe("login");
+    });
+
+    it("strips a trailing slash on the dashboard base URL", () => {
+        const url = new URL(
+            constructDashboardLoginUrl({ ...base, dashboardBaseUrl: "https://dashboard.buildwithfern.com/" })
+        );
+        expect(url.pathname).toBe("/cli-login");
+    });
+
+    it("supports a local dashboard base URL", () => {
+        const url = new URL(constructDashboardLoginUrl({ ...base, dashboardBaseUrl: "http://localhost:3000" }));
+        expect(url.origin).toBe("http://localhost:3000");
+        expect(url.pathname).toBe("/cli-login");
+    });
+});

--- a/packages/cli/login/src/auth0-login/constructDashboardLoginUrl.ts
+++ b/packages/cli/login/src/auth0-login/constructDashboardLoginUrl.ts
@@ -1,0 +1,38 @@
+/**
+ * Builds the URL for the dashboard's `/cli-login` page.
+ *
+ * The CLI opens this URL instead of going to Auth0 directly so the user
+ * can pick from the same set of auth methods the dashboard's `/login`
+ * page offers (email-based SSO + GitHub / Google / Postman). The dashboard
+ * then redirects the browser to Auth0 with the appropriate `connection`
+ * and the CLI's localhost `redirect_uri`, so Auth0 still terminates back
+ * at the local server with a code — same as today.
+ */
+export function constructDashboardLoginUrl({
+    dashboardBaseUrl,
+    auth0ClientId,
+    redirectUri,
+    audience,
+    state,
+    prompt
+}: {
+    dashboardBaseUrl: string;
+    auth0ClientId: string;
+    redirectUri: string;
+    audience: string;
+    state?: string;
+    prompt?: string;
+}): string {
+    const queryParams = new URLSearchParams({
+        client_id: auth0ClientId,
+        redirect_uri: redirectUri,
+        audience
+    });
+    if (state != null && state.length > 0) {
+        queryParams.set("state", state);
+    }
+    if (prompt != null && prompt.length > 0) {
+        queryParams.set("prompt", prompt);
+    }
+    return `${dashboardBaseUrl.replace(/\/$/, "")}/cli-login?${queryParams.toString()}`;
+}

--- a/packages/cli/login/src/auth0-login/doAuth0LoginFlow.ts
+++ b/packages/cli/login/src/auth0-login/doAuth0LoginFlow.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import { IncomingMessage, Server } from "http";
 import open from "open";
 import { LOGIN_SUCCESS_PAGE } from "../pages/login-success-page.js";
+import { constructDashboardLoginUrl } from "./constructDashboardLoginUrl.js";
 import { createServer } from "./createServer.js";
 
 /**
@@ -23,7 +24,8 @@ export async function doAuth0LoginFlow({
     auth0ClientId,
     audience,
     forceReauth = false,
-    connection
+    connection,
+    dashboardBaseUrl
 }: {
     auth0Domain: string;
     auth0ClientId: string;
@@ -32,9 +34,26 @@ export async function doAuth0LoginFlow({
     forceReauth?: boolean;
     /** If set, passes the connection parameter to Auth0 to route directly to a specific IdP. */
     connection?: string;
+    /**
+     * If set and `connection` is not, the browser is sent to the dashboard's
+     * `/cli-login` page (instead of Auth0 directly) so the user can pick from
+     * the same set of auth methods the web dashboard offers. The dashboard
+     * then redirects to Auth0 with the appropriate `connection`, which
+     * redirects back to the CLI's local server with a code.
+     */
+    dashboardBaseUrl?: string;
 }): Promise<Auth0TokenResponse> {
     const { origin, server } = await createServer();
-    const { code } = await getCode({ server, auth0Domain, auth0ClientId, origin, audience, forceReauth, connection });
+    const { code } = await getCode({
+        server,
+        auth0Domain,
+        auth0ClientId,
+        origin,
+        audience,
+        forceReauth,
+        connection,
+        dashboardBaseUrl
+    });
     server.close();
     return await getTokenFromCode({ auth0Domain, auth0ClientId, code, origin });
 }
@@ -46,7 +65,8 @@ function getCode({
     origin,
     audience,
     forceReauth,
-    connection
+    connection,
+    dashboardBaseUrl
 }: {
     server: Server;
     auth0Domain: string;
@@ -55,6 +75,7 @@ function getCode({
     audience: string;
     forceReauth: boolean;
     connection?: string;
+    dashboardBaseUrl?: string;
 }) {
     return new Promise<{ code: string }>((resolve) => {
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -70,7 +91,20 @@ function getCode({
             }
         });
 
-        void open(constructAuth0Url({ auth0ClientId, auth0Domain, origin, audience, forceReauth, connection }));
+        // When `connection` is set the CLI already knows which IdP to use
+        // (e.g. `--email <email>` flow), so go straight to Auth0 and skip
+        // the dashboard picker.
+        const useDashboard = dashboardBaseUrl != null && connection == null;
+        const url = useDashboard
+            ? constructDashboardLoginUrl({
+                  dashboardBaseUrl,
+                  auth0ClientId,
+                  redirectUri: origin,
+                  audience,
+                  prompt: forceReauth ? "login" : undefined
+              })
+            : constructAuth0Url({ auth0ClientId, auth0Domain, origin, audience, forceReauth, connection });
+        void open(url);
     });
 }
 

--- a/packages/cli/login/src/login.ts
+++ b/packages/cli/login/src/login.ts
@@ -67,7 +67,8 @@ export async function getTokenFromAuth0(
             auth0Domain: AUTH0_DOMAIN,
             auth0ClientId: AUTH0_CLIENT_ID,
             audience: VENUS_AUDIENCE,
-            forceReauth
+            forceReauth,
+            dashboardBaseUrl: DASHBOARD_BASE_URL
         });
     } catch {
         return await doAuth0DeviceAuthorizationFlow({


### PR DESCRIPTION
## Description

`fern login` today opens Auth0 universal login directly with the CLI's Auth0 client. That client only has GitHub / Google / Postman connections enabled, so users see no "log in with email" option, and there's no way to sign in via enterprise SSO from the CLI without remembering the `--email <email>` flag.

This PR points the CLI's interactive login at the Fern dashboard's `/cli-login` page (shipped in fern-api/fern-platform#10939) instead of going to Auth0 directly. The dashboard page renders the same email form + GitHub / Google / Postman buttons as the web dashboard's `/login`, resolves the entered email to an Auth0 connection via the dashboard's existing `resolveEmailToConnection` flow, and redirects the browser to Auth0 using the **CLI's** `client_id` and the **CLI's** localhost `redirect_uri`. Auth0 then redirects back to `http://localhost:3129` with a code, which the CLI exchanges for tokens — identical to today's flow on the CLI side.

The dashboard is purely a smart picker / router — no tokens flow through it.

## Changes Made

- New helper `constructDashboardLoginUrl({ dashboardBaseUrl, auth0ClientId, redirectUri, audience, state?, prompt? })` in `packages/cli/login/src/auth0-login/`.
- `doAuth0LoginFlow` accepts an optional `dashboardBaseUrl`. When `connection` is unset and `dashboardBaseUrl` is set, the browser opens the dashboard's `/cli-login?client_id=...&redirect_uri=...&audience=...&prompt=...` instead of Auth0 `/authorize`. When `connection` is set (e.g. `fern login --email <email>`) we still go straight to Auth0.
- `login.ts` passes `DASHBOARD_BASE_URL` (defaults to `https://dashboard.buildwithfern.com`, overridable via `FERN_DASHBOARD_URL`) into the default `doAuth0LoginFlow` call.
- `fern login --device-code` is untouched.
- Changelog entry `packages/cli/cli/changes/unreleased/add-dashboard-email-login.yml` (type: `feat`).

Behavior matrix:

| Invocation                          | Browser opens                                    | Notes                          |
| ----------------------------------- | ------------------------------------------------ | ------------------------------ |
| `fern login`                        | dashboard `/cli-login` → Auth0                   | new in this PR                 |
| `fern login --email alice@acme.com` | Auth0 `/authorize?connection=<acme-sso>` directly | unchanged (`--email` shortcut) |
| `fern login --device-code`          | device-flow URL                                  | unchanged                      |
| `fern login` (re-auth retry)        | dashboard `/cli-login?prompt=login` → Auth0      | new                            |

- [ ] Updated README.md generator (if applicable) — N/A

## Testing

- [x] Unit tests added/updated — `constructDashboardLoginUrl.test.ts` (4 tests covering minimal URL, optional `state`/`prompt`, trailing slash on base URL, local dashboard URL).
- [x] Manual testing completed — the matching dashboard PR ships a `/cli-login` page that's exercised by 34 unit tests on the fern-platform side (helper + API + form).

```
$ pnpm --filter=@fern-api/login test

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

The dashboard PR (https://github.com/fern-api/fern-platform/pull/10939) lands first and rolls out to dev before this PR merges, so by the time this lands `dashboard.buildwithfern.com/cli-login` already exists in production.


Link to Devin session: https://app.devin.ai/sessions/b8809ace369d46dea34b425bff2c9c87
Requested by: @thesandlord