### PR TITLE
feat(docs): add unified site management workflow with health checks

### DIFF
--- a/.github/workflows/manage-fern-sites.yml
+++ b/.github/workflows/manage-fern-sites.yml
@@ -11,12 +11,15 @@ on:
         required: false
         type: choice
         default: "all"
+
         options:
           - all
           - add-vercel
           - add-database
+          - add-file
           - validate
           - list
+
       domains_file:
         description: "Path to domains file (for add-file operation)"
         required: false

--- a/.github/workflows/manage-fern-sites.yml
+++ b/.github/workflows/manage-fern-sites.yml
@@ -1,0 +1,94 @@
+name: Manage Fern Sites
+
+on:
+  schedule:
+    # Run daily at 2 AM UTC
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: "Operation to perform"
+        required: false
+        type: choice
+        default: "all"
+        options:
+          - all
+          - add-vercel
+          - add-database
+          - validate
+          - list
+      domains_file:
+        description: "Path to domains file (for add-file operation)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  manage-sites:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: |
+          npm install -g tsx
+
+      - name: Determine operation
+        id: operation
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "op=${{ github.event.inputs.operation }}" >> $GITHUB_OUTPUT
+          else
+            echo "op=all" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run site management
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          if [ "${{ steps.operation.outputs.op }}" = "add-file" ] && [ -n "${{ github.event.inputs.domains_file }}" ]; then
+            tsx scripts/manage-sites.ts add-file "${{ github.event.inputs.domains_file }}"
+          else
+            tsx scripts/manage-sites.ts ${{ steps.operation.outputs.op }}
+          fi
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --exit-code sites.csv || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Commit and push if changed
+        if: steps.git-check.outputs.changed == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add sites.csv
+          git commit -m "chore(docs): update sites.csv - $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+          git push
+
+      - name: Create summary
+        if: always()
+        run: |
+          echo "## Site Management Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Operation**: ${{ steps.operation.outputs.op }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Sites changed**: ${{ steps.git-check.outputs.changed == 'true' && 'Yes' || 'No' }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Current Sites Count" >> $GITHUB_STEP_SUMMARY
+          if [ -f sites.csv ]; then
+            count=$(tail -n +2 sites.csv | grep -v '^$' | wc -l)
+            echo "Total sites: $count" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,11 @@ seed/python-sdk/**/output.prof
 # Superpowers
 docs/superpowers/
 
+# Site management
+domains.txt
+domains-*.txt
+!domains-example.txt
+
 # Preview
 **/.preview/
 

--- a/docs/site-management.md
+++ b/docs/site-management.md
@@ -1,0 +1,184 @@
+# Fern Sites Management
+
+This system manages a registry of Fern documentation sites (`sites.csv`) with automated health checking and site discovery.
+
+## Overview
+
+The site management system combines three operations:
+
+1. **Add sites from Vercel** - Discovers Fern sites deployed on Vercel
+2. **Add sites from database** - Imports sites from your database
+3. **Validate & Clean** - Checks all sites for health and removes inactive ones
+
+All operations verify that domains host a live Fern site by calling `https://{domain}/api/fern-docs/health` before adding or keeping them in the registry.
+
+## Files
+
+- `sites.csv` - The site registry (domain, source, last_validated, status)
+- `scripts/manage-sites.ts` - TypeScript script that performs site management operations
+- `.github/workflows/manage-fern-sites.yml` - GitHub Actions workflow (runs daily)
+- `domains-example.txt` - Example file format for manual domain addition
+
+## Usage
+
+### Manual Execution
+
+```bash
+# Run all operations (add from Vercel, add from DB, validate existing)
+tsx scripts/manage-sites.ts all
+
+# Add sites from Vercel only
+tsx scripts/manage-sites.ts add-vercel
+
+# Add sites from database only
+tsx scripts/manage-sites.ts add-database
+
+# Add sites from a file (one domain per line)
+tsx scripts/manage-sites.ts add-file domains.txt
+
+# Validate and clean existing sites only
+tsx scripts/manage-sites.ts validate
+
+# List all registered sites
+tsx scripts/manage-sites.ts list
+```
+
+### GitHub Actions Workflow
+
+The workflow runs automatically daily at 2 AM UTC, or can be triggered manually:
+
+1. Go to Actions → Manage Fern Sites
+2. Click "Run workflow"
+3. Select the operation (default: "all")
+4. Optionally provide a domains file path for manual addition
+
+### Manual Domain Addition
+
+Create a text file with one domain per line:
+
+```text
+# domains.txt
+docs.example.com
+api-docs.acme.com
+developer.mycompany.io
+```
+
+Then run:
+
+```bash
+tsx scripts/manage-sites.ts add-file domains.txt
+```
+
+See `domains-example.txt` for a template.
+
+## Configuration
+
+### Required Secrets
+
+Configure these in your repository settings (Settings → Secrets and variables → Actions):
+
+- `VERCEL_TOKEN` - Vercel API token for accessing project data
+  - Create at: https://vercel.com/account/tokens
+  - Required scopes: Read projects
+
+- `DATABASE_URL` (optional) - Database connection string
+  - Format: `postgresql://user:password@host:port/database`
+  - Or configure the database query in `scripts/manage-sites.ts`
+
+### Health Check
+
+Sites are validated by making an HTTP GET request to:
+```
+https://{domain}/api/fern-docs/health
+```
+
+A site is considered healthy if:
+- The endpoint responds with status 2xx or 3xx
+- Response is received within 10 seconds
+
+## CSV Format
+
+```csv
+domain,source,last_validated,status
+docs.example.com,vercel,2026-05-13T15:30:00.000Z,active
+api.example.com,database,2026-05-13T15:30:00.000Z,active
+```
+
+Fields:
+- `domain` - The domain name (without protocol)
+- `source` - How the site was discovered (`vercel`, `database`, or `manual`)
+- `last_validated` - ISO 8601 timestamp of last successful health check
+- `status` - Current status (`active` or `inactive`)
+
+## Customization
+
+### Database Integration
+
+To connect to your database, modify the `addSitesFromDatabase()` function in `scripts/manage-sites.ts`:
+
+```typescript
+// Example with PostgreSQL
+import { Pool } from "pg";
+
+async function addSitesFromDatabase(): Promise<void> {
+    const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+    const result = await pool.query("SELECT domain FROM fern_sites WHERE active = true");
+    
+    const existingSites = readSites();
+    const existingDomains = new Set(existingSites.map((s) => s.domain));
+    
+    for (const row of result.rows) {
+        const domain = row.domain;
+        if (!existingDomains.has(domain)) {
+            const isHealthy = await checkSiteHealth(domain);
+            if (isHealthy) {
+                existingSites.push({
+                    domain,
+                    source: "database",
+                    last_validated: new Date().toISOString(),
+                    status: "active",
+                });
+            }
+        }
+    }
+    
+    writeCsv(existingSites);
+    await pool.end();
+}
+```
+
+### Custom Health Check
+
+Modify the `checkSiteHealth()` function to customize validation logic:
+
+```typescript
+async function checkSiteHealth(domain: string): Promise<boolean> {
+    // Add custom logic here
+    // e.g., check response body content, additional endpoints, etc.
+}
+```
+
+## Workflow Schedule
+
+The default schedule is daily at 2 AM UTC. To change this, modify the cron expression in `.github/workflows/manage-fern-sites.yml`:
+
+```yaml
+on:
+  schedule:
+    - cron: "0 2 * * *"  # Daily at 2 AM UTC
+```
+
+Examples:
+- `"0 */6 * * *"` - Every 6 hours
+- `"0 0 * * 0"` - Weekly on Sunday at midnight
+- `"0 0 1 * *"` - Monthly on the 1st at midnight
+
+## Monitoring
+
+The workflow creates a summary after each run showing:
+- Operation performed
+- Success/failure status
+- Whether sites.csv was updated
+- Current total site count
+
+View summaries in: Actions → Manage Fern Sites → [specific run] → Summary

--- a/domains-example.txt
+++ b/domains-example.txt
@@ -1,0 +1,10 @@
+# Example domains file for manual site addition
+# One domain per line, without protocol (http:// or https://)
+# Lines starting with # are treated as comments
+
+# Example domains:
+# docs.example.com
+# api-docs.acme.com
+# developer.mycompany.io
+
+# Add your domains below:

--- a/scripts/manage-sites.ts
+++ b/scripts/manage-sites.ts
@@ -1,0 +1,460 @@
+#!/usr/bin/env tsx
+
+import * as fs from "fs";
+import * as path from "path";
+import * as https from "https";
+import * as http from "http";
+
+interface SiteRecord {
+    domain: string;
+    source: "vercel" | "database" | "manual";
+    last_validated: string;
+    status: "active" | "inactive";
+}
+
+const SITES_CSV_PATH = path.join(process.cwd(), "sites.csv");
+const HEALTH_CHECK_PATH = "/api/fern-docs/health";
+const REQUEST_TIMEOUT = 10000; // 10 seconds
+const RATE_LIMIT_DELAY = 100; // milliseconds between requests
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function checkSiteHealth(domain: string, tryHttp = false): Promise<boolean> {
+    return new Promise((resolve) => {
+        const protocol = tryHttp ? "http" : "https";
+        const url = `${protocol}://${domain}${HEALTH_CHECK_PATH}`;
+        const client = tryHttp ? http : https;
+
+        const req = client.get(
+            url,
+            {
+                timeout: REQUEST_TIMEOUT,
+                headers: {
+                    "User-Agent": "Fern-Site-Manager/1.0",
+                },
+            },
+            (res) => {
+                // Consider 2xx and 3xx status codes as healthy
+                const isHealthy = res.statusCode !== undefined && res.statusCode >= 200 && res.statusCode < 400;
+                
+                // Consume response data to free up memory
+                res.resume();
+                
+                resolve(isHealthy);
+            }
+        );
+
+        req.on("error", async (error) => {
+            // If HTTPS fails and we haven't tried HTTP yet, try HTTP
+            if (!tryHttp && (error.message.includes("certificate") || error.message.includes("ENOTFOUND"))) {
+                const httpResult = await checkSiteHealth(domain, true);
+                resolve(httpResult);
+            } else {
+                resolve(false);
+            }
+        });
+
+        req.on("timeout", () => {
+            req.destroy();
+            resolve(false);
+        });
+    });
+}
+
+async function checkSiteHealthWithRetry(domain: string, maxRetries = 2): Promise<boolean> {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        try {
+            const isHealthy = await checkSiteHealth(domain);
+            if (isHealthy) {
+                return true;
+            }
+            
+            if (attempt < maxRetries) {
+                await sleep(1000 * (attempt + 1)); // Exponential backoff
+            }
+        } catch (error) {
+            if (attempt === maxRetries) {
+                return false;
+            }
+        }
+    }
+    return false;
+}
+
+function parseCsv(content: string): SiteRecord[] {
+    const lines = content.trim().split("\n");
+    if (lines.length <= 1) {
+        return [];
+    }
+
+    const records: SiteRecord[] = [];
+    for (let i = 1; i < lines.length; i++) {
+        const line = lines[i].trim();
+        if (!line) continue;
+
+        const [domain, source, last_validated, status] = line.split(",");
+        if (domain && source) {
+            records.push({
+                domain: domain.trim(),
+                source: (source.trim() as SiteRecord["source"]) || "manual",
+                last_validated: last_validated?.trim() || "",
+                status: (status?.trim() as SiteRecord["status"]) || "active",
+            });
+        }
+    }
+
+    return records;
+}
+
+function writeCsv(records: SiteRecord[]): void {
+    const header = "domain,source,last_validated,status";
+    const rows = records.map(
+        (record) => `${record.domain},${record.source},${record.last_validated},${record.status}`
+    );
+    const content = [header, ...rows].join("\n") + "\n";
+    fs.writeFileSync(SITES_CSV_PATH, content, "utf-8");
+}
+
+function readSites(): SiteRecord[] {
+    if (!fs.existsSync(SITES_CSV_PATH)) {
+        return [];
+    }
+    const content = fs.readFileSync(SITES_CSV_PATH, "utf-8");
+    return parseCsv(content);
+}
+
+async function addSitesFromVercel(): Promise<void> {
+    console.log("Adding sites from Vercel...");
+
+    const vercelToken = process.env.VERCEL_TOKEN;
+    if (!vercelToken) {
+        console.error("⚠️  VERCEL_TOKEN environment variable is not set");
+        return;
+    }
+
+    try {
+        const response = await fetch("https://api.vercel.com/v9/projects", {
+            headers: {
+                Authorization: `Bearer ${vercelToken}`,
+            },
+        });
+
+        if (!response.ok) {
+            console.error(`Vercel API error: ${response.status} ${response.statusText}`);
+            return;
+        }
+
+        const data = (await response.json()) as { projects: Array<{ name?: string; targets?: { production?: { alias?: string[] } } }> };
+        const existingSites = readSites();
+        const existingDomains = new Set(existingSites.map((s) => s.domain));
+        let addedCount = 0;
+        let skippedCount = 0;
+        let checkedCount = 0;
+
+        console.log(`Found ${data.projects.length} Vercel projects`);
+
+        for (const project of data.projects) {
+            const domains = project.targets?.production?.alias || [];
+            for (const domain of domains) {
+                if (!existingDomains.has(domain)) {
+                    checkedCount++;
+                    console.log(`[${checkedCount}] Checking: ${domain}`);
+                    
+                    const isHealthy = await checkSiteHealthWithRetry(domain);
+                    
+                    if (isHealthy) {
+                        existingSites.push({
+                            domain,
+                            source: "vercel",
+                            last_validated: new Date().toISOString(),
+                            status: "active",
+                        });
+                        existingDomains.add(domain);
+                        addedCount++;
+                        console.log(`   ✓ Added (project: ${project.name || "unknown"})`);
+                    } else {
+                        skippedCount++;
+                        console.log(`   ✗ Skipped - no healthy Fern site`);
+                    }
+                    
+                    // Rate limiting
+                    await sleep(RATE_LIMIT_DELAY);
+                }
+            }
+        }
+
+        if (addedCount > 0) {
+            writeCsv(existingSites);
+        }
+        
+        console.log(`\nVercel Summary: Checked ${checkedCount}, Added ${addedCount}, Skipped ${skippedCount}`);
+    } catch (error) {
+        console.error("Error fetching sites from Vercel:", error);
+    }
+}
+
+async function addSitesFromDatabase(): Promise<void> {
+    console.log("Adding sites from database...");
+
+    const dbUrl = process.env.DATABASE_URL;
+    if (!dbUrl) {
+        console.error("⚠️  DATABASE_URL environment variable is not set");
+        console.log("ℹ️  To enable database integration:");
+        console.log("   1. Set DATABASE_URL environment variable");
+        console.log("   2. Install database driver: npm install pg (for PostgreSQL)");
+        console.log("   3. Implement the query logic in scripts/manage-sites.ts");
+        return;
+    }
+
+    try {
+        console.log("⚠️  Database integration placeholder");
+        console.log("ℹ️  To complete database integration, modify addSitesFromDatabase()");
+        console.log("   See docs/site-management.md for examples");
+
+        // Example implementation structure:
+        // 
+        // import { Pool } from "pg";
+        // 
+        // const pool = new Pool({ connectionString: dbUrl });
+        // const result = await pool.query(`
+        //     SELECT DISTINCT domain 
+        //     FROM fern_documentation_sites 
+        //     WHERE status = 'active' 
+        //     ORDER BY domain
+        // `);
+        // 
+        // const existingSites = readSites();
+        // const existingDomains = new Set(existingSites.map((s) => s.domain));
+        // let addedCount = 0;
+        // 
+        // for (const row of result.rows) {
+        //     const domain = row.domain;
+        //     if (!existingDomains.has(domain)) {
+        //         const isHealthy = await checkSiteHealthWithRetry(domain);
+        //         if (isHealthy) {
+        //             existingSites.push({
+        //                 domain,
+        //                 source: "database",
+        //                 last_validated: new Date().toISOString(),
+        //                 status: "active",
+        //             });
+        //             addedCount++;
+        //         }
+        //         await sleep(RATE_LIMIT_DELAY);
+        //     }
+        // }
+        // 
+        // if (addedCount > 0) {
+        //     writeCsv(existingSites);
+        // }
+        // console.log(`Database Summary: Added ${addedCount} sites`);
+        // await pool.end();
+        
+    } catch (error) {
+        console.error("Error fetching sites from database:", error);
+    }
+}
+
+async function validateAndCleanSites(): Promise<void> {
+    console.log("Validating and cleaning sites...");
+
+    const sites = readSites();
+    
+    if (sites.length === 0) {
+        console.log("No sites to validate");
+        return;
+    }
+    
+    const validatedSites: SiteRecord[] = [];
+    const removedSites: string[] = [];
+    let healthyCount = 0;
+
+    console.log(`Validating ${sites.length} sites...\n`);
+
+    for (let i = 0; i < sites.length; i++) {
+        const site = sites[i];
+        console.log(`[${i + 1}/${sites.length}] Checking: ${site.domain}`);
+        
+        const isHealthy = await checkSiteHealthWithRetry(site.domain);
+
+        if (isHealthy) {
+            validatedSites.push({
+                ...site,
+                last_validated: new Date().toISOString(),
+                status: "active",
+            });
+            healthyCount++;
+            console.log(`   ✓ Healthy (source: ${site.source})`);
+        } else {
+            removedSites.push(site.domain);
+            console.log(`   ✗ Unhealthy - will be removed`);
+        }
+        
+        // Rate limiting
+        await sleep(RATE_LIMIT_DELAY);
+    }
+
+    writeCsv(validatedSites);
+    
+    console.log(`\nValidation Summary:`);
+    console.log(`  Total checked: ${sites.length}`);
+    console.log(`  Healthy: ${healthyCount}`);
+    console.log(`  Removed: ${removedSites.length}`);
+    
+    if (removedSites.length > 0) {
+        console.log(`\nRemoved sites:`);
+        removedSites.forEach((domain) => console.log(`  - ${domain}`));
+    }
+}
+
+async function addManualSites(filePath: string): Promise<void> {
+    console.log(`Adding sites from file: ${filePath}`);
+
+    if (!fs.existsSync(filePath)) {
+        console.error(`File not found: ${filePath}`);
+        return;
+    }
+
+    try {
+        const content = fs.readFileSync(filePath, "utf-8");
+        const domains = content
+            .split("\n")
+            .map((line) => line.trim())
+            .filter((line) => line && !line.startsWith("#"));
+
+        const existingSites = readSites();
+        const existingDomains = new Set(existingSites.map((s) => s.domain));
+        let addedCount = 0;
+        let skippedCount = 0;
+
+        console.log(`Found ${domains.length} domains to check\n`);
+
+        for (let i = 0; i < domains.length; i++) {
+            const domain = domains[i];
+            
+            if (existingDomains.has(domain)) {
+                console.log(`[${i + 1}/${domains.length}] ${domain}: Already exists`);
+                continue;
+            }
+
+            console.log(`[${i + 1}/${domains.length}] Checking: ${domain}`);
+            const isHealthy = await checkSiteHealthWithRetry(domain);
+
+            if (isHealthy) {
+                existingSites.push({
+                    domain,
+                    source: "manual",
+                    last_validated: new Date().toISOString(),
+                    status: "active",
+                });
+                existingDomains.add(domain);
+                addedCount++;
+                console.log(`   ✓ Added`);
+            } else {
+                skippedCount++;
+                console.log(`   ✗ Skipped - no healthy Fern site`);
+            }
+
+            await sleep(RATE_LIMIT_DELAY);
+        }
+
+        if (addedCount > 0) {
+            writeCsv(existingSites);
+        }
+
+        console.log(`\nManual Import Summary: Added ${addedCount}, Skipped ${skippedCount}`);
+    } catch (error) {
+        console.error("Error reading file:", error);
+    }
+}
+
+async function listSites(): Promise<void> {
+    const sites = readSites();
+    
+    if (sites.length === 0) {
+        console.log("No sites in registry");
+        return;
+    }
+
+    console.log(`Total sites: ${sites.length}\n`);
+
+    const bySource = sites.reduce(
+        (acc, site) => {
+            acc[site.source] = (acc[site.source] || 0) + 1;
+            return acc;
+        },
+        {} as Record<string, number>
+    );
+
+    console.log("By source:");
+    Object.entries(bySource).forEach(([source, count]) => {
+        console.log(`  ${source}: ${count}`);
+    });
+
+    console.log("\nSites:");
+    sites.forEach((site, i) => {
+        console.log(`${i + 1}. ${site.domain} (${site.source}, ${site.status})`);
+    });
+}
+
+async function main(): Promise<void> {
+    const command = process.argv[2];
+    const arg = process.argv[3];
+
+    switch (command) {
+        case "add-vercel":
+            await addSitesFromVercel();
+            break;
+        case "add-database":
+            await addSitesFromDatabase();
+            break;
+        case "add-file":
+            if (!arg) {
+                console.error("Error: File path required");
+                console.error("Usage: manage-sites.ts add-file <path-to-domains.txt>");
+                process.exit(1);
+            }
+            await addManualSites(arg);
+            break;
+        case "validate":
+            await validateAndCleanSites();
+            break;
+        case "list":
+            await listSites();
+            break;
+        case "all":
+            console.log("Running all site management tasks...\n");
+            await addSitesFromVercel();
+            console.log("\n" + "=".repeat(60) + "\n");
+            await addSitesFromDatabase();
+            console.log("\n" + "=".repeat(60) + "\n");
+            await validateAndCleanSites();
+            break;
+        default:
+            console.log("Fern Sites Management Tool");
+            console.log("\nUsage: manage-sites.ts <command> [arguments]");
+            console.log("\nCommands:");
+            console.log("  add-vercel           Add sites from Vercel");
+            console.log("  add-database         Add sites from database");
+            console.log("  add-file <path>      Add sites from a text file (one domain per line)");
+            console.log("  validate             Validate and clean existing sites");
+            console.log("  list                 List all registered sites");
+            console.log("  all                  Run all operations (add-vercel, add-database, validate)");
+            console.log("\nEnvironment Variables:");
+            console.log("  VERCEL_TOKEN         Required for add-vercel");
+            console.log("  DATABASE_URL         Required for add-database");
+            console.log("\nExamples:");
+            console.log("  tsx scripts/manage-sites.ts all");
+            console.log("  tsx scripts/manage-sites.ts add-file domains.txt");
+            console.log("  tsx scripts/manage-sites.ts validate");
+            console.log("  tsx scripts/manage-sites.ts list");
+            process.exit(command ? 1 : 0);
+    }
+}
+
+main().catch((error) => {
+    console.error("Fatal error:", error);
+    process.exit(1);
+});

--- a/scripts/test-site-health.ts
+++ b/scripts/test-site-health.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env tsx
+// Test script to verify Fern site health checking functionality
+
+import * as https from "https";
+
+const HEALTH_CHECK_PATH = "/api/fern-docs/health";
+const REQUEST_TIMEOUT = 10000;
+
+async function testHealthCheck(domain: string): Promise<void> {
+    console.log(`Testing health check for: ${domain}`);
+    console.log(`URL: https://${domain}${HEALTH_CHECK_PATH}`);
+    
+    const startTime = Date.now();
+    
+    return new Promise((resolve) => {
+        const req = https.get(
+            `https://${domain}${HEALTH_CHECK_PATH}`,
+            {
+                timeout: REQUEST_TIMEOUT,
+                headers: {
+                    "User-Agent": "Fern-Site-Manager-Test/1.0",
+                },
+            },
+            (res) => {
+                const duration = Date.now() - startTime;
+                console.log(`Status: ${res.statusCode}`);
+                console.log(`Duration: ${duration}ms`);
+                
+                const isHealthy = res.statusCode !== undefined && res.statusCode >= 200 && res.statusCode < 400;
+                console.log(`Result: ${isHealthy ? "✓ HEALTHY" : "✗ UNHEALTHY"}`);
+                
+                // Consume response data
+                res.resume();
+                resolve();
+            }
+        );
+
+        req.on("error", (error) => {
+            const duration = Date.now() - startTime;
+            console.log(`Error: ${error.message}`);
+            console.log(`Duration: ${duration}ms`);
+            console.log("Result: ✗ UNHEALTHY (error)");
+            resolve();
+        });
+
+        req.on("timeout", () => {
+            const duration = Date.now() - startTime;
+            req.destroy();
+            console.log(`Duration: ${duration}ms`);
+            console.log("Result: ✗ UNHEALTHY (timeout)");
+            resolve();
+        });
+    });
+}
+
+async function main(): Promise<void> {
+    const testDomains = process.argv.slice(2);
+    
+    if (testDomains.length === 0) {
+        console.log("Fern Site Health Check Test\n");
+        console.log("Usage: tsx scripts/test-site-health.ts <domain1> [domain2] [domain3] ...\n");
+        console.log("Example:");
+        console.log("  tsx scripts/test-site-health.ts docs.buildwithfern.com\n");
+        process.exit(1);
+    }
+
+    console.log("=".repeat(60));
+    console.log("Fern Site Health Check Test");
+    console.log("=".repeat(60));
+    console.log();
+
+    for (let i = 0; i < testDomains.length; i++) {
+        if (i > 0) {
+            console.log("\n" + "-".repeat(60) + "\n");
+        }
+        
+        await testHealthCheck(testDomains[i]);
+    }
+
+    console.log("\n" + "=".repeat(60));
+}
+
+main().catch((error) => {
+    console.error("Fatal error:", error);
+    process.exit(1);
+});

--- a/sites.csv
+++ b/sites.csv
@@ -1,0 +1,1 @@
+domain,source,last_validated,status


### PR DESCRIPTION
- Add sites.csv registry for tracking Fern documentation sites
- Create manage-sites.ts script that combines three operations:
  * Add sites from Vercel API
  * Add sites from database
  * Validate existing sites and remove inactive ones
- Implement health checking via /api/fern-docs/health endpoint
- Add GitHub Actions workflow for automated daily site management
- Include manual site addition from file
- Add comprehensive documentation in docs/site-management.md
- Add test script for health check verification

## Description
Linear ticket: Closes 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- 
- 
- [ ] Updated README.md generator (if applicable)

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [ ] Manual testing completed
