### PR TITLE
fix(generator-cli): tolerate unreachable previousGenerationSha when creating replay tag commit

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-unreachable-previous-generation-sha.yml
+++ b/packages/cli/cli/changes/unreleased/fix-unreachable-previous-generation-sha.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix SDK generation crashing with `fatal: <sha> is not a valid object`
+    when the prior fern-bot PR was squash-merged and its branch deleted.
+    The stale `fern-generation-base` tag update is now skipped with a
+    warning; the SDK PR still opens.
+  type: fix

--- a/packages/generator-cli/src/__test__/createReplayBranch.test.ts
+++ b/packages/generator-cli/src/__test__/createReplayBranch.test.ts
@@ -1,0 +1,111 @@
+import { ClonedRepository } from "@fern-api/github";
+import { execFileSync } from "child_process";
+import { writeFileSync } from "fs";
+import { join } from "path";
+import tmp from "tmp-promise";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createReplayBranch } from "../pipeline/github/createReplayBranch";
+import type { PipelineLogger } from "../pipeline/PipelineLogger";
+
+function gitExec(args: string[], cwd: string): string {
+    return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: "pipe" }).trim();
+}
+
+function initRepo(repoPath: string): void {
+    gitExec(["init", "--initial-branch=main"], repoPath);
+    gitExec(["config", "user.name", "Test User"], repoPath);
+    gitExec(["config", "user.email", "test@example.com"], repoPath);
+    gitExec(["config", "commit.gpgsign", "false"], repoPath);
+}
+
+function commit(repoPath: string, file: string, contents: string, message: string): string {
+    writeFileSync(join(repoPath, file), contents);
+    gitExec(["add", file], repoPath);
+    gitExec(["commit", "-m", message], repoPath);
+    return gitExec(["rev-parse", "HEAD"], repoPath);
+}
+
+function makeLogger(): { logger: PipelineLogger; warnings: string[] } {
+    const warnings: string[] = [];
+    const logger: PipelineLogger = {
+        debug: () => undefined,
+        info: () => undefined,
+        warn: (msg) => {
+            warnings.push(msg);
+        },
+        error: () => undefined
+    };
+    return { logger, warnings };
+}
+
+describe("createReplayBranch", () => {
+    let cleanup: () => Promise<void>;
+    let repoPath: string;
+
+    beforeEach(async () => {
+        const tmpDir = await tmp.dir({ unsafeCleanup: true });
+        repoPath = tmpDir.path;
+        cleanup = tmpDir.cleanup;
+        initRepo(repoPath);
+    });
+
+    afterEach(async () => {
+        await cleanup();
+    });
+
+    it("returns a tag commit SHA whose tree matches the current generation and whose parent is the previous generation", async () => {
+        // Two real commits in the local clone — simulating the normal case where the prior
+        // fern-bot branch is still alive (no squash + delete yet).
+        const previousGenerationSha = commit(repoPath, "sdk.ts", "old generated", "previous generation");
+        const currentGenerationSha = commit(repoPath, "sdk.ts", "new generated", "current generation");
+        const currentTreeHash = gitExec(["rev-parse", `${currentGenerationSha}^{tree}`], repoPath);
+
+        const repository = ClonedRepository.createAtPath(repoPath);
+        const { logger } = makeLogger();
+
+        const tagCommitSha = await createReplayBranch(
+            repository,
+            "fern-bot/test-branch",
+            "Update SDK",
+            { previousGenerationSha, currentGenerationSha },
+            logger
+        );
+
+        expect(tagCommitSha).toBeTypeOf("string");
+        const tagTree = gitExec(["rev-parse", `${tagCommitSha}^{tree}`], repoPath);
+        const tagParent = gitExec(["rev-parse", `${tagCommitSha}^`], repoPath);
+        expect(tagTree).toBe(currentTreeHash);
+        expect(tagParent).toBe(previousGenerationSha);
+        // Branch was still checked out from HEAD for the PR push path.
+        const currentBranch = gitExec(["rev-parse", "--abbrev-ref", "HEAD"], repoPath);
+        expect(currentBranch).toBe("fern-bot/test-branch");
+    });
+
+    it("returns undefined and does not throw when previousGenerationSha is unreachable", async () => {
+        // HEAD is the current generation; create one real commit.
+        const currentGenerationSha = commit(repoPath, "sdk.ts", "generated", "first generation");
+
+        // previousGenerationSha mimics the auth0-python case: lockfile points at a SHA
+        // whose source branch was squash-merged + deleted, so it's not in this clone's object DB.
+        const unreachableSha = "b61c6fa84f61d6c77d9f4ab0fa6c2bf512c8680d";
+
+        const repository = ClonedRepository.createAtPath(repoPath);
+        const { logger, warnings } = makeLogger();
+
+        const result = await createReplayBranch(
+            repository,
+            "fern-bot/test-branch",
+            "Update SDK",
+            { previousGenerationSha: unreachableSha, currentGenerationSha },
+            logger
+        );
+
+        expect(result).toBeUndefined();
+        // Branch should still be checked out from HEAD so the rest of GithubStep can push it.
+        const currentBranch = gitExec(["rev-parse", "--abbrev-ref", "HEAD"], repoPath);
+        expect(currentBranch).toBe("fern-bot/test-branch");
+        // Operator visibility: warn so logs explain why the moving tag wasn't updated this run.
+        expect(warnings.some((w) => w.includes(unreachableSha))).toBe(true);
+    });
+});

--- a/packages/generator-cli/src/pipeline/github/createReplayBranch.ts
+++ b/packages/generator-cli/src/pipeline/github/createReplayBranch.ts
@@ -30,12 +30,25 @@ export async function createReplayBranch(
     // Tag commit: pure generation tree + previousGenerationSha as parent.
     // Not used as branch content — only pushed as the fern-generation-base tag
     // so that the next run's sync detection works.
-    const genTreeHash = await repository.getCommitTreeHash(replayConflictInfo.currentGenerationSha);
-    const tagCommitSha = await repository.commitTree(
-        genTreeHash,
-        parentSha,
-        `[fern-generated] ${commitMessage ?? "Update SDK"}`
-    );
-
-    return tagCommitSha;
+    //
+    // previousGenerationSha can become unreachable after a squash-merge + branch delete:
+    // the old fern-bot commit only existed on the now-deleted PR branch, and `git fetch
+    // --unshallow` doesn't pull dangling objects. When that happens, `git commit-tree -p
+    // <sha>` fails fatal. Skip the tag update in that case — the branch was already created
+    // from HEAD so the SDK still ships; we just lose the moving tag for this run.
+    try {
+        const genTreeHash = await repository.getCommitTreeHash(replayConflictInfo.currentGenerationSha);
+        const tagCommitSha = await repository.commitTree(
+            genTreeHash,
+            parentSha,
+            `[fern-generated] ${commitMessage ?? "Update SDK"}`
+        );
+        return tagCommitSha;
+    } catch (error) {
+        logger.warn(
+            `Could not create fern-generation-base tag commit: parent ${parentSha} is unreachable in this clone ` +
+                `(likely on a squash-merged + deleted branch). Continuing without tag update. Underlying error: ${String(error)}`
+        );
+        return undefined;
+    }
 }

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,16 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Fix `createReplayBranch` crashing with `fatal: <sha> is not a valid object`
+        when the lockfile's `previousGenerationSha` is unreachable (squash-merged
+        and deleted prior PR branch). Tag update is skipped with a warning; the
+        SDK PR still opens.
+      type: fix
+  createdAt: "2026-05-13"
+  version: 0.9.27
+
+- changelogEntry:
+    - summary: |
         Bump @fern-api/replay to 0.15.0.
       type: chore
   createdAt: "2026-05-06"


### PR DESCRIPTION
## Description
Linear ticket: <!-- not yet filed -->

When `.fern/replay.lock`'s `previousGenerationSha` is no longer reachable in the local clone — typical after the prior fern-bot PR was squash-merged and the source branch was deleted, leaving the original commit orphaned on the remote — `createReplayBranch.ts` died with `fatal: <sha> is not a valid object` from `git commit-tree -p <sha>`. Replay itself had succeeded; only the synthetic `fern-generation-base--<gen>` tag commit failed, but it took the whole post-generation pipeline down with it. The SDK never shipped.

Real customer hit: `auth0/auth0-sdk-config` → management python SDK regen, lockfile pointed at `b61c6fa…` which only existed on the prior squash-merged-and-deleted fern-bot branch.

## Changes Made
- `packages/generator-cli/src/pipeline/github/createReplayBranch.ts`: wrap the `commitTree(...)` call in a try/catch. On failure, log a warning that quotes the unreachable parent SHA and return `undefined`. The branch was already created from HEAD upstream of this call, and `GithubStep.ts:206` already null-guards the tag push, so the SDK PR opens normally — only the moving tag is stale for this one run, and the lockfile self-heals after the next merge.
- `packages/generator-cli/src/__test__/createReplayBranch.test.ts`: new tests pinning (1) the happy path — tag commit's tree matches current generation, parent equals previousGenerationSha; (2) the unreachable-parent path — returns `undefined`, branch is still checked out from HEAD, warning is logged with the SHA.
- `packages/generator-cli/versions.yml`: bump to 0.9.27.
- `packages/cli/cli/changes/unreleased/fix-unreachable-previous-generation-sha.yml`: changelog entry for the next CLI release.

## Testing
- [x] Unit tests added (happy path + unreachable-parent path). `pnpm turbo run test --filter @fern-api/generator-cli` → 395 passed, 1 skipped, no regressions.
- [x] The new test reproduces the production error verbatim (`fatal: b61c6fa… is not a valid object`) before the fix.

## Follow-up
This PR is a defensive fix only. To actually unblock customers already in this state whose self-hosted generation runs inside a `fernapi/fern-*-sdk` Docker image (auth0 included), a follow-up needs to bump `pnpm-workspace.yaml`'s catalog and trigger a fresh build of the affected generator(s).