### PR TITLE
fix(internal): drop --global-response-templating from wire-test docker-compose

### DIFF
--- a/generators/go-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/go-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -71,7 +71,7 @@ export class WireTestSetupGenerator {
       - "0:8080"
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/generators/go/sdk/changes/unreleased/drop-wiremock-global-response-templating.yml
+++ b/generators/go/sdk/changes/unreleased/drop-wiremock-global-response-templating.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Stop launching WireMock with `--global-response-templating` in generated
+    wire-test `docker-compose.test.yml`. Response examples containing literal
+    `{{...}}` are now served verbatim instead of being passed through
+    WireMock's Handlebars transformer, which would fail to resolve them as
+    helpers and return 500.
+  type: fix

--- a/generators/php/sdk/changes/unreleased/drop-wiremock-global-response-templating.yml
+++ b/generators/php/sdk/changes/unreleased/drop-wiremock-global-response-templating.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Stop launching WireMock with `--global-response-templating` in generated
+    wire-test `docker-compose.test.yml`. Response examples containing literal
+    `{{...}}` are now served verbatim instead of being passed through
+    WireMock's Handlebars transformer, which would fail to resolve them as
+    helpers and return 500.
+  type: fix

--- a/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -108,7 +108,7 @@ export class WireTestSetupGenerator {
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -205,7 +205,7 @@ export class WireTestSetupGenerator {
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/generators/python/sdk/changes/unreleased/drop-wiremock-global-response-templating.yml
+++ b/generators/python/sdk/changes/unreleased/drop-wiremock-global-response-templating.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Stop launching WireMock with `--global-response-templating` in generated
+    wire-test `docker-compose.test.yml`. Response examples containing literal
+    `{{...}}` (e.g. FHIR/IPS template strings) are now served verbatim instead
+    of being passed through WireMock's Handlebars transformer, which would
+    fail to resolve them as helpers and return 500.
+  type: fix

--- a/generators/ruby-v2/sdk/changes/unreleased/drop-wiremock-global-response-templating.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/drop-wiremock-global-response-templating.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Stop launching WireMock with `--global-response-templating` in generated
+    wire-test `docker-compose.test.yml`. Response examples containing literal
+    `{{...}}` are now served verbatim instead of being passed through
+    WireMock's Handlebars transformer, which would fail to resolve them as
+    helpers and return 500.
+  type: fix

--- a/generators/ruby-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/ruby-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -222,7 +222,7 @@ export class WireTestSetupGenerator {
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/generators/rust/sdk/changes/unreleased/drop-wiremock-global-response-templating.yml
+++ b/generators/rust/sdk/changes/unreleased/drop-wiremock-global-response-templating.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Stop launching WireMock with `--global-response-templating` in generated
+    wire-test `docker-compose.test.yml`. Response examples containing literal
+    `{{...}}` are now served verbatim instead of being passed through
+    WireMock's Handlebars transformer, which would fail to resolve them as
+    helpers and return 500.
+  type: fix

--- a/generators/rust/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/rust/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -275,7 +275,7 @@ export class WireTestSetupGenerator {
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/go-sdk/basic-auth-pw-omitted/wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/go-sdk/basic-auth-pw-omitted/wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/go-sdk/exhaustive/no-custom-config/wiremock/docker-compose.test.yml
+++ b/seed/go-sdk/exhaustive/no-custom-config/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/wiremock/docker-compose.test.yml
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/go-sdk/go-deterministic-ordering/wiremock/docker-compose.test.yml
+++ b/seed/go-sdk/go-deterministic-ordering/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/go-sdk/go-undiscriminated-union-wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/go-sdk/go-undiscriminated-union-wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/go-sdk/imdb/with-wiremock-tests/wiremock/docker-compose.test.yml
+++ b/seed/go-sdk/imdb/with-wiremock-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/go-sdk/inferred-auth-explicit/wiremock/docker-compose.test.yml
+++ b/seed/go-sdk/inferred-auth-explicit/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/go-sdk/oauth-client-credentials/wiremock/docker-compose.test.yml
+++ b/seed/go-sdk/oauth-client-credentials/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/go-sdk/server-sent-events/with-wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/go-sdk/union-query-parameters/wiremock/docker-compose.test.yml
+++ b/seed/go-sdk/union-query-parameters/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/php-sdk/basic-auth-pw-omitted/wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/php-sdk/basic-auth-pw-omitted/wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/php-sdk/basic-auth/wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/php-sdk/basic-auth/wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/php-sdk/exhaustive/wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/php-sdk/exhaustive/wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/python-sdk/allof-inline/no-custom-config/wiremock/docker-compose.test.yml
+++ b/seed/python-sdk/allof-inline/no-custom-config/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/python-sdk/allof/no-custom-config/wiremock/docker-compose.test.yml
+++ b/seed/python-sdk/allof/no-custom-config/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/python-sdk/basic-auth-pw-omitted/with-wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/python-sdk/exhaustive/no-custom-config/wiremock/docker-compose.test.yml
+++ b/seed/python-sdk/exhaustive/no-custom-config/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/wiremock/docker-compose.test.yml
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/python-sdk/server-sent-events/with-wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/ruby-sdk-v2/basic-auth/wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/ruby-sdk-v2/basic-auth/wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/ruby-sdk-v2/examples/wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/ruby-sdk-v2/examples/wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/rust-sdk/examples/readme-config/wiremock/docker-compose.test.yml
+++ b/seed/rust-sdk/examples/readme-config/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/rust-sdk/exhaustive/wiremock/docker-compose.test.yml
+++ b/seed/rust-sdk/exhaustive/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/rust-sdk/imdb/imdb-custom-config/wiremock/docker-compose.test.yml
+++ b/seed/rust-sdk/imdb/imdb-custom-config/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/rust-sdk/server-sent-events/with-wire-tests/wiremock/docker-compose.test.yml
+++ b/seed/rust-sdk/server-sent-events/with-wire-tests/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/rust-sdk/simple-api/basic-custom-config/wiremock/docker-compose.test.yml
+++ b/seed/rust-sdk/simple-api/basic-custom-config/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s

--- a/seed/rust-sdk/single-url-environment-default/full-custom/wiremock/docker-compose.test.yml
+++ b/seed/rust-sdk/single-url-environment-default/full-custom/wiremock/docker-compose.test.yml
@@ -5,7 +5,7 @@ services:
       - "0:8080"  # Use dynamic port to avoid conflicts with concurrent tests
     volumes:
       - ./wiremock-mappings.json:/home/wiremock/mappings/wiremock-mappings.json
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/__admin/health"]
       interval: 2s


### PR DESCRIPTION
Closes FER-10537 — fixes [#15860](https://github.com/fern-api/fern/issues/15860)

## Summary

Generated wire-test `docker-compose.test.yml` launches WireMock with `--global-response-templating`, which pipes every response body through WireMock's Handlebars transformer. Any OpenAPI response example containing literal `{{...}}` (e.g. FHIR/IPS template syntax) gets interpreted as a template variable, fails to resolve, and WireMock returns 500 to the test client.

Wire tests have no use for Handlebars — `mock-utils` never emits response-templating constructs. The flag is dead weight; this PR drops it from all 5 affected generators and regenerates the affected seed fixtures.

## Example

Reproducer OpenAPI ([from #15860](https://github.com/fern-api/fern/issues/15860)):

```yaml
paths:
  /thing:
    get:
      responses:
        '200':
          content:
            application/json:
              example:
                template: "Hello {{name}}"
```

**Before:** `GET /thing` returns 500 from WireMock with `HandlebarsException: could not find helper: 'name'`.
**After:** response body served verbatim; SDK client parses `Hello {{name}}` and the test passes.

The template change in each generator:

```diff
-    command: ["--global-response-templating", "--verbose"]
+    command: ["--verbose"]
```

## Files

- 5 generator sources: `generators/{python-v2,go-v2,rust,ruby-v2,php}/sdk/src/wire-tests/WireTestSetupGenerator.ts`
- 35 regenerated seed fixtures: 9 python-sdk + 12 go-sdk + 7 rust-sdk + 4 ruby-sdk-v2 + 3 php-sdk
- 5 changelog entries (one per generator)

## Test plan

- [ ] CI green
- [ ] Confirm seed fixtures contain `command: ["--verbose"]` only
- [ ] (Optional) Run a generated SDK's wire test suite against an OpenAPI spec with `{{...}}` response examples and verify no 500s

🤖 Generated with [Claude Code](https://claude.com/claude-code)