### PR TITLE
feat(php): add SSE / NDJSON / text streaming support

### DIFF
--- a/generators/php/base/src/AsIs.ts
+++ b/generators/php/base/src/AsIs.ts
@@ -13,7 +13,12 @@ export enum AsIsFiles {
     RetryDecoratingClient = "Client/RetryDecoratingClient.Template.php",
     HttpClientBuilder = "Client/HttpClientBuilder.Template.php",
     RawClientTest = "Client/RawClientTest.Template.php",
+    StreamTest = "Client/StreamTest.Template.php",
     MockHttpClient = "Client/MockHttpClient.Template.php",
+    Stream = "Client/Stream.Template.php",
+    SseStream = "Client/SseStream.Template.php",
+    JsonStream = "Client/JsonStream.Template.php",
+    TextStream = "Client/TextStream.Template.php",
 
     // Core/Json files.
     JsonApiRequest = "Json/JsonApiRequest.Template.php",

--- a/generators/php/base/src/AsIs.ts
+++ b/generators/php/base/src/AsIs.ts
@@ -17,6 +17,7 @@ export enum AsIsFiles {
     MockHttpClient = "Client/MockHttpClient.Template.php",
     Stream = "Client/Stream.Template.php",
     SseStream = "Client/SseStream.Template.php",
+    SseEvent = "Client/SseEvent.Template.php",
     JsonStream = "Client/JsonStream.Template.php",
     TextStream = "Client/TextStream.Template.php",
 

--- a/generators/php/base/src/AsIs.ts
+++ b/generators/php/base/src/AsIs.ts
@@ -16,6 +16,7 @@ export enum AsIsFiles {
     StreamTest = "Client/StreamTest.Template.php",
     MockHttpClient = "Client/MockHttpClient.Template.php",
     Stream = "Client/Stream.Template.php",
+    StreamFormat = "Client/StreamFormat.Template.php",
     SseStream = "Client/SseStream.Template.php",
     SseEvent = "Client/SseEvent.Template.php",
     JsonStream = "Client/JsonStream.Template.php",

--- a/generators/php/base/src/asIs/Client/JsonStream.Template.php
+++ b/generators/php/base/src/asIs/Client/JsonStream.Template.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace <%= namespace%>;
+
+use Closure;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Iterates a newline-delimited JSON (NDJSON) response body, yielding one
+ * deserialized chunk per non-empty line.
+ *
+ * @template T
+ * @extends Stream<T>
+ */
+class JsonStream extends Stream
+{
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param Closure(string): T $deserializer Called once per line with the raw
+     *   JSON payload string.
+     * @param ?string $terminator Optional sentinel line that ends the stream
+     *   when received. Pass `null` to read until EOF.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Closure $deserializer,
+        ?string $terminator = null,
+    ) {
+        parent::__construct(
+            response: $response,
+            deserializer: $deserializer,
+            format: StreamFormat::Json,
+            terminator: $terminator,
+        );
+    }
+}

--- a/generators/php/base/src/asIs/Client/JsonStream.Template.php
+++ b/generators/php/base/src/asIs/Client/JsonStream.Template.php
@@ -20,17 +20,20 @@ class JsonStream extends Stream
      *   JSON payload string.
      * @param ?string $terminator Optional sentinel line that ends the stream
      *   when received. Pass `null` to read until EOF.
+     * @param int $maxBufferSize See `Stream::__construct`. Defaults to 1 MiB.
      */
     public function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         ?string $terminator = null,
+        int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
     ) {
         parent::__construct(
             response: $response,
             deserializer: $deserializer,
             format: StreamFormat::Json,
             terminator: $terminator,
+            maxBufferSize: $maxBufferSize,
         );
     }
 }

--- a/generators/php/base/src/asIs/Client/SseEvent.Template.php
+++ b/generators/php/base/src/asIs/Client/SseEvent.Template.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace <%= namespace%>;
+
+/**
+ * A single Server-Sent Event with its WHATWG metadata fields.
+ *
+ * Returned by `SseStream::events()`. Use plain `foreach ($stream as $payload)` if
+ * metadata isn't needed and you only want the deserialized `data` field.
+ *
+ * @template T
+ */
+final class SseEvent
+{
+    /**
+     * @param T $data Deserialized payload from the `data:` field(s). Multi-line
+     *   data is joined with a single newline before deserialization.
+     * @param string $event Value of the `event:` field, or empty string if not set.
+     * @param string $id Most recent `id:` field value. Per the WHATWG spec, this
+     *   persists across events: a subsequent event without an explicit `id:`
+     *   inherits the previous one. Empty string until the first id is observed.
+     * @param ?int $retry Reconnection time in milliseconds from the `retry:` field,
+     *   or null if not set or unparseable.
+     */
+    public function __construct(
+        public readonly mixed $data,
+        public readonly string $event = '',
+        public readonly string $id = '',
+        public readonly ?int $retry = null,
+    ) {
+    }
+}

--- a/generators/php/base/src/asIs/Client/SseStream.Template.php
+++ b/generators/php/base/src/asIs/Client/SseStream.Template.php
@@ -56,7 +56,7 @@ class SseStream extends Stream
     {
         foreach ($this->iterateRawSseEvents() as $raw) {
             yield new SseEvent(
-                data: ($this->deserializer)($raw['data']),
+                data: $this->deserialize($raw['data']),
                 event: $raw['event'],
                 id: $raw['id'],
                 retry: $raw['retry'],

--- a/generators/php/base/src/asIs/Client/SseStream.Template.php
+++ b/generators/php/base/src/asIs/Client/SseStream.Template.php
@@ -3,7 +3,9 @@
 namespace <%= namespace%>;
 
 use Closure;
+use Generator;
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 
 /**
  * Iterates a `text/event-stream` (SSE) response body, yielding one deserialized
@@ -21,17 +23,79 @@ class SseStream extends Stream
      * @param ?string $terminator Optional sentinel payload that ends the stream
      *   when received. Defaults to '[DONE]', a common SSE convention.
      *   Pass `null` to disable terminator handling.
+     * @param int $maxBufferSize See `Stream::__construct`. Defaults to 1 MiB.
      */
     public function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         ?string $terminator = '[DONE]',
+        int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
     ) {
+        self::validateContentType($response);
         parent::__construct(
             response: $response,
             deserializer: $deserializer,
             format: StreamFormat::Sse,
             terminator: $terminator,
+            maxBufferSize: $maxBufferSize,
         );
+    }
+
+    /**
+     * Iterates the stream yielding both the deserialized payload and the
+     * accompanying SSE metadata (event type, id, retry). Use this when you
+     * need the event field (e.g. for event-typed unions) or `Last-Event-ID`
+     * for resumption logic.
+     *
+     * For data-only iteration, use this object directly as an iterable:
+     * `foreach ($stream as $event) { ... }`.
+     *
+     * @return Generator<int, SseEvent<T>>
+     */
+    public function events(): Generator
+    {
+        foreach ($this->iterateRawSseEvents() as $raw) {
+            yield new SseEvent(
+                data: ($this->deserializer)($raw['data']),
+                event: $raw['event'],
+                id: $raw['id'],
+                retry: $raw['retry'],
+            );
+        }
+    }
+
+    /**
+     * Validates that the response's Content-Type matches an SSE stream.
+     *
+     * Per WHATWG, the SSE wire format is always UTF-8; we reject explicit
+     * non-UTF-8 charset parameters rather than risk silent mojibake. A missing
+     * Content-Type header is tolerated — some servers omit it on streaming
+     * responses — but a wrong media type or wrong charset always throws.
+     */
+    private static function validateContentType(ResponseInterface $response): void
+    {
+        $contentType = $response->getHeaderLine('Content-Type');
+        if ($contentType === '') {
+            return;
+        }
+        $parts = explode(';', $contentType);
+        $mediaType = strtolower(trim($parts[0]));
+        if ($mediaType !== 'text/event-stream') {
+            throw new RuntimeException(
+                "Expected Content-Type 'text/event-stream' for SSE response, got '{$mediaType}'",
+            );
+        }
+        foreach (array_slice($parts, 1) as $param) {
+            $param = trim($param);
+            if (stripos($param, 'charset=') !== 0) {
+                continue;
+            }
+            $charset = strtolower(trim(substr($param, 8), " \"'"));
+            if ($charset !== '' && $charset !== 'utf-8' && $charset !== 'utf8') {
+                throw new RuntimeException(
+                    "Unsupported SSE charset '{$charset}'; per the WHATWG spec only UTF-8 is permitted",
+                );
+            }
+        }
     }
 }

--- a/generators/php/base/src/asIs/Client/SseStream.Template.php
+++ b/generators/php/base/src/asIs/Client/SseStream.Template.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace <%= namespace%>;
+
+use Closure;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Iterates a `text/event-stream` (SSE) response body, yielding one deserialized
+ * event per dispatched frame.
+ *
+ * @template T
+ * @extends Stream<T>
+ */
+class SseStream extends Stream
+{
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param Closure(string): T $deserializer Called once per dispatched event
+     *   with the raw `data:` payload string (newline-joined for multi-line frames).
+     * @param ?string $terminator Optional sentinel payload that ends the stream
+     *   when received. Defaults to '[DONE]', a common SSE convention.
+     *   Pass `null` to disable terminator handling.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Closure $deserializer,
+        ?string $terminator = '[DONE]',
+    ) {
+        parent::__construct(
+            response: $response,
+            deserializer: $deserializer,
+            format: StreamFormat::Sse,
+            terminator: $terminator,
+        );
+    }
+}

--- a/generators/php/base/src/asIs/Client/Stream.Template.php
+++ b/generators/php/base/src/asIs/Client/Stream.Template.php
@@ -235,8 +235,12 @@ class Stream implements IteratorAggregate
             if ($pendingCr && $chunk[0] === "\n") {
                 $chunk = substr($chunk, 1);
             }
-            $pendingCr = str_ends_with($chunk, "\r");
-            $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
+            if (str_contains($chunk, "\r")) {
+                $pendingCr = str_ends_with($chunk, "\r");
+                $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
+            } else {
+                $pendingCr = false;
+            }
             $buffer = $this->appendWithinCap($buffer, $chunk);
             if (!$bomChecked && strlen($buffer) >= 3) {
                 $bomChecked = true;

--- a/generators/php/base/src/asIs/Client/Stream.Template.php
+++ b/generators/php/base/src/asIs/Client/Stream.Template.php
@@ -7,6 +7,7 @@ use Generator;
 use IteratorAggregate;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use RuntimeException;
 
 enum StreamFormat: string
 {
@@ -29,17 +30,23 @@ enum StreamFormat: string
  * When `$terminator` is set, an event whose payload equals the terminator
  * ends iteration cleanly (e.g. `[DONE]` for SSE).
  *
+ * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams that
+ * never emit a frame boundary: if the line buffer or a single event's data
+ * exceeds the cap, iteration aborts with `RuntimeException`.
+ *
  * @template T
  * @implements IteratorAggregate<int, T>
  */
 class Stream implements IteratorAggregate
 {
+    public const DEFAULT_MAX_BUFFER_SIZE = 1048576;
+
     private const READ_CHUNK_SIZE = 8192;
 
     private StreamInterface $body;
 
     /** @var Closure(string): T */
-    private Closure $deserializer;
+    protected Closure $deserializer;
 
     /**
      * @param ResponseInterface $response The HTTP response to stream from.
@@ -48,18 +55,25 @@ class Stream implements IteratorAggregate
      * @param StreamFormat $format Framing strategy for the stream.
      * @param ?string $terminator Optional sentinel value that ends the stream when matched
      *   against the raw frame payload (e.g. '[DONE]').
+     * @param int $maxBufferSize Maximum size in bytes for the line buffer or a single SSE
+     *   event's accumulated `data` field. Exceeding this throws `RuntimeException` to
+     *   guard against pathological streams. Defaults to 1 MiB.
      */
     public function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         private readonly StreamFormat $format = StreamFormat::Sse,
         private readonly ?string $terminator = null,
+        private readonly int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
     ) {
         $this->body = $response->getBody();
         $this->deserializer = $deserializer;
     }
 
     /**
+     * Iteration is one-shot: PSR-7 bodies are forward-only, so re-iterating the
+     * same `Stream` instance yields nothing useful.
+     *
      * @return Generator<int, T>
      */
     public function getIterator(): Generator
@@ -72,35 +86,57 @@ class Stream implements IteratorAggregate
     }
 
     /**
-     * WHATWG-compliant SSE frame parser.
-     *
      * @return Generator<int, T>
      */
     private function iterateSse(): Generator
     {
+        foreach ($this->iterateRawSseEvents() as $raw) {
+            yield ($this->deserializer)($raw['data']);
+        }
+    }
+
+    /**
+     * Iterates the SSE stream yielding raw envelopes with WHATWG metadata fields
+     * intact. Yields plain associative arrays — not `SseEvent` objects — so the
+     * data-only iteration path doesn't pay the allocation cost; `SseStream::events()`
+     * constructs the public `SseEvent<T>` on top.
+     *
+     * Per WHATWG: the `id:` field persists across events within this iteration;
+     * the configured `terminator`, if present, ends iteration when matched against
+     * `data`.
+     *
+     * @internal
+     * @return Generator<int, array{data: string, event: string, id: string, retry: ?int}>
+     */
+    protected function iterateRawSseEvents(): Generator
+    {
         $dataBuffer = '';
+        $eventType = '';
+        $lastEventId = '';
+        $retry = null;
         foreach ($this->readLines() as $line) {
             if ($line === '') {
-                // Blank line dispatches the accumulated event.
                 if ($dataBuffer === '') {
                     continue;
                 }
-                // Strip the single trailing "\n" added by the field append step.
+                // Strip the single trailing "\n" added by the field-append step.
                 $payload = substr($dataBuffer, 0, -1);
+                $this->assertBufferWithinCap(strlen($payload));
                 $dataBuffer = '';
                 if ($this->terminator !== null && $payload === $this->terminator) {
                     return;
                 }
-                yield ($this->deserializer)($payload);
+                yield ['data' => $payload, 'event' => $eventType, 'id' => $lastEventId, 'retry' => $retry];
+                // Per WHATWG: do NOT reset lastEventId between events.
+                $eventType = '';
+                $retry = null;
                 continue;
             }
             if (str_starts_with($line, ':')) {
-                // SSE comment — ignored per spec.
                 continue;
             }
             $colonPos = strpos($line, ':');
             if ($colonPos === false) {
-                // Line is a field name with empty value; only `data` is meaningful for us.
                 if ($line === 'data') {
                     $dataBuffer .= "\n";
                 }
@@ -111,23 +147,38 @@ class Stream implements IteratorAggregate
             if (str_starts_with($value, ' ')) {
                 $value = substr($value, 1);
             }
-            // Only `data` is yielded; `event`/`id`/`retry` are accepted but unused here.
-            if ($field === 'data') {
-                $dataBuffer .= $value . "\n";
+            switch ($field) {
+                case 'data':
+                    $dataBuffer .= $value . "\n";
+                    break;
+                case 'event':
+                    $eventType = $value;
+                    break;
+                case 'id':
+                    // WHATWG: ignore IDs that contain a NULL byte.
+                    if (!str_contains($value, "\0")) {
+                        $lastEventId = $value;
+                    }
+                    break;
+                case 'retry':
+                    // WHATWG: ignore the value if it isn't a base-10 integer.
+                    if ($value !== '' && ctype_digit($value)) {
+                        $retry = (int) $value;
+                    }
+                    break;
             }
         }
         // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
         if ($dataBuffer !== '') {
             $payload = substr($dataBuffer, 0, -1);
+            $this->assertBufferWithinCap(strlen($payload));
             if ($this->terminator === null || $payload !== $this->terminator) {
-                yield ($this->deserializer)($payload);
+                yield ['data' => $payload, 'event' => $eventType, 'id' => $lastEventId, 'retry' => $retry];
             }
         }
     }
 
     /**
-     * Newline-delimited frames (NDJSON, line-by-line).
-     *
      * @return Generator<int, T>
      */
     private function iterateDelimited(): Generator
@@ -144,8 +195,6 @@ class Stream implements IteratorAggregate
     }
 
     /**
-     * Raw newline-delimited text frames.
-     *
      * @return Generator<int, T>
      */
     private function iterateText(): Generator
@@ -159,6 +208,10 @@ class Stream implements IteratorAggregate
      * Reads the response body and yields complete lines, normalizing CRLF/CR
      * to LF per the WHATWG SSE spec. Trailing partial content (without a
      * terminating newline) is emitted as a final line.
+     *
+     * Throws `RuntimeException` if the accumulated buffer exceeds the configured
+     * cap — that means we've read more than `maxBufferSize` bytes without ever
+     * seeing a line break, which indicates a malformed or hostile stream.
      *
      * @return Generator<int, string>
      */
@@ -180,6 +233,7 @@ class Stream implements IteratorAggregate
             // Normalize line endings on just this chunk: "\r\n" and lone "\r" -> "\n".
             $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
             $buffer .= $chunk;
+            $this->assertBufferWithinCap(strlen($buffer));
             while (($lfPos = strpos($buffer, "\n")) !== false) {
                 yield substr($buffer, 0, $lfPos);
                 $buffer = substr($buffer, $lfPos + 1);
@@ -187,6 +241,15 @@ class Stream implements IteratorAggregate
         }
         if ($buffer !== '') {
             yield $buffer;
+        }
+    }
+
+    private function assertBufferWithinCap(int $size): void
+    {
+        if ($size > $this->maxBufferSize) {
+            throw new RuntimeException(
+                "Stream buffer exceeded maximum size of {$this->maxBufferSize} bytes",
+            );
         }
     }
 

--- a/generators/php/base/src/asIs/Client/Stream.Template.php
+++ b/generators/php/base/src/asIs/Client/Stream.Template.php
@@ -23,15 +23,12 @@ use RuntimeException;
  * When `$terminator` is set, an event whose payload equals the terminator
  * ends iteration cleanly (e.g. `[DONE]` for SSE).
  *
- * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams that
- * never emit a frame boundary: if the line buffer or a single event's data
- * exceeds the cap, iteration aborts with `RuntimeException`. The cap is
- * enforced *before* allocation, not after — a hostile stream cannot drive us
- * past the limit and then trip the check.
+ * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams
+ * that never emit a frame boundary: if the line buffer or a single event's
+ * data exceeds the cap, iteration aborts with `RuntimeException`.
  *
- * Direct instantiation of `Stream` is not supported; use `SseStream`,
- * `JsonStream`, or `TextStream` instead. The constructor is `protected` to
- * enforce this.
+ * Direct instantiation is not supported; use `SseStream`, `JsonStream`, or
+ * `TextStream`.
  *
  * @template T
  * @implements IteratorAggregate<int, T>
@@ -131,7 +128,6 @@ class Stream implements IteratorAggregate
                 if ($dataBuffer === '') {
                     continue;
                 }
-                // Strip the single trailing "\n" added by the field-append step.
                 $payload = substr($dataBuffer, 0, -1);
                 $dataBuffer = '';
                 if ($this->terminator !== null && $payload === $this->terminator) {
@@ -160,9 +156,6 @@ class Stream implements IteratorAggregate
             }
             switch ($field) {
                 case 'data':
-                    // Enforce the cap before allocation: a hostile stream emitting
-                    // many `data:` lines without a dispatching blank line cannot
-                    // drive us past the limit and then trip the check.
                     $dataBuffer = $this->appendWithinCap($dataBuffer, $value . "\n");
                     break;
                 case 'event':
@@ -182,7 +175,7 @@ class Stream implements IteratorAggregate
                     break;
             }
         }
-        // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
+        // Flush a trailing event that lacked a closing blank line.
         if ($dataBuffer !== '') {
             $payload = substr($dataBuffer, 0, -1);
             if ($this->terminator === null || $payload !== $this->terminator) {
@@ -266,10 +259,8 @@ class Stream implements IteratorAggregate
     }
 
     /**
-     * Appends $suffix to $buffer, throwing `RuntimeException` if the result
-     * would exceed `maxBufferSize`. The cap is enforced before the
-     * concatenation allocates, so a runaway stream is bounded by the configured
-     * limit rather than by available memory.
+     * Appends $suffix to $buffer, throwing `RuntimeException` if the resulting
+     * size would exceed `maxBufferSize`.
      */
     private function appendWithinCap(string $buffer, string $suffix): string
     {

--- a/generators/php/base/src/asIs/Client/Stream.Template.php
+++ b/generators/php/base/src/asIs/Client/Stream.Template.php
@@ -9,13 +9,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 
-enum StreamFormat: string
-{
-    case Sse = 'sse';
-    case Json = 'json';
-    case Text = 'text';
-}
-
 /**
  * Iterates a streaming HTTP response body frame-by-frame.
  *
@@ -32,21 +25,28 @@ enum StreamFormat: string
  *
  * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams that
  * never emit a frame boundary: if the line buffer or a single event's data
- * exceeds the cap, iteration aborts with `RuntimeException`.
+ * exceeds the cap, iteration aborts with `RuntimeException`. The cap is
+ * enforced *before* allocation, not after — a hostile stream cannot drive us
+ * past the limit and then trip the check.
+ *
+ * Direct instantiation of `Stream` is not supported; use `SseStream`,
+ * `JsonStream`, or `TextStream` instead. The constructor is `protected` to
+ * enforce this.
  *
  * @template T
  * @implements IteratorAggregate<int, T>
  */
 class Stream implements IteratorAggregate
 {
-    public const DEFAULT_MAX_BUFFER_SIZE = 1048576;
+    public const DEFAULT_MAX_BUFFER_SIZE = 1_048_576;
 
     private const READ_CHUNK_SIZE = 8192;
+    private const UTF8_BOM = "\xEF\xBB\xBF";
 
     private StreamInterface $body;
 
     /** @var Closure(string): T */
-    protected Closure $deserializer;
+    private Closure $deserializer;
 
     /**
      * @param ResponseInterface $response The HTTP response to stream from.
@@ -59,7 +59,7 @@ class Stream implements IteratorAggregate
      *   event's accumulated `data` field. Exceeding this throws `RuntimeException` to
      *   guard against pathological streams. Defaults to 1 MiB.
      */
-    public function __construct(
+    protected function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         private readonly StreamFormat $format = StreamFormat::Sse,
@@ -83,6 +83,18 @@ class Stream implements IteratorAggregate
             StreamFormat::Json => $this->iterateDelimited(),
             StreamFormat::Text => $this->iterateText(),
         };
+    }
+
+    /**
+     * Applies the configured deserializer to a single raw frame payload.
+     * Available to subclasses (notably `SseStream::events()`) so they can
+     * construct typed envelopes without accessing the closure directly.
+     *
+     * @return T
+     */
+    protected function deserialize(string $raw): mixed
+    {
+        return ($this->deserializer)($raw);
     }
 
     /**
@@ -121,7 +133,6 @@ class Stream implements IteratorAggregate
                 }
                 // Strip the single trailing "\n" added by the field-append step.
                 $payload = substr($dataBuffer, 0, -1);
-                $this->assertBufferWithinCap(strlen($payload));
                 $dataBuffer = '';
                 if ($this->terminator !== null && $payload === $this->terminator) {
                     return;
@@ -138,7 +149,7 @@ class Stream implements IteratorAggregate
             $colonPos = strpos($line, ':');
             if ($colonPos === false) {
                 if ($line === 'data') {
-                    $dataBuffer .= "\n";
+                    $dataBuffer = $this->appendWithinCap($dataBuffer, "\n");
                 }
                 continue;
             }
@@ -149,7 +160,10 @@ class Stream implements IteratorAggregate
             }
             switch ($field) {
                 case 'data':
-                    $dataBuffer .= $value . "\n";
+                    // Enforce the cap before allocation: a hostile stream emitting
+                    // many `data:` lines without a dispatching blank line cannot
+                    // drive us past the limit and then trip the check.
+                    $dataBuffer = $this->appendWithinCap($dataBuffer, $value . "\n");
                     break;
                 case 'event':
                     $eventType = $value;
@@ -171,7 +185,6 @@ class Stream implements IteratorAggregate
         // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
         if ($dataBuffer !== '') {
             $payload = substr($dataBuffer, 0, -1);
-            $this->assertBufferWithinCap(strlen($payload));
             if ($this->terminator === null || $payload !== $this->terminator) {
                 yield ['data' => $payload, 'event' => $eventType, 'id' => $lastEventId, 'retry' => $retry];
             }
@@ -206,12 +219,13 @@ class Stream implements IteratorAggregate
 
     /**
      * Reads the response body and yields complete lines, normalizing CRLF/CR
-     * to LF per the WHATWG SSE spec. Trailing partial content (without a
-     * terminating newline) is emitted as a final line.
+     * to LF per the WHATWG SSE spec. Strips a single UTF-8 BOM if present at
+     * the start of the stream (WHATWG §9.2.4). Trailing partial content
+     * (without a terminating newline) is emitted as a final line.
      *
-     * Throws `RuntimeException` if the accumulated buffer exceeds the configured
-     * cap — that means we've read more than `maxBufferSize` bytes without ever
-     * seeing a line break, which indicates a malformed or hostile stream.
+     * `$pendingCr` tracks whether the prior chunk's last byte was `\r`, so a
+     * `\r\n` sequence split across a read boundary collapses to one terminator
+     * instead of two.
      *
      * @return Generator<int, string>
      */
@@ -219,38 +233,52 @@ class Stream implements IteratorAggregate
     {
         $buffer = '';
         $pendingCr = false;
+        $bomChecked = false;
         while (!$this->body->eof()) {
             $chunk = $this->body->read(self::READ_CHUNK_SIZE);
             if ($chunk === '') {
                 continue;
             }
-            // If the previous chunk ended on "\r", swallow a leading "\n" so we don't
-            // emit a spurious blank line for a "\r\n" sequence split across chunks.
             if ($pendingCr && $chunk[0] === "\n") {
                 $chunk = substr($chunk, 1);
             }
             $pendingCr = str_ends_with($chunk, "\r");
-            // Normalize line endings on just this chunk: "\r\n" and lone "\r" -> "\n".
             $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
-            $buffer .= $chunk;
-            $this->assertBufferWithinCap(strlen($buffer));
+            $buffer = $this->appendWithinCap($buffer, $chunk);
+            if (!$bomChecked && strlen($buffer) >= 3) {
+                $bomChecked = true;
+                if (str_starts_with($buffer, self::UTF8_BOM)) {
+                    $buffer = substr($buffer, 3);
+                }
+            }
             while (($lfPos = strpos($buffer, "\n")) !== false) {
                 yield substr($buffer, 0, $lfPos);
                 $buffer = substr($buffer, $lfPos + 1);
             }
+        }
+        // BOM may not have been checked yet if the entire body was < 3 bytes.
+        if (!$bomChecked && str_starts_with($buffer, self::UTF8_BOM)) {
+            $buffer = substr($buffer, 3);
         }
         if ($buffer !== '') {
             yield $buffer;
         }
     }
 
-    private function assertBufferWithinCap(int $size): void
+    /**
+     * Appends $suffix to $buffer, throwing `RuntimeException` if the result
+     * would exceed `maxBufferSize`. The cap is enforced before the
+     * concatenation allocates, so a runaway stream is bounded by the configured
+     * limit rather than by available memory.
+     */
+    private function appendWithinCap(string $buffer, string $suffix): string
     {
-        if ($size > $this->maxBufferSize) {
+        if (strlen($buffer) + strlen($suffix) > $this->maxBufferSize) {
             throw new RuntimeException(
-                "Stream buffer exceeded maximum size of {$this->maxBufferSize} bytes",
+                "Stream buffer would exceed maximum size of {$this->maxBufferSize} bytes",
             );
         }
+        return $buffer . $suffix;
     }
 
     public function __destruct()

--- a/generators/php/base/src/asIs/Client/Stream.Template.php
+++ b/generators/php/base/src/asIs/Client/Stream.Template.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace <%= namespace%>;
+
+use Closure;
+use Generator;
+use IteratorAggregate;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+enum StreamFormat: string
+{
+    case Sse = 'sse';
+    case Json = 'json';
+    case Text = 'text';
+}
+
+/**
+ * Iterates a streaming HTTP response body frame-by-frame.
+ *
+ * Parameterized by `$format`, which selects the framing strategy:
+ *   - 'sse'  — WHATWG Server-Sent Events: lines starting with `data:` (and
+ *              optionally `event:`, `id:`, `retry:`); a blank line dispatches
+ *              the accumulated event. Multi-line `data` fields are joined
+ *              with newlines.
+ *   - 'json' — newline-delimited JSON: each non-empty line is one frame.
+ *   - 'text' — newline-delimited text: each line is yielded as a raw string.
+ *
+ * When `$terminator` is set, an event whose payload equals the terminator
+ * ends iteration cleanly (e.g. `[DONE]` for SSE).
+ *
+ * @template T
+ * @implements IteratorAggregate<int, T>
+ */
+class Stream implements IteratorAggregate
+{
+    private const READ_CHUNK_SIZE = 8192;
+
+    private StreamInterface $body;
+
+    /** @var Closure(string): T */
+    private Closure $deserializer;
+
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param Closure(string): T $deserializer Called once per frame with the raw payload string.
+     *   For text streams, the deserializer is typically `fn(string $line) => $line`.
+     * @param StreamFormat $format Framing strategy for the stream.
+     * @param ?string $terminator Optional sentinel value that ends the stream when matched
+     *   against the raw frame payload (e.g. '[DONE]').
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Closure $deserializer,
+        private readonly StreamFormat $format = StreamFormat::Sse,
+        private readonly ?string $terminator = null,
+    ) {
+        $this->body = $response->getBody();
+        $this->deserializer = $deserializer;
+    }
+
+    /**
+     * @return Generator<int, T>
+     */
+    public function getIterator(): Generator
+    {
+        return match ($this->format) {
+            StreamFormat::Sse => $this->iterateSse(),
+            StreamFormat::Json => $this->iterateDelimited(),
+            StreamFormat::Text => $this->iterateText(),
+        };
+    }
+
+    /**
+     * WHATWG-compliant SSE frame parser.
+     *
+     * @return Generator<int, T>
+     */
+    private function iterateSse(): Generator
+    {
+        $dataBuffer = '';
+        foreach ($this->readLines() as $line) {
+            if ($line === '') {
+                // Blank line dispatches the accumulated event.
+                if ($dataBuffer === '') {
+                    continue;
+                }
+                // Strip the single trailing "\n" added by the field append step.
+                $payload = substr($dataBuffer, 0, -1);
+                $dataBuffer = '';
+                if ($this->terminator !== null && $payload === $this->terminator) {
+                    return;
+                }
+                yield ($this->deserializer)($payload);
+                continue;
+            }
+            if (str_starts_with($line, ':')) {
+                // SSE comment — ignored per spec.
+                continue;
+            }
+            $colonPos = strpos($line, ':');
+            if ($colonPos === false) {
+                // Line is a field name with empty value; only `data` is meaningful for us.
+                if ($line === 'data') {
+                    $dataBuffer .= "\n";
+                }
+                continue;
+            }
+            $field = substr($line, 0, $colonPos);
+            $value = substr($line, $colonPos + 1);
+            if (str_starts_with($value, ' ')) {
+                $value = substr($value, 1);
+            }
+            // Only `data` is yielded; `event`/`id`/`retry` are accepted but unused here.
+            if ($field === 'data') {
+                $dataBuffer .= $value . "\n";
+            }
+        }
+        // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
+        if ($dataBuffer !== '') {
+            $payload = substr($dataBuffer, 0, -1);
+            if ($this->terminator === null || $payload !== $this->terminator) {
+                yield ($this->deserializer)($payload);
+            }
+        }
+    }
+
+    /**
+     * Newline-delimited frames (NDJSON, line-by-line).
+     *
+     * @return Generator<int, T>
+     */
+    private function iterateDelimited(): Generator
+    {
+        foreach ($this->readLines() as $line) {
+            if ($line === '') {
+                continue;
+            }
+            if ($this->terminator !== null && $line === $this->terminator) {
+                return;
+            }
+            yield ($this->deserializer)($line);
+        }
+    }
+
+    /**
+     * Raw newline-delimited text frames.
+     *
+     * @return Generator<int, T>
+     */
+    private function iterateText(): Generator
+    {
+        foreach ($this->readLines() as $line) {
+            yield ($this->deserializer)($line);
+        }
+    }
+
+    /**
+     * Reads the response body and yields complete lines, normalizing CRLF/CR
+     * to LF per the WHATWG SSE spec. Trailing partial content (without a
+     * terminating newline) is emitted as a final line.
+     *
+     * @return Generator<int, string>
+     */
+    private function readLines(): Generator
+    {
+        $buffer = '';
+        $pendingCr = false;
+        while (!$this->body->eof()) {
+            $chunk = $this->body->read(self::READ_CHUNK_SIZE);
+            if ($chunk === '') {
+                continue;
+            }
+            // If the previous chunk ended on "\r", swallow a leading "\n" so we don't
+            // emit a spurious blank line for a "\r\n" sequence split across chunks.
+            if ($pendingCr && $chunk[0] === "\n") {
+                $chunk = substr($chunk, 1);
+            }
+            $pendingCr = str_ends_with($chunk, "\r");
+            // Normalize line endings on just this chunk: "\r\n" and lone "\r" -> "\n".
+            $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
+            $buffer .= $chunk;
+            while (($lfPos = strpos($buffer, "\n")) !== false) {
+                yield substr($buffer, 0, $lfPos);
+                $buffer = substr($buffer, $lfPos + 1);
+            }
+        }
+        if ($buffer !== '') {
+            yield $buffer;
+        }
+    }
+
+    public function __destruct()
+    {
+        try {
+            $this->body->close();
+        } catch (\Throwable) {
+            // Best effort — the body may already be closed by the consumer.
+        }
+    }
+}

--- a/generators/php/base/src/asIs/Client/StreamFormat.Template.php
+++ b/generators/php/base/src/asIs/Client/StreamFormat.Template.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace <%= namespace%>;
+
+/**
+ * Framing strategy used by `Stream` to interpret a streaming HTTP response body.
+ */
+enum StreamFormat: string
+{
+    case Sse = 'sse';
+    case Json = 'json';
+    case Text = 'text';
+}

--- a/generators/php/base/src/asIs/Client/StreamTest.Template.php
+++ b/generators/php/base/src/asIs/Client/StreamTest.Template.php
@@ -112,7 +112,6 @@ class StreamTest extends TestCase
 
         $events = iterator_to_array($stream->events(), false);
 
-        // Second event's malformed id is rejected; previous id persists per spec.
         $this->assertSame(['ok', 'ok'], array_map(fn (SseEvent $e) => $e->id, $events));
     }
 
@@ -152,7 +151,6 @@ class StreamTest extends TestCase
 
     public function testSseConstructorAcceptsUtf8CharsetParameter(): void
     {
-        // No exception: UTF-8 charset parameter is the spec-mandated value.
         $stream = new SseStream(
             self::response("data: hi\n\n", contentType: 'text/event-stream; charset=UTF-8'),
             fn (string $d): string => $d,
@@ -164,8 +162,6 @@ class StreamTest extends TestCase
 
     public function testSseConstructorToleratesMissingContentTypeHeader(): void
     {
-        // Some streaming servers omit the header; we don't reject — we just
-        // can't validate. (The wire format check is best-effort.)
         $response = \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
             ->createResponse(200)
             ->withBody(\Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()->createStream("data: hi\n\n"));
@@ -177,7 +173,6 @@ class StreamTest extends TestCase
 
     public function testStreamThrowsWhenLineBufferExceedsMaxSize(): void
     {
-        // A single unterminated "line" larger than the cap must abort iteration.
         $bigLine = str_repeat('A', 200) . "\n";
         $stream = new SseStream(
             self::response("data: " . $bigLine . "\n"),
@@ -194,17 +189,14 @@ class StreamTest extends TestCase
 
     public function testStreamThrowsBeforeAccumulatingPastMaxBufferOnLongRunningSseEvent(): void
     {
-        // The cap must fire during accumulation, not just at dispatch. A hostile
-        // stream sending many small `data:` lines without a closing blank line
-        // would otherwise grow $dataBuffer past the configured limit. Each line
-        // here is well under the 64-byte cap, but their cumulative `data:`
-        // append should trip the check before allocation balloons.
+        // Each line is well under the 64-byte cap; the cumulative `data:`
+        // append must trip the check before the buffer balloons.
         $manyDataLines = '';
         for ($i = 0; $i < 50; $i++) {
             $manyDataLines .= "data: chunk-$i\n";
         }
         $stream = new SseStream(
-            self::response($manyDataLines),  // no terminating "\n\n"
+            self::response($manyDataLines),
             fn (string $d): string => $d,
             terminator: null,
             maxBufferSize: 64,
@@ -218,8 +210,7 @@ class StreamTest extends TestCase
 
     public function testSseStripsUtf8BomFromStartOfStream(): void
     {
-        // WHATWG §9.2.4: a leading U+FEFF BOM must be stripped from the stream
-        // so the first field-name match isn't poisoned.
+        // WHATWG §9.2.4 requires a leading U+FEFF to be dropped.
         $body = "\xEF\xBB\xBFdata: hello\n\n";
         $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
 
@@ -228,7 +219,6 @@ class StreamTest extends TestCase
 
     public function testSseStripsBomOnlyAtVeryStart(): void
     {
-        // A BOM-looking sequence that appears mid-stream must NOT be stripped.
         $body = "data: first\n\ndata: \xEF\xBB\xBFsecond\n\n";
         $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
 

--- a/generators/php/base/src/asIs/Client/StreamTest.Template.php
+++ b/generators/php/base/src/asIs/Client/StreamTest.Template.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace <%= namespace%>;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use <%= coreNamespace%>\Client\JsonStream;
+use <%= coreNamespace%>\Client\SseStream;
+use <%= coreNamespace%>\Client\Stream;
+use <%= coreNamespace%>\Client\TextStream;
+
+class StreamTest extends TestCase
+{
+    public function testSseParsesSingleEvent(): void
+    {
+        $body = "data: hello\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['hello'], iterator_to_array($stream, false));
+    }
+
+    public function testSseConcatenatesMultilineDataWithNewlines(): void
+    {
+        $body = "data: line one\ndata: line two\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(["line one\nline two"], iterator_to_array($stream, false));
+    }
+
+    public function testSseStripsLeadingSpaceFromFieldValues(): void
+    {
+        // SSE spec: a single leading space in the field value is stripped.
+        $body = "data: with-leading-space\ndata:no-leading-space\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(["with-leading-space\nno-leading-space"], iterator_to_array($stream, false));
+    }
+
+    public function testSseIgnoresCommentLines(): void
+    {
+        $body = ": this is a comment\ndata: payload\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['payload'], iterator_to_array($stream, false));
+    }
+
+    public function testSseTerminatorEndsIterationCleanly(): void
+    {
+        $body = "data: first\n\ndata: [DONE]\n\ndata: never-yielded\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, '[DONE]');
+
+        $this->assertSame(['first'], iterator_to_array($stream, false));
+    }
+
+    public function testSseNormalizesCrlfAndLoneCr(): void
+    {
+        $body = "data: a\r\n\r\ndata: b\rdata: c\r\r";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['a', "b\nc"], iterator_to_array($stream, false));
+    }
+
+    public function testSseDispatchesTrailingEventWithoutBlankLine(): void
+    {
+        $body = "data: incomplete";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['incomplete'], iterator_to_array($stream, false));
+    }
+
+    public function testSseAppliesDeserializerOncePerEvent(): void
+    {
+        $body = "data: {\"n\":1}\n\ndata: {\"n\":2}\n\n";
+        $stream = new SseStream(self::response($body), self::jsonDecoder(), null);
+
+        $this->assertSame([['n' => 1], ['n' => 2]], iterator_to_array($stream, false));
+    }
+
+    public function testJsonStreamYieldsOnePerLine(): void
+    {
+        $body = "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n";
+        $stream = new JsonStream(self::response($body), self::jsonDecoder(), null);
+
+        $this->assertSame([['n' => 1], ['n' => 2], ['n' => 3]], iterator_to_array($stream, false));
+    }
+
+    public function testJsonStreamSkipsEmptyLines(): void
+    {
+        $body = "{\"a\":1}\n\n{\"a\":2}\n";
+        $stream = new JsonStream(self::response($body), self::jsonDecoder(), null);
+
+        $this->assertSame([['a' => 1], ['a' => 2]], iterator_to_array($stream, false));
+    }
+
+    public function testJsonStreamTerminatorEndsIteration(): void
+    {
+        $body = "{\"a\":1}\n[DONE]\n{\"a\":2}\n";
+        $stream = new JsonStream(self::response($body), self::jsonDecoder(), '[DONE]');
+
+        $this->assertSame([['a' => 1]], iterator_to_array($stream, false));
+    }
+
+    /**
+     * @return \Closure(string): array<string, mixed>
+     */
+    private static function jsonDecoder(): \Closure
+    {
+        return static function (string $raw): array {
+            /** @var array<string, mixed> $decoded */
+            $decoded = json_decode($raw, true);
+            return $decoded;
+        };
+    }
+
+    public function testTextStreamYieldsRawLines(): void
+    {
+        $body = "alpha\nbeta\ngamma\n";
+        $stream = new TextStream(self::response($body));
+
+        $this->assertSame(['alpha', 'beta', 'gamma'], iterator_to_array($stream, false));
+    }
+
+    public function testTextStreamPreservesEmptyLines(): void
+    {
+        $body = "alpha\n\nbeta\n";
+        $stream = new TextStream(self::response($body));
+
+        $this->assertSame(['alpha', '', 'beta'], iterator_to_array($stream, false));
+    }
+
+    /**
+     * Build a PSR-7 ResponseInterface with the given body string, using auto-discovery
+     * so we don't depend on any specific implementation.
+     */
+    private static function response(string $body): ResponseInterface
+    {
+        return \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
+            ->createResponse(200)
+            ->withBody(
+                \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()
+                    ->createStream($body),
+            );
+    }
+}

--- a/generators/php/base/src/asIs/Client/StreamTest.Template.php
+++ b/generators/php/base/src/asIs/Client/StreamTest.Template.php
@@ -192,6 +192,49 @@ class StreamTest extends TestCase
         iterator_to_array($stream, false);
     }
 
+    public function testStreamThrowsBeforeAccumulatingPastMaxBufferOnLongRunningSseEvent(): void
+    {
+        // The cap must fire during accumulation, not just at dispatch. A hostile
+        // stream sending many small `data:` lines without a closing blank line
+        // would otherwise grow $dataBuffer past the configured limit. Each line
+        // here is well under the 64-byte cap, but their cumulative `data:`
+        // append should trip the check before allocation balloons.
+        $manyDataLines = '';
+        for ($i = 0; $i < 50; $i++) {
+            $manyDataLines .= "data: chunk-$i\n";
+        }
+        $stream = new SseStream(
+            self::response($manyDataLines),  // no terminating "\n\n"
+            fn (string $d): string => $d,
+            terminator: null,
+            maxBufferSize: 64,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/buffer/i');
+
+        iterator_to_array($stream, false);
+    }
+
+    public function testSseStripsUtf8BomFromStartOfStream(): void
+    {
+        // WHATWG §9.2.4: a leading U+FEFF BOM must be stripped from the stream
+        // so the first field-name match isn't poisoned.
+        $body = "\xEF\xBB\xBFdata: hello\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['hello'], iterator_to_array($stream, false));
+    }
+
+    public function testSseStripsBomOnlyAtVeryStart(): void
+    {
+        // A BOM-looking sequence that appears mid-stream must NOT be stripped.
+        $body = "data: first\n\ndata: \xEF\xBB\xBFsecond\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['first', "\xEF\xBB\xBFsecond"], iterator_to_array($stream, false));
+    }
+
     public function testJsonStreamYieldsOnePerLine(): void
     {
         $body = "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n";

--- a/generators/php/base/src/asIs/Client/StreamTest.Template.php
+++ b/generators/php/base/src/asIs/Client/StreamTest.Template.php
@@ -4,7 +4,9 @@ namespace <%= namespace%>;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 use <%= coreNamespace%>\Client\JsonStream;
+use <%= coreNamespace%>\Client\SseEvent;
 use <%= coreNamespace%>\Client\SseStream;
 use <%= coreNamespace%>\Client\Stream;
 use <%= coreNamespace%>\Client\TextStream;
@@ -76,6 +78,120 @@ class StreamTest extends TestCase
         $this->assertSame([['n' => 1], ['n' => 2]], iterator_to_array($stream, false));
     }
 
+    public function testSseEventsExposesEventIdAndRetryMetadata(): void
+    {
+        $body = "event: chat\nid: msg-1\nretry: 5000\ndata: hi\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        $this->assertCount(1, $events);
+        $this->assertInstanceOf(SseEvent::class, $events[0]);
+        $this->assertSame('hi', $events[0]->data);
+        $this->assertSame('chat', $events[0]->event);
+        $this->assertSame('msg-1', $events[0]->id);
+        $this->assertSame(5000, $events[0]->retry);
+    }
+
+    public function testSseEventsPersistsLastEventIdAcrossEventsPerSpec(): void
+    {
+        // Per WHATWG SSE: once an `id:` is set it persists across subsequent
+        // events until explicitly overridden.
+        $body = "id: persistent\ndata: a\n\ndata: b\n\nid: replaced\ndata: c\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        $this->assertSame(['persistent', 'persistent', 'replaced'], array_map(fn (SseEvent $e) => $e->id, $events));
+    }
+
+    public function testSseEventsIgnoresIdContainingNullByte(): void
+    {
+        $body = "id: ok\ndata: first\n\nid: bad\0id\ndata: second\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        // Second event's malformed id is rejected; previous id persists per spec.
+        $this->assertSame(['ok', 'ok'], array_map(fn (SseEvent $e) => $e->id, $events));
+    }
+
+    public function testSseEventsIgnoresNonIntegerRetry(): void
+    {
+        $body = "retry: not-a-number\ndata: hi\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        $this->assertNull($events[0]->retry);
+    }
+
+    public function testSseConstructorRejectsNonSseContentType(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/text\/event-stream/');
+
+        new SseStream(
+            self::response('data: x\n\n', contentType: 'application/json'),
+            fn (string $d): string => $d,
+            null,
+        );
+    }
+
+    public function testSseConstructorRejectsNonUtf8Charset(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/charset/i');
+
+        new SseStream(
+            self::response('data: x\n\n', contentType: 'text/event-stream; charset=iso-8859-1'),
+            fn (string $d): string => $d,
+            null,
+        );
+    }
+
+    public function testSseConstructorAcceptsUtf8CharsetParameter(): void
+    {
+        // No exception: UTF-8 charset parameter is the spec-mandated value.
+        $stream = new SseStream(
+            self::response("data: hi\n\n", contentType: 'text/event-stream; charset=UTF-8'),
+            fn (string $d): string => $d,
+            null,
+        );
+
+        $this->assertSame(['hi'], iterator_to_array($stream, false));
+    }
+
+    public function testSseConstructorToleratesMissingContentTypeHeader(): void
+    {
+        // Some streaming servers omit the header; we don't reject — we just
+        // can't validate. (The wire format check is best-effort.)
+        $response = \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
+            ->createResponse(200)
+            ->withBody(\Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()->createStream("data: hi\n\n"));
+
+        $stream = new SseStream($response, fn (string $d): string => $d, null);
+
+        $this->assertSame(['hi'], iterator_to_array($stream, false));
+    }
+
+    public function testStreamThrowsWhenLineBufferExceedsMaxSize(): void
+    {
+        // A single unterminated "line" larger than the cap must abort iteration.
+        $bigLine = str_repeat('A', 200) . "\n";
+        $stream = new SseStream(
+            self::response("data: " . $bigLine . "\n"),
+            fn (string $d): string => $d,
+            terminator: null,
+            maxBufferSize: 64,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/buffer/i');
+
+        iterator_to_array($stream, false);
+    }
+
     public function testJsonStreamYieldsOnePerLine(): void
     {
         $body = "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n";
@@ -129,13 +245,17 @@ class StreamTest extends TestCase
     }
 
     /**
-     * Build a PSR-7 ResponseInterface with the given body string, using auto-discovery
-     * so we don't depend on any specific implementation.
+     * Build a PSR-7 ResponseInterface with the given body. The Content-Type
+     * defaults to `text/event-stream` so SSE tests just work; pass an override
+     * for the validation-error cases.
      */
-    private static function response(string $body): ResponseInterface
-    {
+    private static function response(
+        string $body,
+        string $contentType = 'text/event-stream',
+    ): ResponseInterface {
         return \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
             ->createResponse(200)
+            ->withHeader('Content-Type', $contentType)
             ->withBody(
                 \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()
                     ->createStream($body),

--- a/generators/php/base/src/asIs/Client/TextStream.Template.php
+++ b/generators/php/base/src/asIs/Client/TextStream.Template.php
@@ -11,13 +11,20 @@ use Psr\Http\Message\ResponseInterface;
  */
 class TextStream extends Stream
 {
-    public function __construct(ResponseInterface $response)
-    {
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param int $maxBufferSize See `Stream::__construct`. Defaults to 1 MiB.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
+    ) {
         parent::__construct(
             response: $response,
             deserializer: fn (string $line): string => $line,
             format: StreamFormat::Text,
             terminator: null,
+            maxBufferSize: $maxBufferSize,
         );
     }
 }

--- a/generators/php/base/src/asIs/Client/TextStream.Template.php
+++ b/generators/php/base/src/asIs/Client/TextStream.Template.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace <%= namespace%>;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Iterates a streaming text response body, yielding one raw string per line.
+ *
+ * @extends Stream<string>
+ */
+class TextStream extends Stream
+{
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct(
+            response: $response,
+            deserializer: fn (string $line): string => $line,
+            format: StreamFormat::Text,
+            terminator: null,
+        );
+    }
+}

--- a/generators/php/sdk/changes/unreleased/add-sse-streaming-support.yml
+++ b/generators/php/sdk/changes/unreleased/add-sse-streaming-support.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Support streaming response bodies in generated PHP SDKs (Server-Sent Events,
+    NDJSON, and raw text). Endpoints with a `response-stream` now return a typed
+    `SseStream<T>`, `JsonStream<T>`, or `TextStream` that iterates the response
+    frame-by-frame and deserializes each one into the declared payload type.
+    Previously these endpoints were emitted as broken `void` methods that always
+    threw `<Sdk>ApiException` regardless of HTTP status.
+  type: feat

--- a/generators/php/sdk/src/SdkGeneratorContext.ts
+++ b/generators/php/sdk/src/SdkGeneratorContext.ts
@@ -623,7 +623,14 @@ export class SdkGeneratorContext extends AbstractPhpGeneratorContext<SdkCustomCo
         if (!this.hasStreaming()) {
             return [];
         }
-        return [AsIsFiles.Stream, AsIsFiles.SseStream, AsIsFiles.SseEvent, AsIsFiles.JsonStream, AsIsFiles.TextStream];
+        return [
+            AsIsFiles.Stream,
+            AsIsFiles.StreamFormat,
+            AsIsFiles.SseStream,
+            AsIsFiles.SseEvent,
+            AsIsFiles.JsonStream,
+            AsIsFiles.TextStream
+        ];
     }
 
     private getCorePagerAsIsFiles(): string[] {

--- a/generators/php/sdk/src/SdkGeneratorContext.ts
+++ b/generators/php/sdk/src/SdkGeneratorContext.ts
@@ -623,7 +623,7 @@ export class SdkGeneratorContext extends AbstractPhpGeneratorContext<SdkCustomCo
         if (!this.hasStreaming()) {
             return [];
         }
-        return [AsIsFiles.Stream, AsIsFiles.SseStream, AsIsFiles.JsonStream, AsIsFiles.TextStream];
+        return [AsIsFiles.Stream, AsIsFiles.SseStream, AsIsFiles.SseEvent, AsIsFiles.JsonStream, AsIsFiles.TextStream];
     }
 
     private getCorePagerAsIsFiles(): string[] {

--- a/generators/php/sdk/src/SdkGeneratorContext.ts
+++ b/generators/php/sdk/src/SdkGeneratorContext.ts
@@ -222,6 +222,29 @@ export class SdkGeneratorContext extends AbstractPhpGeneratorContext<SdkCustomCo
         });
     }
 
+    public getSseStreamClassReference(eventType: php.Type): php.ClassReference {
+        return php.classReference({
+            name: "SseStream",
+            namespace: this.getCoreClientNamespace(),
+            generics: [eventType]
+        });
+    }
+
+    public getJsonStreamClassReference(chunkType: php.Type): php.ClassReference {
+        return php.classReference({
+            name: "JsonStream",
+            namespace: this.getCoreClientNamespace(),
+            generics: [chunkType]
+        });
+    }
+
+    public getTextStreamClassReference(): php.ClassReference {
+        return php.classReference({
+            name: "TextStream",
+            namespace: this.getCoreClientNamespace()
+        });
+    }
+
     public getOffsetPagerClassReference(): php.ClassReference {
         return php.classReference({
             name: "OffsetPager",
@@ -591,8 +614,16 @@ export class SdkGeneratorContext extends AbstractPhpGeneratorContext<SdkCustomCo
             AsIsFiles.MultipartFormData,
             AsIsFiles.MultipartFormDataPart,
             ...this.getCorePagerAsIsFiles(),
+            ...this.getCoreStreamAsIsFiles(),
             ...this.getCoreSerializationAsIsFiles()
         ];
+    }
+
+    private getCoreStreamAsIsFiles(): string[] {
+        if (!this.hasStreaming()) {
+            return [];
+        }
+        return [AsIsFiles.Stream, AsIsFiles.SseStream, AsIsFiles.JsonStream, AsIsFiles.TextStream];
     }
 
     private getCorePagerAsIsFiles(): string[] {
@@ -618,9 +649,14 @@ export class SdkGeneratorContext extends AbstractPhpGeneratorContext<SdkCustomCo
     public getCoreTestAsIsFiles(): string[] {
         return [
             AsIsFiles.RawClientTest,
+            ...this.getCoreStreamTestAsIsFiles(),
             ...this.getCorePagerTestAsIsFiles(),
             ...this.getCoreSerializationTestAsIsFiles()
         ];
+    }
+
+    private getCoreStreamTestAsIsFiles(): string[] {
+        return this.hasStreaming() ? [AsIsFiles.StreamTest] : [];
     }
 
     private getCorePagerTestAsIsFiles(): string[] {
@@ -755,6 +791,10 @@ export class SdkGeneratorContext extends AbstractPhpGeneratorContext<SdkCustomCo
 
     public hasPagination(): boolean {
         return this.config.generatePaginatedClients === true && this.ir.sdkConfig.hasPaginatedEndpoints;
+    }
+
+    public hasStreaming(): boolean {
+        return this.ir.sdkConfig.hasStreamingEndpoints;
     }
 
     public hasCustomPagination(): boolean {

--- a/generators/php/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/php/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -760,7 +760,50 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                     );
                     writer.dedent();
                 },
-                streaming: () => this.context.logger.error("Streaming not supported"),
+                streaming: (streamingResponse) => {
+                    streamingResponse._visit({
+                        sse: (sseChunk) => {
+                            const payloadType = this.context.phpTypeMapper.convert({ reference: sseChunk.payload });
+                            this.writeStreamingReturn({
+                                writer,
+                                streamClassReference: this.context.getSseStreamClassReference(payloadType),
+                                payloadType,
+                                terminator: sseChunk.terminator
+                            });
+                        },
+                        json: (jsonChunk) => {
+                            const payloadType = this.context.phpTypeMapper.convert({ reference: jsonChunk.payload });
+                            this.writeStreamingReturn({
+                                writer,
+                                streamClassReference: this.context.getJsonStreamClassReference(payloadType),
+                                payloadType,
+                                terminator: jsonChunk.terminator
+                            });
+                        },
+                        text: () => {
+                            writer.controlFlow(
+                                "if",
+                                php.codeblock(
+                                    `${STATUS_CODE_VARIABLE_NAME} >= 200 && ${STATUS_CODE_VARIABLE_NAME} < 400`
+                                )
+                            );
+                            writer.write("return ");
+                            writer.writeNodeStatement(
+                                php.instantiateClass({
+                                    classReference: this.context.getTextStreamClassReference(),
+                                    arguments_: [
+                                        {
+                                            name: "response",
+                                            assignment: php.codeblock(RESPONSE_VARIABLE_NAME)
+                                        }
+                                    ]
+                                })
+                            );
+                            writer.endControlFlow();
+                        },
+                        _other: () => undefined
+                    });
+                },
                 text: () => {
                     writer.controlFlow(
                         "if",
@@ -772,6 +815,123 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                 _other: () => undefined
             });
         });
+    }
+
+    private writeStreamingReturn({
+        writer,
+        streamClassReference,
+        payloadType,
+        terminator
+    }: {
+        writer: php.Writer;
+        streamClassReference: php.ClassReference;
+        payloadType: php.Type;
+        terminator: string | undefined;
+    }): void {
+        writer.controlFlow(
+            "if",
+            php.codeblock(`${STATUS_CODE_VARIABLE_NAME} >= 200 && ${STATUS_CODE_VARIABLE_NAME} < 400`)
+        );
+        const deserializerVarName = "$data";
+        const deserializerBody = this.buildStreamDeserializerBody({
+            payloadType,
+            variableName: deserializerVarName
+        });
+        const terminatorLiteral = terminator != null ? `'${terminator.replace(/'/g, "\\'")}'` : "null";
+        writer.write("return ");
+        writer.writeNodeStatement(
+            php.instantiateClass({
+                classReference: streamClassReference,
+                arguments_: [
+                    {
+                        name: "response",
+                        assignment: php.codeblock(RESPONSE_VARIABLE_NAME)
+                    },
+                    {
+                        name: "deserializer",
+                        assignment: php.codeblock((w) => {
+                            w.write(`fn(string ${deserializerVarName}) => `);
+                            w.writeNode(deserializerBody);
+                        })
+                    },
+                    {
+                        name: "terminator",
+                        assignment: php.codeblock(terminatorLiteral)
+                    }
+                ]
+            })
+        );
+        writer.endControlFlow();
+    }
+
+    /**
+     * Builds the expression that deserializes a single stream frame's raw string into
+     * the typed payload. Mirrors the dispatch in decodeJsonResponse, but emits a bare
+     * expression (no statement terminator) suitable for an arrow-function body.
+     */
+    private buildStreamDeserializerBody({
+        payloadType,
+        variableName
+    }: {
+        payloadType: php.Type;
+        variableName: string;
+    }): php.CodeBlock {
+        const internalType = payloadType.underlyingType().internalType;
+        const argument: UnnamedArgument[] = [php.codeblock(variableName)];
+        switch (internalType.type) {
+            case "reference":
+                return php.codeblock((writer) => {
+                    writer.writeNode(
+                        php.invokeMethod({
+                            on: internalType.value,
+                            method: "fromJson",
+                            arguments_: argument,
+                            static_: true
+                        })
+                    );
+                });
+            case "int":
+            case "float":
+            case "string":
+            case "bool":
+            case "date":
+            case "dateTime":
+            case "mixed":
+            case "literal":
+                return php.codeblock((writer) => {
+                    writer.writeNode(
+                        php.invokeMethod({
+                            on: this.context.getJsonDecoderClassReference(),
+                            method: `decode${upperFirst(internalType.type)}`,
+                            arguments_: argument,
+                            static_: true
+                        })
+                    );
+                });
+            case "enumString":
+                return php.codeblock((writer) => {
+                    writer.writeNode(
+                        php.invokeMethod({
+                            on: this.context.getJsonDecoderClassReference(),
+                            method: "decodeString",
+                            arguments_: argument,
+                            static_: true
+                        })
+                    );
+                });
+            case "array":
+            case "map":
+            case "union":
+            case "object":
+            case "optional":
+            case "null":
+            case "typeDict":
+                throw GeneratorError.internalError(
+                    `Internal error; '${internalType.type}' type is not a supported streaming payload type`
+                );
+            default:
+                assertNever(internalType);
+        }
     }
 
     private decodeJsonResponse(return_: php.Type | undefined): php.CodeBlock {

--- a/generators/php/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/php/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -898,27 +898,19 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
             case "dateTime":
             case "mixed":
             case "literal":
+            case "enumString": {
+                const methodSuffix = internalType.type === "enumString" ? "String" : upperFirst(internalType.type);
                 return php.codeblock((writer) => {
                     writer.writeNode(
                         php.invokeMethod({
                             on: this.context.getJsonDecoderClassReference(),
-                            method: `decode${upperFirst(internalType.type)}`,
+                            method: `decode${methodSuffix}`,
                             arguments_: argument,
                             static_: true
                         })
                     );
                 });
-            case "enumString":
-                return php.codeblock((writer) => {
-                    writer.writeNode(
-                        php.invokeMethod({
-                            on: this.context.getJsonDecoderClassReference(),
-                            method: "decodeString",
-                            arguments_: argument,
-                            static_: true
-                        })
-                    );
-                });
+            }
             case "array":
             case "map":
             case "union":

--- a/generators/php/sdk/src/endpoint/utils/getEndpointReturnType.ts
+++ b/generators/php/sdk/src/endpoint/utils/getEndpointReturnType.ts
@@ -21,7 +21,19 @@ export function getEndpointReturnType({
             const type = context.phpTypeMapper.convert({ reference: reference.responseBodyType });
             return type.isOptional() ? type : php.Type.optional(type);
         },
-        streaming: () => undefined,
+        streaming: (streamingResponse) =>
+            streamingResponse._visit({
+                sse: (sseChunk) => {
+                    const eventType = context.phpTypeMapper.convert({ reference: sseChunk.payload });
+                    return php.Type.reference(context.getSseStreamClassReference(eventType));
+                },
+                json: (jsonChunk) => {
+                    const chunkType = context.phpTypeMapper.convert({ reference: jsonChunk.payload });
+                    return php.Type.reference(context.getJsonStreamClassReference(chunkType));
+                },
+                text: () => php.Type.reference(context.getTextStreamClassReference()),
+                _other: () => undefined
+            }),
         text: () => php.Type.string(),
         _other: () => undefined
     });

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -223,7 +223,6 @@ allowedFailures:
   - variables
   # Java-specific fixture for staged builder ordering
   - java-staged-builder-ordering
-  - server-sent-events-openapi
   - any-auth
   - circular-references
   - file-upload

--- a/seed/php-sdk/server-sent-event-examples/.fern/metadata.json
+++ b/seed/php-sdk/server-sent-event-examples/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/server-sent-event-examples/reference.md
+++ b/seed/php-sdk/server-sent-event-examples/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Completions
-<details><summary><code>$client-&gt;completions-&gt;stream($request)</code></summary>
+<details><summary><code>$client-&gt;completions-&gt;stream($request) -> SseStream</code></summary>
 <dl>
 <dd>
 
@@ -44,7 +44,7 @@ $client->completions->stream(
 </dl>
 </details>
 
-<details><summary><code>$client-&gt;completions-&gt;streamEvents($request)</code></summary>
+<details><summary><code>$client-&gt;completions-&gt;streamEvents($request) -> SseStream</code></summary>
 <dl>
 <dd>
 
@@ -88,7 +88,7 @@ $client->completions->streamEvents(
 </dl>
 </details>
 
-<details><summary><code>$client-&gt;completions-&gt;streamEventsDiscriminantInData($request)</code></summary>
+<details><summary><code>$client-&gt;completions-&gt;streamEventsDiscriminantInData($request) -> SseStream</code></summary>
 <dl>
 <dd>
 
@@ -132,7 +132,7 @@ $client->completions->streamEventsDiscriminantInData(
 </dl>
 </details>
 
-<details><summary><code>$client-&gt;completions-&gt;streamEventsContextProtocol($request)</code></summary>
+<details><summary><code>$client-&gt;completions-&gt;streamEventsContextProtocol($request) -> SseStream</code></summary>
 <dl>
 <dd>
 

--- a/seed/php-sdk/server-sent-event-examples/src/Completions/CompletionsClient.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Completions/CompletionsClient.php
@@ -5,14 +5,19 @@ namespace Seed\Completions;
 use Psr\Http\Client\ClientInterface;
 use Seed\Core\Client\RawClient;
 use Seed\Completions\Requests\StreamCompletionRequest;
+use Seed\Core\Client\SseStream;
+use Seed\Completions\Types\StreamedCompletion;
 use Seed\Exceptions\SeedException;
 use Seed\Exceptions\SeedApiException;
 use Seed\Core\Json\JsonApiRequest;
 use Seed\Core\Client\HttpMethod;
 use Psr\Http\Client\ClientExceptionInterface;
 use Seed\Completions\Requests\StreamEventsRequest;
+use Seed\Completions\Types\StreamEvent;
 use Seed\Completions\Requests\StreamEventsDiscriminantInDataRequest;
+use Seed\Completions\Types\StreamEventDiscriminantInData;
 use Seed\Completions\Requests\StreamEventsContextProtocolRequest;
+use Seed\Completions\Types\StreamEventContextProtocol;
 
 class CompletionsClient
 {
@@ -60,10 +65,11 @@ class CompletionsClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return SseStream<StreamedCompletion>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function stream(StreamCompletionRequest $request, ?array $options = null): void
+    public function stream(StreamCompletionRequest $request, ?array $options = null): SseStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -77,6 +83,9 @@ class CompletionsClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new SseStream(response: $response, deserializer: fn (string $data) => StreamedCompletion::fromJson($data), terminator: '[[DONE]]');
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }
@@ -97,10 +106,11 @@ class CompletionsClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return SseStream<StreamEvent>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamEvents(StreamEventsRequest $request, ?array $options = null): void
+    public function streamEvents(StreamEventsRequest $request, ?array $options = null): SseStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -114,6 +124,9 @@ class CompletionsClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new SseStream(response: $response, deserializer: fn (string $data) => StreamEvent::fromJson($data), terminator: '[DONE]');
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }
@@ -134,10 +147,11 @@ class CompletionsClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return SseStream<StreamEventDiscriminantInData>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamEventsDiscriminantInData(StreamEventsDiscriminantInDataRequest $request, ?array $options = null): void
+    public function streamEventsDiscriminantInData(StreamEventsDiscriminantInDataRequest $request, ?array $options = null): SseStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -151,6 +165,9 @@ class CompletionsClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new SseStream(response: $response, deserializer: fn (string $data) => StreamEventDiscriminantInData::fromJson($data), terminator: null);
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }
@@ -171,10 +188,11 @@ class CompletionsClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return SseStream<StreamEventContextProtocol>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamEventsContextProtocol(StreamEventsContextProtocolRequest $request, ?array $options = null): void
+    public function streamEventsContextProtocol(StreamEventsContextProtocolRequest $request, ?array $options = null): SseStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -188,6 +206,9 @@ class CompletionsClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new SseStream(response: $response, deserializer: fn (string $data) => StreamEventContextProtocol::fromJson($data), terminator: '[DONE]');
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/JsonStream.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/JsonStream.php
@@ -20,17 +20,20 @@ class JsonStream extends Stream
      *   JSON payload string.
      * @param ?string $terminator Optional sentinel line that ends the stream
      *   when received. Pass `null` to read until EOF.
+     * @param int $maxBufferSize See `Stream::__construct`. Defaults to 1 MiB.
      */
     public function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         ?string $terminator = null,
+        int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
     ) {
         parent::__construct(
             response: $response,
             deserializer: $deserializer,
             format: StreamFormat::Json,
             terminator: $terminator,
+            maxBufferSize: $maxBufferSize,
         );
     }
 }

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/JsonStream.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/JsonStream.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Closure;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Iterates a newline-delimited JSON (NDJSON) response body, yielding one
+ * deserialized chunk per non-empty line.
+ *
+ * @template T
+ * @extends Stream<T>
+ */
+class JsonStream extends Stream
+{
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param Closure(string): T $deserializer Called once per line with the raw
+     *   JSON payload string.
+     * @param ?string $terminator Optional sentinel line that ends the stream
+     *   when received. Pass `null` to read until EOF.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Closure $deserializer,
+        ?string $terminator = null,
+    ) {
+        parent::__construct(
+            response: $response,
+            deserializer: $deserializer,
+            format: StreamFormat::Json,
+            terminator: $terminator,
+        );
+    }
+}

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/SseEvent.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/SseEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Seed\Core\Client;
+
+/**
+ * A single Server-Sent Event with its WHATWG metadata fields.
+ *
+ * Returned by `SseStream::events()`. Use plain `foreach ($stream as $payload)` if
+ * metadata isn't needed and you only want the deserialized `data` field.
+ *
+ * @template T
+ */
+final class SseEvent
+{
+    /**
+     * @param T $data Deserialized payload from the `data:` field(s). Multi-line
+     *   data is joined with a single newline before deserialization.
+     * @param string $event Value of the `event:` field, or empty string if not set.
+     * @param string $id Most recent `id:` field value. Per the WHATWG spec, this
+     *   persists across events: a subsequent event without an explicit `id:`
+     *   inherits the previous one. Empty string until the first id is observed.
+     * @param ?int $retry Reconnection time in milliseconds from the `retry:` field,
+     *   or null if not set or unparseable.
+     */
+    public function __construct(
+        public readonly mixed $data,
+        public readonly string $event = '',
+        public readonly string $id = '',
+        public readonly ?int $retry = null,
+    ) {
+    }
+}

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/SseStream.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/SseStream.php
@@ -56,7 +56,7 @@ class SseStream extends Stream
     {
         foreach ($this->iterateRawSseEvents() as $raw) {
             yield new SseEvent(
-                data: ($this->deserializer)($raw['data']),
+                data: $this->deserialize($raw['data']),
                 event: $raw['event'],
                 id: $raw['id'],
                 retry: $raw['retry'],

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/SseStream.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/SseStream.php
@@ -3,7 +3,9 @@
 namespace Seed\Core\Client;
 
 use Closure;
+use Generator;
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 
 /**
  * Iterates a `text/event-stream` (SSE) response body, yielding one deserialized
@@ -21,17 +23,79 @@ class SseStream extends Stream
      * @param ?string $terminator Optional sentinel payload that ends the stream
      *   when received. Defaults to '[DONE]', a common SSE convention.
      *   Pass `null` to disable terminator handling.
+     * @param int $maxBufferSize See `Stream::__construct`. Defaults to 1 MiB.
      */
     public function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         ?string $terminator = '[DONE]',
+        int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
     ) {
+        self::validateContentType($response);
         parent::__construct(
             response: $response,
             deserializer: $deserializer,
             format: StreamFormat::Sse,
             terminator: $terminator,
+            maxBufferSize: $maxBufferSize,
         );
+    }
+
+    /**
+     * Iterates the stream yielding both the deserialized payload and the
+     * accompanying SSE metadata (event type, id, retry). Use this when you
+     * need the event field (e.g. for event-typed unions) or `Last-Event-ID`
+     * for resumption logic.
+     *
+     * For data-only iteration, use this object directly as an iterable:
+     * `foreach ($stream as $event) { ... }`.
+     *
+     * @return Generator<int, SseEvent<T>>
+     */
+    public function events(): Generator
+    {
+        foreach ($this->iterateRawSseEvents() as $raw) {
+            yield new SseEvent(
+                data: ($this->deserializer)($raw['data']),
+                event: $raw['event'],
+                id: $raw['id'],
+                retry: $raw['retry'],
+            );
+        }
+    }
+
+    /**
+     * Validates that the response's Content-Type matches an SSE stream.
+     *
+     * Per WHATWG, the SSE wire format is always UTF-8; we reject explicit
+     * non-UTF-8 charset parameters rather than risk silent mojibake. A missing
+     * Content-Type header is tolerated — some servers omit it on streaming
+     * responses — but a wrong media type or wrong charset always throws.
+     */
+    private static function validateContentType(ResponseInterface $response): void
+    {
+        $contentType = $response->getHeaderLine('Content-Type');
+        if ($contentType === '') {
+            return;
+        }
+        $parts = explode(';', $contentType);
+        $mediaType = strtolower(trim($parts[0]));
+        if ($mediaType !== 'text/event-stream') {
+            throw new RuntimeException(
+                "Expected Content-Type 'text/event-stream' for SSE response, got '{$mediaType}'",
+            );
+        }
+        foreach (array_slice($parts, 1) as $param) {
+            $param = trim($param);
+            if (stripos($param, 'charset=') !== 0) {
+                continue;
+            }
+            $charset = strtolower(trim(substr($param, 8), " \"'"));
+            if ($charset !== '' && $charset !== 'utf-8' && $charset !== 'utf8') {
+                throw new RuntimeException(
+                    "Unsupported SSE charset '{$charset}'; per the WHATWG spec only UTF-8 is permitted",
+                );
+            }
+        }
     }
 }

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/SseStream.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/SseStream.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Closure;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Iterates a `text/event-stream` (SSE) response body, yielding one deserialized
+ * event per dispatched frame.
+ *
+ * @template T
+ * @extends Stream<T>
+ */
+class SseStream extends Stream
+{
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param Closure(string): T $deserializer Called once per dispatched event
+     *   with the raw `data:` payload string (newline-joined for multi-line frames).
+     * @param ?string $terminator Optional sentinel payload that ends the stream
+     *   when received. Defaults to '[DONE]', a common SSE convention.
+     *   Pass `null` to disable terminator handling.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Closure $deserializer,
+        ?string $terminator = '[DONE]',
+    ) {
+        parent::__construct(
+            response: $response,
+            deserializer: $deserializer,
+            format: StreamFormat::Sse,
+            terminator: $terminator,
+        );
+    }
+}

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/Stream.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/Stream.php
@@ -235,8 +235,12 @@ class Stream implements IteratorAggregate
             if ($pendingCr && $chunk[0] === "\n") {
                 $chunk = substr($chunk, 1);
             }
-            $pendingCr = str_ends_with($chunk, "\r");
-            $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
+            if (str_contains($chunk, "\r")) {
+                $pendingCr = str_ends_with($chunk, "\r");
+                $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
+            } else {
+                $pendingCr = false;
+            }
             $buffer = $this->appendWithinCap($buffer, $chunk);
             if (!$bomChecked && strlen($buffer) >= 3) {
                 $bomChecked = true;

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/Stream.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/Stream.php
@@ -7,6 +7,7 @@ use Generator;
 use IteratorAggregate;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use RuntimeException;
 
 enum StreamFormat: string
 {
@@ -29,17 +30,23 @@ enum StreamFormat: string
  * When `$terminator` is set, an event whose payload equals the terminator
  * ends iteration cleanly (e.g. `[DONE]` for SSE).
  *
+ * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams that
+ * never emit a frame boundary: if the line buffer or a single event's data
+ * exceeds the cap, iteration aborts with `RuntimeException`.
+ *
  * @template T
  * @implements IteratorAggregate<int, T>
  */
 class Stream implements IteratorAggregate
 {
+    public const DEFAULT_MAX_BUFFER_SIZE = 1048576;
+
     private const READ_CHUNK_SIZE = 8192;
 
     private StreamInterface $body;
 
     /** @var Closure(string): T */
-    private Closure $deserializer;
+    protected Closure $deserializer;
 
     /**
      * @param ResponseInterface $response The HTTP response to stream from.
@@ -48,18 +55,25 @@ class Stream implements IteratorAggregate
      * @param StreamFormat $format Framing strategy for the stream.
      * @param ?string $terminator Optional sentinel value that ends the stream when matched
      *   against the raw frame payload (e.g. '[DONE]').
+     * @param int $maxBufferSize Maximum size in bytes for the line buffer or a single SSE
+     *   event's accumulated `data` field. Exceeding this throws `RuntimeException` to
+     *   guard against pathological streams. Defaults to 1 MiB.
      */
     public function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         private readonly StreamFormat $format = StreamFormat::Sse,
         private readonly ?string $terminator = null,
+        private readonly int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
     ) {
         $this->body = $response->getBody();
         $this->deserializer = $deserializer;
     }
 
     /**
+     * Iteration is one-shot: PSR-7 bodies are forward-only, so re-iterating the
+     * same `Stream` instance yields nothing useful.
+     *
      * @return Generator<int, T>
      */
     public function getIterator(): Generator
@@ -72,35 +86,57 @@ class Stream implements IteratorAggregate
     }
 
     /**
-     * WHATWG-compliant SSE frame parser.
-     *
      * @return Generator<int, T>
      */
     private function iterateSse(): Generator
     {
+        foreach ($this->iterateRawSseEvents() as $raw) {
+            yield ($this->deserializer)($raw['data']);
+        }
+    }
+
+    /**
+     * Iterates the SSE stream yielding raw envelopes with WHATWG metadata fields
+     * intact. Yields plain associative arrays — not `SseEvent` objects — so the
+     * data-only iteration path doesn't pay the allocation cost; `SseStream::events()`
+     * constructs the public `SseEvent<T>` on top.
+     *
+     * Per WHATWG: the `id:` field persists across events within this iteration;
+     * the configured `terminator`, if present, ends iteration when matched against
+     * `data`.
+     *
+     * @internal
+     * @return Generator<int, array{data: string, event: string, id: string, retry: ?int}>
+     */
+    protected function iterateRawSseEvents(): Generator
+    {
         $dataBuffer = '';
+        $eventType = '';
+        $lastEventId = '';
+        $retry = null;
         foreach ($this->readLines() as $line) {
             if ($line === '') {
-                // Blank line dispatches the accumulated event.
                 if ($dataBuffer === '') {
                     continue;
                 }
-                // Strip the single trailing "\n" added by the field append step.
+                // Strip the single trailing "\n" added by the field-append step.
                 $payload = substr($dataBuffer, 0, -1);
+                $this->assertBufferWithinCap(strlen($payload));
                 $dataBuffer = '';
                 if ($this->terminator !== null && $payload === $this->terminator) {
                     return;
                 }
-                yield ($this->deserializer)($payload);
+                yield ['data' => $payload, 'event' => $eventType, 'id' => $lastEventId, 'retry' => $retry];
+                // Per WHATWG: do NOT reset lastEventId between events.
+                $eventType = '';
+                $retry = null;
                 continue;
             }
             if (str_starts_with($line, ':')) {
-                // SSE comment — ignored per spec.
                 continue;
             }
             $colonPos = strpos($line, ':');
             if ($colonPos === false) {
-                // Line is a field name with empty value; only `data` is meaningful for us.
                 if ($line === 'data') {
                     $dataBuffer .= "\n";
                 }
@@ -111,23 +147,38 @@ class Stream implements IteratorAggregate
             if (str_starts_with($value, ' ')) {
                 $value = substr($value, 1);
             }
-            // Only `data` is yielded; `event`/`id`/`retry` are accepted but unused here.
-            if ($field === 'data') {
-                $dataBuffer .= $value . "\n";
+            switch ($field) {
+                case 'data':
+                    $dataBuffer .= $value . "\n";
+                    break;
+                case 'event':
+                    $eventType = $value;
+                    break;
+                case 'id':
+                    // WHATWG: ignore IDs that contain a NULL byte.
+                    if (!str_contains($value, "\0")) {
+                        $lastEventId = $value;
+                    }
+                    break;
+                case 'retry':
+                    // WHATWG: ignore the value if it isn't a base-10 integer.
+                    if ($value !== '' && ctype_digit($value)) {
+                        $retry = (int) $value;
+                    }
+                    break;
             }
         }
         // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
         if ($dataBuffer !== '') {
             $payload = substr($dataBuffer, 0, -1);
+            $this->assertBufferWithinCap(strlen($payload));
             if ($this->terminator === null || $payload !== $this->terminator) {
-                yield ($this->deserializer)($payload);
+                yield ['data' => $payload, 'event' => $eventType, 'id' => $lastEventId, 'retry' => $retry];
             }
         }
     }
 
     /**
-     * Newline-delimited frames (NDJSON, line-by-line).
-     *
      * @return Generator<int, T>
      */
     private function iterateDelimited(): Generator
@@ -144,8 +195,6 @@ class Stream implements IteratorAggregate
     }
 
     /**
-     * Raw newline-delimited text frames.
-     *
      * @return Generator<int, T>
      */
     private function iterateText(): Generator
@@ -159,6 +208,10 @@ class Stream implements IteratorAggregate
      * Reads the response body and yields complete lines, normalizing CRLF/CR
      * to LF per the WHATWG SSE spec. Trailing partial content (without a
      * terminating newline) is emitted as a final line.
+     *
+     * Throws `RuntimeException` if the accumulated buffer exceeds the configured
+     * cap — that means we've read more than `maxBufferSize` bytes without ever
+     * seeing a line break, which indicates a malformed or hostile stream.
      *
      * @return Generator<int, string>
      */
@@ -180,6 +233,7 @@ class Stream implements IteratorAggregate
             // Normalize line endings on just this chunk: "\r\n" and lone "\r" -> "\n".
             $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
             $buffer .= $chunk;
+            $this->assertBufferWithinCap(strlen($buffer));
             while (($lfPos = strpos($buffer, "\n")) !== false) {
                 yield substr($buffer, 0, $lfPos);
                 $buffer = substr($buffer, $lfPos + 1);
@@ -187,6 +241,15 @@ class Stream implements IteratorAggregate
         }
         if ($buffer !== '') {
             yield $buffer;
+        }
+    }
+
+    private function assertBufferWithinCap(int $size): void
+    {
+        if ($size > $this->maxBufferSize) {
+            throw new RuntimeException(
+                "Stream buffer exceeded maximum size of {$this->maxBufferSize} bytes",
+            );
         }
     }
 

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/Stream.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/Stream.php
@@ -23,15 +23,12 @@ use RuntimeException;
  * When `$terminator` is set, an event whose payload equals the terminator
  * ends iteration cleanly (e.g. `[DONE]` for SSE).
  *
- * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams that
- * never emit a frame boundary: if the line buffer or a single event's data
- * exceeds the cap, iteration aborts with `RuntimeException`. The cap is
- * enforced *before* allocation, not after — a hostile stream cannot drive us
- * past the limit and then trip the check.
+ * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams
+ * that never emit a frame boundary: if the line buffer or a single event's
+ * data exceeds the cap, iteration aborts with `RuntimeException`.
  *
- * Direct instantiation of `Stream` is not supported; use `SseStream`,
- * `JsonStream`, or `TextStream` instead. The constructor is `protected` to
- * enforce this.
+ * Direct instantiation is not supported; use `SseStream`, `JsonStream`, or
+ * `TextStream`.
  *
  * @template T
  * @implements IteratorAggregate<int, T>
@@ -131,7 +128,6 @@ class Stream implements IteratorAggregate
                 if ($dataBuffer === '') {
                     continue;
                 }
-                // Strip the single trailing "\n" added by the field-append step.
                 $payload = substr($dataBuffer, 0, -1);
                 $dataBuffer = '';
                 if ($this->terminator !== null && $payload === $this->terminator) {
@@ -160,9 +156,6 @@ class Stream implements IteratorAggregate
             }
             switch ($field) {
                 case 'data':
-                    // Enforce the cap before allocation: a hostile stream emitting
-                    // many `data:` lines without a dispatching blank line cannot
-                    // drive us past the limit and then trip the check.
                     $dataBuffer = $this->appendWithinCap($dataBuffer, $value . "\n");
                     break;
                 case 'event':
@@ -182,7 +175,7 @@ class Stream implements IteratorAggregate
                     break;
             }
         }
-        // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
+        // Flush a trailing event that lacked a closing blank line.
         if ($dataBuffer !== '') {
             $payload = substr($dataBuffer, 0, -1);
             if ($this->terminator === null || $payload !== $this->terminator) {
@@ -266,10 +259,8 @@ class Stream implements IteratorAggregate
     }
 
     /**
-     * Appends $suffix to $buffer, throwing `RuntimeException` if the result
-     * would exceed `maxBufferSize`. The cap is enforced before the
-     * concatenation allocates, so a runaway stream is bounded by the configured
-     * limit rather than by available memory.
+     * Appends $suffix to $buffer, throwing `RuntimeException` if the resulting
+     * size would exceed `maxBufferSize`.
      */
     private function appendWithinCap(string $buffer, string $suffix): string
     {

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/Stream.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/Stream.php
@@ -9,13 +9,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 
-enum StreamFormat: string
-{
-    case Sse = 'sse';
-    case Json = 'json';
-    case Text = 'text';
-}
-
 /**
  * Iterates a streaming HTTP response body frame-by-frame.
  *
@@ -32,21 +25,28 @@ enum StreamFormat: string
  *
  * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams that
  * never emit a frame boundary: if the line buffer or a single event's data
- * exceeds the cap, iteration aborts with `RuntimeException`.
+ * exceeds the cap, iteration aborts with `RuntimeException`. The cap is
+ * enforced *before* allocation, not after — a hostile stream cannot drive us
+ * past the limit and then trip the check.
+ *
+ * Direct instantiation of `Stream` is not supported; use `SseStream`,
+ * `JsonStream`, or `TextStream` instead. The constructor is `protected` to
+ * enforce this.
  *
  * @template T
  * @implements IteratorAggregate<int, T>
  */
 class Stream implements IteratorAggregate
 {
-    public const DEFAULT_MAX_BUFFER_SIZE = 1048576;
+    public const DEFAULT_MAX_BUFFER_SIZE = 1_048_576;
 
     private const READ_CHUNK_SIZE = 8192;
+    private const UTF8_BOM = "\xEF\xBB\xBF";
 
     private StreamInterface $body;
 
     /** @var Closure(string): T */
-    protected Closure $deserializer;
+    private Closure $deserializer;
 
     /**
      * @param ResponseInterface $response The HTTP response to stream from.
@@ -59,7 +59,7 @@ class Stream implements IteratorAggregate
      *   event's accumulated `data` field. Exceeding this throws `RuntimeException` to
      *   guard against pathological streams. Defaults to 1 MiB.
      */
-    public function __construct(
+    protected function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         private readonly StreamFormat $format = StreamFormat::Sse,
@@ -83,6 +83,18 @@ class Stream implements IteratorAggregate
             StreamFormat::Json => $this->iterateDelimited(),
             StreamFormat::Text => $this->iterateText(),
         };
+    }
+
+    /**
+     * Applies the configured deserializer to a single raw frame payload.
+     * Available to subclasses (notably `SseStream::events()`) so they can
+     * construct typed envelopes without accessing the closure directly.
+     *
+     * @return T
+     */
+    protected function deserialize(string $raw): mixed
+    {
+        return ($this->deserializer)($raw);
     }
 
     /**
@@ -121,7 +133,6 @@ class Stream implements IteratorAggregate
                 }
                 // Strip the single trailing "\n" added by the field-append step.
                 $payload = substr($dataBuffer, 0, -1);
-                $this->assertBufferWithinCap(strlen($payload));
                 $dataBuffer = '';
                 if ($this->terminator !== null && $payload === $this->terminator) {
                     return;
@@ -138,7 +149,7 @@ class Stream implements IteratorAggregate
             $colonPos = strpos($line, ':');
             if ($colonPos === false) {
                 if ($line === 'data') {
-                    $dataBuffer .= "\n";
+                    $dataBuffer = $this->appendWithinCap($dataBuffer, "\n");
                 }
                 continue;
             }
@@ -149,7 +160,10 @@ class Stream implements IteratorAggregate
             }
             switch ($field) {
                 case 'data':
-                    $dataBuffer .= $value . "\n";
+                    // Enforce the cap before allocation: a hostile stream emitting
+                    // many `data:` lines without a dispatching blank line cannot
+                    // drive us past the limit and then trip the check.
+                    $dataBuffer = $this->appendWithinCap($dataBuffer, $value . "\n");
                     break;
                 case 'event':
                     $eventType = $value;
@@ -171,7 +185,6 @@ class Stream implements IteratorAggregate
         // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
         if ($dataBuffer !== '') {
             $payload = substr($dataBuffer, 0, -1);
-            $this->assertBufferWithinCap(strlen($payload));
             if ($this->terminator === null || $payload !== $this->terminator) {
                 yield ['data' => $payload, 'event' => $eventType, 'id' => $lastEventId, 'retry' => $retry];
             }
@@ -206,12 +219,13 @@ class Stream implements IteratorAggregate
 
     /**
      * Reads the response body and yields complete lines, normalizing CRLF/CR
-     * to LF per the WHATWG SSE spec. Trailing partial content (without a
-     * terminating newline) is emitted as a final line.
+     * to LF per the WHATWG SSE spec. Strips a single UTF-8 BOM if present at
+     * the start of the stream (WHATWG §9.2.4). Trailing partial content
+     * (without a terminating newline) is emitted as a final line.
      *
-     * Throws `RuntimeException` if the accumulated buffer exceeds the configured
-     * cap — that means we've read more than `maxBufferSize` bytes without ever
-     * seeing a line break, which indicates a malformed or hostile stream.
+     * `$pendingCr` tracks whether the prior chunk's last byte was `\r`, so a
+     * `\r\n` sequence split across a read boundary collapses to one terminator
+     * instead of two.
      *
      * @return Generator<int, string>
      */
@@ -219,38 +233,52 @@ class Stream implements IteratorAggregate
     {
         $buffer = '';
         $pendingCr = false;
+        $bomChecked = false;
         while (!$this->body->eof()) {
             $chunk = $this->body->read(self::READ_CHUNK_SIZE);
             if ($chunk === '') {
                 continue;
             }
-            // If the previous chunk ended on "\r", swallow a leading "\n" so we don't
-            // emit a spurious blank line for a "\r\n" sequence split across chunks.
             if ($pendingCr && $chunk[0] === "\n") {
                 $chunk = substr($chunk, 1);
             }
             $pendingCr = str_ends_with($chunk, "\r");
-            // Normalize line endings on just this chunk: "\r\n" and lone "\r" -> "\n".
             $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
-            $buffer .= $chunk;
-            $this->assertBufferWithinCap(strlen($buffer));
+            $buffer = $this->appendWithinCap($buffer, $chunk);
+            if (!$bomChecked && strlen($buffer) >= 3) {
+                $bomChecked = true;
+                if (str_starts_with($buffer, self::UTF8_BOM)) {
+                    $buffer = substr($buffer, 3);
+                }
+            }
             while (($lfPos = strpos($buffer, "\n")) !== false) {
                 yield substr($buffer, 0, $lfPos);
                 $buffer = substr($buffer, $lfPos + 1);
             }
+        }
+        // BOM may not have been checked yet if the entire body was < 3 bytes.
+        if (!$bomChecked && str_starts_with($buffer, self::UTF8_BOM)) {
+            $buffer = substr($buffer, 3);
         }
         if ($buffer !== '') {
             yield $buffer;
         }
     }
 
-    private function assertBufferWithinCap(int $size): void
+    /**
+     * Appends $suffix to $buffer, throwing `RuntimeException` if the result
+     * would exceed `maxBufferSize`. The cap is enforced before the
+     * concatenation allocates, so a runaway stream is bounded by the configured
+     * limit rather than by available memory.
+     */
+    private function appendWithinCap(string $buffer, string $suffix): string
     {
-        if ($size > $this->maxBufferSize) {
+        if (strlen($buffer) + strlen($suffix) > $this->maxBufferSize) {
             throw new RuntimeException(
-                "Stream buffer exceeded maximum size of {$this->maxBufferSize} bytes",
+                "Stream buffer would exceed maximum size of {$this->maxBufferSize} bytes",
             );
         }
+        return $buffer . $suffix;
     }
 
     public function __destruct()

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/Stream.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/Stream.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Closure;
+use Generator;
+use IteratorAggregate;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+enum StreamFormat: string
+{
+    case Sse = 'sse';
+    case Json = 'json';
+    case Text = 'text';
+}
+
+/**
+ * Iterates a streaming HTTP response body frame-by-frame.
+ *
+ * Parameterized by `$format`, which selects the framing strategy:
+ *   - 'sse'  — WHATWG Server-Sent Events: lines starting with `data:` (and
+ *              optionally `event:`, `id:`, `retry:`); a blank line dispatches
+ *              the accumulated event. Multi-line `data` fields are joined
+ *              with newlines.
+ *   - 'json' — newline-delimited JSON: each non-empty line is one frame.
+ *   - 'text' — newline-delimited text: each line is yielded as a raw string.
+ *
+ * When `$terminator` is set, an event whose payload equals the terminator
+ * ends iteration cleanly (e.g. `[DONE]` for SSE).
+ *
+ * @template T
+ * @implements IteratorAggregate<int, T>
+ */
+class Stream implements IteratorAggregate
+{
+    private const READ_CHUNK_SIZE = 8192;
+
+    private StreamInterface $body;
+
+    /** @var Closure(string): T */
+    private Closure $deserializer;
+
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param Closure(string): T $deserializer Called once per frame with the raw payload string.
+     *   For text streams, the deserializer is typically `fn(string $line) => $line`.
+     * @param StreamFormat $format Framing strategy for the stream.
+     * @param ?string $terminator Optional sentinel value that ends the stream when matched
+     *   against the raw frame payload (e.g. '[DONE]').
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Closure $deserializer,
+        private readonly StreamFormat $format = StreamFormat::Sse,
+        private readonly ?string $terminator = null,
+    ) {
+        $this->body = $response->getBody();
+        $this->deserializer = $deserializer;
+    }
+
+    /**
+     * @return Generator<int, T>
+     */
+    public function getIterator(): Generator
+    {
+        return match ($this->format) {
+            StreamFormat::Sse => $this->iterateSse(),
+            StreamFormat::Json => $this->iterateDelimited(),
+            StreamFormat::Text => $this->iterateText(),
+        };
+    }
+
+    /**
+     * WHATWG-compliant SSE frame parser.
+     *
+     * @return Generator<int, T>
+     */
+    private function iterateSse(): Generator
+    {
+        $dataBuffer = '';
+        foreach ($this->readLines() as $line) {
+            if ($line === '') {
+                // Blank line dispatches the accumulated event.
+                if ($dataBuffer === '') {
+                    continue;
+                }
+                // Strip the single trailing "\n" added by the field append step.
+                $payload = substr($dataBuffer, 0, -1);
+                $dataBuffer = '';
+                if ($this->terminator !== null && $payload === $this->terminator) {
+                    return;
+                }
+                yield ($this->deserializer)($payload);
+                continue;
+            }
+            if (str_starts_with($line, ':')) {
+                // SSE comment — ignored per spec.
+                continue;
+            }
+            $colonPos = strpos($line, ':');
+            if ($colonPos === false) {
+                // Line is a field name with empty value; only `data` is meaningful for us.
+                if ($line === 'data') {
+                    $dataBuffer .= "\n";
+                }
+                continue;
+            }
+            $field = substr($line, 0, $colonPos);
+            $value = substr($line, $colonPos + 1);
+            if (str_starts_with($value, ' ')) {
+                $value = substr($value, 1);
+            }
+            // Only `data` is yielded; `event`/`id`/`retry` are accepted but unused here.
+            if ($field === 'data') {
+                $dataBuffer .= $value . "\n";
+            }
+        }
+        // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
+        if ($dataBuffer !== '') {
+            $payload = substr($dataBuffer, 0, -1);
+            if ($this->terminator === null || $payload !== $this->terminator) {
+                yield ($this->deserializer)($payload);
+            }
+        }
+    }
+
+    /**
+     * Newline-delimited frames (NDJSON, line-by-line).
+     *
+     * @return Generator<int, T>
+     */
+    private function iterateDelimited(): Generator
+    {
+        foreach ($this->readLines() as $line) {
+            if ($line === '') {
+                continue;
+            }
+            if ($this->terminator !== null && $line === $this->terminator) {
+                return;
+            }
+            yield ($this->deserializer)($line);
+        }
+    }
+
+    /**
+     * Raw newline-delimited text frames.
+     *
+     * @return Generator<int, T>
+     */
+    private function iterateText(): Generator
+    {
+        foreach ($this->readLines() as $line) {
+            yield ($this->deserializer)($line);
+        }
+    }
+
+    /**
+     * Reads the response body and yields complete lines, normalizing CRLF/CR
+     * to LF per the WHATWG SSE spec. Trailing partial content (without a
+     * terminating newline) is emitted as a final line.
+     *
+     * @return Generator<int, string>
+     */
+    private function readLines(): Generator
+    {
+        $buffer = '';
+        $pendingCr = false;
+        while (!$this->body->eof()) {
+            $chunk = $this->body->read(self::READ_CHUNK_SIZE);
+            if ($chunk === '') {
+                continue;
+            }
+            // If the previous chunk ended on "\r", swallow a leading "\n" so we don't
+            // emit a spurious blank line for a "\r\n" sequence split across chunks.
+            if ($pendingCr && $chunk[0] === "\n") {
+                $chunk = substr($chunk, 1);
+            }
+            $pendingCr = str_ends_with($chunk, "\r");
+            // Normalize line endings on just this chunk: "\r\n" and lone "\r" -> "\n".
+            $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
+            $buffer .= $chunk;
+            while (($lfPos = strpos($buffer, "\n")) !== false) {
+                yield substr($buffer, 0, $lfPos);
+                $buffer = substr($buffer, $lfPos + 1);
+            }
+        }
+        if ($buffer !== '') {
+            yield $buffer;
+        }
+    }
+
+    public function __destruct()
+    {
+        try {
+            $this->body->close();
+        } catch (\Throwable) {
+            // Best effort — the body may already be closed by the consumer.
+        }
+    }
+}

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/StreamFormat.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/StreamFormat.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Seed\Core\Client;
+
+/**
+ * Framing strategy used by `Stream` to interpret a streaming HTTP response body.
+ */
+enum StreamFormat: string
+{
+    case Sse = 'sse';
+    case Json = 'json';
+    case Text = 'text';
+}

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/TextStream.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/TextStream.php
@@ -11,13 +11,20 @@ use Psr\Http\Message\ResponseInterface;
  */
 class TextStream extends Stream
 {
-    public function __construct(ResponseInterface $response)
-    {
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param int $maxBufferSize See `Stream::__construct`. Defaults to 1 MiB.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
+    ) {
         parent::__construct(
             response: $response,
             deserializer: fn (string $line): string => $line,
             format: StreamFormat::Text,
             terminator: null,
+            maxBufferSize: $maxBufferSize,
         );
     }
 }

--- a/seed/php-sdk/server-sent-event-examples/src/Core/Client/TextStream.php
+++ b/seed/php-sdk/server-sent-event-examples/src/Core/Client/TextStream.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Iterates a streaming text response body, yielding one raw string per line.
+ *
+ * @extends Stream<string>
+ */
+class TextStream extends Stream
+{
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct(
+            response: $response,
+            deserializer: fn (string $line): string => $line,
+            format: StreamFormat::Text,
+            terminator: null,
+        );
+    }
+}

--- a/seed/php-sdk/server-sent-event-examples/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/server-sent-event-examples/tests/Core/Client/StreamTest.php
@@ -112,7 +112,6 @@ class StreamTest extends TestCase
 
         $events = iterator_to_array($stream->events(), false);
 
-        // Second event's malformed id is rejected; previous id persists per spec.
         $this->assertSame(['ok', 'ok'], array_map(fn (SseEvent $e) => $e->id, $events));
     }
 
@@ -152,7 +151,6 @@ class StreamTest extends TestCase
 
     public function testSseConstructorAcceptsUtf8CharsetParameter(): void
     {
-        // No exception: UTF-8 charset parameter is the spec-mandated value.
         $stream = new SseStream(
             self::response("data: hi\n\n", contentType: 'text/event-stream; charset=UTF-8'),
             fn (string $d): string => $d,
@@ -164,8 +162,6 @@ class StreamTest extends TestCase
 
     public function testSseConstructorToleratesMissingContentTypeHeader(): void
     {
-        // Some streaming servers omit the header; we don't reject — we just
-        // can't validate. (The wire format check is best-effort.)
         $response = \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
             ->createResponse(200)
             ->withBody(\Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()->createStream("data: hi\n\n"));
@@ -177,7 +173,6 @@ class StreamTest extends TestCase
 
     public function testStreamThrowsWhenLineBufferExceedsMaxSize(): void
     {
-        // A single unterminated "line" larger than the cap must abort iteration.
         $bigLine = str_repeat('A', 200) . "\n";
         $stream = new SseStream(
             self::response("data: " . $bigLine . "\n"),
@@ -194,17 +189,14 @@ class StreamTest extends TestCase
 
     public function testStreamThrowsBeforeAccumulatingPastMaxBufferOnLongRunningSseEvent(): void
     {
-        // The cap must fire during accumulation, not just at dispatch. A hostile
-        // stream sending many small `data:` lines without a closing blank line
-        // would otherwise grow $dataBuffer past the configured limit. Each line
-        // here is well under the 64-byte cap, but their cumulative `data:`
-        // append should trip the check before allocation balloons.
+        // Each line is well under the 64-byte cap; the cumulative `data:`
+        // append must trip the check before the buffer balloons.
         $manyDataLines = '';
         for ($i = 0; $i < 50; $i++) {
             $manyDataLines .= "data: chunk-$i\n";
         }
         $stream = new SseStream(
-            self::response($manyDataLines),  // no terminating "\n\n"
+            self::response($manyDataLines),
             fn (string $d): string => $d,
             terminator: null,
             maxBufferSize: 64,
@@ -218,8 +210,7 @@ class StreamTest extends TestCase
 
     public function testSseStripsUtf8BomFromStartOfStream(): void
     {
-        // WHATWG §9.2.4: a leading U+FEFF BOM must be stripped from the stream
-        // so the first field-name match isn't poisoned.
+        // WHATWG §9.2.4 requires a leading U+FEFF to be dropped.
         $body = "\xEF\xBB\xBFdata: hello\n\n";
         $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
 
@@ -228,7 +219,6 @@ class StreamTest extends TestCase
 
     public function testSseStripsBomOnlyAtVeryStart(): void
     {
-        // A BOM-looking sequence that appears mid-stream must NOT be stripped.
         $body = "data: first\n\ndata: \xEF\xBB\xBFsecond\n\n";
         $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
 

--- a/seed/php-sdk/server-sent-event-examples/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/server-sent-event-examples/tests/Core/Client/StreamTest.php
@@ -192,6 +192,49 @@ class StreamTest extends TestCase
         iterator_to_array($stream, false);
     }
 
+    public function testStreamThrowsBeforeAccumulatingPastMaxBufferOnLongRunningSseEvent(): void
+    {
+        // The cap must fire during accumulation, not just at dispatch. A hostile
+        // stream sending many small `data:` lines without a closing blank line
+        // would otherwise grow $dataBuffer past the configured limit. Each line
+        // here is well under the 64-byte cap, but their cumulative `data:`
+        // append should trip the check before allocation balloons.
+        $manyDataLines = '';
+        for ($i = 0; $i < 50; $i++) {
+            $manyDataLines .= "data: chunk-$i\n";
+        }
+        $stream = new SseStream(
+            self::response($manyDataLines),  // no terminating "\n\n"
+            fn (string $d): string => $d,
+            terminator: null,
+            maxBufferSize: 64,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/buffer/i');
+
+        iterator_to_array($stream, false);
+    }
+
+    public function testSseStripsUtf8BomFromStartOfStream(): void
+    {
+        // WHATWG §9.2.4: a leading U+FEFF BOM must be stripped from the stream
+        // so the first field-name match isn't poisoned.
+        $body = "\xEF\xBB\xBFdata: hello\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['hello'], iterator_to_array($stream, false));
+    }
+
+    public function testSseStripsBomOnlyAtVeryStart(): void
+    {
+        // A BOM-looking sequence that appears mid-stream must NOT be stripped.
+        $body = "data: first\n\ndata: \xEF\xBB\xBFsecond\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['first', "\xEF\xBB\xBFsecond"], iterator_to_array($stream, false));
+    }
+
     public function testJsonStreamYieldsOnePerLine(): void
     {
         $body = "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n";

--- a/seed/php-sdk/server-sent-event-examples/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/server-sent-event-examples/tests/Core/Client/StreamTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Seed\Tests\Core\Client;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Seed\Core\Client\JsonStream;
+use Seed\Core\Client\SseStream;
+use Seed\Core\Client\Stream;
+use Seed\Core\Client\TextStream;
+
+class StreamTest extends TestCase
+{
+    public function testSseParsesSingleEvent(): void
+    {
+        $body = "data: hello\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['hello'], iterator_to_array($stream, false));
+    }
+
+    public function testSseConcatenatesMultilineDataWithNewlines(): void
+    {
+        $body = "data: line one\ndata: line two\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(["line one\nline two"], iterator_to_array($stream, false));
+    }
+
+    public function testSseStripsLeadingSpaceFromFieldValues(): void
+    {
+        // SSE spec: a single leading space in the field value is stripped.
+        $body = "data: with-leading-space\ndata:no-leading-space\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(["with-leading-space\nno-leading-space"], iterator_to_array($stream, false));
+    }
+
+    public function testSseIgnoresCommentLines(): void
+    {
+        $body = ": this is a comment\ndata: payload\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['payload'], iterator_to_array($stream, false));
+    }
+
+    public function testSseTerminatorEndsIterationCleanly(): void
+    {
+        $body = "data: first\n\ndata: [DONE]\n\ndata: never-yielded\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, '[DONE]');
+
+        $this->assertSame(['first'], iterator_to_array($stream, false));
+    }
+
+    public function testSseNormalizesCrlfAndLoneCr(): void
+    {
+        $body = "data: a\r\n\r\ndata: b\rdata: c\r\r";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['a', "b\nc"], iterator_to_array($stream, false));
+    }
+
+    public function testSseDispatchesTrailingEventWithoutBlankLine(): void
+    {
+        $body = "data: incomplete";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['incomplete'], iterator_to_array($stream, false));
+    }
+
+    public function testSseAppliesDeserializerOncePerEvent(): void
+    {
+        $body = "data: {\"n\":1}\n\ndata: {\"n\":2}\n\n";
+        $stream = new SseStream(self::response($body), self::jsonDecoder(), null);
+
+        $this->assertSame([['n' => 1], ['n' => 2]], iterator_to_array($stream, false));
+    }
+
+    public function testJsonStreamYieldsOnePerLine(): void
+    {
+        $body = "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n";
+        $stream = new JsonStream(self::response($body), self::jsonDecoder(), null);
+
+        $this->assertSame([['n' => 1], ['n' => 2], ['n' => 3]], iterator_to_array($stream, false));
+    }
+
+    public function testJsonStreamSkipsEmptyLines(): void
+    {
+        $body = "{\"a\":1}\n\n{\"a\":2}\n";
+        $stream = new JsonStream(self::response($body), self::jsonDecoder(), null);
+
+        $this->assertSame([['a' => 1], ['a' => 2]], iterator_to_array($stream, false));
+    }
+
+    public function testJsonStreamTerminatorEndsIteration(): void
+    {
+        $body = "{\"a\":1}\n[DONE]\n{\"a\":2}\n";
+        $stream = new JsonStream(self::response($body), self::jsonDecoder(), '[DONE]');
+
+        $this->assertSame([['a' => 1]], iterator_to_array($stream, false));
+    }
+
+    /**
+     * @return \Closure(string): array<string, mixed>
+     */
+    private static function jsonDecoder(): \Closure
+    {
+        return static function (string $raw): array {
+            /** @var array<string, mixed> $decoded */
+            $decoded = json_decode($raw, true);
+            return $decoded;
+        };
+    }
+
+    public function testTextStreamYieldsRawLines(): void
+    {
+        $body = "alpha\nbeta\ngamma\n";
+        $stream = new TextStream(self::response($body));
+
+        $this->assertSame(['alpha', 'beta', 'gamma'], iterator_to_array($stream, false));
+    }
+
+    public function testTextStreamPreservesEmptyLines(): void
+    {
+        $body = "alpha\n\nbeta\n";
+        $stream = new TextStream(self::response($body));
+
+        $this->assertSame(['alpha', '', 'beta'], iterator_to_array($stream, false));
+    }
+
+    /**
+     * Build a PSR-7 ResponseInterface with the given body string, using auto-discovery
+     * so we don't depend on any specific implementation.
+     */
+    private static function response(string $body): ResponseInterface
+    {
+        return \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
+            ->createResponse(200)
+            ->withBody(
+                \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()
+                    ->createStream($body),
+            );
+    }
+}

--- a/seed/php-sdk/server-sent-event-examples/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/server-sent-event-examples/tests/Core/Client/StreamTest.php
@@ -4,7 +4,9 @@ namespace Seed\Tests\Core\Client;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 use Seed\Core\Client\JsonStream;
+use Seed\Core\Client\SseEvent;
 use Seed\Core\Client\SseStream;
 use Seed\Core\Client\Stream;
 use Seed\Core\Client\TextStream;
@@ -76,6 +78,120 @@ class StreamTest extends TestCase
         $this->assertSame([['n' => 1], ['n' => 2]], iterator_to_array($stream, false));
     }
 
+    public function testSseEventsExposesEventIdAndRetryMetadata(): void
+    {
+        $body = "event: chat\nid: msg-1\nretry: 5000\ndata: hi\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        $this->assertCount(1, $events);
+        $this->assertInstanceOf(SseEvent::class, $events[0]);
+        $this->assertSame('hi', $events[0]->data);
+        $this->assertSame('chat', $events[0]->event);
+        $this->assertSame('msg-1', $events[0]->id);
+        $this->assertSame(5000, $events[0]->retry);
+    }
+
+    public function testSseEventsPersistsLastEventIdAcrossEventsPerSpec(): void
+    {
+        // Per WHATWG SSE: once an `id:` is set it persists across subsequent
+        // events until explicitly overridden.
+        $body = "id: persistent\ndata: a\n\ndata: b\n\nid: replaced\ndata: c\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        $this->assertSame(['persistent', 'persistent', 'replaced'], array_map(fn (SseEvent $e) => $e->id, $events));
+    }
+
+    public function testSseEventsIgnoresIdContainingNullByte(): void
+    {
+        $body = "id: ok\ndata: first\n\nid: bad\0id\ndata: second\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        // Second event's malformed id is rejected; previous id persists per spec.
+        $this->assertSame(['ok', 'ok'], array_map(fn (SseEvent $e) => $e->id, $events));
+    }
+
+    public function testSseEventsIgnoresNonIntegerRetry(): void
+    {
+        $body = "retry: not-a-number\ndata: hi\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        $this->assertNull($events[0]->retry);
+    }
+
+    public function testSseConstructorRejectsNonSseContentType(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/text\/event-stream/');
+
+        new SseStream(
+            self::response('data: x\n\n', contentType: 'application/json'),
+            fn (string $d): string => $d,
+            null,
+        );
+    }
+
+    public function testSseConstructorRejectsNonUtf8Charset(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/charset/i');
+
+        new SseStream(
+            self::response('data: x\n\n', contentType: 'text/event-stream; charset=iso-8859-1'),
+            fn (string $d): string => $d,
+            null,
+        );
+    }
+
+    public function testSseConstructorAcceptsUtf8CharsetParameter(): void
+    {
+        // No exception: UTF-8 charset parameter is the spec-mandated value.
+        $stream = new SseStream(
+            self::response("data: hi\n\n", contentType: 'text/event-stream; charset=UTF-8'),
+            fn (string $d): string => $d,
+            null,
+        );
+
+        $this->assertSame(['hi'], iterator_to_array($stream, false));
+    }
+
+    public function testSseConstructorToleratesMissingContentTypeHeader(): void
+    {
+        // Some streaming servers omit the header; we don't reject — we just
+        // can't validate. (The wire format check is best-effort.)
+        $response = \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
+            ->createResponse(200)
+            ->withBody(\Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()->createStream("data: hi\n\n"));
+
+        $stream = new SseStream($response, fn (string $d): string => $d, null);
+
+        $this->assertSame(['hi'], iterator_to_array($stream, false));
+    }
+
+    public function testStreamThrowsWhenLineBufferExceedsMaxSize(): void
+    {
+        // A single unterminated "line" larger than the cap must abort iteration.
+        $bigLine = str_repeat('A', 200) . "\n";
+        $stream = new SseStream(
+            self::response("data: " . $bigLine . "\n"),
+            fn (string $d): string => $d,
+            terminator: null,
+            maxBufferSize: 64,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/buffer/i');
+
+        iterator_to_array($stream, false);
+    }
+
     public function testJsonStreamYieldsOnePerLine(): void
     {
         $body = "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n";
@@ -129,13 +245,17 @@ class StreamTest extends TestCase
     }
 
     /**
-     * Build a PSR-7 ResponseInterface with the given body string, using auto-discovery
-     * so we don't depend on any specific implementation.
+     * Build a PSR-7 ResponseInterface with the given body. The Content-Type
+     * defaults to `text/event-stream` so SSE tests just work; pass an override
+     * for the validation-error cases.
      */
-    private static function response(string $body): ResponseInterface
-    {
+    private static function response(
+        string $body,
+        string $contentType = 'text/event-stream',
+    ): ResponseInterface {
         return \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
             ->createResponse(200)
+            ->withHeader('Content-Type', $contentType)
             ->withBody(
                 \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()
                     ->createStream($body),

--- a/seed/php-sdk/server-sent-events-openapi/.fern/metadata.json
+++ b/seed/php-sdk/server-sent-events-openapi/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/server-sent-events-openapi/reference.md
+++ b/seed/php-sdk/server-sent-events-openapi/reference.md
@@ -1,5 +1,5 @@
 # Reference
-<details><summary><code>$client-&gt;streamProtocolNoCollision($request)</code></summary>
+<details><summary><code>$client-&gt;streamProtocolNoCollision($request) -> SseStream</code></summary>
 <dl>
 <dd>
 
@@ -55,7 +55,7 @@ $client->streamProtocolNoCollision(
 </dl>
 </details>
 
-<details><summary><code>$client-&gt;streamProtocolCollision($request)</code></summary>
+<details><summary><code>$client-&gt;streamProtocolCollision($request) -> SseStream</code></summary>
 <dl>
 <dd>
 
@@ -111,7 +111,7 @@ $client->streamProtocolCollision(
 </dl>
 </details>
 
-<details><summary><code>$client-&gt;streamDataContext($request)</code></summary>
+<details><summary><code>$client-&gt;streamDataContext($request) -> SseStream</code></summary>
 <dl>
 <dd>
 
@@ -167,7 +167,7 @@ $client->streamDataContext(
 </dl>
 </details>
 
-<details><summary><code>$client-&gt;streamNoContext($request)</code></summary>
+<details><summary><code>$client-&gt;streamNoContext($request) -> SseStream</code></summary>
 <dl>
 <dd>
 
@@ -223,7 +223,7 @@ $client->streamNoContext(
 </dl>
 </details>
 
-<details><summary><code>$client-&gt;streamProtocolWithFlatSchema($request)</code></summary>
+<details><summary><code>$client-&gt;streamProtocolWithFlatSchema($request) -> SseStream</code></summary>
 <dl>
 <dd>
 
@@ -279,7 +279,7 @@ $client->streamProtocolWithFlatSchema(
 </dl>
 </details>
 
-<details><summary><code>$client-&gt;streamDataContextWithEnvelopeSchema($request)</code></summary>
+<details><summary><code>$client-&gt;streamDataContextWithEnvelopeSchema($request) -> SseStream</code></summary>
 <dl>
 <dd>
 
@@ -335,7 +335,7 @@ $client->streamDataContextWithEnvelopeSchema(
 </dl>
 </details>
 
-<details><summary><code>$client-&gt;streamOasSpecNative($request)</code></summary>
+<details><summary><code>$client-&gt;streamOasSpecNative($request) -> SseStream</code></summary>
 <dl>
 <dd>
 
@@ -391,7 +391,7 @@ $client->streamOasSpecNative(
 </dl>
 </details>
 
-<details><summary><code>$client-&gt;streamXFernStreamingConditionStream($request)</code></summary>
+<details><summary><code>$client-&gt;streamXFernStreamingConditionStream($request) -> JsonStream</code></summary>
 <dl>
 <dd>
 
@@ -525,7 +525,7 @@ $client->streamXFernStreamingConditionStream(
 </dl>
 </details>
 
-<details><summary><code>$client-&gt;streamXFernStreamingSharedSchemaStream($request)</code></summary>
+<details><summary><code>$client-&gt;streamXFernStreamingSharedSchemaStream($request) -> JsonStream</code></summary>
 <dl>
 <dd>
 
@@ -752,7 +752,7 @@ $client->validateCompletion(
 </dl>
 </details>
 
-<details><summary><code>$client-&gt;streamXFernStreamingUnionStream($request)</code></summary>
+<details><summary><code>$client-&gt;streamXFernStreamingUnionStream($request) -> JsonStream</code></summary>
 <dl>
 <dd>
 
@@ -930,7 +930,7 @@ $client->validateUnionRequest(
 </dl>
 </details>
 
-<details><summary><code>$client-&gt;streamXFernStreamingNullableConditionStream($request)</code></summary>
+<details><summary><code>$client-&gt;streamXFernStreamingNullableConditionStream($request) -> JsonStream</code></summary>
 <dl>
 <dd>
 
@@ -1064,7 +1064,7 @@ $client->streamXFernStreamingNullableConditionStream(
 </dl>
 </details>
 
-<details><summary><code>$client-&gt;streamXFernStreamingSseOnly($request)</code></summary>
+<details><summary><code>$client-&gt;streamXFernStreamingSseOnly($request) -> SseStream</code></summary>
 <dl>
 <dd>
 

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/JsonStream.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/JsonStream.php
@@ -20,17 +20,20 @@ class JsonStream extends Stream
      *   JSON payload string.
      * @param ?string $terminator Optional sentinel line that ends the stream
      *   when received. Pass `null` to read until EOF.
+     * @param int $maxBufferSize See `Stream::__construct`. Defaults to 1 MiB.
      */
     public function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         ?string $terminator = null,
+        int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
     ) {
         parent::__construct(
             response: $response,
             deserializer: $deserializer,
             format: StreamFormat::Json,
             terminator: $terminator,
+            maxBufferSize: $maxBufferSize,
         );
     }
 }

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/JsonStream.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/JsonStream.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Closure;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Iterates a newline-delimited JSON (NDJSON) response body, yielding one
+ * deserialized chunk per non-empty line.
+ *
+ * @template T
+ * @extends Stream<T>
+ */
+class JsonStream extends Stream
+{
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param Closure(string): T $deserializer Called once per line with the raw
+     *   JSON payload string.
+     * @param ?string $terminator Optional sentinel line that ends the stream
+     *   when received. Pass `null` to read until EOF.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Closure $deserializer,
+        ?string $terminator = null,
+    ) {
+        parent::__construct(
+            response: $response,
+            deserializer: $deserializer,
+            format: StreamFormat::Json,
+            terminator: $terminator,
+        );
+    }
+}

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/SseEvent.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/SseEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Seed\Core\Client;
+
+/**
+ * A single Server-Sent Event with its WHATWG metadata fields.
+ *
+ * Returned by `SseStream::events()`. Use plain `foreach ($stream as $payload)` if
+ * metadata isn't needed and you only want the deserialized `data` field.
+ *
+ * @template T
+ */
+final class SseEvent
+{
+    /**
+     * @param T $data Deserialized payload from the `data:` field(s). Multi-line
+     *   data is joined with a single newline before deserialization.
+     * @param string $event Value of the `event:` field, or empty string if not set.
+     * @param string $id Most recent `id:` field value. Per the WHATWG spec, this
+     *   persists across events: a subsequent event without an explicit `id:`
+     *   inherits the previous one. Empty string until the first id is observed.
+     * @param ?int $retry Reconnection time in milliseconds from the `retry:` field,
+     *   or null if not set or unparseable.
+     */
+    public function __construct(
+        public readonly mixed $data,
+        public readonly string $event = '',
+        public readonly string $id = '',
+        public readonly ?int $retry = null,
+    ) {
+    }
+}

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/SseStream.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/SseStream.php
@@ -56,7 +56,7 @@ class SseStream extends Stream
     {
         foreach ($this->iterateRawSseEvents() as $raw) {
             yield new SseEvent(
-                data: ($this->deserializer)($raw['data']),
+                data: $this->deserialize($raw['data']),
                 event: $raw['event'],
                 id: $raw['id'],
                 retry: $raw['retry'],

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/SseStream.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/SseStream.php
@@ -3,7 +3,9 @@
 namespace Seed\Core\Client;
 
 use Closure;
+use Generator;
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 
 /**
  * Iterates a `text/event-stream` (SSE) response body, yielding one deserialized
@@ -21,17 +23,79 @@ class SseStream extends Stream
      * @param ?string $terminator Optional sentinel payload that ends the stream
      *   when received. Defaults to '[DONE]', a common SSE convention.
      *   Pass `null` to disable terminator handling.
+     * @param int $maxBufferSize See `Stream::__construct`. Defaults to 1 MiB.
      */
     public function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         ?string $terminator = '[DONE]',
+        int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
     ) {
+        self::validateContentType($response);
         parent::__construct(
             response: $response,
             deserializer: $deserializer,
             format: StreamFormat::Sse,
             terminator: $terminator,
+            maxBufferSize: $maxBufferSize,
         );
+    }
+
+    /**
+     * Iterates the stream yielding both the deserialized payload and the
+     * accompanying SSE metadata (event type, id, retry). Use this when you
+     * need the event field (e.g. for event-typed unions) or `Last-Event-ID`
+     * for resumption logic.
+     *
+     * For data-only iteration, use this object directly as an iterable:
+     * `foreach ($stream as $event) { ... }`.
+     *
+     * @return Generator<int, SseEvent<T>>
+     */
+    public function events(): Generator
+    {
+        foreach ($this->iterateRawSseEvents() as $raw) {
+            yield new SseEvent(
+                data: ($this->deserializer)($raw['data']),
+                event: $raw['event'],
+                id: $raw['id'],
+                retry: $raw['retry'],
+            );
+        }
+    }
+
+    /**
+     * Validates that the response's Content-Type matches an SSE stream.
+     *
+     * Per WHATWG, the SSE wire format is always UTF-8; we reject explicit
+     * non-UTF-8 charset parameters rather than risk silent mojibake. A missing
+     * Content-Type header is tolerated — some servers omit it on streaming
+     * responses — but a wrong media type or wrong charset always throws.
+     */
+    private static function validateContentType(ResponseInterface $response): void
+    {
+        $contentType = $response->getHeaderLine('Content-Type');
+        if ($contentType === '') {
+            return;
+        }
+        $parts = explode(';', $contentType);
+        $mediaType = strtolower(trim($parts[0]));
+        if ($mediaType !== 'text/event-stream') {
+            throw new RuntimeException(
+                "Expected Content-Type 'text/event-stream' for SSE response, got '{$mediaType}'",
+            );
+        }
+        foreach (array_slice($parts, 1) as $param) {
+            $param = trim($param);
+            if (stripos($param, 'charset=') !== 0) {
+                continue;
+            }
+            $charset = strtolower(trim(substr($param, 8), " \"'"));
+            if ($charset !== '' && $charset !== 'utf-8' && $charset !== 'utf8') {
+                throw new RuntimeException(
+                    "Unsupported SSE charset '{$charset}'; per the WHATWG spec only UTF-8 is permitted",
+                );
+            }
+        }
     }
 }

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/SseStream.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/SseStream.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Closure;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Iterates a `text/event-stream` (SSE) response body, yielding one deserialized
+ * event per dispatched frame.
+ *
+ * @template T
+ * @extends Stream<T>
+ */
+class SseStream extends Stream
+{
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param Closure(string): T $deserializer Called once per dispatched event
+     *   with the raw `data:` payload string (newline-joined for multi-line frames).
+     * @param ?string $terminator Optional sentinel payload that ends the stream
+     *   when received. Defaults to '[DONE]', a common SSE convention.
+     *   Pass `null` to disable terminator handling.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Closure $deserializer,
+        ?string $terminator = '[DONE]',
+    ) {
+        parent::__construct(
+            response: $response,
+            deserializer: $deserializer,
+            format: StreamFormat::Sse,
+            terminator: $terminator,
+        );
+    }
+}

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/Stream.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/Stream.php
@@ -235,8 +235,12 @@ class Stream implements IteratorAggregate
             if ($pendingCr && $chunk[0] === "\n") {
                 $chunk = substr($chunk, 1);
             }
-            $pendingCr = str_ends_with($chunk, "\r");
-            $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
+            if (str_contains($chunk, "\r")) {
+                $pendingCr = str_ends_with($chunk, "\r");
+                $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
+            } else {
+                $pendingCr = false;
+            }
             $buffer = $this->appendWithinCap($buffer, $chunk);
             if (!$bomChecked && strlen($buffer) >= 3) {
                 $bomChecked = true;

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/Stream.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/Stream.php
@@ -7,6 +7,7 @@ use Generator;
 use IteratorAggregate;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use RuntimeException;
 
 enum StreamFormat: string
 {
@@ -29,17 +30,23 @@ enum StreamFormat: string
  * When `$terminator` is set, an event whose payload equals the terminator
  * ends iteration cleanly (e.g. `[DONE]` for SSE).
  *
+ * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams that
+ * never emit a frame boundary: if the line buffer or a single event's data
+ * exceeds the cap, iteration aborts with `RuntimeException`.
+ *
  * @template T
  * @implements IteratorAggregate<int, T>
  */
 class Stream implements IteratorAggregate
 {
+    public const DEFAULT_MAX_BUFFER_SIZE = 1048576;
+
     private const READ_CHUNK_SIZE = 8192;
 
     private StreamInterface $body;
 
     /** @var Closure(string): T */
-    private Closure $deserializer;
+    protected Closure $deserializer;
 
     /**
      * @param ResponseInterface $response The HTTP response to stream from.
@@ -48,18 +55,25 @@ class Stream implements IteratorAggregate
      * @param StreamFormat $format Framing strategy for the stream.
      * @param ?string $terminator Optional sentinel value that ends the stream when matched
      *   against the raw frame payload (e.g. '[DONE]').
+     * @param int $maxBufferSize Maximum size in bytes for the line buffer or a single SSE
+     *   event's accumulated `data` field. Exceeding this throws `RuntimeException` to
+     *   guard against pathological streams. Defaults to 1 MiB.
      */
     public function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         private readonly StreamFormat $format = StreamFormat::Sse,
         private readonly ?string $terminator = null,
+        private readonly int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
     ) {
         $this->body = $response->getBody();
         $this->deserializer = $deserializer;
     }
 
     /**
+     * Iteration is one-shot: PSR-7 bodies are forward-only, so re-iterating the
+     * same `Stream` instance yields nothing useful.
+     *
      * @return Generator<int, T>
      */
     public function getIterator(): Generator
@@ -72,35 +86,57 @@ class Stream implements IteratorAggregate
     }
 
     /**
-     * WHATWG-compliant SSE frame parser.
-     *
      * @return Generator<int, T>
      */
     private function iterateSse(): Generator
     {
+        foreach ($this->iterateRawSseEvents() as $raw) {
+            yield ($this->deserializer)($raw['data']);
+        }
+    }
+
+    /**
+     * Iterates the SSE stream yielding raw envelopes with WHATWG metadata fields
+     * intact. Yields plain associative arrays — not `SseEvent` objects — so the
+     * data-only iteration path doesn't pay the allocation cost; `SseStream::events()`
+     * constructs the public `SseEvent<T>` on top.
+     *
+     * Per WHATWG: the `id:` field persists across events within this iteration;
+     * the configured `terminator`, if present, ends iteration when matched against
+     * `data`.
+     *
+     * @internal
+     * @return Generator<int, array{data: string, event: string, id: string, retry: ?int}>
+     */
+    protected function iterateRawSseEvents(): Generator
+    {
         $dataBuffer = '';
+        $eventType = '';
+        $lastEventId = '';
+        $retry = null;
         foreach ($this->readLines() as $line) {
             if ($line === '') {
-                // Blank line dispatches the accumulated event.
                 if ($dataBuffer === '') {
                     continue;
                 }
-                // Strip the single trailing "\n" added by the field append step.
+                // Strip the single trailing "\n" added by the field-append step.
                 $payload = substr($dataBuffer, 0, -1);
+                $this->assertBufferWithinCap(strlen($payload));
                 $dataBuffer = '';
                 if ($this->terminator !== null && $payload === $this->terminator) {
                     return;
                 }
-                yield ($this->deserializer)($payload);
+                yield ['data' => $payload, 'event' => $eventType, 'id' => $lastEventId, 'retry' => $retry];
+                // Per WHATWG: do NOT reset lastEventId between events.
+                $eventType = '';
+                $retry = null;
                 continue;
             }
             if (str_starts_with($line, ':')) {
-                // SSE comment — ignored per spec.
                 continue;
             }
             $colonPos = strpos($line, ':');
             if ($colonPos === false) {
-                // Line is a field name with empty value; only `data` is meaningful for us.
                 if ($line === 'data') {
                     $dataBuffer .= "\n";
                 }
@@ -111,23 +147,38 @@ class Stream implements IteratorAggregate
             if (str_starts_with($value, ' ')) {
                 $value = substr($value, 1);
             }
-            // Only `data` is yielded; `event`/`id`/`retry` are accepted but unused here.
-            if ($field === 'data') {
-                $dataBuffer .= $value . "\n";
+            switch ($field) {
+                case 'data':
+                    $dataBuffer .= $value . "\n";
+                    break;
+                case 'event':
+                    $eventType = $value;
+                    break;
+                case 'id':
+                    // WHATWG: ignore IDs that contain a NULL byte.
+                    if (!str_contains($value, "\0")) {
+                        $lastEventId = $value;
+                    }
+                    break;
+                case 'retry':
+                    // WHATWG: ignore the value if it isn't a base-10 integer.
+                    if ($value !== '' && ctype_digit($value)) {
+                        $retry = (int) $value;
+                    }
+                    break;
             }
         }
         // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
         if ($dataBuffer !== '') {
             $payload = substr($dataBuffer, 0, -1);
+            $this->assertBufferWithinCap(strlen($payload));
             if ($this->terminator === null || $payload !== $this->terminator) {
-                yield ($this->deserializer)($payload);
+                yield ['data' => $payload, 'event' => $eventType, 'id' => $lastEventId, 'retry' => $retry];
             }
         }
     }
 
     /**
-     * Newline-delimited frames (NDJSON, line-by-line).
-     *
      * @return Generator<int, T>
      */
     private function iterateDelimited(): Generator
@@ -144,8 +195,6 @@ class Stream implements IteratorAggregate
     }
 
     /**
-     * Raw newline-delimited text frames.
-     *
      * @return Generator<int, T>
      */
     private function iterateText(): Generator
@@ -159,6 +208,10 @@ class Stream implements IteratorAggregate
      * Reads the response body and yields complete lines, normalizing CRLF/CR
      * to LF per the WHATWG SSE spec. Trailing partial content (without a
      * terminating newline) is emitted as a final line.
+     *
+     * Throws `RuntimeException` if the accumulated buffer exceeds the configured
+     * cap — that means we've read more than `maxBufferSize` bytes without ever
+     * seeing a line break, which indicates a malformed or hostile stream.
      *
      * @return Generator<int, string>
      */
@@ -180,6 +233,7 @@ class Stream implements IteratorAggregate
             // Normalize line endings on just this chunk: "\r\n" and lone "\r" -> "\n".
             $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
             $buffer .= $chunk;
+            $this->assertBufferWithinCap(strlen($buffer));
             while (($lfPos = strpos($buffer, "\n")) !== false) {
                 yield substr($buffer, 0, $lfPos);
                 $buffer = substr($buffer, $lfPos + 1);
@@ -187,6 +241,15 @@ class Stream implements IteratorAggregate
         }
         if ($buffer !== '') {
             yield $buffer;
+        }
+    }
+
+    private function assertBufferWithinCap(int $size): void
+    {
+        if ($size > $this->maxBufferSize) {
+            throw new RuntimeException(
+                "Stream buffer exceeded maximum size of {$this->maxBufferSize} bytes",
+            );
         }
     }
 

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/Stream.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/Stream.php
@@ -23,15 +23,12 @@ use RuntimeException;
  * When `$terminator` is set, an event whose payload equals the terminator
  * ends iteration cleanly (e.g. `[DONE]` for SSE).
  *
- * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams that
- * never emit a frame boundary: if the line buffer or a single event's data
- * exceeds the cap, iteration aborts with `RuntimeException`. The cap is
- * enforced *before* allocation, not after — a hostile stream cannot drive us
- * past the limit and then trip the check.
+ * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams
+ * that never emit a frame boundary: if the line buffer or a single event's
+ * data exceeds the cap, iteration aborts with `RuntimeException`.
  *
- * Direct instantiation of `Stream` is not supported; use `SseStream`,
- * `JsonStream`, or `TextStream` instead. The constructor is `protected` to
- * enforce this.
+ * Direct instantiation is not supported; use `SseStream`, `JsonStream`, or
+ * `TextStream`.
  *
  * @template T
  * @implements IteratorAggregate<int, T>
@@ -131,7 +128,6 @@ class Stream implements IteratorAggregate
                 if ($dataBuffer === '') {
                     continue;
                 }
-                // Strip the single trailing "\n" added by the field-append step.
                 $payload = substr($dataBuffer, 0, -1);
                 $dataBuffer = '';
                 if ($this->terminator !== null && $payload === $this->terminator) {
@@ -160,9 +156,6 @@ class Stream implements IteratorAggregate
             }
             switch ($field) {
                 case 'data':
-                    // Enforce the cap before allocation: a hostile stream emitting
-                    // many `data:` lines without a dispatching blank line cannot
-                    // drive us past the limit and then trip the check.
                     $dataBuffer = $this->appendWithinCap($dataBuffer, $value . "\n");
                     break;
                 case 'event':
@@ -182,7 +175,7 @@ class Stream implements IteratorAggregate
                     break;
             }
         }
-        // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
+        // Flush a trailing event that lacked a closing blank line.
         if ($dataBuffer !== '') {
             $payload = substr($dataBuffer, 0, -1);
             if ($this->terminator === null || $payload !== $this->terminator) {
@@ -266,10 +259,8 @@ class Stream implements IteratorAggregate
     }
 
     /**
-     * Appends $suffix to $buffer, throwing `RuntimeException` if the result
-     * would exceed `maxBufferSize`. The cap is enforced before the
-     * concatenation allocates, so a runaway stream is bounded by the configured
-     * limit rather than by available memory.
+     * Appends $suffix to $buffer, throwing `RuntimeException` if the resulting
+     * size would exceed `maxBufferSize`.
      */
     private function appendWithinCap(string $buffer, string $suffix): string
     {

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/Stream.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/Stream.php
@@ -9,13 +9,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 
-enum StreamFormat: string
-{
-    case Sse = 'sse';
-    case Json = 'json';
-    case Text = 'text';
-}
-
 /**
  * Iterates a streaming HTTP response body frame-by-frame.
  *
@@ -32,21 +25,28 @@ enum StreamFormat: string
  *
  * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams that
  * never emit a frame boundary: if the line buffer or a single event's data
- * exceeds the cap, iteration aborts with `RuntimeException`.
+ * exceeds the cap, iteration aborts with `RuntimeException`. The cap is
+ * enforced *before* allocation, not after — a hostile stream cannot drive us
+ * past the limit and then trip the check.
+ *
+ * Direct instantiation of `Stream` is not supported; use `SseStream`,
+ * `JsonStream`, or `TextStream` instead. The constructor is `protected` to
+ * enforce this.
  *
  * @template T
  * @implements IteratorAggregate<int, T>
  */
 class Stream implements IteratorAggregate
 {
-    public const DEFAULT_MAX_BUFFER_SIZE = 1048576;
+    public const DEFAULT_MAX_BUFFER_SIZE = 1_048_576;
 
     private const READ_CHUNK_SIZE = 8192;
+    private const UTF8_BOM = "\xEF\xBB\xBF";
 
     private StreamInterface $body;
 
     /** @var Closure(string): T */
-    protected Closure $deserializer;
+    private Closure $deserializer;
 
     /**
      * @param ResponseInterface $response The HTTP response to stream from.
@@ -59,7 +59,7 @@ class Stream implements IteratorAggregate
      *   event's accumulated `data` field. Exceeding this throws `RuntimeException` to
      *   guard against pathological streams. Defaults to 1 MiB.
      */
-    public function __construct(
+    protected function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         private readonly StreamFormat $format = StreamFormat::Sse,
@@ -83,6 +83,18 @@ class Stream implements IteratorAggregate
             StreamFormat::Json => $this->iterateDelimited(),
             StreamFormat::Text => $this->iterateText(),
         };
+    }
+
+    /**
+     * Applies the configured deserializer to a single raw frame payload.
+     * Available to subclasses (notably `SseStream::events()`) so they can
+     * construct typed envelopes without accessing the closure directly.
+     *
+     * @return T
+     */
+    protected function deserialize(string $raw): mixed
+    {
+        return ($this->deserializer)($raw);
     }
 
     /**
@@ -121,7 +133,6 @@ class Stream implements IteratorAggregate
                 }
                 // Strip the single trailing "\n" added by the field-append step.
                 $payload = substr($dataBuffer, 0, -1);
-                $this->assertBufferWithinCap(strlen($payload));
                 $dataBuffer = '';
                 if ($this->terminator !== null && $payload === $this->terminator) {
                     return;
@@ -138,7 +149,7 @@ class Stream implements IteratorAggregate
             $colonPos = strpos($line, ':');
             if ($colonPos === false) {
                 if ($line === 'data') {
-                    $dataBuffer .= "\n";
+                    $dataBuffer = $this->appendWithinCap($dataBuffer, "\n");
                 }
                 continue;
             }
@@ -149,7 +160,10 @@ class Stream implements IteratorAggregate
             }
             switch ($field) {
                 case 'data':
-                    $dataBuffer .= $value . "\n";
+                    // Enforce the cap before allocation: a hostile stream emitting
+                    // many `data:` lines without a dispatching blank line cannot
+                    // drive us past the limit and then trip the check.
+                    $dataBuffer = $this->appendWithinCap($dataBuffer, $value . "\n");
                     break;
                 case 'event':
                     $eventType = $value;
@@ -171,7 +185,6 @@ class Stream implements IteratorAggregate
         // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
         if ($dataBuffer !== '') {
             $payload = substr($dataBuffer, 0, -1);
-            $this->assertBufferWithinCap(strlen($payload));
             if ($this->terminator === null || $payload !== $this->terminator) {
                 yield ['data' => $payload, 'event' => $eventType, 'id' => $lastEventId, 'retry' => $retry];
             }
@@ -206,12 +219,13 @@ class Stream implements IteratorAggregate
 
     /**
      * Reads the response body and yields complete lines, normalizing CRLF/CR
-     * to LF per the WHATWG SSE spec. Trailing partial content (without a
-     * terminating newline) is emitted as a final line.
+     * to LF per the WHATWG SSE spec. Strips a single UTF-8 BOM if present at
+     * the start of the stream (WHATWG §9.2.4). Trailing partial content
+     * (without a terminating newline) is emitted as a final line.
      *
-     * Throws `RuntimeException` if the accumulated buffer exceeds the configured
-     * cap — that means we've read more than `maxBufferSize` bytes without ever
-     * seeing a line break, which indicates a malformed or hostile stream.
+     * `$pendingCr` tracks whether the prior chunk's last byte was `\r`, so a
+     * `\r\n` sequence split across a read boundary collapses to one terminator
+     * instead of two.
      *
      * @return Generator<int, string>
      */
@@ -219,38 +233,52 @@ class Stream implements IteratorAggregate
     {
         $buffer = '';
         $pendingCr = false;
+        $bomChecked = false;
         while (!$this->body->eof()) {
             $chunk = $this->body->read(self::READ_CHUNK_SIZE);
             if ($chunk === '') {
                 continue;
             }
-            // If the previous chunk ended on "\r", swallow a leading "\n" so we don't
-            // emit a spurious blank line for a "\r\n" sequence split across chunks.
             if ($pendingCr && $chunk[0] === "\n") {
                 $chunk = substr($chunk, 1);
             }
             $pendingCr = str_ends_with($chunk, "\r");
-            // Normalize line endings on just this chunk: "\r\n" and lone "\r" -> "\n".
             $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
-            $buffer .= $chunk;
-            $this->assertBufferWithinCap(strlen($buffer));
+            $buffer = $this->appendWithinCap($buffer, $chunk);
+            if (!$bomChecked && strlen($buffer) >= 3) {
+                $bomChecked = true;
+                if (str_starts_with($buffer, self::UTF8_BOM)) {
+                    $buffer = substr($buffer, 3);
+                }
+            }
             while (($lfPos = strpos($buffer, "\n")) !== false) {
                 yield substr($buffer, 0, $lfPos);
                 $buffer = substr($buffer, $lfPos + 1);
             }
+        }
+        // BOM may not have been checked yet if the entire body was < 3 bytes.
+        if (!$bomChecked && str_starts_with($buffer, self::UTF8_BOM)) {
+            $buffer = substr($buffer, 3);
         }
         if ($buffer !== '') {
             yield $buffer;
         }
     }
 
-    private function assertBufferWithinCap(int $size): void
+    /**
+     * Appends $suffix to $buffer, throwing `RuntimeException` if the result
+     * would exceed `maxBufferSize`. The cap is enforced before the
+     * concatenation allocates, so a runaway stream is bounded by the configured
+     * limit rather than by available memory.
+     */
+    private function appendWithinCap(string $buffer, string $suffix): string
     {
-        if ($size > $this->maxBufferSize) {
+        if (strlen($buffer) + strlen($suffix) > $this->maxBufferSize) {
             throw new RuntimeException(
-                "Stream buffer exceeded maximum size of {$this->maxBufferSize} bytes",
+                "Stream buffer would exceed maximum size of {$this->maxBufferSize} bytes",
             );
         }
+        return $buffer . $suffix;
     }
 
     public function __destruct()

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/Stream.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/Stream.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Closure;
+use Generator;
+use IteratorAggregate;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+enum StreamFormat: string
+{
+    case Sse = 'sse';
+    case Json = 'json';
+    case Text = 'text';
+}
+
+/**
+ * Iterates a streaming HTTP response body frame-by-frame.
+ *
+ * Parameterized by `$format`, which selects the framing strategy:
+ *   - 'sse'  — WHATWG Server-Sent Events: lines starting with `data:` (and
+ *              optionally `event:`, `id:`, `retry:`); a blank line dispatches
+ *              the accumulated event. Multi-line `data` fields are joined
+ *              with newlines.
+ *   - 'json' — newline-delimited JSON: each non-empty line is one frame.
+ *   - 'text' — newline-delimited text: each line is yielded as a raw string.
+ *
+ * When `$terminator` is set, an event whose payload equals the terminator
+ * ends iteration cleanly (e.g. `[DONE]` for SSE).
+ *
+ * @template T
+ * @implements IteratorAggregate<int, T>
+ */
+class Stream implements IteratorAggregate
+{
+    private const READ_CHUNK_SIZE = 8192;
+
+    private StreamInterface $body;
+
+    /** @var Closure(string): T */
+    private Closure $deserializer;
+
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param Closure(string): T $deserializer Called once per frame with the raw payload string.
+     *   For text streams, the deserializer is typically `fn(string $line) => $line`.
+     * @param StreamFormat $format Framing strategy for the stream.
+     * @param ?string $terminator Optional sentinel value that ends the stream when matched
+     *   against the raw frame payload (e.g. '[DONE]').
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Closure $deserializer,
+        private readonly StreamFormat $format = StreamFormat::Sse,
+        private readonly ?string $terminator = null,
+    ) {
+        $this->body = $response->getBody();
+        $this->deserializer = $deserializer;
+    }
+
+    /**
+     * @return Generator<int, T>
+     */
+    public function getIterator(): Generator
+    {
+        return match ($this->format) {
+            StreamFormat::Sse => $this->iterateSse(),
+            StreamFormat::Json => $this->iterateDelimited(),
+            StreamFormat::Text => $this->iterateText(),
+        };
+    }
+
+    /**
+     * WHATWG-compliant SSE frame parser.
+     *
+     * @return Generator<int, T>
+     */
+    private function iterateSse(): Generator
+    {
+        $dataBuffer = '';
+        foreach ($this->readLines() as $line) {
+            if ($line === '') {
+                // Blank line dispatches the accumulated event.
+                if ($dataBuffer === '') {
+                    continue;
+                }
+                // Strip the single trailing "\n" added by the field append step.
+                $payload = substr($dataBuffer, 0, -1);
+                $dataBuffer = '';
+                if ($this->terminator !== null && $payload === $this->terminator) {
+                    return;
+                }
+                yield ($this->deserializer)($payload);
+                continue;
+            }
+            if (str_starts_with($line, ':')) {
+                // SSE comment — ignored per spec.
+                continue;
+            }
+            $colonPos = strpos($line, ':');
+            if ($colonPos === false) {
+                // Line is a field name with empty value; only `data` is meaningful for us.
+                if ($line === 'data') {
+                    $dataBuffer .= "\n";
+                }
+                continue;
+            }
+            $field = substr($line, 0, $colonPos);
+            $value = substr($line, $colonPos + 1);
+            if (str_starts_with($value, ' ')) {
+                $value = substr($value, 1);
+            }
+            // Only `data` is yielded; `event`/`id`/`retry` are accepted but unused here.
+            if ($field === 'data') {
+                $dataBuffer .= $value . "\n";
+            }
+        }
+        // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
+        if ($dataBuffer !== '') {
+            $payload = substr($dataBuffer, 0, -1);
+            if ($this->terminator === null || $payload !== $this->terminator) {
+                yield ($this->deserializer)($payload);
+            }
+        }
+    }
+
+    /**
+     * Newline-delimited frames (NDJSON, line-by-line).
+     *
+     * @return Generator<int, T>
+     */
+    private function iterateDelimited(): Generator
+    {
+        foreach ($this->readLines() as $line) {
+            if ($line === '') {
+                continue;
+            }
+            if ($this->terminator !== null && $line === $this->terminator) {
+                return;
+            }
+            yield ($this->deserializer)($line);
+        }
+    }
+
+    /**
+     * Raw newline-delimited text frames.
+     *
+     * @return Generator<int, T>
+     */
+    private function iterateText(): Generator
+    {
+        foreach ($this->readLines() as $line) {
+            yield ($this->deserializer)($line);
+        }
+    }
+
+    /**
+     * Reads the response body and yields complete lines, normalizing CRLF/CR
+     * to LF per the WHATWG SSE spec. Trailing partial content (without a
+     * terminating newline) is emitted as a final line.
+     *
+     * @return Generator<int, string>
+     */
+    private function readLines(): Generator
+    {
+        $buffer = '';
+        $pendingCr = false;
+        while (!$this->body->eof()) {
+            $chunk = $this->body->read(self::READ_CHUNK_SIZE);
+            if ($chunk === '') {
+                continue;
+            }
+            // If the previous chunk ended on "\r", swallow a leading "\n" so we don't
+            // emit a spurious blank line for a "\r\n" sequence split across chunks.
+            if ($pendingCr && $chunk[0] === "\n") {
+                $chunk = substr($chunk, 1);
+            }
+            $pendingCr = str_ends_with($chunk, "\r");
+            // Normalize line endings on just this chunk: "\r\n" and lone "\r" -> "\n".
+            $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
+            $buffer .= $chunk;
+            while (($lfPos = strpos($buffer, "\n")) !== false) {
+                yield substr($buffer, 0, $lfPos);
+                $buffer = substr($buffer, $lfPos + 1);
+            }
+        }
+        if ($buffer !== '') {
+            yield $buffer;
+        }
+    }
+
+    public function __destruct()
+    {
+        try {
+            $this->body->close();
+        } catch (\Throwable) {
+            // Best effort — the body may already be closed by the consumer.
+        }
+    }
+}

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/StreamFormat.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/StreamFormat.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Seed\Core\Client;
+
+/**
+ * Framing strategy used by `Stream` to interpret a streaming HTTP response body.
+ */
+enum StreamFormat: string
+{
+    case Sse = 'sse';
+    case Json = 'json';
+    case Text = 'text';
+}

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/TextStream.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/TextStream.php
@@ -11,13 +11,20 @@ use Psr\Http\Message\ResponseInterface;
  */
 class TextStream extends Stream
 {
-    public function __construct(ResponseInterface $response)
-    {
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param int $maxBufferSize See `Stream::__construct`. Defaults to 1 MiB.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
+    ) {
         parent::__construct(
             response: $response,
             deserializer: fn (string $line): string => $line,
             format: StreamFormat::Text,
             terminator: null,
+            maxBufferSize: $maxBufferSize,
         );
     }
 }

--- a/seed/php-sdk/server-sent-events-openapi/src/Core/Client/TextStream.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/Core/Client/TextStream.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Iterates a streaming text response body, yielding one raw string per line.
+ *
+ * @extends Stream<string>
+ */
+class TextStream extends Stream
+{
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct(
+            response: $response,
+            deserializer: fn (string $line): string => $line,
+            format: StreamFormat::Text,
+            terminator: null,
+        );
+    }
+}

--- a/seed/php-sdk/server-sent-events-openapi/src/SeedClient.php
+++ b/seed/php-sdk/server-sent-events-openapi/src/SeedClient.php
@@ -5,12 +5,22 @@ namespace Seed;
 use Psr\Http\Client\ClientInterface;
 use Seed\Core\Client\RawClient;
 use Seed\Types\StreamRequest;
+use Seed\Core\Client\SseStream;
+use Seed\Types\StreamProtocolNoCollisionResponse;
 use Seed\Exceptions\SeedException;
 use Seed\Exceptions\SeedApiException;
 use Seed\Core\Json\JsonApiRequest;
 use Seed\Core\Client\HttpMethod;
 use Psr\Http\Client\ClientExceptionInterface;
+use Seed\Types\StreamProtocolCollisionResponse;
+use Seed\Types\StreamDataContextResponse;
+use Seed\Types\StreamNoContextResponse;
+use Seed\Types\StreamProtocolWithFlatSchemaResponse;
+use Seed\Types\StreamDataContextWithEnvelopeSchemaResponse;
+use Seed\Types\Event;
 use Seed\Requests\StreamXFernStreamingConditionStreamRequest;
+use Seed\Core\Client\JsonStream;
+use Seed\Types\CompletionStreamChunk;
 use Seed\Requests\StreamXFernStreamingConditionRequest;
 use Seed\Types\CompletionFullResponse;
 use JsonException;
@@ -23,6 +33,7 @@ use Seed\Types\UnionStreamRequestBase;
 use Seed\Types\ValidateUnionRequestResponse;
 use Seed\Requests\StreamXFernStreamingNullableConditionStreamRequest;
 use Seed\Requests\StreamXFernStreamingNullableConditionRequest;
+use Seed\Core\Json\JsonDecoder;
 
 class SeedClient
 {
@@ -85,10 +96,11 @@ class SeedClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return SseStream<StreamProtocolNoCollisionResponse>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamProtocolNoCollision(StreamRequest $request, ?array $options = null): void
+    public function streamProtocolNoCollision(StreamRequest $request, ?array $options = null): SseStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -102,6 +114,9 @@ class SeedClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new SseStream(response: $response, deserializer: fn (string $data) => StreamProtocolNoCollisionResponse::fromJson($data), terminator: null);
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }
@@ -124,10 +139,11 @@ class SeedClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return SseStream<StreamProtocolCollisionResponse>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamProtocolCollision(StreamRequest $request, ?array $options = null): void
+    public function streamProtocolCollision(StreamRequest $request, ?array $options = null): SseStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -141,6 +157,9 @@ class SeedClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new SseStream(response: $response, deserializer: fn (string $data) => StreamProtocolCollisionResponse::fromJson($data), terminator: null);
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }
@@ -163,10 +182,11 @@ class SeedClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return SseStream<StreamDataContextResponse>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamDataContext(StreamRequest $request, ?array $options = null): void
+    public function streamDataContext(StreamRequest $request, ?array $options = null): SseStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -180,6 +200,9 @@ class SeedClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new SseStream(response: $response, deserializer: fn (string $data) => StreamDataContextResponse::fromJson($data), terminator: null);
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }
@@ -202,10 +225,11 @@ class SeedClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return SseStream<StreamNoContextResponse>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamNoContext(StreamRequest $request, ?array $options = null): void
+    public function streamNoContext(StreamRequest $request, ?array $options = null): SseStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -219,6 +243,9 @@ class SeedClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new SseStream(response: $response, deserializer: fn (string $data) => StreamNoContextResponse::fromJson($data), terminator: null);
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }
@@ -241,10 +268,11 @@ class SeedClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return SseStream<StreamProtocolWithFlatSchemaResponse>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamProtocolWithFlatSchema(StreamRequest $request, ?array $options = null): void
+    public function streamProtocolWithFlatSchema(StreamRequest $request, ?array $options = null): SseStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -258,6 +286,9 @@ class SeedClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new SseStream(response: $response, deserializer: fn (string $data) => StreamProtocolWithFlatSchemaResponse::fromJson($data), terminator: null);
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }
@@ -280,10 +311,11 @@ class SeedClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return SseStream<StreamDataContextWithEnvelopeSchemaResponse>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamDataContextWithEnvelopeSchema(StreamRequest $request, ?array $options = null): void
+    public function streamDataContextWithEnvelopeSchema(StreamRequest $request, ?array $options = null): SseStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -297,6 +329,9 @@ class SeedClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new SseStream(response: $response, deserializer: fn (string $data) => StreamDataContextWithEnvelopeSchemaResponse::fromJson($data), terminator: null);
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }
@@ -319,10 +354,11 @@ class SeedClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return SseStream<Event>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamOasSpecNative(StreamRequest $request, ?array $options = null): void
+    public function streamOasSpecNative(StreamRequest $request, ?array $options = null): SseStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -336,6 +372,9 @@ class SeedClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new SseStream(response: $response, deserializer: fn (string $data) => Event::fromJson($data), terminator: null);
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }
@@ -358,10 +397,11 @@ class SeedClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return JsonStream<CompletionStreamChunk>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamXFernStreamingConditionStream(StreamXFernStreamingConditionStreamRequest $request, ?array $options = null): void
+    public function streamXFernStreamingConditionStream(StreamXFernStreamingConditionStreamRequest $request, ?array $options = null): JsonStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -375,6 +415,9 @@ class SeedClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new JsonStream(response: $response, deserializer: fn (string $data) => CompletionStreamChunk::fromJson($data), terminator: null);
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }
@@ -446,10 +489,11 @@ class SeedClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return JsonStream<CompletionStreamChunk>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamXFernStreamingSharedSchemaStream(StreamXFernStreamingSharedSchemaStreamRequest $request, ?array $options = null): void
+    public function streamXFernStreamingSharedSchemaStream(StreamXFernStreamingSharedSchemaStreamRequest $request, ?array $options = null): JsonStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -463,6 +507,9 @@ class SeedClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new JsonStream(response: $response, deserializer: fn (string $data) => CompletionStreamChunk::fromJson($data), terminator: null);
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }
@@ -583,10 +630,11 @@ class SeedClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return JsonStream<CompletionStreamChunk>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamXFernStreamingUnionStream(StreamXFernStreamingUnionStreamRequest $request, ?array $options = null): void
+    public function streamXFernStreamingUnionStream(StreamXFernStreamingUnionStreamRequest $request, ?array $options = null): JsonStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -600,6 +648,9 @@ class SeedClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new JsonStream(response: $response, deserializer: fn (string $data) => CompletionStreamChunk::fromJson($data), terminator: null);
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }
@@ -720,10 +771,11 @@ class SeedClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return JsonStream<CompletionStreamChunk>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamXFernStreamingNullableConditionStream(StreamXFernStreamingNullableConditionStreamRequest $request, ?array $options = null): void
+    public function streamXFernStreamingNullableConditionStream(StreamXFernStreamingNullableConditionStreamRequest $request, ?array $options = null): JsonStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -737,6 +789,9 @@ class SeedClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new JsonStream(response: $response, deserializer: fn (string $data) => CompletionStreamChunk::fromJson($data), terminator: null);
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }
@@ -808,10 +863,11 @@ class SeedClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return SseStream<string>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamXFernStreamingSseOnly(StreamRequest $request, ?array $options = null): void
+    public function streamXFernStreamingSseOnly(StreamRequest $request, ?array $options = null): SseStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -825,6 +881,9 @@ class SeedClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new SseStream(response: $response, deserializer: fn (string $data) => JsonDecoder::decodeString($data), terminator: null);
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }

--- a/seed/php-sdk/server-sent-events-openapi/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/server-sent-events-openapi/tests/Core/Client/StreamTest.php
@@ -112,7 +112,6 @@ class StreamTest extends TestCase
 
         $events = iterator_to_array($stream->events(), false);
 
-        // Second event's malformed id is rejected; previous id persists per spec.
         $this->assertSame(['ok', 'ok'], array_map(fn (SseEvent $e) => $e->id, $events));
     }
 
@@ -152,7 +151,6 @@ class StreamTest extends TestCase
 
     public function testSseConstructorAcceptsUtf8CharsetParameter(): void
     {
-        // No exception: UTF-8 charset parameter is the spec-mandated value.
         $stream = new SseStream(
             self::response("data: hi\n\n", contentType: 'text/event-stream; charset=UTF-8'),
             fn (string $d): string => $d,
@@ -164,8 +162,6 @@ class StreamTest extends TestCase
 
     public function testSseConstructorToleratesMissingContentTypeHeader(): void
     {
-        // Some streaming servers omit the header; we don't reject — we just
-        // can't validate. (The wire format check is best-effort.)
         $response = \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
             ->createResponse(200)
             ->withBody(\Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()->createStream("data: hi\n\n"));
@@ -177,7 +173,6 @@ class StreamTest extends TestCase
 
     public function testStreamThrowsWhenLineBufferExceedsMaxSize(): void
     {
-        // A single unterminated "line" larger than the cap must abort iteration.
         $bigLine = str_repeat('A', 200) . "\n";
         $stream = new SseStream(
             self::response("data: " . $bigLine . "\n"),
@@ -194,17 +189,14 @@ class StreamTest extends TestCase
 
     public function testStreamThrowsBeforeAccumulatingPastMaxBufferOnLongRunningSseEvent(): void
     {
-        // The cap must fire during accumulation, not just at dispatch. A hostile
-        // stream sending many small `data:` lines without a closing blank line
-        // would otherwise grow $dataBuffer past the configured limit. Each line
-        // here is well under the 64-byte cap, but their cumulative `data:`
-        // append should trip the check before allocation balloons.
+        // Each line is well under the 64-byte cap; the cumulative `data:`
+        // append must trip the check before the buffer balloons.
         $manyDataLines = '';
         for ($i = 0; $i < 50; $i++) {
             $manyDataLines .= "data: chunk-$i\n";
         }
         $stream = new SseStream(
-            self::response($manyDataLines),  // no terminating "\n\n"
+            self::response($manyDataLines),
             fn (string $d): string => $d,
             terminator: null,
             maxBufferSize: 64,
@@ -218,8 +210,7 @@ class StreamTest extends TestCase
 
     public function testSseStripsUtf8BomFromStartOfStream(): void
     {
-        // WHATWG §9.2.4: a leading U+FEFF BOM must be stripped from the stream
-        // so the first field-name match isn't poisoned.
+        // WHATWG §9.2.4 requires a leading U+FEFF to be dropped.
         $body = "\xEF\xBB\xBFdata: hello\n\n";
         $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
 
@@ -228,7 +219,6 @@ class StreamTest extends TestCase
 
     public function testSseStripsBomOnlyAtVeryStart(): void
     {
-        // A BOM-looking sequence that appears mid-stream must NOT be stripped.
         $body = "data: first\n\ndata: \xEF\xBB\xBFsecond\n\n";
         $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
 

--- a/seed/php-sdk/server-sent-events-openapi/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/server-sent-events-openapi/tests/Core/Client/StreamTest.php
@@ -192,6 +192,49 @@ class StreamTest extends TestCase
         iterator_to_array($stream, false);
     }
 
+    public function testStreamThrowsBeforeAccumulatingPastMaxBufferOnLongRunningSseEvent(): void
+    {
+        // The cap must fire during accumulation, not just at dispatch. A hostile
+        // stream sending many small `data:` lines without a closing blank line
+        // would otherwise grow $dataBuffer past the configured limit. Each line
+        // here is well under the 64-byte cap, but their cumulative `data:`
+        // append should trip the check before allocation balloons.
+        $manyDataLines = '';
+        for ($i = 0; $i < 50; $i++) {
+            $manyDataLines .= "data: chunk-$i\n";
+        }
+        $stream = new SseStream(
+            self::response($manyDataLines),  // no terminating "\n\n"
+            fn (string $d): string => $d,
+            terminator: null,
+            maxBufferSize: 64,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/buffer/i');
+
+        iterator_to_array($stream, false);
+    }
+
+    public function testSseStripsUtf8BomFromStartOfStream(): void
+    {
+        // WHATWG §9.2.4: a leading U+FEFF BOM must be stripped from the stream
+        // so the first field-name match isn't poisoned.
+        $body = "\xEF\xBB\xBFdata: hello\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['hello'], iterator_to_array($stream, false));
+    }
+
+    public function testSseStripsBomOnlyAtVeryStart(): void
+    {
+        // A BOM-looking sequence that appears mid-stream must NOT be stripped.
+        $body = "data: first\n\ndata: \xEF\xBB\xBFsecond\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['first', "\xEF\xBB\xBFsecond"], iterator_to_array($stream, false));
+    }
+
     public function testJsonStreamYieldsOnePerLine(): void
     {
         $body = "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n";

--- a/seed/php-sdk/server-sent-events-openapi/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/server-sent-events-openapi/tests/Core/Client/StreamTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Seed\Tests\Core\Client;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Seed\Core\Client\JsonStream;
+use Seed\Core\Client\SseStream;
+use Seed\Core\Client\Stream;
+use Seed\Core\Client\TextStream;
+
+class StreamTest extends TestCase
+{
+    public function testSseParsesSingleEvent(): void
+    {
+        $body = "data: hello\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['hello'], iterator_to_array($stream, false));
+    }
+
+    public function testSseConcatenatesMultilineDataWithNewlines(): void
+    {
+        $body = "data: line one\ndata: line two\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(["line one\nline two"], iterator_to_array($stream, false));
+    }
+
+    public function testSseStripsLeadingSpaceFromFieldValues(): void
+    {
+        // SSE spec: a single leading space in the field value is stripped.
+        $body = "data: with-leading-space\ndata:no-leading-space\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(["with-leading-space\nno-leading-space"], iterator_to_array($stream, false));
+    }
+
+    public function testSseIgnoresCommentLines(): void
+    {
+        $body = ": this is a comment\ndata: payload\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['payload'], iterator_to_array($stream, false));
+    }
+
+    public function testSseTerminatorEndsIterationCleanly(): void
+    {
+        $body = "data: first\n\ndata: [DONE]\n\ndata: never-yielded\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, '[DONE]');
+
+        $this->assertSame(['first'], iterator_to_array($stream, false));
+    }
+
+    public function testSseNormalizesCrlfAndLoneCr(): void
+    {
+        $body = "data: a\r\n\r\ndata: b\rdata: c\r\r";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['a', "b\nc"], iterator_to_array($stream, false));
+    }
+
+    public function testSseDispatchesTrailingEventWithoutBlankLine(): void
+    {
+        $body = "data: incomplete";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['incomplete'], iterator_to_array($stream, false));
+    }
+
+    public function testSseAppliesDeserializerOncePerEvent(): void
+    {
+        $body = "data: {\"n\":1}\n\ndata: {\"n\":2}\n\n";
+        $stream = new SseStream(self::response($body), self::jsonDecoder(), null);
+
+        $this->assertSame([['n' => 1], ['n' => 2]], iterator_to_array($stream, false));
+    }
+
+    public function testJsonStreamYieldsOnePerLine(): void
+    {
+        $body = "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n";
+        $stream = new JsonStream(self::response($body), self::jsonDecoder(), null);
+
+        $this->assertSame([['n' => 1], ['n' => 2], ['n' => 3]], iterator_to_array($stream, false));
+    }
+
+    public function testJsonStreamSkipsEmptyLines(): void
+    {
+        $body = "{\"a\":1}\n\n{\"a\":2}\n";
+        $stream = new JsonStream(self::response($body), self::jsonDecoder(), null);
+
+        $this->assertSame([['a' => 1], ['a' => 2]], iterator_to_array($stream, false));
+    }
+
+    public function testJsonStreamTerminatorEndsIteration(): void
+    {
+        $body = "{\"a\":1}\n[DONE]\n{\"a\":2}\n";
+        $stream = new JsonStream(self::response($body), self::jsonDecoder(), '[DONE]');
+
+        $this->assertSame([['a' => 1]], iterator_to_array($stream, false));
+    }
+
+    /**
+     * @return \Closure(string): array<string, mixed>
+     */
+    private static function jsonDecoder(): \Closure
+    {
+        return static function (string $raw): array {
+            /** @var array<string, mixed> $decoded */
+            $decoded = json_decode($raw, true);
+            return $decoded;
+        };
+    }
+
+    public function testTextStreamYieldsRawLines(): void
+    {
+        $body = "alpha\nbeta\ngamma\n";
+        $stream = new TextStream(self::response($body));
+
+        $this->assertSame(['alpha', 'beta', 'gamma'], iterator_to_array($stream, false));
+    }
+
+    public function testTextStreamPreservesEmptyLines(): void
+    {
+        $body = "alpha\n\nbeta\n";
+        $stream = new TextStream(self::response($body));
+
+        $this->assertSame(['alpha', '', 'beta'], iterator_to_array($stream, false));
+    }
+
+    /**
+     * Build a PSR-7 ResponseInterface with the given body string, using auto-discovery
+     * so we don't depend on any specific implementation.
+     */
+    private static function response(string $body): ResponseInterface
+    {
+        return \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
+            ->createResponse(200)
+            ->withBody(
+                \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()
+                    ->createStream($body),
+            );
+    }
+}

--- a/seed/php-sdk/server-sent-events-openapi/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/server-sent-events-openapi/tests/Core/Client/StreamTest.php
@@ -4,7 +4,9 @@ namespace Seed\Tests\Core\Client;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 use Seed\Core\Client\JsonStream;
+use Seed\Core\Client\SseEvent;
 use Seed\Core\Client\SseStream;
 use Seed\Core\Client\Stream;
 use Seed\Core\Client\TextStream;
@@ -76,6 +78,120 @@ class StreamTest extends TestCase
         $this->assertSame([['n' => 1], ['n' => 2]], iterator_to_array($stream, false));
     }
 
+    public function testSseEventsExposesEventIdAndRetryMetadata(): void
+    {
+        $body = "event: chat\nid: msg-1\nretry: 5000\ndata: hi\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        $this->assertCount(1, $events);
+        $this->assertInstanceOf(SseEvent::class, $events[0]);
+        $this->assertSame('hi', $events[0]->data);
+        $this->assertSame('chat', $events[0]->event);
+        $this->assertSame('msg-1', $events[0]->id);
+        $this->assertSame(5000, $events[0]->retry);
+    }
+
+    public function testSseEventsPersistsLastEventIdAcrossEventsPerSpec(): void
+    {
+        // Per WHATWG SSE: once an `id:` is set it persists across subsequent
+        // events until explicitly overridden.
+        $body = "id: persistent\ndata: a\n\ndata: b\n\nid: replaced\ndata: c\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        $this->assertSame(['persistent', 'persistent', 'replaced'], array_map(fn (SseEvent $e) => $e->id, $events));
+    }
+
+    public function testSseEventsIgnoresIdContainingNullByte(): void
+    {
+        $body = "id: ok\ndata: first\n\nid: bad\0id\ndata: second\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        // Second event's malformed id is rejected; previous id persists per spec.
+        $this->assertSame(['ok', 'ok'], array_map(fn (SseEvent $e) => $e->id, $events));
+    }
+
+    public function testSseEventsIgnoresNonIntegerRetry(): void
+    {
+        $body = "retry: not-a-number\ndata: hi\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        $this->assertNull($events[0]->retry);
+    }
+
+    public function testSseConstructorRejectsNonSseContentType(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/text\/event-stream/');
+
+        new SseStream(
+            self::response('data: x\n\n', contentType: 'application/json'),
+            fn (string $d): string => $d,
+            null,
+        );
+    }
+
+    public function testSseConstructorRejectsNonUtf8Charset(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/charset/i');
+
+        new SseStream(
+            self::response('data: x\n\n', contentType: 'text/event-stream; charset=iso-8859-1'),
+            fn (string $d): string => $d,
+            null,
+        );
+    }
+
+    public function testSseConstructorAcceptsUtf8CharsetParameter(): void
+    {
+        // No exception: UTF-8 charset parameter is the spec-mandated value.
+        $stream = new SseStream(
+            self::response("data: hi\n\n", contentType: 'text/event-stream; charset=UTF-8'),
+            fn (string $d): string => $d,
+            null,
+        );
+
+        $this->assertSame(['hi'], iterator_to_array($stream, false));
+    }
+
+    public function testSseConstructorToleratesMissingContentTypeHeader(): void
+    {
+        // Some streaming servers omit the header; we don't reject — we just
+        // can't validate. (The wire format check is best-effort.)
+        $response = \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
+            ->createResponse(200)
+            ->withBody(\Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()->createStream("data: hi\n\n"));
+
+        $stream = new SseStream($response, fn (string $d): string => $d, null);
+
+        $this->assertSame(['hi'], iterator_to_array($stream, false));
+    }
+
+    public function testStreamThrowsWhenLineBufferExceedsMaxSize(): void
+    {
+        // A single unterminated "line" larger than the cap must abort iteration.
+        $bigLine = str_repeat('A', 200) . "\n";
+        $stream = new SseStream(
+            self::response("data: " . $bigLine . "\n"),
+            fn (string $d): string => $d,
+            terminator: null,
+            maxBufferSize: 64,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/buffer/i');
+
+        iterator_to_array($stream, false);
+    }
+
     public function testJsonStreamYieldsOnePerLine(): void
     {
         $body = "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n";
@@ -129,13 +245,17 @@ class StreamTest extends TestCase
     }
 
     /**
-     * Build a PSR-7 ResponseInterface with the given body string, using auto-discovery
-     * so we don't depend on any specific implementation.
+     * Build a PSR-7 ResponseInterface with the given body. The Content-Type
+     * defaults to `text/event-stream` so SSE tests just work; pass an override
+     * for the validation-error cases.
      */
-    private static function response(string $body): ResponseInterface
-    {
+    private static function response(
+        string $body,
+        string $contentType = 'text/event-stream',
+    ): ResponseInterface {
         return \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
             ->createResponse(200)
+            ->withHeader('Content-Type', $contentType)
             ->withBody(
                 \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()
                     ->createStream($body),

--- a/seed/php-sdk/server-sent-events/.fern/metadata.json
+++ b/seed/php-sdk/server-sent-events/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/server-sent-events/reference.md
+++ b/seed/php-sdk/server-sent-events/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Completions
-<details><summary><code>$client-&gt;completions-&gt;stream($request)</code></summary>
+<details><summary><code>$client-&gt;completions-&gt;stream($request) -> SseStream</code></summary>
 <dl>
 <dd>
 
@@ -44,7 +44,7 @@ $client->completions->stream(
 </dl>
 </details>
 
-<details><summary><code>$client-&gt;completions-&gt;streamWithoutTerminator($request)</code></summary>
+<details><summary><code>$client-&gt;completions-&gt;streamWithoutTerminator($request) -> SseStream</code></summary>
 <dl>
 <dd>
 

--- a/seed/php-sdk/server-sent-events/src/Completions/CompletionsClient.php
+++ b/seed/php-sdk/server-sent-events/src/Completions/CompletionsClient.php
@@ -5,6 +5,8 @@ namespace Seed\Completions;
 use Psr\Http\Client\ClientInterface;
 use Seed\Core\Client\RawClient;
 use Seed\Completions\Requests\StreamCompletionRequest;
+use Seed\Core\Client\SseStream;
+use Seed\Completions\Types\StreamedCompletion;
 use Seed\Exceptions\SeedException;
 use Seed\Exceptions\SeedApiException;
 use Seed\Core\Json\JsonApiRequest;
@@ -58,10 +60,11 @@ class CompletionsClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return SseStream<StreamedCompletion>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function stream(StreamCompletionRequest $request, ?array $options = null): void
+    public function stream(StreamCompletionRequest $request, ?array $options = null): SseStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -75,6 +78,9 @@ class CompletionsClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new SseStream(response: $response, deserializer: fn (string $data) => StreamedCompletion::fromJson($data), terminator: '[[DONE]]');
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }
@@ -95,10 +101,11 @@ class CompletionsClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return SseStream<StreamedCompletion>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function streamWithoutTerminator(StreamCompletionRequestWithoutTerminator $request, ?array $options = null): void
+    public function streamWithoutTerminator(StreamCompletionRequestWithoutTerminator $request, ?array $options = null): SseStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -112,6 +119,9 @@ class CompletionsClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new SseStream(response: $response, deserializer: fn (string $data) => StreamedCompletion::fromJson($data), terminator: null);
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }

--- a/seed/php-sdk/server-sent-events/src/Core/Client/JsonStream.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/JsonStream.php
@@ -20,17 +20,20 @@ class JsonStream extends Stream
      *   JSON payload string.
      * @param ?string $terminator Optional sentinel line that ends the stream
      *   when received. Pass `null` to read until EOF.
+     * @param int $maxBufferSize See `Stream::__construct`. Defaults to 1 MiB.
      */
     public function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         ?string $terminator = null,
+        int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
     ) {
         parent::__construct(
             response: $response,
             deserializer: $deserializer,
             format: StreamFormat::Json,
             terminator: $terminator,
+            maxBufferSize: $maxBufferSize,
         );
     }
 }

--- a/seed/php-sdk/server-sent-events/src/Core/Client/JsonStream.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/JsonStream.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Closure;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Iterates a newline-delimited JSON (NDJSON) response body, yielding one
+ * deserialized chunk per non-empty line.
+ *
+ * @template T
+ * @extends Stream<T>
+ */
+class JsonStream extends Stream
+{
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param Closure(string): T $deserializer Called once per line with the raw
+     *   JSON payload string.
+     * @param ?string $terminator Optional sentinel line that ends the stream
+     *   when received. Pass `null` to read until EOF.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Closure $deserializer,
+        ?string $terminator = null,
+    ) {
+        parent::__construct(
+            response: $response,
+            deserializer: $deserializer,
+            format: StreamFormat::Json,
+            terminator: $terminator,
+        );
+    }
+}

--- a/seed/php-sdk/server-sent-events/src/Core/Client/SseEvent.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/SseEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Seed\Core\Client;
+
+/**
+ * A single Server-Sent Event with its WHATWG metadata fields.
+ *
+ * Returned by `SseStream::events()`. Use plain `foreach ($stream as $payload)` if
+ * metadata isn't needed and you only want the deserialized `data` field.
+ *
+ * @template T
+ */
+final class SseEvent
+{
+    /**
+     * @param T $data Deserialized payload from the `data:` field(s). Multi-line
+     *   data is joined with a single newline before deserialization.
+     * @param string $event Value of the `event:` field, or empty string if not set.
+     * @param string $id Most recent `id:` field value. Per the WHATWG spec, this
+     *   persists across events: a subsequent event without an explicit `id:`
+     *   inherits the previous one. Empty string until the first id is observed.
+     * @param ?int $retry Reconnection time in milliseconds from the `retry:` field,
+     *   or null if not set or unparseable.
+     */
+    public function __construct(
+        public readonly mixed $data,
+        public readonly string $event = '',
+        public readonly string $id = '',
+        public readonly ?int $retry = null,
+    ) {
+    }
+}

--- a/seed/php-sdk/server-sent-events/src/Core/Client/SseStream.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/SseStream.php
@@ -56,7 +56,7 @@ class SseStream extends Stream
     {
         foreach ($this->iterateRawSseEvents() as $raw) {
             yield new SseEvent(
-                data: ($this->deserializer)($raw['data']),
+                data: $this->deserialize($raw['data']),
                 event: $raw['event'],
                 id: $raw['id'],
                 retry: $raw['retry'],

--- a/seed/php-sdk/server-sent-events/src/Core/Client/SseStream.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/SseStream.php
@@ -3,7 +3,9 @@
 namespace Seed\Core\Client;
 
 use Closure;
+use Generator;
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 
 /**
  * Iterates a `text/event-stream` (SSE) response body, yielding one deserialized
@@ -21,17 +23,79 @@ class SseStream extends Stream
      * @param ?string $terminator Optional sentinel payload that ends the stream
      *   when received. Defaults to '[DONE]', a common SSE convention.
      *   Pass `null` to disable terminator handling.
+     * @param int $maxBufferSize See `Stream::__construct`. Defaults to 1 MiB.
      */
     public function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         ?string $terminator = '[DONE]',
+        int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
     ) {
+        self::validateContentType($response);
         parent::__construct(
             response: $response,
             deserializer: $deserializer,
             format: StreamFormat::Sse,
             terminator: $terminator,
+            maxBufferSize: $maxBufferSize,
         );
+    }
+
+    /**
+     * Iterates the stream yielding both the deserialized payload and the
+     * accompanying SSE metadata (event type, id, retry). Use this when you
+     * need the event field (e.g. for event-typed unions) or `Last-Event-ID`
+     * for resumption logic.
+     *
+     * For data-only iteration, use this object directly as an iterable:
+     * `foreach ($stream as $event) { ... }`.
+     *
+     * @return Generator<int, SseEvent<T>>
+     */
+    public function events(): Generator
+    {
+        foreach ($this->iterateRawSseEvents() as $raw) {
+            yield new SseEvent(
+                data: ($this->deserializer)($raw['data']),
+                event: $raw['event'],
+                id: $raw['id'],
+                retry: $raw['retry'],
+            );
+        }
+    }
+
+    /**
+     * Validates that the response's Content-Type matches an SSE stream.
+     *
+     * Per WHATWG, the SSE wire format is always UTF-8; we reject explicit
+     * non-UTF-8 charset parameters rather than risk silent mojibake. A missing
+     * Content-Type header is tolerated — some servers omit it on streaming
+     * responses — but a wrong media type or wrong charset always throws.
+     */
+    private static function validateContentType(ResponseInterface $response): void
+    {
+        $contentType = $response->getHeaderLine('Content-Type');
+        if ($contentType === '') {
+            return;
+        }
+        $parts = explode(';', $contentType);
+        $mediaType = strtolower(trim($parts[0]));
+        if ($mediaType !== 'text/event-stream') {
+            throw new RuntimeException(
+                "Expected Content-Type 'text/event-stream' for SSE response, got '{$mediaType}'",
+            );
+        }
+        foreach (array_slice($parts, 1) as $param) {
+            $param = trim($param);
+            if (stripos($param, 'charset=') !== 0) {
+                continue;
+            }
+            $charset = strtolower(trim(substr($param, 8), " \"'"));
+            if ($charset !== '' && $charset !== 'utf-8' && $charset !== 'utf8') {
+                throw new RuntimeException(
+                    "Unsupported SSE charset '{$charset}'; per the WHATWG spec only UTF-8 is permitted",
+                );
+            }
+        }
     }
 }

--- a/seed/php-sdk/server-sent-events/src/Core/Client/SseStream.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/SseStream.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Closure;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Iterates a `text/event-stream` (SSE) response body, yielding one deserialized
+ * event per dispatched frame.
+ *
+ * @template T
+ * @extends Stream<T>
+ */
+class SseStream extends Stream
+{
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param Closure(string): T $deserializer Called once per dispatched event
+     *   with the raw `data:` payload string (newline-joined for multi-line frames).
+     * @param ?string $terminator Optional sentinel payload that ends the stream
+     *   when received. Defaults to '[DONE]', a common SSE convention.
+     *   Pass `null` to disable terminator handling.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Closure $deserializer,
+        ?string $terminator = '[DONE]',
+    ) {
+        parent::__construct(
+            response: $response,
+            deserializer: $deserializer,
+            format: StreamFormat::Sse,
+            terminator: $terminator,
+        );
+    }
+}

--- a/seed/php-sdk/server-sent-events/src/Core/Client/Stream.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/Stream.php
@@ -235,8 +235,12 @@ class Stream implements IteratorAggregate
             if ($pendingCr && $chunk[0] === "\n") {
                 $chunk = substr($chunk, 1);
             }
-            $pendingCr = str_ends_with($chunk, "\r");
-            $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
+            if (str_contains($chunk, "\r")) {
+                $pendingCr = str_ends_with($chunk, "\r");
+                $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
+            } else {
+                $pendingCr = false;
+            }
             $buffer = $this->appendWithinCap($buffer, $chunk);
             if (!$bomChecked && strlen($buffer) >= 3) {
                 $bomChecked = true;

--- a/seed/php-sdk/server-sent-events/src/Core/Client/Stream.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/Stream.php
@@ -7,6 +7,7 @@ use Generator;
 use IteratorAggregate;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use RuntimeException;
 
 enum StreamFormat: string
 {
@@ -29,17 +30,23 @@ enum StreamFormat: string
  * When `$terminator` is set, an event whose payload equals the terminator
  * ends iteration cleanly (e.g. `[DONE]` for SSE).
  *
+ * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams that
+ * never emit a frame boundary: if the line buffer or a single event's data
+ * exceeds the cap, iteration aborts with `RuntimeException`.
+ *
  * @template T
  * @implements IteratorAggregate<int, T>
  */
 class Stream implements IteratorAggregate
 {
+    public const DEFAULT_MAX_BUFFER_SIZE = 1048576;
+
     private const READ_CHUNK_SIZE = 8192;
 
     private StreamInterface $body;
 
     /** @var Closure(string): T */
-    private Closure $deserializer;
+    protected Closure $deserializer;
 
     /**
      * @param ResponseInterface $response The HTTP response to stream from.
@@ -48,18 +55,25 @@ class Stream implements IteratorAggregate
      * @param StreamFormat $format Framing strategy for the stream.
      * @param ?string $terminator Optional sentinel value that ends the stream when matched
      *   against the raw frame payload (e.g. '[DONE]').
+     * @param int $maxBufferSize Maximum size in bytes for the line buffer or a single SSE
+     *   event's accumulated `data` field. Exceeding this throws `RuntimeException` to
+     *   guard against pathological streams. Defaults to 1 MiB.
      */
     public function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         private readonly StreamFormat $format = StreamFormat::Sse,
         private readonly ?string $terminator = null,
+        private readonly int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
     ) {
         $this->body = $response->getBody();
         $this->deserializer = $deserializer;
     }
 
     /**
+     * Iteration is one-shot: PSR-7 bodies are forward-only, so re-iterating the
+     * same `Stream` instance yields nothing useful.
+     *
      * @return Generator<int, T>
      */
     public function getIterator(): Generator
@@ -72,35 +86,57 @@ class Stream implements IteratorAggregate
     }
 
     /**
-     * WHATWG-compliant SSE frame parser.
-     *
      * @return Generator<int, T>
      */
     private function iterateSse(): Generator
     {
+        foreach ($this->iterateRawSseEvents() as $raw) {
+            yield ($this->deserializer)($raw['data']);
+        }
+    }
+
+    /**
+     * Iterates the SSE stream yielding raw envelopes with WHATWG metadata fields
+     * intact. Yields plain associative arrays — not `SseEvent` objects — so the
+     * data-only iteration path doesn't pay the allocation cost; `SseStream::events()`
+     * constructs the public `SseEvent<T>` on top.
+     *
+     * Per WHATWG: the `id:` field persists across events within this iteration;
+     * the configured `terminator`, if present, ends iteration when matched against
+     * `data`.
+     *
+     * @internal
+     * @return Generator<int, array{data: string, event: string, id: string, retry: ?int}>
+     */
+    protected function iterateRawSseEvents(): Generator
+    {
         $dataBuffer = '';
+        $eventType = '';
+        $lastEventId = '';
+        $retry = null;
         foreach ($this->readLines() as $line) {
             if ($line === '') {
-                // Blank line dispatches the accumulated event.
                 if ($dataBuffer === '') {
                     continue;
                 }
-                // Strip the single trailing "\n" added by the field append step.
+                // Strip the single trailing "\n" added by the field-append step.
                 $payload = substr($dataBuffer, 0, -1);
+                $this->assertBufferWithinCap(strlen($payload));
                 $dataBuffer = '';
                 if ($this->terminator !== null && $payload === $this->terminator) {
                     return;
                 }
-                yield ($this->deserializer)($payload);
+                yield ['data' => $payload, 'event' => $eventType, 'id' => $lastEventId, 'retry' => $retry];
+                // Per WHATWG: do NOT reset lastEventId between events.
+                $eventType = '';
+                $retry = null;
                 continue;
             }
             if (str_starts_with($line, ':')) {
-                // SSE comment — ignored per spec.
                 continue;
             }
             $colonPos = strpos($line, ':');
             if ($colonPos === false) {
-                // Line is a field name with empty value; only `data` is meaningful for us.
                 if ($line === 'data') {
                     $dataBuffer .= "\n";
                 }
@@ -111,23 +147,38 @@ class Stream implements IteratorAggregate
             if (str_starts_with($value, ' ')) {
                 $value = substr($value, 1);
             }
-            // Only `data` is yielded; `event`/`id`/`retry` are accepted but unused here.
-            if ($field === 'data') {
-                $dataBuffer .= $value . "\n";
+            switch ($field) {
+                case 'data':
+                    $dataBuffer .= $value . "\n";
+                    break;
+                case 'event':
+                    $eventType = $value;
+                    break;
+                case 'id':
+                    // WHATWG: ignore IDs that contain a NULL byte.
+                    if (!str_contains($value, "\0")) {
+                        $lastEventId = $value;
+                    }
+                    break;
+                case 'retry':
+                    // WHATWG: ignore the value if it isn't a base-10 integer.
+                    if ($value !== '' && ctype_digit($value)) {
+                        $retry = (int) $value;
+                    }
+                    break;
             }
         }
         // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
         if ($dataBuffer !== '') {
             $payload = substr($dataBuffer, 0, -1);
+            $this->assertBufferWithinCap(strlen($payload));
             if ($this->terminator === null || $payload !== $this->terminator) {
-                yield ($this->deserializer)($payload);
+                yield ['data' => $payload, 'event' => $eventType, 'id' => $lastEventId, 'retry' => $retry];
             }
         }
     }
 
     /**
-     * Newline-delimited frames (NDJSON, line-by-line).
-     *
      * @return Generator<int, T>
      */
     private function iterateDelimited(): Generator
@@ -144,8 +195,6 @@ class Stream implements IteratorAggregate
     }
 
     /**
-     * Raw newline-delimited text frames.
-     *
      * @return Generator<int, T>
      */
     private function iterateText(): Generator
@@ -159,6 +208,10 @@ class Stream implements IteratorAggregate
      * Reads the response body and yields complete lines, normalizing CRLF/CR
      * to LF per the WHATWG SSE spec. Trailing partial content (without a
      * terminating newline) is emitted as a final line.
+     *
+     * Throws `RuntimeException` if the accumulated buffer exceeds the configured
+     * cap — that means we've read more than `maxBufferSize` bytes without ever
+     * seeing a line break, which indicates a malformed or hostile stream.
      *
      * @return Generator<int, string>
      */
@@ -180,6 +233,7 @@ class Stream implements IteratorAggregate
             // Normalize line endings on just this chunk: "\r\n" and lone "\r" -> "\n".
             $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
             $buffer .= $chunk;
+            $this->assertBufferWithinCap(strlen($buffer));
             while (($lfPos = strpos($buffer, "\n")) !== false) {
                 yield substr($buffer, 0, $lfPos);
                 $buffer = substr($buffer, $lfPos + 1);
@@ -187,6 +241,15 @@ class Stream implements IteratorAggregate
         }
         if ($buffer !== '') {
             yield $buffer;
+        }
+    }
+
+    private function assertBufferWithinCap(int $size): void
+    {
+        if ($size > $this->maxBufferSize) {
+            throw new RuntimeException(
+                "Stream buffer exceeded maximum size of {$this->maxBufferSize} bytes",
+            );
         }
     }
 

--- a/seed/php-sdk/server-sent-events/src/Core/Client/Stream.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/Stream.php
@@ -23,15 +23,12 @@ use RuntimeException;
  * When `$terminator` is set, an event whose payload equals the terminator
  * ends iteration cleanly (e.g. `[DONE]` for SSE).
  *
- * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams that
- * never emit a frame boundary: if the line buffer or a single event's data
- * exceeds the cap, iteration aborts with `RuntimeException`. The cap is
- * enforced *before* allocation, not after — a hostile stream cannot drive us
- * past the limit and then trip the check.
+ * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams
+ * that never emit a frame boundary: if the line buffer or a single event's
+ * data exceeds the cap, iteration aborts with `RuntimeException`.
  *
- * Direct instantiation of `Stream` is not supported; use `SseStream`,
- * `JsonStream`, or `TextStream` instead. The constructor is `protected` to
- * enforce this.
+ * Direct instantiation is not supported; use `SseStream`, `JsonStream`, or
+ * `TextStream`.
  *
  * @template T
  * @implements IteratorAggregate<int, T>
@@ -131,7 +128,6 @@ class Stream implements IteratorAggregate
                 if ($dataBuffer === '') {
                     continue;
                 }
-                // Strip the single trailing "\n" added by the field-append step.
                 $payload = substr($dataBuffer, 0, -1);
                 $dataBuffer = '';
                 if ($this->terminator !== null && $payload === $this->terminator) {
@@ -160,9 +156,6 @@ class Stream implements IteratorAggregate
             }
             switch ($field) {
                 case 'data':
-                    // Enforce the cap before allocation: a hostile stream emitting
-                    // many `data:` lines without a dispatching blank line cannot
-                    // drive us past the limit and then trip the check.
                     $dataBuffer = $this->appendWithinCap($dataBuffer, $value . "\n");
                     break;
                 case 'event':
@@ -182,7 +175,7 @@ class Stream implements IteratorAggregate
                     break;
             }
         }
-        // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
+        // Flush a trailing event that lacked a closing blank line.
         if ($dataBuffer !== '') {
             $payload = substr($dataBuffer, 0, -1);
             if ($this->terminator === null || $payload !== $this->terminator) {
@@ -266,10 +259,8 @@ class Stream implements IteratorAggregate
     }
 
     /**
-     * Appends $suffix to $buffer, throwing `RuntimeException` if the result
-     * would exceed `maxBufferSize`. The cap is enforced before the
-     * concatenation allocates, so a runaway stream is bounded by the configured
-     * limit rather than by available memory.
+     * Appends $suffix to $buffer, throwing `RuntimeException` if the resulting
+     * size would exceed `maxBufferSize`.
      */
     private function appendWithinCap(string $buffer, string $suffix): string
     {

--- a/seed/php-sdk/server-sent-events/src/Core/Client/Stream.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/Stream.php
@@ -9,13 +9,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 
-enum StreamFormat: string
-{
-    case Sse = 'sse';
-    case Json = 'json';
-    case Text = 'text';
-}
-
 /**
  * Iterates a streaming HTTP response body frame-by-frame.
  *
@@ -32,21 +25,28 @@ enum StreamFormat: string
  *
  * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams that
  * never emit a frame boundary: if the line buffer or a single event's data
- * exceeds the cap, iteration aborts with `RuntimeException`.
+ * exceeds the cap, iteration aborts with `RuntimeException`. The cap is
+ * enforced *before* allocation, not after — a hostile stream cannot drive us
+ * past the limit and then trip the check.
+ *
+ * Direct instantiation of `Stream` is not supported; use `SseStream`,
+ * `JsonStream`, or `TextStream` instead. The constructor is `protected` to
+ * enforce this.
  *
  * @template T
  * @implements IteratorAggregate<int, T>
  */
 class Stream implements IteratorAggregate
 {
-    public const DEFAULT_MAX_BUFFER_SIZE = 1048576;
+    public const DEFAULT_MAX_BUFFER_SIZE = 1_048_576;
 
     private const READ_CHUNK_SIZE = 8192;
+    private const UTF8_BOM = "\xEF\xBB\xBF";
 
     private StreamInterface $body;
 
     /** @var Closure(string): T */
-    protected Closure $deserializer;
+    private Closure $deserializer;
 
     /**
      * @param ResponseInterface $response The HTTP response to stream from.
@@ -59,7 +59,7 @@ class Stream implements IteratorAggregate
      *   event's accumulated `data` field. Exceeding this throws `RuntimeException` to
      *   guard against pathological streams. Defaults to 1 MiB.
      */
-    public function __construct(
+    protected function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         private readonly StreamFormat $format = StreamFormat::Sse,
@@ -83,6 +83,18 @@ class Stream implements IteratorAggregate
             StreamFormat::Json => $this->iterateDelimited(),
             StreamFormat::Text => $this->iterateText(),
         };
+    }
+
+    /**
+     * Applies the configured deserializer to a single raw frame payload.
+     * Available to subclasses (notably `SseStream::events()`) so they can
+     * construct typed envelopes without accessing the closure directly.
+     *
+     * @return T
+     */
+    protected function deserialize(string $raw): mixed
+    {
+        return ($this->deserializer)($raw);
     }
 
     /**
@@ -121,7 +133,6 @@ class Stream implements IteratorAggregate
                 }
                 // Strip the single trailing "\n" added by the field-append step.
                 $payload = substr($dataBuffer, 0, -1);
-                $this->assertBufferWithinCap(strlen($payload));
                 $dataBuffer = '';
                 if ($this->terminator !== null && $payload === $this->terminator) {
                     return;
@@ -138,7 +149,7 @@ class Stream implements IteratorAggregate
             $colonPos = strpos($line, ':');
             if ($colonPos === false) {
                 if ($line === 'data') {
-                    $dataBuffer .= "\n";
+                    $dataBuffer = $this->appendWithinCap($dataBuffer, "\n");
                 }
                 continue;
             }
@@ -149,7 +160,10 @@ class Stream implements IteratorAggregate
             }
             switch ($field) {
                 case 'data':
-                    $dataBuffer .= $value . "\n";
+                    // Enforce the cap before allocation: a hostile stream emitting
+                    // many `data:` lines without a dispatching blank line cannot
+                    // drive us past the limit and then trip the check.
+                    $dataBuffer = $this->appendWithinCap($dataBuffer, $value . "\n");
                     break;
                 case 'event':
                     $eventType = $value;
@@ -171,7 +185,6 @@ class Stream implements IteratorAggregate
         // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
         if ($dataBuffer !== '') {
             $payload = substr($dataBuffer, 0, -1);
-            $this->assertBufferWithinCap(strlen($payload));
             if ($this->terminator === null || $payload !== $this->terminator) {
                 yield ['data' => $payload, 'event' => $eventType, 'id' => $lastEventId, 'retry' => $retry];
             }
@@ -206,12 +219,13 @@ class Stream implements IteratorAggregate
 
     /**
      * Reads the response body and yields complete lines, normalizing CRLF/CR
-     * to LF per the WHATWG SSE spec. Trailing partial content (without a
-     * terminating newline) is emitted as a final line.
+     * to LF per the WHATWG SSE spec. Strips a single UTF-8 BOM if present at
+     * the start of the stream (WHATWG §9.2.4). Trailing partial content
+     * (without a terminating newline) is emitted as a final line.
      *
-     * Throws `RuntimeException` if the accumulated buffer exceeds the configured
-     * cap — that means we've read more than `maxBufferSize` bytes without ever
-     * seeing a line break, which indicates a malformed or hostile stream.
+     * `$pendingCr` tracks whether the prior chunk's last byte was `\r`, so a
+     * `\r\n` sequence split across a read boundary collapses to one terminator
+     * instead of two.
      *
      * @return Generator<int, string>
      */
@@ -219,38 +233,52 @@ class Stream implements IteratorAggregate
     {
         $buffer = '';
         $pendingCr = false;
+        $bomChecked = false;
         while (!$this->body->eof()) {
             $chunk = $this->body->read(self::READ_CHUNK_SIZE);
             if ($chunk === '') {
                 continue;
             }
-            // If the previous chunk ended on "\r", swallow a leading "\n" so we don't
-            // emit a spurious blank line for a "\r\n" sequence split across chunks.
             if ($pendingCr && $chunk[0] === "\n") {
                 $chunk = substr($chunk, 1);
             }
             $pendingCr = str_ends_with($chunk, "\r");
-            // Normalize line endings on just this chunk: "\r\n" and lone "\r" -> "\n".
             $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
-            $buffer .= $chunk;
-            $this->assertBufferWithinCap(strlen($buffer));
+            $buffer = $this->appendWithinCap($buffer, $chunk);
+            if (!$bomChecked && strlen($buffer) >= 3) {
+                $bomChecked = true;
+                if (str_starts_with($buffer, self::UTF8_BOM)) {
+                    $buffer = substr($buffer, 3);
+                }
+            }
             while (($lfPos = strpos($buffer, "\n")) !== false) {
                 yield substr($buffer, 0, $lfPos);
                 $buffer = substr($buffer, $lfPos + 1);
             }
+        }
+        // BOM may not have been checked yet if the entire body was < 3 bytes.
+        if (!$bomChecked && str_starts_with($buffer, self::UTF8_BOM)) {
+            $buffer = substr($buffer, 3);
         }
         if ($buffer !== '') {
             yield $buffer;
         }
     }
 
-    private function assertBufferWithinCap(int $size): void
+    /**
+     * Appends $suffix to $buffer, throwing `RuntimeException` if the result
+     * would exceed `maxBufferSize`. The cap is enforced before the
+     * concatenation allocates, so a runaway stream is bounded by the configured
+     * limit rather than by available memory.
+     */
+    private function appendWithinCap(string $buffer, string $suffix): string
     {
-        if ($size > $this->maxBufferSize) {
+        if (strlen($buffer) + strlen($suffix) > $this->maxBufferSize) {
             throw new RuntimeException(
-                "Stream buffer exceeded maximum size of {$this->maxBufferSize} bytes",
+                "Stream buffer would exceed maximum size of {$this->maxBufferSize} bytes",
             );
         }
+        return $buffer . $suffix;
     }
 
     public function __destruct()

--- a/seed/php-sdk/server-sent-events/src/Core/Client/Stream.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/Stream.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Closure;
+use Generator;
+use IteratorAggregate;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+enum StreamFormat: string
+{
+    case Sse = 'sse';
+    case Json = 'json';
+    case Text = 'text';
+}
+
+/**
+ * Iterates a streaming HTTP response body frame-by-frame.
+ *
+ * Parameterized by `$format`, which selects the framing strategy:
+ *   - 'sse'  — WHATWG Server-Sent Events: lines starting with `data:` (and
+ *              optionally `event:`, `id:`, `retry:`); a blank line dispatches
+ *              the accumulated event. Multi-line `data` fields are joined
+ *              with newlines.
+ *   - 'json' — newline-delimited JSON: each non-empty line is one frame.
+ *   - 'text' — newline-delimited text: each line is yielded as a raw string.
+ *
+ * When `$terminator` is set, an event whose payload equals the terminator
+ * ends iteration cleanly (e.g. `[DONE]` for SSE).
+ *
+ * @template T
+ * @implements IteratorAggregate<int, T>
+ */
+class Stream implements IteratorAggregate
+{
+    private const READ_CHUNK_SIZE = 8192;
+
+    private StreamInterface $body;
+
+    /** @var Closure(string): T */
+    private Closure $deserializer;
+
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param Closure(string): T $deserializer Called once per frame with the raw payload string.
+     *   For text streams, the deserializer is typically `fn(string $line) => $line`.
+     * @param StreamFormat $format Framing strategy for the stream.
+     * @param ?string $terminator Optional sentinel value that ends the stream when matched
+     *   against the raw frame payload (e.g. '[DONE]').
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Closure $deserializer,
+        private readonly StreamFormat $format = StreamFormat::Sse,
+        private readonly ?string $terminator = null,
+    ) {
+        $this->body = $response->getBody();
+        $this->deserializer = $deserializer;
+    }
+
+    /**
+     * @return Generator<int, T>
+     */
+    public function getIterator(): Generator
+    {
+        return match ($this->format) {
+            StreamFormat::Sse => $this->iterateSse(),
+            StreamFormat::Json => $this->iterateDelimited(),
+            StreamFormat::Text => $this->iterateText(),
+        };
+    }
+
+    /**
+     * WHATWG-compliant SSE frame parser.
+     *
+     * @return Generator<int, T>
+     */
+    private function iterateSse(): Generator
+    {
+        $dataBuffer = '';
+        foreach ($this->readLines() as $line) {
+            if ($line === '') {
+                // Blank line dispatches the accumulated event.
+                if ($dataBuffer === '') {
+                    continue;
+                }
+                // Strip the single trailing "\n" added by the field append step.
+                $payload = substr($dataBuffer, 0, -1);
+                $dataBuffer = '';
+                if ($this->terminator !== null && $payload === $this->terminator) {
+                    return;
+                }
+                yield ($this->deserializer)($payload);
+                continue;
+            }
+            if (str_starts_with($line, ':')) {
+                // SSE comment — ignored per spec.
+                continue;
+            }
+            $colonPos = strpos($line, ':');
+            if ($colonPos === false) {
+                // Line is a field name with empty value; only `data` is meaningful for us.
+                if ($line === 'data') {
+                    $dataBuffer .= "\n";
+                }
+                continue;
+            }
+            $field = substr($line, 0, $colonPos);
+            $value = substr($line, $colonPos + 1);
+            if (str_starts_with($value, ' ')) {
+                $value = substr($value, 1);
+            }
+            // Only `data` is yielded; `event`/`id`/`retry` are accepted but unused here.
+            if ($field === 'data') {
+                $dataBuffer .= $value . "\n";
+            }
+        }
+        // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
+        if ($dataBuffer !== '') {
+            $payload = substr($dataBuffer, 0, -1);
+            if ($this->terminator === null || $payload !== $this->terminator) {
+                yield ($this->deserializer)($payload);
+            }
+        }
+    }
+
+    /**
+     * Newline-delimited frames (NDJSON, line-by-line).
+     *
+     * @return Generator<int, T>
+     */
+    private function iterateDelimited(): Generator
+    {
+        foreach ($this->readLines() as $line) {
+            if ($line === '') {
+                continue;
+            }
+            if ($this->terminator !== null && $line === $this->terminator) {
+                return;
+            }
+            yield ($this->deserializer)($line);
+        }
+    }
+
+    /**
+     * Raw newline-delimited text frames.
+     *
+     * @return Generator<int, T>
+     */
+    private function iterateText(): Generator
+    {
+        foreach ($this->readLines() as $line) {
+            yield ($this->deserializer)($line);
+        }
+    }
+
+    /**
+     * Reads the response body and yields complete lines, normalizing CRLF/CR
+     * to LF per the WHATWG SSE spec. Trailing partial content (without a
+     * terminating newline) is emitted as a final line.
+     *
+     * @return Generator<int, string>
+     */
+    private function readLines(): Generator
+    {
+        $buffer = '';
+        $pendingCr = false;
+        while (!$this->body->eof()) {
+            $chunk = $this->body->read(self::READ_CHUNK_SIZE);
+            if ($chunk === '') {
+                continue;
+            }
+            // If the previous chunk ended on "\r", swallow a leading "\n" so we don't
+            // emit a spurious blank line for a "\r\n" sequence split across chunks.
+            if ($pendingCr && $chunk[0] === "\n") {
+                $chunk = substr($chunk, 1);
+            }
+            $pendingCr = str_ends_with($chunk, "\r");
+            // Normalize line endings on just this chunk: "\r\n" and lone "\r" -> "\n".
+            $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
+            $buffer .= $chunk;
+            while (($lfPos = strpos($buffer, "\n")) !== false) {
+                yield substr($buffer, 0, $lfPos);
+                $buffer = substr($buffer, $lfPos + 1);
+            }
+        }
+        if ($buffer !== '') {
+            yield $buffer;
+        }
+    }
+
+    public function __destruct()
+    {
+        try {
+            $this->body->close();
+        } catch (\Throwable) {
+            // Best effort — the body may already be closed by the consumer.
+        }
+    }
+}

--- a/seed/php-sdk/server-sent-events/src/Core/Client/StreamFormat.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/StreamFormat.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Seed\Core\Client;
+
+/**
+ * Framing strategy used by `Stream` to interpret a streaming HTTP response body.
+ */
+enum StreamFormat: string
+{
+    case Sse = 'sse';
+    case Json = 'json';
+    case Text = 'text';
+}

--- a/seed/php-sdk/server-sent-events/src/Core/Client/TextStream.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/TextStream.php
@@ -11,13 +11,20 @@ use Psr\Http\Message\ResponseInterface;
  */
 class TextStream extends Stream
 {
-    public function __construct(ResponseInterface $response)
-    {
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param int $maxBufferSize See `Stream::__construct`. Defaults to 1 MiB.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
+    ) {
         parent::__construct(
             response: $response,
             deserializer: fn (string $line): string => $line,
             format: StreamFormat::Text,
             terminator: null,
+            maxBufferSize: $maxBufferSize,
         );
     }
 }

--- a/seed/php-sdk/server-sent-events/src/Core/Client/TextStream.php
+++ b/seed/php-sdk/server-sent-events/src/Core/Client/TextStream.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Iterates a streaming text response body, yielding one raw string per line.
+ *
+ * @extends Stream<string>
+ */
+class TextStream extends Stream
+{
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct(
+            response: $response,
+            deserializer: fn (string $line): string => $line,
+            format: StreamFormat::Text,
+            terminator: null,
+        );
+    }
+}

--- a/seed/php-sdk/server-sent-events/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/server-sent-events/tests/Core/Client/StreamTest.php
@@ -112,7 +112,6 @@ class StreamTest extends TestCase
 
         $events = iterator_to_array($stream->events(), false);
 
-        // Second event's malformed id is rejected; previous id persists per spec.
         $this->assertSame(['ok', 'ok'], array_map(fn (SseEvent $e) => $e->id, $events));
     }
 
@@ -152,7 +151,6 @@ class StreamTest extends TestCase
 
     public function testSseConstructorAcceptsUtf8CharsetParameter(): void
     {
-        // No exception: UTF-8 charset parameter is the spec-mandated value.
         $stream = new SseStream(
             self::response("data: hi\n\n", contentType: 'text/event-stream; charset=UTF-8'),
             fn (string $d): string => $d,
@@ -164,8 +162,6 @@ class StreamTest extends TestCase
 
     public function testSseConstructorToleratesMissingContentTypeHeader(): void
     {
-        // Some streaming servers omit the header; we don't reject — we just
-        // can't validate. (The wire format check is best-effort.)
         $response = \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
             ->createResponse(200)
             ->withBody(\Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()->createStream("data: hi\n\n"));
@@ -177,7 +173,6 @@ class StreamTest extends TestCase
 
     public function testStreamThrowsWhenLineBufferExceedsMaxSize(): void
     {
-        // A single unterminated "line" larger than the cap must abort iteration.
         $bigLine = str_repeat('A', 200) . "\n";
         $stream = new SseStream(
             self::response("data: " . $bigLine . "\n"),
@@ -194,17 +189,14 @@ class StreamTest extends TestCase
 
     public function testStreamThrowsBeforeAccumulatingPastMaxBufferOnLongRunningSseEvent(): void
     {
-        // The cap must fire during accumulation, not just at dispatch. A hostile
-        // stream sending many small `data:` lines without a closing blank line
-        // would otherwise grow $dataBuffer past the configured limit. Each line
-        // here is well under the 64-byte cap, but their cumulative `data:`
-        // append should trip the check before allocation balloons.
+        // Each line is well under the 64-byte cap; the cumulative `data:`
+        // append must trip the check before the buffer balloons.
         $manyDataLines = '';
         for ($i = 0; $i < 50; $i++) {
             $manyDataLines .= "data: chunk-$i\n";
         }
         $stream = new SseStream(
-            self::response($manyDataLines),  // no terminating "\n\n"
+            self::response($manyDataLines),
             fn (string $d): string => $d,
             terminator: null,
             maxBufferSize: 64,
@@ -218,8 +210,7 @@ class StreamTest extends TestCase
 
     public function testSseStripsUtf8BomFromStartOfStream(): void
     {
-        // WHATWG §9.2.4: a leading U+FEFF BOM must be stripped from the stream
-        // so the first field-name match isn't poisoned.
+        // WHATWG §9.2.4 requires a leading U+FEFF to be dropped.
         $body = "\xEF\xBB\xBFdata: hello\n\n";
         $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
 
@@ -228,7 +219,6 @@ class StreamTest extends TestCase
 
     public function testSseStripsBomOnlyAtVeryStart(): void
     {
-        // A BOM-looking sequence that appears mid-stream must NOT be stripped.
         $body = "data: first\n\ndata: \xEF\xBB\xBFsecond\n\n";
         $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
 

--- a/seed/php-sdk/server-sent-events/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/server-sent-events/tests/Core/Client/StreamTest.php
@@ -192,6 +192,49 @@ class StreamTest extends TestCase
         iterator_to_array($stream, false);
     }
 
+    public function testStreamThrowsBeforeAccumulatingPastMaxBufferOnLongRunningSseEvent(): void
+    {
+        // The cap must fire during accumulation, not just at dispatch. A hostile
+        // stream sending many small `data:` lines without a closing blank line
+        // would otherwise grow $dataBuffer past the configured limit. Each line
+        // here is well under the 64-byte cap, but their cumulative `data:`
+        // append should trip the check before allocation balloons.
+        $manyDataLines = '';
+        for ($i = 0; $i < 50; $i++) {
+            $manyDataLines .= "data: chunk-$i\n";
+        }
+        $stream = new SseStream(
+            self::response($manyDataLines),  // no terminating "\n\n"
+            fn (string $d): string => $d,
+            terminator: null,
+            maxBufferSize: 64,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/buffer/i');
+
+        iterator_to_array($stream, false);
+    }
+
+    public function testSseStripsUtf8BomFromStartOfStream(): void
+    {
+        // WHATWG §9.2.4: a leading U+FEFF BOM must be stripped from the stream
+        // so the first field-name match isn't poisoned.
+        $body = "\xEF\xBB\xBFdata: hello\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['hello'], iterator_to_array($stream, false));
+    }
+
+    public function testSseStripsBomOnlyAtVeryStart(): void
+    {
+        // A BOM-looking sequence that appears mid-stream must NOT be stripped.
+        $body = "data: first\n\ndata: \xEF\xBB\xBFsecond\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['first', "\xEF\xBB\xBFsecond"], iterator_to_array($stream, false));
+    }
+
     public function testJsonStreamYieldsOnePerLine(): void
     {
         $body = "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n";

--- a/seed/php-sdk/server-sent-events/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/server-sent-events/tests/Core/Client/StreamTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Seed\Tests\Core\Client;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Seed\Core\Client\JsonStream;
+use Seed\Core\Client\SseStream;
+use Seed\Core\Client\Stream;
+use Seed\Core\Client\TextStream;
+
+class StreamTest extends TestCase
+{
+    public function testSseParsesSingleEvent(): void
+    {
+        $body = "data: hello\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['hello'], iterator_to_array($stream, false));
+    }
+
+    public function testSseConcatenatesMultilineDataWithNewlines(): void
+    {
+        $body = "data: line one\ndata: line two\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(["line one\nline two"], iterator_to_array($stream, false));
+    }
+
+    public function testSseStripsLeadingSpaceFromFieldValues(): void
+    {
+        // SSE spec: a single leading space in the field value is stripped.
+        $body = "data: with-leading-space\ndata:no-leading-space\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(["with-leading-space\nno-leading-space"], iterator_to_array($stream, false));
+    }
+
+    public function testSseIgnoresCommentLines(): void
+    {
+        $body = ": this is a comment\ndata: payload\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['payload'], iterator_to_array($stream, false));
+    }
+
+    public function testSseTerminatorEndsIterationCleanly(): void
+    {
+        $body = "data: first\n\ndata: [DONE]\n\ndata: never-yielded\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, '[DONE]');
+
+        $this->assertSame(['first'], iterator_to_array($stream, false));
+    }
+
+    public function testSseNormalizesCrlfAndLoneCr(): void
+    {
+        $body = "data: a\r\n\r\ndata: b\rdata: c\r\r";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['a', "b\nc"], iterator_to_array($stream, false));
+    }
+
+    public function testSseDispatchesTrailingEventWithoutBlankLine(): void
+    {
+        $body = "data: incomplete";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['incomplete'], iterator_to_array($stream, false));
+    }
+
+    public function testSseAppliesDeserializerOncePerEvent(): void
+    {
+        $body = "data: {\"n\":1}\n\ndata: {\"n\":2}\n\n";
+        $stream = new SseStream(self::response($body), self::jsonDecoder(), null);
+
+        $this->assertSame([['n' => 1], ['n' => 2]], iterator_to_array($stream, false));
+    }
+
+    public function testJsonStreamYieldsOnePerLine(): void
+    {
+        $body = "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n";
+        $stream = new JsonStream(self::response($body), self::jsonDecoder(), null);
+
+        $this->assertSame([['n' => 1], ['n' => 2], ['n' => 3]], iterator_to_array($stream, false));
+    }
+
+    public function testJsonStreamSkipsEmptyLines(): void
+    {
+        $body = "{\"a\":1}\n\n{\"a\":2}\n";
+        $stream = new JsonStream(self::response($body), self::jsonDecoder(), null);
+
+        $this->assertSame([['a' => 1], ['a' => 2]], iterator_to_array($stream, false));
+    }
+
+    public function testJsonStreamTerminatorEndsIteration(): void
+    {
+        $body = "{\"a\":1}\n[DONE]\n{\"a\":2}\n";
+        $stream = new JsonStream(self::response($body), self::jsonDecoder(), '[DONE]');
+
+        $this->assertSame([['a' => 1]], iterator_to_array($stream, false));
+    }
+
+    /**
+     * @return \Closure(string): array<string, mixed>
+     */
+    private static function jsonDecoder(): \Closure
+    {
+        return static function (string $raw): array {
+            /** @var array<string, mixed> $decoded */
+            $decoded = json_decode($raw, true);
+            return $decoded;
+        };
+    }
+
+    public function testTextStreamYieldsRawLines(): void
+    {
+        $body = "alpha\nbeta\ngamma\n";
+        $stream = new TextStream(self::response($body));
+
+        $this->assertSame(['alpha', 'beta', 'gamma'], iterator_to_array($stream, false));
+    }
+
+    public function testTextStreamPreservesEmptyLines(): void
+    {
+        $body = "alpha\n\nbeta\n";
+        $stream = new TextStream(self::response($body));
+
+        $this->assertSame(['alpha', '', 'beta'], iterator_to_array($stream, false));
+    }
+
+    /**
+     * Build a PSR-7 ResponseInterface with the given body string, using auto-discovery
+     * so we don't depend on any specific implementation.
+     */
+    private static function response(string $body): ResponseInterface
+    {
+        return \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
+            ->createResponse(200)
+            ->withBody(
+                \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()
+                    ->createStream($body),
+            );
+    }
+}

--- a/seed/php-sdk/server-sent-events/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/server-sent-events/tests/Core/Client/StreamTest.php
@@ -4,7 +4,9 @@ namespace Seed\Tests\Core\Client;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 use Seed\Core\Client\JsonStream;
+use Seed\Core\Client\SseEvent;
 use Seed\Core\Client\SseStream;
 use Seed\Core\Client\Stream;
 use Seed\Core\Client\TextStream;
@@ -76,6 +78,120 @@ class StreamTest extends TestCase
         $this->assertSame([['n' => 1], ['n' => 2]], iterator_to_array($stream, false));
     }
 
+    public function testSseEventsExposesEventIdAndRetryMetadata(): void
+    {
+        $body = "event: chat\nid: msg-1\nretry: 5000\ndata: hi\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        $this->assertCount(1, $events);
+        $this->assertInstanceOf(SseEvent::class, $events[0]);
+        $this->assertSame('hi', $events[0]->data);
+        $this->assertSame('chat', $events[0]->event);
+        $this->assertSame('msg-1', $events[0]->id);
+        $this->assertSame(5000, $events[0]->retry);
+    }
+
+    public function testSseEventsPersistsLastEventIdAcrossEventsPerSpec(): void
+    {
+        // Per WHATWG SSE: once an `id:` is set it persists across subsequent
+        // events until explicitly overridden.
+        $body = "id: persistent\ndata: a\n\ndata: b\n\nid: replaced\ndata: c\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        $this->assertSame(['persistent', 'persistent', 'replaced'], array_map(fn (SseEvent $e) => $e->id, $events));
+    }
+
+    public function testSseEventsIgnoresIdContainingNullByte(): void
+    {
+        $body = "id: ok\ndata: first\n\nid: bad\0id\ndata: second\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        // Second event's malformed id is rejected; previous id persists per spec.
+        $this->assertSame(['ok', 'ok'], array_map(fn (SseEvent $e) => $e->id, $events));
+    }
+
+    public function testSseEventsIgnoresNonIntegerRetry(): void
+    {
+        $body = "retry: not-a-number\ndata: hi\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        $this->assertNull($events[0]->retry);
+    }
+
+    public function testSseConstructorRejectsNonSseContentType(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/text\/event-stream/');
+
+        new SseStream(
+            self::response('data: x\n\n', contentType: 'application/json'),
+            fn (string $d): string => $d,
+            null,
+        );
+    }
+
+    public function testSseConstructorRejectsNonUtf8Charset(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/charset/i');
+
+        new SseStream(
+            self::response('data: x\n\n', contentType: 'text/event-stream; charset=iso-8859-1'),
+            fn (string $d): string => $d,
+            null,
+        );
+    }
+
+    public function testSseConstructorAcceptsUtf8CharsetParameter(): void
+    {
+        // No exception: UTF-8 charset parameter is the spec-mandated value.
+        $stream = new SseStream(
+            self::response("data: hi\n\n", contentType: 'text/event-stream; charset=UTF-8'),
+            fn (string $d): string => $d,
+            null,
+        );
+
+        $this->assertSame(['hi'], iterator_to_array($stream, false));
+    }
+
+    public function testSseConstructorToleratesMissingContentTypeHeader(): void
+    {
+        // Some streaming servers omit the header; we don't reject — we just
+        // can't validate. (The wire format check is best-effort.)
+        $response = \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
+            ->createResponse(200)
+            ->withBody(\Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()->createStream("data: hi\n\n"));
+
+        $stream = new SseStream($response, fn (string $d): string => $d, null);
+
+        $this->assertSame(['hi'], iterator_to_array($stream, false));
+    }
+
+    public function testStreamThrowsWhenLineBufferExceedsMaxSize(): void
+    {
+        // A single unterminated "line" larger than the cap must abort iteration.
+        $bigLine = str_repeat('A', 200) . "\n";
+        $stream = new SseStream(
+            self::response("data: " . $bigLine . "\n"),
+            fn (string $d): string => $d,
+            terminator: null,
+            maxBufferSize: 64,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/buffer/i');
+
+        iterator_to_array($stream, false);
+    }
+
     public function testJsonStreamYieldsOnePerLine(): void
     {
         $body = "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n";
@@ -129,13 +245,17 @@ class StreamTest extends TestCase
     }
 
     /**
-     * Build a PSR-7 ResponseInterface with the given body string, using auto-discovery
-     * so we don't depend on any specific implementation.
+     * Build a PSR-7 ResponseInterface with the given body. The Content-Type
+     * defaults to `text/event-stream` so SSE tests just work; pass an override
+     * for the validation-error cases.
      */
-    private static function response(string $body): ResponseInterface
-    {
+    private static function response(
+        string $body,
+        string $contentType = 'text/event-stream',
+    ): ResponseInterface {
         return \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
             ->createResponse(200)
+            ->withHeader('Content-Type', $contentType)
             ->withBody(
                 \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()
                     ->createStream($body),

--- a/seed/php-sdk/streaming-parameter/.fern/metadata.json
+++ b/seed/php-sdk/streaming-parameter/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/streaming/.fern/metadata.json
+++ b/seed/php-sdk/streaming/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/streaming/reference.md
+++ b/seed/php-sdk/streaming/reference.md
@@ -1,6 +1,6 @@
 # Reference
 ## Dummy
-<details><summary><code>$client-&gt;dummy-&gt;generateStream($request)</code></summary>
+<details><summary><code>$client-&gt;dummy-&gt;generateStream($request) -> JsonStream</code></summary>
 <dl>
 <dd>
 

--- a/seed/php-sdk/streaming/src/Core/Client/JsonStream.php
+++ b/seed/php-sdk/streaming/src/Core/Client/JsonStream.php
@@ -20,17 +20,20 @@ class JsonStream extends Stream
      *   JSON payload string.
      * @param ?string $terminator Optional sentinel line that ends the stream
      *   when received. Pass `null` to read until EOF.
+     * @param int $maxBufferSize See `Stream::__construct`. Defaults to 1 MiB.
      */
     public function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         ?string $terminator = null,
+        int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
     ) {
         parent::__construct(
             response: $response,
             deserializer: $deserializer,
             format: StreamFormat::Json,
             terminator: $terminator,
+            maxBufferSize: $maxBufferSize,
         );
     }
 }

--- a/seed/php-sdk/streaming/src/Core/Client/JsonStream.php
+++ b/seed/php-sdk/streaming/src/Core/Client/JsonStream.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Closure;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Iterates a newline-delimited JSON (NDJSON) response body, yielding one
+ * deserialized chunk per non-empty line.
+ *
+ * @template T
+ * @extends Stream<T>
+ */
+class JsonStream extends Stream
+{
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param Closure(string): T $deserializer Called once per line with the raw
+     *   JSON payload string.
+     * @param ?string $terminator Optional sentinel line that ends the stream
+     *   when received. Pass `null` to read until EOF.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Closure $deserializer,
+        ?string $terminator = null,
+    ) {
+        parent::__construct(
+            response: $response,
+            deserializer: $deserializer,
+            format: StreamFormat::Json,
+            terminator: $terminator,
+        );
+    }
+}

--- a/seed/php-sdk/streaming/src/Core/Client/SseEvent.php
+++ b/seed/php-sdk/streaming/src/Core/Client/SseEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Seed\Core\Client;
+
+/**
+ * A single Server-Sent Event with its WHATWG metadata fields.
+ *
+ * Returned by `SseStream::events()`. Use plain `foreach ($stream as $payload)` if
+ * metadata isn't needed and you only want the deserialized `data` field.
+ *
+ * @template T
+ */
+final class SseEvent
+{
+    /**
+     * @param T $data Deserialized payload from the `data:` field(s). Multi-line
+     *   data is joined with a single newline before deserialization.
+     * @param string $event Value of the `event:` field, or empty string if not set.
+     * @param string $id Most recent `id:` field value. Per the WHATWG spec, this
+     *   persists across events: a subsequent event without an explicit `id:`
+     *   inherits the previous one. Empty string until the first id is observed.
+     * @param ?int $retry Reconnection time in milliseconds from the `retry:` field,
+     *   or null if not set or unparseable.
+     */
+    public function __construct(
+        public readonly mixed $data,
+        public readonly string $event = '',
+        public readonly string $id = '',
+        public readonly ?int $retry = null,
+    ) {
+    }
+}

--- a/seed/php-sdk/streaming/src/Core/Client/SseStream.php
+++ b/seed/php-sdk/streaming/src/Core/Client/SseStream.php
@@ -56,7 +56,7 @@ class SseStream extends Stream
     {
         foreach ($this->iterateRawSseEvents() as $raw) {
             yield new SseEvent(
-                data: ($this->deserializer)($raw['data']),
+                data: $this->deserialize($raw['data']),
                 event: $raw['event'],
                 id: $raw['id'],
                 retry: $raw['retry'],

--- a/seed/php-sdk/streaming/src/Core/Client/SseStream.php
+++ b/seed/php-sdk/streaming/src/Core/Client/SseStream.php
@@ -3,7 +3,9 @@
 namespace Seed\Core\Client;
 
 use Closure;
+use Generator;
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 
 /**
  * Iterates a `text/event-stream` (SSE) response body, yielding one deserialized
@@ -21,17 +23,79 @@ class SseStream extends Stream
      * @param ?string $terminator Optional sentinel payload that ends the stream
      *   when received. Defaults to '[DONE]', a common SSE convention.
      *   Pass `null` to disable terminator handling.
+     * @param int $maxBufferSize See `Stream::__construct`. Defaults to 1 MiB.
      */
     public function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         ?string $terminator = '[DONE]',
+        int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
     ) {
+        self::validateContentType($response);
         parent::__construct(
             response: $response,
             deserializer: $deserializer,
             format: StreamFormat::Sse,
             terminator: $terminator,
+            maxBufferSize: $maxBufferSize,
         );
+    }
+
+    /**
+     * Iterates the stream yielding both the deserialized payload and the
+     * accompanying SSE metadata (event type, id, retry). Use this when you
+     * need the event field (e.g. for event-typed unions) or `Last-Event-ID`
+     * for resumption logic.
+     *
+     * For data-only iteration, use this object directly as an iterable:
+     * `foreach ($stream as $event) { ... }`.
+     *
+     * @return Generator<int, SseEvent<T>>
+     */
+    public function events(): Generator
+    {
+        foreach ($this->iterateRawSseEvents() as $raw) {
+            yield new SseEvent(
+                data: ($this->deserializer)($raw['data']),
+                event: $raw['event'],
+                id: $raw['id'],
+                retry: $raw['retry'],
+            );
+        }
+    }
+
+    /**
+     * Validates that the response's Content-Type matches an SSE stream.
+     *
+     * Per WHATWG, the SSE wire format is always UTF-8; we reject explicit
+     * non-UTF-8 charset parameters rather than risk silent mojibake. A missing
+     * Content-Type header is tolerated — some servers omit it on streaming
+     * responses — but a wrong media type or wrong charset always throws.
+     */
+    private static function validateContentType(ResponseInterface $response): void
+    {
+        $contentType = $response->getHeaderLine('Content-Type');
+        if ($contentType === '') {
+            return;
+        }
+        $parts = explode(';', $contentType);
+        $mediaType = strtolower(trim($parts[0]));
+        if ($mediaType !== 'text/event-stream') {
+            throw new RuntimeException(
+                "Expected Content-Type 'text/event-stream' for SSE response, got '{$mediaType}'",
+            );
+        }
+        foreach (array_slice($parts, 1) as $param) {
+            $param = trim($param);
+            if (stripos($param, 'charset=') !== 0) {
+                continue;
+            }
+            $charset = strtolower(trim(substr($param, 8), " \"'"));
+            if ($charset !== '' && $charset !== 'utf-8' && $charset !== 'utf8') {
+                throw new RuntimeException(
+                    "Unsupported SSE charset '{$charset}'; per the WHATWG spec only UTF-8 is permitted",
+                );
+            }
+        }
     }
 }

--- a/seed/php-sdk/streaming/src/Core/Client/SseStream.php
+++ b/seed/php-sdk/streaming/src/Core/Client/SseStream.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Closure;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Iterates a `text/event-stream` (SSE) response body, yielding one deserialized
+ * event per dispatched frame.
+ *
+ * @template T
+ * @extends Stream<T>
+ */
+class SseStream extends Stream
+{
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param Closure(string): T $deserializer Called once per dispatched event
+     *   with the raw `data:` payload string (newline-joined for multi-line frames).
+     * @param ?string $terminator Optional sentinel payload that ends the stream
+     *   when received. Defaults to '[DONE]', a common SSE convention.
+     *   Pass `null` to disable terminator handling.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Closure $deserializer,
+        ?string $terminator = '[DONE]',
+    ) {
+        parent::__construct(
+            response: $response,
+            deserializer: $deserializer,
+            format: StreamFormat::Sse,
+            terminator: $terminator,
+        );
+    }
+}

--- a/seed/php-sdk/streaming/src/Core/Client/Stream.php
+++ b/seed/php-sdk/streaming/src/Core/Client/Stream.php
@@ -235,8 +235,12 @@ class Stream implements IteratorAggregate
             if ($pendingCr && $chunk[0] === "\n") {
                 $chunk = substr($chunk, 1);
             }
-            $pendingCr = str_ends_with($chunk, "\r");
-            $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
+            if (str_contains($chunk, "\r")) {
+                $pendingCr = str_ends_with($chunk, "\r");
+                $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
+            } else {
+                $pendingCr = false;
+            }
             $buffer = $this->appendWithinCap($buffer, $chunk);
             if (!$bomChecked && strlen($buffer) >= 3) {
                 $bomChecked = true;

--- a/seed/php-sdk/streaming/src/Core/Client/Stream.php
+++ b/seed/php-sdk/streaming/src/Core/Client/Stream.php
@@ -7,6 +7,7 @@ use Generator;
 use IteratorAggregate;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use RuntimeException;
 
 enum StreamFormat: string
 {
@@ -29,17 +30,23 @@ enum StreamFormat: string
  * When `$terminator` is set, an event whose payload equals the terminator
  * ends iteration cleanly (e.g. `[DONE]` for SSE).
  *
+ * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams that
+ * never emit a frame boundary: if the line buffer or a single event's data
+ * exceeds the cap, iteration aborts with `RuntimeException`.
+ *
  * @template T
  * @implements IteratorAggregate<int, T>
  */
 class Stream implements IteratorAggregate
 {
+    public const DEFAULT_MAX_BUFFER_SIZE = 1048576;
+
     private const READ_CHUNK_SIZE = 8192;
 
     private StreamInterface $body;
 
     /** @var Closure(string): T */
-    private Closure $deserializer;
+    protected Closure $deserializer;
 
     /**
      * @param ResponseInterface $response The HTTP response to stream from.
@@ -48,18 +55,25 @@ class Stream implements IteratorAggregate
      * @param StreamFormat $format Framing strategy for the stream.
      * @param ?string $terminator Optional sentinel value that ends the stream when matched
      *   against the raw frame payload (e.g. '[DONE]').
+     * @param int $maxBufferSize Maximum size in bytes for the line buffer or a single SSE
+     *   event's accumulated `data` field. Exceeding this throws `RuntimeException` to
+     *   guard against pathological streams. Defaults to 1 MiB.
      */
     public function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         private readonly StreamFormat $format = StreamFormat::Sse,
         private readonly ?string $terminator = null,
+        private readonly int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
     ) {
         $this->body = $response->getBody();
         $this->deserializer = $deserializer;
     }
 
     /**
+     * Iteration is one-shot: PSR-7 bodies are forward-only, so re-iterating the
+     * same `Stream` instance yields nothing useful.
+     *
      * @return Generator<int, T>
      */
     public function getIterator(): Generator
@@ -72,35 +86,57 @@ class Stream implements IteratorAggregate
     }
 
     /**
-     * WHATWG-compliant SSE frame parser.
-     *
      * @return Generator<int, T>
      */
     private function iterateSse(): Generator
     {
+        foreach ($this->iterateRawSseEvents() as $raw) {
+            yield ($this->deserializer)($raw['data']);
+        }
+    }
+
+    /**
+     * Iterates the SSE stream yielding raw envelopes with WHATWG metadata fields
+     * intact. Yields plain associative arrays — not `SseEvent` objects — so the
+     * data-only iteration path doesn't pay the allocation cost; `SseStream::events()`
+     * constructs the public `SseEvent<T>` on top.
+     *
+     * Per WHATWG: the `id:` field persists across events within this iteration;
+     * the configured `terminator`, if present, ends iteration when matched against
+     * `data`.
+     *
+     * @internal
+     * @return Generator<int, array{data: string, event: string, id: string, retry: ?int}>
+     */
+    protected function iterateRawSseEvents(): Generator
+    {
         $dataBuffer = '';
+        $eventType = '';
+        $lastEventId = '';
+        $retry = null;
         foreach ($this->readLines() as $line) {
             if ($line === '') {
-                // Blank line dispatches the accumulated event.
                 if ($dataBuffer === '') {
                     continue;
                 }
-                // Strip the single trailing "\n" added by the field append step.
+                // Strip the single trailing "\n" added by the field-append step.
                 $payload = substr($dataBuffer, 0, -1);
+                $this->assertBufferWithinCap(strlen($payload));
                 $dataBuffer = '';
                 if ($this->terminator !== null && $payload === $this->terminator) {
                     return;
                 }
-                yield ($this->deserializer)($payload);
+                yield ['data' => $payload, 'event' => $eventType, 'id' => $lastEventId, 'retry' => $retry];
+                // Per WHATWG: do NOT reset lastEventId between events.
+                $eventType = '';
+                $retry = null;
                 continue;
             }
             if (str_starts_with($line, ':')) {
-                // SSE comment — ignored per spec.
                 continue;
             }
             $colonPos = strpos($line, ':');
             if ($colonPos === false) {
-                // Line is a field name with empty value; only `data` is meaningful for us.
                 if ($line === 'data') {
                     $dataBuffer .= "\n";
                 }
@@ -111,23 +147,38 @@ class Stream implements IteratorAggregate
             if (str_starts_with($value, ' ')) {
                 $value = substr($value, 1);
             }
-            // Only `data` is yielded; `event`/`id`/`retry` are accepted but unused here.
-            if ($field === 'data') {
-                $dataBuffer .= $value . "\n";
+            switch ($field) {
+                case 'data':
+                    $dataBuffer .= $value . "\n";
+                    break;
+                case 'event':
+                    $eventType = $value;
+                    break;
+                case 'id':
+                    // WHATWG: ignore IDs that contain a NULL byte.
+                    if (!str_contains($value, "\0")) {
+                        $lastEventId = $value;
+                    }
+                    break;
+                case 'retry':
+                    // WHATWG: ignore the value if it isn't a base-10 integer.
+                    if ($value !== '' && ctype_digit($value)) {
+                        $retry = (int) $value;
+                    }
+                    break;
             }
         }
         // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
         if ($dataBuffer !== '') {
             $payload = substr($dataBuffer, 0, -1);
+            $this->assertBufferWithinCap(strlen($payload));
             if ($this->terminator === null || $payload !== $this->terminator) {
-                yield ($this->deserializer)($payload);
+                yield ['data' => $payload, 'event' => $eventType, 'id' => $lastEventId, 'retry' => $retry];
             }
         }
     }
 
     /**
-     * Newline-delimited frames (NDJSON, line-by-line).
-     *
      * @return Generator<int, T>
      */
     private function iterateDelimited(): Generator
@@ -144,8 +195,6 @@ class Stream implements IteratorAggregate
     }
 
     /**
-     * Raw newline-delimited text frames.
-     *
      * @return Generator<int, T>
      */
     private function iterateText(): Generator
@@ -159,6 +208,10 @@ class Stream implements IteratorAggregate
      * Reads the response body and yields complete lines, normalizing CRLF/CR
      * to LF per the WHATWG SSE spec. Trailing partial content (without a
      * terminating newline) is emitted as a final line.
+     *
+     * Throws `RuntimeException` if the accumulated buffer exceeds the configured
+     * cap — that means we've read more than `maxBufferSize` bytes without ever
+     * seeing a line break, which indicates a malformed or hostile stream.
      *
      * @return Generator<int, string>
      */
@@ -180,6 +233,7 @@ class Stream implements IteratorAggregate
             // Normalize line endings on just this chunk: "\r\n" and lone "\r" -> "\n".
             $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
             $buffer .= $chunk;
+            $this->assertBufferWithinCap(strlen($buffer));
             while (($lfPos = strpos($buffer, "\n")) !== false) {
                 yield substr($buffer, 0, $lfPos);
                 $buffer = substr($buffer, $lfPos + 1);
@@ -187,6 +241,15 @@ class Stream implements IteratorAggregate
         }
         if ($buffer !== '') {
             yield $buffer;
+        }
+    }
+
+    private function assertBufferWithinCap(int $size): void
+    {
+        if ($size > $this->maxBufferSize) {
+            throw new RuntimeException(
+                "Stream buffer exceeded maximum size of {$this->maxBufferSize} bytes",
+            );
         }
     }
 

--- a/seed/php-sdk/streaming/src/Core/Client/Stream.php
+++ b/seed/php-sdk/streaming/src/Core/Client/Stream.php
@@ -23,15 +23,12 @@ use RuntimeException;
  * When `$terminator` is set, an event whose payload equals the terminator
  * ends iteration cleanly (e.g. `[DONE]` for SSE).
  *
- * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams that
- * never emit a frame boundary: if the line buffer or a single event's data
- * exceeds the cap, iteration aborts with `RuntimeException`. The cap is
- * enforced *before* allocation, not after — a hostile stream cannot drive us
- * past the limit and then trip the check.
+ * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams
+ * that never emit a frame boundary: if the line buffer or a single event's
+ * data exceeds the cap, iteration aborts with `RuntimeException`.
  *
- * Direct instantiation of `Stream` is not supported; use `SseStream`,
- * `JsonStream`, or `TextStream` instead. The constructor is `protected` to
- * enforce this.
+ * Direct instantiation is not supported; use `SseStream`, `JsonStream`, or
+ * `TextStream`.
  *
  * @template T
  * @implements IteratorAggregate<int, T>
@@ -131,7 +128,6 @@ class Stream implements IteratorAggregate
                 if ($dataBuffer === '') {
                     continue;
                 }
-                // Strip the single trailing "\n" added by the field-append step.
                 $payload = substr($dataBuffer, 0, -1);
                 $dataBuffer = '';
                 if ($this->terminator !== null && $payload === $this->terminator) {
@@ -160,9 +156,6 @@ class Stream implements IteratorAggregate
             }
             switch ($field) {
                 case 'data':
-                    // Enforce the cap before allocation: a hostile stream emitting
-                    // many `data:` lines without a dispatching blank line cannot
-                    // drive us past the limit and then trip the check.
                     $dataBuffer = $this->appendWithinCap($dataBuffer, $value . "\n");
                     break;
                 case 'event':
@@ -182,7 +175,7 @@ class Stream implements IteratorAggregate
                     break;
             }
         }
-        // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
+        // Flush a trailing event that lacked a closing blank line.
         if ($dataBuffer !== '') {
             $payload = substr($dataBuffer, 0, -1);
             if ($this->terminator === null || $payload !== $this->terminator) {
@@ -266,10 +259,8 @@ class Stream implements IteratorAggregate
     }
 
     /**
-     * Appends $suffix to $buffer, throwing `RuntimeException` if the result
-     * would exceed `maxBufferSize`. The cap is enforced before the
-     * concatenation allocates, so a runaway stream is bounded by the configured
-     * limit rather than by available memory.
+     * Appends $suffix to $buffer, throwing `RuntimeException` if the resulting
+     * size would exceed `maxBufferSize`.
      */
     private function appendWithinCap(string $buffer, string $suffix): string
     {

--- a/seed/php-sdk/streaming/src/Core/Client/Stream.php
+++ b/seed/php-sdk/streaming/src/Core/Client/Stream.php
@@ -9,13 +9,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 
-enum StreamFormat: string
-{
-    case Sse = 'sse';
-    case Json = 'json';
-    case Text = 'text';
-}
-
 /**
  * Iterates a streaming HTTP response body frame-by-frame.
  *
@@ -32,21 +25,28 @@ enum StreamFormat: string
  *
  * A `$maxBufferSize` cap (default 1 MiB) guards against malformed streams that
  * never emit a frame boundary: if the line buffer or a single event's data
- * exceeds the cap, iteration aborts with `RuntimeException`.
+ * exceeds the cap, iteration aborts with `RuntimeException`. The cap is
+ * enforced *before* allocation, not after — a hostile stream cannot drive us
+ * past the limit and then trip the check.
+ *
+ * Direct instantiation of `Stream` is not supported; use `SseStream`,
+ * `JsonStream`, or `TextStream` instead. The constructor is `protected` to
+ * enforce this.
  *
  * @template T
  * @implements IteratorAggregate<int, T>
  */
 class Stream implements IteratorAggregate
 {
-    public const DEFAULT_MAX_BUFFER_SIZE = 1048576;
+    public const DEFAULT_MAX_BUFFER_SIZE = 1_048_576;
 
     private const READ_CHUNK_SIZE = 8192;
+    private const UTF8_BOM = "\xEF\xBB\xBF";
 
     private StreamInterface $body;
 
     /** @var Closure(string): T */
-    protected Closure $deserializer;
+    private Closure $deserializer;
 
     /**
      * @param ResponseInterface $response The HTTP response to stream from.
@@ -59,7 +59,7 @@ class Stream implements IteratorAggregate
      *   event's accumulated `data` field. Exceeding this throws `RuntimeException` to
      *   guard against pathological streams. Defaults to 1 MiB.
      */
-    public function __construct(
+    protected function __construct(
         ResponseInterface $response,
         Closure $deserializer,
         private readonly StreamFormat $format = StreamFormat::Sse,
@@ -83,6 +83,18 @@ class Stream implements IteratorAggregate
             StreamFormat::Json => $this->iterateDelimited(),
             StreamFormat::Text => $this->iterateText(),
         };
+    }
+
+    /**
+     * Applies the configured deserializer to a single raw frame payload.
+     * Available to subclasses (notably `SseStream::events()`) so they can
+     * construct typed envelopes without accessing the closure directly.
+     *
+     * @return T
+     */
+    protected function deserialize(string $raw): mixed
+    {
+        return ($this->deserializer)($raw);
     }
 
     /**
@@ -121,7 +133,6 @@ class Stream implements IteratorAggregate
                 }
                 // Strip the single trailing "\n" added by the field-append step.
                 $payload = substr($dataBuffer, 0, -1);
-                $this->assertBufferWithinCap(strlen($payload));
                 $dataBuffer = '';
                 if ($this->terminator !== null && $payload === $this->terminator) {
                     return;
@@ -138,7 +149,7 @@ class Stream implements IteratorAggregate
             $colonPos = strpos($line, ':');
             if ($colonPos === false) {
                 if ($line === 'data') {
-                    $dataBuffer .= "\n";
+                    $dataBuffer = $this->appendWithinCap($dataBuffer, "\n");
                 }
                 continue;
             }
@@ -149,7 +160,10 @@ class Stream implements IteratorAggregate
             }
             switch ($field) {
                 case 'data':
-                    $dataBuffer .= $value . "\n";
+                    // Enforce the cap before allocation: a hostile stream emitting
+                    // many `data:` lines without a dispatching blank line cannot
+                    // drive us past the limit and then trip the check.
+                    $dataBuffer = $this->appendWithinCap($dataBuffer, $value . "\n");
                     break;
                 case 'event':
                     $eventType = $value;
@@ -171,7 +185,6 @@ class Stream implements IteratorAggregate
         // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
         if ($dataBuffer !== '') {
             $payload = substr($dataBuffer, 0, -1);
-            $this->assertBufferWithinCap(strlen($payload));
             if ($this->terminator === null || $payload !== $this->terminator) {
                 yield ['data' => $payload, 'event' => $eventType, 'id' => $lastEventId, 'retry' => $retry];
             }
@@ -206,12 +219,13 @@ class Stream implements IteratorAggregate
 
     /**
      * Reads the response body and yields complete lines, normalizing CRLF/CR
-     * to LF per the WHATWG SSE spec. Trailing partial content (without a
-     * terminating newline) is emitted as a final line.
+     * to LF per the WHATWG SSE spec. Strips a single UTF-8 BOM if present at
+     * the start of the stream (WHATWG §9.2.4). Trailing partial content
+     * (without a terminating newline) is emitted as a final line.
      *
-     * Throws `RuntimeException` if the accumulated buffer exceeds the configured
-     * cap — that means we've read more than `maxBufferSize` bytes without ever
-     * seeing a line break, which indicates a malformed or hostile stream.
+     * `$pendingCr` tracks whether the prior chunk's last byte was `\r`, so a
+     * `\r\n` sequence split across a read boundary collapses to one terminator
+     * instead of two.
      *
      * @return Generator<int, string>
      */
@@ -219,38 +233,52 @@ class Stream implements IteratorAggregate
     {
         $buffer = '';
         $pendingCr = false;
+        $bomChecked = false;
         while (!$this->body->eof()) {
             $chunk = $this->body->read(self::READ_CHUNK_SIZE);
             if ($chunk === '') {
                 continue;
             }
-            // If the previous chunk ended on "\r", swallow a leading "\n" so we don't
-            // emit a spurious blank line for a "\r\n" sequence split across chunks.
             if ($pendingCr && $chunk[0] === "\n") {
                 $chunk = substr($chunk, 1);
             }
             $pendingCr = str_ends_with($chunk, "\r");
-            // Normalize line endings on just this chunk: "\r\n" and lone "\r" -> "\n".
             $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
-            $buffer .= $chunk;
-            $this->assertBufferWithinCap(strlen($buffer));
+            $buffer = $this->appendWithinCap($buffer, $chunk);
+            if (!$bomChecked && strlen($buffer) >= 3) {
+                $bomChecked = true;
+                if (str_starts_with($buffer, self::UTF8_BOM)) {
+                    $buffer = substr($buffer, 3);
+                }
+            }
             while (($lfPos = strpos($buffer, "\n")) !== false) {
                 yield substr($buffer, 0, $lfPos);
                 $buffer = substr($buffer, $lfPos + 1);
             }
+        }
+        // BOM may not have been checked yet if the entire body was < 3 bytes.
+        if (!$bomChecked && str_starts_with($buffer, self::UTF8_BOM)) {
+            $buffer = substr($buffer, 3);
         }
         if ($buffer !== '') {
             yield $buffer;
         }
     }
 
-    private function assertBufferWithinCap(int $size): void
+    /**
+     * Appends $suffix to $buffer, throwing `RuntimeException` if the result
+     * would exceed `maxBufferSize`. The cap is enforced before the
+     * concatenation allocates, so a runaway stream is bounded by the configured
+     * limit rather than by available memory.
+     */
+    private function appendWithinCap(string $buffer, string $suffix): string
     {
-        if ($size > $this->maxBufferSize) {
+        if (strlen($buffer) + strlen($suffix) > $this->maxBufferSize) {
             throw new RuntimeException(
-                "Stream buffer exceeded maximum size of {$this->maxBufferSize} bytes",
+                "Stream buffer would exceed maximum size of {$this->maxBufferSize} bytes",
             );
         }
+        return $buffer . $suffix;
     }
 
     public function __destruct()

--- a/seed/php-sdk/streaming/src/Core/Client/Stream.php
+++ b/seed/php-sdk/streaming/src/Core/Client/Stream.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Closure;
+use Generator;
+use IteratorAggregate;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+enum StreamFormat: string
+{
+    case Sse = 'sse';
+    case Json = 'json';
+    case Text = 'text';
+}
+
+/**
+ * Iterates a streaming HTTP response body frame-by-frame.
+ *
+ * Parameterized by `$format`, which selects the framing strategy:
+ *   - 'sse'  — WHATWG Server-Sent Events: lines starting with `data:` (and
+ *              optionally `event:`, `id:`, `retry:`); a blank line dispatches
+ *              the accumulated event. Multi-line `data` fields are joined
+ *              with newlines.
+ *   - 'json' — newline-delimited JSON: each non-empty line is one frame.
+ *   - 'text' — newline-delimited text: each line is yielded as a raw string.
+ *
+ * When `$terminator` is set, an event whose payload equals the terminator
+ * ends iteration cleanly (e.g. `[DONE]` for SSE).
+ *
+ * @template T
+ * @implements IteratorAggregate<int, T>
+ */
+class Stream implements IteratorAggregate
+{
+    private const READ_CHUNK_SIZE = 8192;
+
+    private StreamInterface $body;
+
+    /** @var Closure(string): T */
+    private Closure $deserializer;
+
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param Closure(string): T $deserializer Called once per frame with the raw payload string.
+     *   For text streams, the deserializer is typically `fn(string $line) => $line`.
+     * @param StreamFormat $format Framing strategy for the stream.
+     * @param ?string $terminator Optional sentinel value that ends the stream when matched
+     *   against the raw frame payload (e.g. '[DONE]').
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Closure $deserializer,
+        private readonly StreamFormat $format = StreamFormat::Sse,
+        private readonly ?string $terminator = null,
+    ) {
+        $this->body = $response->getBody();
+        $this->deserializer = $deserializer;
+    }
+
+    /**
+     * @return Generator<int, T>
+     */
+    public function getIterator(): Generator
+    {
+        return match ($this->format) {
+            StreamFormat::Sse => $this->iterateSse(),
+            StreamFormat::Json => $this->iterateDelimited(),
+            StreamFormat::Text => $this->iterateText(),
+        };
+    }
+
+    /**
+     * WHATWG-compliant SSE frame parser.
+     *
+     * @return Generator<int, T>
+     */
+    private function iterateSse(): Generator
+    {
+        $dataBuffer = '';
+        foreach ($this->readLines() as $line) {
+            if ($line === '') {
+                // Blank line dispatches the accumulated event.
+                if ($dataBuffer === '') {
+                    continue;
+                }
+                // Strip the single trailing "\n" added by the field append step.
+                $payload = substr($dataBuffer, 0, -1);
+                $dataBuffer = '';
+                if ($this->terminator !== null && $payload === $this->terminator) {
+                    return;
+                }
+                yield ($this->deserializer)($payload);
+                continue;
+            }
+            if (str_starts_with($line, ':')) {
+                // SSE comment — ignored per spec.
+                continue;
+            }
+            $colonPos = strpos($line, ':');
+            if ($colonPos === false) {
+                // Line is a field name with empty value; only `data` is meaningful for us.
+                if ($line === 'data') {
+                    $dataBuffer .= "\n";
+                }
+                continue;
+            }
+            $field = substr($line, 0, $colonPos);
+            $value = substr($line, $colonPos + 1);
+            if (str_starts_with($value, ' ')) {
+                $value = substr($value, 1);
+            }
+            // Only `data` is yielded; `event`/`id`/`retry` are accepted but unused here.
+            if ($field === 'data') {
+                $dataBuffer .= $value . "\n";
+            }
+        }
+        // Stream ended mid-event (no terminating blank line). Dispatch whatever we have.
+        if ($dataBuffer !== '') {
+            $payload = substr($dataBuffer, 0, -1);
+            if ($this->terminator === null || $payload !== $this->terminator) {
+                yield ($this->deserializer)($payload);
+            }
+        }
+    }
+
+    /**
+     * Newline-delimited frames (NDJSON, line-by-line).
+     *
+     * @return Generator<int, T>
+     */
+    private function iterateDelimited(): Generator
+    {
+        foreach ($this->readLines() as $line) {
+            if ($line === '') {
+                continue;
+            }
+            if ($this->terminator !== null && $line === $this->terminator) {
+                return;
+            }
+            yield ($this->deserializer)($line);
+        }
+    }
+
+    /**
+     * Raw newline-delimited text frames.
+     *
+     * @return Generator<int, T>
+     */
+    private function iterateText(): Generator
+    {
+        foreach ($this->readLines() as $line) {
+            yield ($this->deserializer)($line);
+        }
+    }
+
+    /**
+     * Reads the response body and yields complete lines, normalizing CRLF/CR
+     * to LF per the WHATWG SSE spec. Trailing partial content (without a
+     * terminating newline) is emitted as a final line.
+     *
+     * @return Generator<int, string>
+     */
+    private function readLines(): Generator
+    {
+        $buffer = '';
+        $pendingCr = false;
+        while (!$this->body->eof()) {
+            $chunk = $this->body->read(self::READ_CHUNK_SIZE);
+            if ($chunk === '') {
+                continue;
+            }
+            // If the previous chunk ended on "\r", swallow a leading "\n" so we don't
+            // emit a spurious blank line for a "\r\n" sequence split across chunks.
+            if ($pendingCr && $chunk[0] === "\n") {
+                $chunk = substr($chunk, 1);
+            }
+            $pendingCr = str_ends_with($chunk, "\r");
+            // Normalize line endings on just this chunk: "\r\n" and lone "\r" -> "\n".
+            $chunk = str_replace(["\r\n", "\r"], "\n", $chunk);
+            $buffer .= $chunk;
+            while (($lfPos = strpos($buffer, "\n")) !== false) {
+                yield substr($buffer, 0, $lfPos);
+                $buffer = substr($buffer, $lfPos + 1);
+            }
+        }
+        if ($buffer !== '') {
+            yield $buffer;
+        }
+    }
+
+    public function __destruct()
+    {
+        try {
+            $this->body->close();
+        } catch (\Throwable) {
+            // Best effort — the body may already be closed by the consumer.
+        }
+    }
+}

--- a/seed/php-sdk/streaming/src/Core/Client/StreamFormat.php
+++ b/seed/php-sdk/streaming/src/Core/Client/StreamFormat.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Seed\Core\Client;
+
+/**
+ * Framing strategy used by `Stream` to interpret a streaming HTTP response body.
+ */
+enum StreamFormat: string
+{
+    case Sse = 'sse';
+    case Json = 'json';
+    case Text = 'text';
+}

--- a/seed/php-sdk/streaming/src/Core/Client/TextStream.php
+++ b/seed/php-sdk/streaming/src/Core/Client/TextStream.php
@@ -11,13 +11,20 @@ use Psr\Http\Message\ResponseInterface;
  */
 class TextStream extends Stream
 {
-    public function __construct(ResponseInterface $response)
-    {
+    /**
+     * @param ResponseInterface $response The HTTP response to stream from.
+     * @param int $maxBufferSize See `Stream::__construct`. Defaults to 1 MiB.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        int $maxBufferSize = self::DEFAULT_MAX_BUFFER_SIZE,
+    ) {
         parent::__construct(
             response: $response,
             deserializer: fn (string $line): string => $line,
             format: StreamFormat::Text,
             terminator: null,
+            maxBufferSize: $maxBufferSize,
         );
     }
 }

--- a/seed/php-sdk/streaming/src/Core/Client/TextStream.php
+++ b/seed/php-sdk/streaming/src/Core/Client/TextStream.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Seed\Core\Client;
+
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Iterates a streaming text response body, yielding one raw string per line.
+ *
+ * @extends Stream<string>
+ */
+class TextStream extends Stream
+{
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct(
+            response: $response,
+            deserializer: fn (string $line): string => $line,
+            format: StreamFormat::Text,
+            terminator: null,
+        );
+    }
+}

--- a/seed/php-sdk/streaming/src/Dummy/DummyClient.php
+++ b/seed/php-sdk/streaming/src/Dummy/DummyClient.php
@@ -5,13 +5,14 @@ namespace Seed\Dummy;
 use Psr\Http\Client\ClientInterface;
 use Seed\Core\Client\RawClient;
 use Seed\Dummy\Requests\GenerateStreamRequest;
+use Seed\Core\Client\JsonStream;
+use Seed\Dummy\Types\StreamResponse;
 use Seed\Exceptions\SeedException;
 use Seed\Exceptions\SeedApiException;
 use Seed\Core\Json\JsonApiRequest;
 use Seed\Core\Client\HttpMethod;
 use Psr\Http\Client\ClientExceptionInterface;
 use Seed\Dummy\Requests\Generateequest;
-use Seed\Dummy\Types\StreamResponse;
 use JsonException;
 
 class DummyClient
@@ -60,10 +61,11 @@ class DummyClient
      *   queryParameters?: array<string, mixed>,
      *   bodyProperties?: array<string, mixed>,
      * } $options
+     * @return JsonStream<StreamResponse>
      * @throws SeedException
      * @throws SeedApiException
      */
-    public function generateStream(GenerateStreamRequest $request, ?array $options = null): void
+    public function generateStream(GenerateStreamRequest $request, ?array $options = null): JsonStream
     {
         $options = array_merge($this->options, $options ?? []);
         try {
@@ -77,6 +79,9 @@ class DummyClient
                 $options,
             );
             $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 400) {
+                return new JsonStream(response: $response, deserializer: fn (string $data) => StreamResponse::fromJson($data), terminator: null);
+            }
         } catch (ClientExceptionInterface $e) {
             throw new SeedException(message: $e->getMessage(), previous: $e);
         }

--- a/seed/php-sdk/streaming/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/streaming/tests/Core/Client/StreamTest.php
@@ -112,7 +112,6 @@ class StreamTest extends TestCase
 
         $events = iterator_to_array($stream->events(), false);
 
-        // Second event's malformed id is rejected; previous id persists per spec.
         $this->assertSame(['ok', 'ok'], array_map(fn (SseEvent $e) => $e->id, $events));
     }
 
@@ -152,7 +151,6 @@ class StreamTest extends TestCase
 
     public function testSseConstructorAcceptsUtf8CharsetParameter(): void
     {
-        // No exception: UTF-8 charset parameter is the spec-mandated value.
         $stream = new SseStream(
             self::response("data: hi\n\n", contentType: 'text/event-stream; charset=UTF-8'),
             fn (string $d): string => $d,
@@ -164,8 +162,6 @@ class StreamTest extends TestCase
 
     public function testSseConstructorToleratesMissingContentTypeHeader(): void
     {
-        // Some streaming servers omit the header; we don't reject — we just
-        // can't validate. (The wire format check is best-effort.)
         $response = \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
             ->createResponse(200)
             ->withBody(\Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()->createStream("data: hi\n\n"));
@@ -177,7 +173,6 @@ class StreamTest extends TestCase
 
     public function testStreamThrowsWhenLineBufferExceedsMaxSize(): void
     {
-        // A single unterminated "line" larger than the cap must abort iteration.
         $bigLine = str_repeat('A', 200) . "\n";
         $stream = new SseStream(
             self::response("data: " . $bigLine . "\n"),
@@ -194,17 +189,14 @@ class StreamTest extends TestCase
 
     public function testStreamThrowsBeforeAccumulatingPastMaxBufferOnLongRunningSseEvent(): void
     {
-        // The cap must fire during accumulation, not just at dispatch. A hostile
-        // stream sending many small `data:` lines without a closing blank line
-        // would otherwise grow $dataBuffer past the configured limit. Each line
-        // here is well under the 64-byte cap, but their cumulative `data:`
-        // append should trip the check before allocation balloons.
+        // Each line is well under the 64-byte cap; the cumulative `data:`
+        // append must trip the check before the buffer balloons.
         $manyDataLines = '';
         for ($i = 0; $i < 50; $i++) {
             $manyDataLines .= "data: chunk-$i\n";
         }
         $stream = new SseStream(
-            self::response($manyDataLines),  // no terminating "\n\n"
+            self::response($manyDataLines),
             fn (string $d): string => $d,
             terminator: null,
             maxBufferSize: 64,
@@ -218,8 +210,7 @@ class StreamTest extends TestCase
 
     public function testSseStripsUtf8BomFromStartOfStream(): void
     {
-        // WHATWG §9.2.4: a leading U+FEFF BOM must be stripped from the stream
-        // so the first field-name match isn't poisoned.
+        // WHATWG §9.2.4 requires a leading U+FEFF to be dropped.
         $body = "\xEF\xBB\xBFdata: hello\n\n";
         $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
 
@@ -228,7 +219,6 @@ class StreamTest extends TestCase
 
     public function testSseStripsBomOnlyAtVeryStart(): void
     {
-        // A BOM-looking sequence that appears mid-stream must NOT be stripped.
         $body = "data: first\n\ndata: \xEF\xBB\xBFsecond\n\n";
         $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
 

--- a/seed/php-sdk/streaming/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/streaming/tests/Core/Client/StreamTest.php
@@ -192,6 +192,49 @@ class StreamTest extends TestCase
         iterator_to_array($stream, false);
     }
 
+    public function testStreamThrowsBeforeAccumulatingPastMaxBufferOnLongRunningSseEvent(): void
+    {
+        // The cap must fire during accumulation, not just at dispatch. A hostile
+        // stream sending many small `data:` lines without a closing blank line
+        // would otherwise grow $dataBuffer past the configured limit. Each line
+        // here is well under the 64-byte cap, but their cumulative `data:`
+        // append should trip the check before allocation balloons.
+        $manyDataLines = '';
+        for ($i = 0; $i < 50; $i++) {
+            $manyDataLines .= "data: chunk-$i\n";
+        }
+        $stream = new SseStream(
+            self::response($manyDataLines),  // no terminating "\n\n"
+            fn (string $d): string => $d,
+            terminator: null,
+            maxBufferSize: 64,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/buffer/i');
+
+        iterator_to_array($stream, false);
+    }
+
+    public function testSseStripsUtf8BomFromStartOfStream(): void
+    {
+        // WHATWG §9.2.4: a leading U+FEFF BOM must be stripped from the stream
+        // so the first field-name match isn't poisoned.
+        $body = "\xEF\xBB\xBFdata: hello\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['hello'], iterator_to_array($stream, false));
+    }
+
+    public function testSseStripsBomOnlyAtVeryStart(): void
+    {
+        // A BOM-looking sequence that appears mid-stream must NOT be stripped.
+        $body = "data: first\n\ndata: \xEF\xBB\xBFsecond\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['first', "\xEF\xBB\xBFsecond"], iterator_to_array($stream, false));
+    }
+
     public function testJsonStreamYieldsOnePerLine(): void
     {
         $body = "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n";

--- a/seed/php-sdk/streaming/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/streaming/tests/Core/Client/StreamTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Seed\Tests\Core\Client;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Seed\Core\Client\JsonStream;
+use Seed\Core\Client\SseStream;
+use Seed\Core\Client\Stream;
+use Seed\Core\Client\TextStream;
+
+class StreamTest extends TestCase
+{
+    public function testSseParsesSingleEvent(): void
+    {
+        $body = "data: hello\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['hello'], iterator_to_array($stream, false));
+    }
+
+    public function testSseConcatenatesMultilineDataWithNewlines(): void
+    {
+        $body = "data: line one\ndata: line two\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(["line one\nline two"], iterator_to_array($stream, false));
+    }
+
+    public function testSseStripsLeadingSpaceFromFieldValues(): void
+    {
+        // SSE spec: a single leading space in the field value is stripped.
+        $body = "data: with-leading-space\ndata:no-leading-space\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(["with-leading-space\nno-leading-space"], iterator_to_array($stream, false));
+    }
+
+    public function testSseIgnoresCommentLines(): void
+    {
+        $body = ": this is a comment\ndata: payload\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['payload'], iterator_to_array($stream, false));
+    }
+
+    public function testSseTerminatorEndsIterationCleanly(): void
+    {
+        $body = "data: first\n\ndata: [DONE]\n\ndata: never-yielded\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, '[DONE]');
+
+        $this->assertSame(['first'], iterator_to_array($stream, false));
+    }
+
+    public function testSseNormalizesCrlfAndLoneCr(): void
+    {
+        $body = "data: a\r\n\r\ndata: b\rdata: c\r\r";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['a', "b\nc"], iterator_to_array($stream, false));
+    }
+
+    public function testSseDispatchesTrailingEventWithoutBlankLine(): void
+    {
+        $body = "data: incomplete";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $this->assertSame(['incomplete'], iterator_to_array($stream, false));
+    }
+
+    public function testSseAppliesDeserializerOncePerEvent(): void
+    {
+        $body = "data: {\"n\":1}\n\ndata: {\"n\":2}\n\n";
+        $stream = new SseStream(self::response($body), self::jsonDecoder(), null);
+
+        $this->assertSame([['n' => 1], ['n' => 2]], iterator_to_array($stream, false));
+    }
+
+    public function testJsonStreamYieldsOnePerLine(): void
+    {
+        $body = "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n";
+        $stream = new JsonStream(self::response($body), self::jsonDecoder(), null);
+
+        $this->assertSame([['n' => 1], ['n' => 2], ['n' => 3]], iterator_to_array($stream, false));
+    }
+
+    public function testJsonStreamSkipsEmptyLines(): void
+    {
+        $body = "{\"a\":1}\n\n{\"a\":2}\n";
+        $stream = new JsonStream(self::response($body), self::jsonDecoder(), null);
+
+        $this->assertSame([['a' => 1], ['a' => 2]], iterator_to_array($stream, false));
+    }
+
+    public function testJsonStreamTerminatorEndsIteration(): void
+    {
+        $body = "{\"a\":1}\n[DONE]\n{\"a\":2}\n";
+        $stream = new JsonStream(self::response($body), self::jsonDecoder(), '[DONE]');
+
+        $this->assertSame([['a' => 1]], iterator_to_array($stream, false));
+    }
+
+    /**
+     * @return \Closure(string): array<string, mixed>
+     */
+    private static function jsonDecoder(): \Closure
+    {
+        return static function (string $raw): array {
+            /** @var array<string, mixed> $decoded */
+            $decoded = json_decode($raw, true);
+            return $decoded;
+        };
+    }
+
+    public function testTextStreamYieldsRawLines(): void
+    {
+        $body = "alpha\nbeta\ngamma\n";
+        $stream = new TextStream(self::response($body));
+
+        $this->assertSame(['alpha', 'beta', 'gamma'], iterator_to_array($stream, false));
+    }
+
+    public function testTextStreamPreservesEmptyLines(): void
+    {
+        $body = "alpha\n\nbeta\n";
+        $stream = new TextStream(self::response($body));
+
+        $this->assertSame(['alpha', '', 'beta'], iterator_to_array($stream, false));
+    }
+
+    /**
+     * Build a PSR-7 ResponseInterface with the given body string, using auto-discovery
+     * so we don't depend on any specific implementation.
+     */
+    private static function response(string $body): ResponseInterface
+    {
+        return \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
+            ->createResponse(200)
+            ->withBody(
+                \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()
+                    ->createStream($body),
+            );
+    }
+}

--- a/seed/php-sdk/streaming/tests/Core/Client/StreamTest.php
+++ b/seed/php-sdk/streaming/tests/Core/Client/StreamTest.php
@@ -4,7 +4,9 @@ namespace Seed\Tests\Core\Client;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 use Seed\Core\Client\JsonStream;
+use Seed\Core\Client\SseEvent;
 use Seed\Core\Client\SseStream;
 use Seed\Core\Client\Stream;
 use Seed\Core\Client\TextStream;
@@ -76,6 +78,120 @@ class StreamTest extends TestCase
         $this->assertSame([['n' => 1], ['n' => 2]], iterator_to_array($stream, false));
     }
 
+    public function testSseEventsExposesEventIdAndRetryMetadata(): void
+    {
+        $body = "event: chat\nid: msg-1\nretry: 5000\ndata: hi\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        $this->assertCount(1, $events);
+        $this->assertInstanceOf(SseEvent::class, $events[0]);
+        $this->assertSame('hi', $events[0]->data);
+        $this->assertSame('chat', $events[0]->event);
+        $this->assertSame('msg-1', $events[0]->id);
+        $this->assertSame(5000, $events[0]->retry);
+    }
+
+    public function testSseEventsPersistsLastEventIdAcrossEventsPerSpec(): void
+    {
+        // Per WHATWG SSE: once an `id:` is set it persists across subsequent
+        // events until explicitly overridden.
+        $body = "id: persistent\ndata: a\n\ndata: b\n\nid: replaced\ndata: c\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        $this->assertSame(['persistent', 'persistent', 'replaced'], array_map(fn (SseEvent $e) => $e->id, $events));
+    }
+
+    public function testSseEventsIgnoresIdContainingNullByte(): void
+    {
+        $body = "id: ok\ndata: first\n\nid: bad\0id\ndata: second\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        // Second event's malformed id is rejected; previous id persists per spec.
+        $this->assertSame(['ok', 'ok'], array_map(fn (SseEvent $e) => $e->id, $events));
+    }
+
+    public function testSseEventsIgnoresNonIntegerRetry(): void
+    {
+        $body = "retry: not-a-number\ndata: hi\n\n";
+        $stream = new SseStream(self::response($body), fn (string $d): string => $d, null);
+
+        $events = iterator_to_array($stream->events(), false);
+
+        $this->assertNull($events[0]->retry);
+    }
+
+    public function testSseConstructorRejectsNonSseContentType(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/text\/event-stream/');
+
+        new SseStream(
+            self::response('data: x\n\n', contentType: 'application/json'),
+            fn (string $d): string => $d,
+            null,
+        );
+    }
+
+    public function testSseConstructorRejectsNonUtf8Charset(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/charset/i');
+
+        new SseStream(
+            self::response('data: x\n\n', contentType: 'text/event-stream; charset=iso-8859-1'),
+            fn (string $d): string => $d,
+            null,
+        );
+    }
+
+    public function testSseConstructorAcceptsUtf8CharsetParameter(): void
+    {
+        // No exception: UTF-8 charset parameter is the spec-mandated value.
+        $stream = new SseStream(
+            self::response("data: hi\n\n", contentType: 'text/event-stream; charset=UTF-8'),
+            fn (string $d): string => $d,
+            null,
+        );
+
+        $this->assertSame(['hi'], iterator_to_array($stream, false));
+    }
+
+    public function testSseConstructorToleratesMissingContentTypeHeader(): void
+    {
+        // Some streaming servers omit the header; we don't reject — we just
+        // can't validate. (The wire format check is best-effort.)
+        $response = \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
+            ->createResponse(200)
+            ->withBody(\Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()->createStream("data: hi\n\n"));
+
+        $stream = new SseStream($response, fn (string $d): string => $d, null);
+
+        $this->assertSame(['hi'], iterator_to_array($stream, false));
+    }
+
+    public function testStreamThrowsWhenLineBufferExceedsMaxSize(): void
+    {
+        // A single unterminated "line" larger than the cap must abort iteration.
+        $bigLine = str_repeat('A', 200) . "\n";
+        $stream = new SseStream(
+            self::response("data: " . $bigLine . "\n"),
+            fn (string $d): string => $d,
+            terminator: null,
+            maxBufferSize: 64,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/buffer/i');
+
+        iterator_to_array($stream, false);
+    }
+
     public function testJsonStreamYieldsOnePerLine(): void
     {
         $body = "{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n";
@@ -129,13 +245,17 @@ class StreamTest extends TestCase
     }
 
     /**
-     * Build a PSR-7 ResponseInterface with the given body string, using auto-discovery
-     * so we don't depend on any specific implementation.
+     * Build a PSR-7 ResponseInterface with the given body. The Content-Type
+     * defaults to `text/event-stream` so SSE tests just work; pass an override
+     * for the validation-error cases.
      */
-    private static function response(string $body): ResponseInterface
-    {
+    private static function response(
+        string $body,
+        string $contentType = 'text/event-stream',
+    ): ResponseInterface {
         return \Http\Discovery\Psr17FactoryDiscovery::findResponseFactory()
             ->createResponse(200)
+            ->withHeader('Content-Type', $contentType)
             ->withBody(
                 \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory()
                     ->createStream($body),


### PR DESCRIPTION
Closes FER-10530.

## Summary

Adding PHP streaming support to match Python/Java/Go/etc.

Generated PHP SDKs now emit real streaming methods for endpoints with a `response-stream` instead of broken `void` methods that always throw. `SSE`, `NDJSON`, and raw text streaming all dispatch through a single unified `Stream<T>` runtime helper (Go's strategy from `internal/streamer.go`) with thin `SseStream` / `JsonStream` / `TextStream` wrappers for clean named return types.

## What gets generated

For each `response-stream` endpoint, the generator picks the format from the IR's `StreamingResponse` union (`sse` / `json` / `text`) and emits a method whose return type is one of the three wrappers below. All three share a buffer-cap and BOM-safe line reader; the differences are framing and constructor signature.

### SSE — `SseStream<T>`

**Interface**

```php
final class SseStream<T> extends Stream<T>
{
    public function __construct(
        ResponseInterface $response,
        Closure $deserializer,                // fn(string $data): T
        ?string $terminator = '[DONE]',       // null disables terminator handling
        int $maxBufferSize = 1_048_576,       // 1 MiB cap on buffered data
    );

    /** @return Generator<int, T>           — yields payloads only (foreach) */
    public function getIterator(): Generator;

    /** @return Generator<int, SseEvent<T>> — yields payload + WHATWG metadata */
    public function events(): Generator;
}

final class SseEvent<T>
{
    public readonly T       $data;     // deserialized payload
    public readonly string  $event;    // `event:` field, '' if absent
    public readonly string  $id;       // last `id:` (persists per WHATWG)
    public readonly ?int    $retry;    // `retry:` ms, or null
}
```

Validates `Content-Type: text/event-stream` and rejects non-UTF-8 charsets. Handles multi-line `data:` (newline-joined), comment lines (`:` prefix), CRLF/CR normalization, and leading-space stripping per WHATWG §9.2.

**Generated method**

```php
public function subscribe(?array $options = null): SseStream
{
    // ... sends request, captures $statusCode ...
    if ($statusCode >= 200 && $statusCode < 400) {
        return new SseStream(
            response: $response,
            deserializer: fn (string $data) => EventStreamResponse::fromJson($data),
            terminator: null,
        );
    }
    throw new Auth0ApiException(...);
}
```

**Consumer usage**

```php
// Data-only iteration:
foreach ($auth0->events->subscribe() as $event) {
    match ($event->getType()) {
        'user.created' => handleUserCreated($event->getValue()),
        'offset-only'  => updateCursor($event->getValue()->getOffset()),
        default        => null,
    };
}

// With SSE metadata (event type, id for resume, retry hint):
foreach ($auth0->events->subscribe()->events() as $sse) {
    echo "event={$sse->event} id={$sse->id}\n";
    handlePayload($sse->data);
}
```

### NDJSON — `JsonStream<T>`

**Interface**

```php
final class JsonStream<T> extends Stream<T>
{
    public function __construct(
        ResponseInterface $response,
        Closure $deserializer,                // fn(string $line): T
        ?string $terminator = null,           // optional sentinel line
        int $maxBufferSize = 1_048_576,
    );

    /** @return Generator<int, T> */
    public function getIterator(): Generator;
}
```

One JSON document per line. Empty lines are skipped; a terminator line (if set) ends iteration cleanly.

**Generated method**

```php
public function generateStream(GenerateStreamRequest $request, ?array $options = null): JsonStream
{
    // ... sends request, captures $statusCode ...
    if ($statusCode >= 200 && $statusCode < 400) {
        return new JsonStream(
            response: $response,
            deserializer: fn (string $data) => StreamResponse::fromJson($data),
            terminator: null,
        );
    }
    throw new SeedApiException(...);
}
```

**Consumer usage**

```php
foreach ($client->dummy->generateStream($req) as $chunk) {
    echo $chunk->getId() . "\n";
}
```

### Plain text — `TextStream`

**Interface**

```php
final class TextStream extends Stream<string>
{
    public function __construct(
        ResponseInterface $response,
        int $maxBufferSize = 1_048_576,
    );

    /** @return Generator<int, string> */
    public function getIterator(): Generator;
}
```

No deserializer — yields each line of the response body as a raw string. CRLF/CR normalized to LF; UTF-8 BOM stripped if present.

**Generated method**

```php
public function tail(?array $options = null): TextStream
{
    // ... sends request, captures $statusCode ...
    if ($statusCode >= 200 && $statusCode < 400) {
        return new TextStream(response: $response);
    }
    throw new SeedApiException(...);
}
```

**Consumer usage** (illustrative — no current fixture exercises text streaming end-to-end, but the codegen path is identical to NDJSON minus the deserializer)

```php
foreach ($client->logs->tail() as $line) {
    echo $line . "\n";
}
```

## Implementation

- New runtime helper `Stream.Template.php` emitted into every generated SDK with streaming endpoints, plus thin `SseStream` / `JsonStream` / `TextStream` wrappers and an `SseEvent<T>` envelope for the metadata path.
- IR's existing `StreamingResponse._visit({ sse, json, text })` is now consumed by both the return-type generator and the success-branch emitter; no IR change needed.
- Gated on `ir.sdkConfig.hasStreamingEndpoints` so SDKs without streaming endpoints are unaffected.
- 13 new PHPUnit cases in `StreamTest.Template.php` covering the WHATWG SSE spec corners (multi-line `data:`, comment lines, CRLF, terminator, charset validation) plus JSON/text framing.

## Test plan

- [x] `pnpm seed test --generator php-sdk --fixture streaming` — passes, NDJSON output now emits `JsonStream<StreamResponse>`.
- [x] `pnpm seed test --generator php-sdk --fixture streaming-parameter` — passes.
- [x] `pnpm seed test --generator php-sdk --fixture server-sent-events` — passes, emits `SseStream<StreamedCompletion>`.
- [x] `pnpm seed test --generator php-sdk --fixture server-sent-events-openapi` — passes (removed from `allowedFailures`).
- [x] `pnpm seed test --generator php-sdk --fixture server-sent-event-examples` — passes.
- [x] PHPStan and PHPUnit clean on regenerated `seed/php-sdk/server-sent-events` (65 tests, 233 assertions).
- [x] Manually generated Auth0's PHP SDK and verified `EventsClient::subscribe()` now produces a real SSE method. Wrote an integration test exercising MockHttpClient → RawClient → EventsClient::subscribe() → SseStream → discriminated-union dispatch; all 4 cases pass.
