### PR TITLE
fix(generator-cli): set explicit author/committer on API-created commits

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-commit-author-attribution.yml
+++ b/packages/cli/cli/changes/unreleased/fix-commit-author-attribution.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix commit author attribution for GitHub Enterprise: API-created commits now
+    use the Fern bot identity instead of the PAT-owning user, matching the git CLI
+    behavior of Fern 3.x generators.
+  type: fix

--- a/packages/generator-cli/src/__test__/pushSignedCommit.test.ts
+++ b/packages/generator-cli/src/__test__/pushSignedCommit.test.ts
@@ -102,7 +102,9 @@ describe("pushSignedCommit", () => {
             repo: "acme-sdk",
             message: "SDK Generation",
             tree: "tree-sha",
-            parents: ["parent-sha"]
+            parents: ["parent-sha"],
+            author: { name: "fern-api", email: "115122769+fern-api[bot]@users.noreply.github.com" },
+            committer: { name: "fern-api", email: "115122769+fern-api[bot]@users.noreply.github.com" }
         });
         expect(octokit.git.updateRef).toHaveBeenCalledWith({
             owner: "acme",
@@ -226,7 +228,9 @@ describe("pushSignedCommit", () => {
             repo: "acme-sdk",
             message: "SDK Generation",
             tree: "tree-sha-2",
-            parents: ["parent-sha-2"]
+            parents: ["parent-sha-2"],
+            author: { name: "fern-api", email: "115122769+fern-api[bot]@users.noreply.github.com" },
+            committer: { name: "fern-api", email: "115122769+fern-api[bot]@users.noreply.github.com" }
         });
         // Temp ref re-push on the rebase retry must force, because the rebased commit
         // is not a descendant of the original tempRef tip.

--- a/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
+++ b/packages/generator-cli/src/pipeline/github/pushSignedCommit.ts
@@ -3,8 +3,14 @@ import type { ClonedRepository } from "@fern-api/github";
 import type { Octokit } from "@octokit/rest";
 
 import type { PipelineLogger } from "../PipelineLogger";
+import { FERN_BOT_EMAIL, FERN_BOT_NAME } from "./constants";
 
 const MAX_CONCURRENT_PUSH_RETRIES = 3;
+
+export interface CommitAuthor {
+    name: string;
+    email: string;
+}
 
 export interface PushSignedCommitOptions {
     repository: ClonedRepository;
@@ -26,6 +32,11 @@ export interface PushSignedCommitOptions {
      * remote changes) is only safe for bot-owned branches and is therefore never done here.
      */
     rebaseOnConflict?: boolean;
+    /**
+     * Override the commit author and committer identity.
+     * Defaults to the Fern bot identity (fern-api / fern-api[bot] noreply email).
+     */
+    author?: CommitAuthor;
     logger: PipelineLogger;
 }
 
@@ -48,6 +59,7 @@ export async function pushSignedCommit({
     branch,
     force,
     rebaseOnConflict = false,
+    author,
     logger
 }: PushSignedCommitOptions): Promise<string> {
     const tempRef = `refs/temp/fern-${Date.now()}`;
@@ -65,12 +77,18 @@ export async function pushSignedCommit({
         tempRefPushed = true;
 
         for (let attempt = 0; attempt < MAX_CONCURRENT_PUSH_RETRIES; attempt++) {
+            const commitAuthor = {
+                name: author?.name ?? FERN_BOT_NAME,
+                email: author?.email ?? FERN_BOT_EMAIL
+            };
             const { data: signedCommit } = await octokit.git.createCommit({
                 owner,
                 repo,
                 message,
                 tree: treeSha,
-                parents
+                parents,
+                author: commitAuthor,
+                committer: commitAuthor
             });
             const signedSha = signedCommit.sha;
 

--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -197,6 +197,7 @@ export class GithubStep extends BaseStep {
                 repo,
                 branch: prBranch,
                 force: isUpdatingExistingPR,
+                author: this.config.author,
                 logger: this.logger
             });
             const pushedBranch = await repository.getCurrentBranch();
@@ -342,6 +343,7 @@ export class GithubStep extends BaseStep {
                 branch: baseBranch,
                 force: false,
                 rebaseOnConflict: true,
+                author: this.config.author,
                 logger: this.logger
             });
 

--- a/packages/generator-cli/src/pipeline/types.ts
+++ b/packages/generator-cli/src/pipeline/types.ts
@@ -152,6 +152,11 @@ export interface GithubStepConfig {
     runId?: string;
     /** GitHub API base URL for GitHub Enterprise (e.g. "https://github.intuit.com/api/v3"). Omit for github.com. */
     apiBaseUrl?: string;
+    /** Override the commit author/committer identity for API-created commits. Defaults to the Fern bot identity. */
+    author?: {
+        name: string;
+        email: string;
+    };
 }
 
 export interface PipelineResult {


### PR DESCRIPTION
## Description

Fixes commit attribution on GitHub Enterprise (and any PAT-authenticated flow): API-created commits via `octokit.git.createCommit()` now explicitly set `author` and `committer` to the Fern bot identity instead of relying on the authenticated user default.

**Problem:** When pushing via the GitHub REST API with a PAT (common for GHE self-hosted repos), commits get attributed to the PAT-owning user (e.g. `svc-sbseg-ci`) rather than a stable bot identity. This breaks CI strategies that filter on committer email (e.g. Jenkins "Ignore Committer Strategy") because Fern's commits become indistinguishable from the service account's own commits.

**Before (Fern 5.x, Octokit):**
```
commit abc123
Author: svc-sbseg-ci <SBSEGCI-Admins@intuit.com>    ← PAT owner, breaks Jenkins filter
```

**After (this fix):**
```
commit abc123
Author: fern-api <115122769+fern-api[bot]@users.noreply.github.com>    ← stable bot identity
```

**Contrast with Fern 3.x (git CLI):**
```
commit def456
Author: fern-api[bot] <115122769+fern-api[bot]@users.noreply.github.com>    ← already correct
```

**Fix:** Always pass `author` and `committer` fields to `octokit.git.createCommit()`, defaulting to the existing `FERN_BOT_NAME` / `FERN_BOT_EMAIL` constants. This makes API-created commits consistent with the git CLI path. On github.com, the email matches the `fern-api[bot]` account so GitHub still links commits correctly. On GHE, commits show as "fern-api" instead of the service account.

The `GithubStepConfig` also accepts an optional `author` override for callers that need a custom committer identity.

### Example

No config changes needed — the default behavior now matches Fern 3.x:

```yaml
# generators.yml — works as-is, no changes required
groups:
  production:
    generators:
      - name: fernapi/fern-python-sdk
        version: 5.x.x
        github:
          repository: github.intuit.com/money/fintech-python-sdk
          mode: push
```

Commits will be attributed to `fern-api` instead of the PAT-owning service account.

## Changes Made
- `pushSignedCommit.ts`: Import Fern bot constants; add optional `author` field to `PushSignedCommitOptions`; pass `author`/`committer` to `createCommit()` with Fern bot defaults
- `GithubStep.ts`: Thread `config.author` to both `pushSignedCommit` call sites (pull-request and push modes)
- `types.ts`: Add optional `author` field to `GithubStepConfig`
- `pushSignedCommit.test.ts`: Update test assertions to expect `author`/`committer` fields
- Added unreleased changelog entry

## Testing
- [x] Unit tests updated and passing (pushSignedCommit.test.ts)
- [x] TypeScript compilation passes
- [x] All CI checks green (compile, test, test-ete, lint, biome, seed tests)
- [x] Change is backward-compatible: `author` defaults to Fern bot identity when not provided

Link to Devin session: https://app.devin.ai/sessions/d6f0693ed3d54dc59a04619b58f2a599
Requested by: @iamnamananand996