### PR TITLE
fix(cli): authenticate Venus calls during local Docker generation

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-local-docker-venus-auth.yml
+++ b/packages/cli/cli/changes/unreleased/fix-local-docker-venus-auth.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Authenticate Venus calls during local Docker generation (`fern generate --local`)
+    by silently picking up an existing `FERN_TOKEN` env var or saved login token,
+    matching the remote generation path. Previously, `useLocalDocker` skipped the
+    auth flow entirely, leaving Venus calls (e.g. `GET /organizations/{org_id}`)
+    unauthenticated.
+  type: fix

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
@@ -1,4 +1,4 @@
-import { createOrganizationIfDoesNotExist, FernToken } from "@fern-api/auth";
+import { createOrganizationIfDoesNotExist, FernToken, getToken } from "@fern-api/auth";
 import { ContainerRunner, Values } from "@fern-api/core-utils";
 import { AbsoluteFilePath, cwd, join, RelativeFilePath, resolve } from "@fern-api/fs-utils";
 import { askToLogin } from "@fern-api/login";
@@ -100,6 +100,11 @@ export async function generateAPIWorkspaces({
             });
         }
         token = currentToken;
+    } else {
+        // Local generation must stay non-interactive: silently pick up an existing
+        // token (FERN_TOKEN env var or saved login file) so Venus calls are
+        // authenticated when possible, and leave `token` undefined otherwise.
+        token = await getToken();
     }
 
     await confirmOutputDirectoriesForEligibleGenerators({


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-10551](https://linear.app/buildwithfern/issue/FER-10551)

When running `fern generate` with `useLocalDocker=true` (i.e. `--local`), the CLI skipped the auth flow entirely, leaving `token` as `undefined`. The token was then threaded down to `runLocalGenerationForWorkspace`, which instantiates the Venus client with `createVenusService({ token: token?.value })` — so the `GET /organizations/{org_id}` call (used to fetch whitelabel / self-hosted SDK metadata) went out unauthenticated.

This PR fixes the local Docker path to use the same token resolution as the remote path, but **without** prompting interactively (local generation must stay non-interactive). It calls `getToken()` from `@fern-api/auth`, which:

1. Checks the `FERN_TOKEN` env var first.
2. Falls back to the saved login token file.
3. Returns `undefined` if neither exists (no prompting, no error).

The resolved token is reused through the existing `token` plumbing, so Venus calls during local generation are now authenticated whenever a token is available. If no token is found, the call falls back to the previous unauthenticated behavior so existing flows (e.g. genuinely local-only generation with no Fern account) keep working.

## Changes Made
- `packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts`: in the `useLocalDocker` branch, call `getToken()` to silently pick up an existing token instead of leaving `token` as `undefined`. Do **not** call `askToLogin` — that prompts interactively, which is wrong for local Docker generation.
- Added changelog entry: `packages/cli/cli/changes/unreleased/fix-local-docker-venus-auth.yml`.
- [ ] Updated README.md generator (if applicable) — N/A

## Testing
- [x] `pnpm turbo run compile --filter @fern-api/cli` — passes (94/94 tasks successful).
- [x] `pnpm turbo run test --filter @fern-api/cli` — 565/565 tests pass.
- [x] `pnpm run check` (Biome) — clean across 4555 files.
- [ ] Unit tests added/updated — no existing test pattern for `generateAPIWorkspaces.ts` (the sibling `__test__` directory only covers pure helper functions like `resolveGroupsForWorkspace`, `expandGroupFilter`, etc.). Adding a test for this branch would require substantial mocking of `cliContext`, `askToLogin`, and the full generation pipeline, which doesn't match existing patterns in the directory.
- [x] Manual testing completed via the build/typecheck/test loop above.

## Notes for reviewer
- `runLocalGenerationForWorkspace` already re-runs `getAccessToken()` later (lines 192–202) for the GitHub-publish branch, but that happens *after* the Venus organization lookup at line 204, which is why the org call was going unauthenticated. Doing the lookup earlier in `generateAPIWorkspaces` keeps the Venus client authenticated for the entire workspace run and matches the remote path's structure.
- The `token?.value` access in `createVenusService` already gracefully handles an undefined token, so the existing fallback behavior is preserved when no token is present.

Link to Devin session: https://app.devin.ai/sessions/d894c5dbf46e462b9e9b04f3bc92339f
Requested by: @jsklan