### PR TITLE
fix(csharp): bump WireMock.Net to 2.6.0 in generated test projects

### DIFF
--- a/generators/csharp/base/src/asIs/test/Template.Test.csproj
+++ b/generators/csharp/base/src/asIs/test/Template.Test.csproj
@@ -26,7 +26,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="WireMock.Net" Version="2.2.0" />
+        <PackageReference Include="WireMock.Net" Version="2.6.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/generators/csharp/sdk/changes/unreleased/bump-wiremock-net-to-2-6-0.yml
+++ b/generators/csharp/sdk/changes/unreleased/bump-wiremock-net-to-2-6-0.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Bump WireMock.Net from 2.2.0 to 2.6.0 in generated test projects to resolve Snyk
+    vulnerability reports flagging the older version.
+  type: fix

--- a/seed/csharp-sdk/accept-header/src/SeedAccept.Test/SeedAccept.Test.csproj
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept.Test/SeedAccept.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends.Test/SeedAliasExtends.Test.csproj
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends.Test/SeedAliasExtends.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/alias/src/SeedAlias.Test/SeedAlias.Test.csproj
+++ b/seed/csharp-sdk/alias/src/SeedAlias.Test/SeedAlias.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/allof-inline/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/allof-inline/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/allof/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/allof/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/SeedAnyAuth.Test.csproj
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/SeedAnyAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath.Test/SeedApiWideBasePath.Test.csproj
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath.Test/SeedApiWideBasePath.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/audiences/src/SeedAudiences.Test/SeedAudiences.Test.csproj
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences.Test/SeedAudiences.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/SeedBasicAuthEnvironmentVariables.Test.csproj
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/SeedBasicAuthEnvironmentVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth-pw-omitted/src/SeedBasicAuthPwOmitted.Test/SeedBasicAuthPwOmitted.Test.csproj
+++ b/seed/csharp-sdk/basic-auth-pw-omitted/src/SeedBasicAuthPwOmitted.Test/SeedBasicAuthPwOmitted.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
+++ b/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload.Test/SeedBytesDownload.Test.csproj
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload.Test/SeedBytesDownload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload.Test/SeedBytesUpload.Test.csproj
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload.Test/SeedBytesUpload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/circular-references-extends/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/circular-references-extends/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/circular-references/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/circular-references/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/SeedClientSideParams.Test.csproj
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/SeedClientSideParams.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes.Test/SeedContentTypes.Test.csproj
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes.Test/SeedContentTypes.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/SeedCrossPackageTypeNames.Test.csproj
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/SeedCrossPackageTypeNames.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-inline-types/inline-types/src/SeedObject.Test/SeedObject.Test.csproj
+++ b/seed/csharp-sdk/csharp-inline-types/inline-types/src/SeedObject.Test/SeedObject.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net.Test/Contoso.Net.Test.csproj
+++ b/seed/csharp-sdk/csharp-namespace-collision/explicit-namespaces/src/Contoso.Net.Test/Contoso.Net.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/SeedCsharpNamespaceCollision.Test.csproj
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/SeedCsharpNamespaceCollision.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net.Test/Contoso.Net.Test.csproj
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net.Test/Contoso.Net.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net.Test/Contoso.Net.Test.csproj
+++ b/seed/csharp-sdk/csharp-namespace-collision/no-client-namespace-match/src/Contoso.Net.Test/Contoso.Net.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict.Test/Seed.CsharpNamespaceConflict.Test.csproj
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict.Test/Seed.CsharpNamespaceConflict.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-property-name-collision/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/SeedCsharpReadonlyRequest.Test.csproj
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/SeedCsharpReadonlyRequest.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/SeedCsharpSystemCollision.Test.csproj
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/SeedCsharpSystemCollision.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities.Test/SeedCsharpXmlEntities.Test.csproj
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities.Test/SeedCsharpXmlEntities.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples.Test/SeedDollarStringExamples.Test.csproj
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples.Test/SeedDollarStringExamples.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients.Test/SeedEmptyClients.Test.csproj
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients.Test/SeedEmptyClients.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/SeedEndpointSecurityAuth.Test.csproj
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/SeedEndpointSecurityAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty.Test/SeedErrorProperty.Test.csproj
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty.Test/SeedErrorProperty.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/errors/src/SeedErrors.Test/SeedErrors.Test.csproj
+++ b/seed/csharp-sdk/errors/src/SeedErrors.Test/SeedErrors.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples.Test/SeedExamples.Test.csproj
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples.Test/SeedExamples.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples.Test/SeedExamples.Test.csproj
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples.Test/SeedExamples.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/extends/src/SeedExtends.Test/SeedExtends.Test.csproj
+++ b/seed/csharp-sdk/extends/src/SeedExtends.Test/SeedExtends.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties.Test/SeedExtraProperties.Test.csproj
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties.Test/SeedExtraProperties.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload.Test/SeedFileDownload.Test.csproj
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload.Test/SeedFileDownload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload.Test/SeedFileUpload.Test.csproj
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload.Test/SeedFileUpload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/folders/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/folders/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/SeedHeaderTokenEnvironmentVariable.Test.csproj
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/SeedHeaderTokenEnvironmentVariable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken.Test/SeedHeaderToken.Test.csproj
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken.Test/SeedHeaderToken.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead.Test/SeedHttpHead.Test.csproj
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead.Test/SeedHttpHead.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/SeedIdempotencyHeaders.Test.csproj
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/SeedIdempotencyHeaders.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/extra-dependencies-override/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/extra-dependencies-override/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/SeedInferredAuthExplicit.Test.csproj
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/SeedInferredAuthExplicit.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/SeedInferredAuthImplicitApiKey.Test.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/SeedInferredAuthImplicitApiKey.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/SeedInferredAuthImplicitNoExpiry.Test.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/SeedInferredAuthImplicitNoExpiry.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense.Test/SeedLicense.Test.csproj
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense.Test/SeedLicense.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense.Test/SeedLicense.Test.csproj
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense.Test/SeedLicense.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/literal-user-agent/src/SeedLiteralUserAgent.Test/SeedLiteralUserAgent.Test.csproj
+++ b/seed/csharp-sdk/literal-user-agent/src/SeedLiteralUserAgent.Test/SeedLiteralUserAgent.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/SeedLiteral.Test.csproj
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/SeedLiteral.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/SeedLiteral.Test.csproj
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/SeedLiteral.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions.Test/SeedLiteralsUnions.Test.csproj
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions.Test/SeedLiteralsUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase.Test/SeedMixedCase.Test.csproj
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase.Test/SeedMixedCase.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/SeedMixedFileDirectory.Test.csproj
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/SeedMixedFileDirectory.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs.Test/SeedMultiLineDocs.Test.csproj
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs.Test/SeedMultiLineDocs.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/SeedMultiUrlEnvironmentNoDefault.Test.csproj
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/SeedMultiUrlEnvironmentNoDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/multi-url-environment-reference/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/no-content-response/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/no-content-response/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.Test/SeedNoEnvironment.Test.csproj
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.Test/SeedNoEnvironment.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries.Test/SeedNoRetries.Test.csproj
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries.Test/SeedNoRetries.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/null-type/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/null-type/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/SeedNullable.Test.csproj
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/SeedNullable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/SeedNullable.Test.csproj
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/SeedNullable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/SeedOauthClientCredentialsDefault.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/SeedOauthClientCredentialsDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/SeedOauthClientCredentialsEnvironmentVariables.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/SeedOauthClientCredentialsEnvironmentVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/SeedOauthClientCredentialsReference.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/SeedOauthClientCredentialsReference.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/SeedOauthClientCredentialsWithVariables.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/SeedOauthClientCredentialsWithVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/object/src/SeedObject.Test/SeedObject.Test.csproj
+++ b/seed/csharp-sdk/object/src/SeedObject.Test/SeedObject.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/openapi-request-body-ref/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml.Test/SeedPackageYml.Test.csproj
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml.Test/SeedPackageYml.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/SeedPaginationUriPath.Test.csproj
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/SeedPaginationUriPath.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-sdk/pagination/page-index-semantics/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText.Test/SeedPlainText.Test.csproj
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText.Test/SeedPlainText.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess.Test/SeedPropertyAccess.Test.csproj
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess.Test/SeedPropertyAccess.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject.Test/SeedPublicObject.Test.csproj
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject.Test/SeedPublicObject.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/query-param-name-conflict/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/query-param-name-conflict/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.Test/SeedQueryParameters.Test.csproj
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.Test/SeedQueryParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi.Test/SeedNurseryApi.Test.csproj
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi.Test/SeedNurseryApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty.Test/SeedResponseProperty.Test.csproj
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty.Test/SeedResponseProperty.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/schemaless-request-body-examples/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/schemaless-request-body-examples/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/test/SeedApi.Test/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/test/SeedApi.Test/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
+++ b/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/SeedSingleUrlEnvironmentDefault.Test.csproj
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/SeedSingleUrlEnvironmentDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/SeedSingleUrlEnvironmentNoDefault.Test.csproj
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/SeedSingleUrlEnvironmentNoDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming.Test/SeedStreaming.Test.csproj
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming.Test/SeedStreaming.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming.Test/SeedStreaming.Test.csproj
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming.Test/SeedStreaming.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming.Test/SeedStreaming.Test.csproj
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming.Test/SeedStreaming.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/trace/src/SeedTrace.Test/SeedTrace.Test.csproj
+++ b/seed/csharp-sdk/trace/src/SeedTrace.Test/SeedTrace.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/SeedUndiscriminatedUnionWithResponseProperty.Test.csproj
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/SeedUndiscriminatedUnionWithResponseProperty.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/union-query-parameters/src/SeedUnionQueryParameters.Test/SeedUnionQueryParameters.Test.csproj
+++ b/seed/csharp-sdk/union-query-parameters/src/SeedUnionQueryParameters.Test/SeedUnionQueryParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions.Test/SeedUnions.Test.csproj
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions.Test/SeedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions.Test/SeedUnions.Test.csproj
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions.Test/SeedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions.Test/SeedUnions.Test.csproj
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions.Test/SeedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/SeedUnknownAsAny.Test.csproj
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/SeedUnknownAsAny.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/validation/src/SeedValidation.Test/SeedValidation.Test.csproj
+++ b/seed/csharp-sdk/validation/src/SeedValidation.Test/SeedValidation.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/variables/src/SeedVariables.Test/SeedVariables.Test.csproj
+++ b/seed/csharp-sdk/variables/src/SeedVariables.Test/SeedVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion.Test/SeedVersion.Test.csproj
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion.Test/SeedVersion.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/version/src/SeedVersion.Test/SeedVersion.Test.csproj
+++ b/seed/csharp-sdk/version/src/SeedVersion.Test/SeedVersion.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks.Test/SeedWebhooks.Test.csproj
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks.Test/SeedWebhooks.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/SeedWebsocketBearerAuth.Test.csproj
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/SeedWebsocketBearerAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/SeedWebsocketAuth.Test.csproj
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/SeedWebsocketAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl.Test/SeedWebsocketMultiUrl.Test.csproj
+++ b/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl.Test/SeedWebsocketMultiUrl.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/x-fern-default/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/x-fern-default/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.2.0" />
+    <PackageReference Include="WireMock.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes FER-10540

## Summary

- Auth0 reported Snyk flagging `WireMock.Net 2.2.0` in their generated C# SDK test project ([failing job](https://github.com/auth0/auth0.net/actions/runs/25729144237/job/75549572943)). The version was hardcoded in our shared test-project template, so every C# SDK ships with the same pinned 2.2.0.
- Bumps the template to `2.6.0` (latest stable on NuGet). Test-only dependency, no runtime impact on SDK consumers.

## Example

Before — `generators/csharp/base/src/asIs/test/Template.Test.csproj`:

```xml
<PackageReference Include="WireMock.Net" Version="2.2.0" />
```

After:

```xml
<PackageReference Include="WireMock.Net" Version="2.6.0" />
```

All 174 `seed/csharp-sdk/**/<Project>.Test.csproj` snapshots were regenerated to reflect the bump — the only content change across them is the version string.

## Test plan

- [x] `pnpm seed test --generator csharp-sdk --local --skip-scripts` — 174/174 fixtures pass
- [x] `git diff --unified=0 | grep -E "^[+-][^+-]"` confirms every changed line is the `WireMock.Net Version` bump (350 lines, all matching)
- [ ] Downstream check: regenerate Auth0's SDK after release and confirm Snyk no longer flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)